### PR TITLE
Close procedure streams on failures

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/java/org/neo4j/internal/cypher/acceptance/TestResourceProcedure.java
+++ b/community/cypher/acceptance-spec-suite/src/test/java/org/neo4j/internal/cypher/acceptance/TestResourceProcedure.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance;
+
+import java.util.Iterator;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.kernel.impl.proc.ComponentRegistry;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Mode;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+import org.neo4j.procedure.UserFunction;
+
+public class TestResourceProcedure
+{
+    public static abstract class SimulateFailureBaseException extends RuntimeException
+    {
+    }
+
+    public static class SimulateFailureException extends SimulateFailureBaseException
+    {
+    }
+
+    public static class SimulateFailureOnCloseException extends SimulateFailureBaseException
+    {
+    }
+
+    @Context
+    public GraphDatabaseService db;
+
+    @Context
+    public Counters counters;
+
+    public static class Counters
+    {
+        public int closeCountTestResourceProcedure = 0;
+        public int closeCountTestFailingResourceProcedure = 0;
+        public int closeCountTestOnCloseFailingResourceProcedure = 0;
+
+        public int openCountTestResourceProcedure = 0;
+        public int openCountTestFailingResourceProcedure = 0;
+        public int openCountTestOnCloseFailingResourceProcedure = 0;
+
+        public int liveCountTestResourceProcedure()
+        {
+            return openCountTestResourceProcedure - closeCountTestResourceProcedure;
+        }
+
+        public int liveCountTestFailingResourceProcedure()
+        {
+            return openCountTestFailingResourceProcedure - closeCountTestFailingResourceProcedure;
+        }
+
+        public int liveCountTestOnCloseFailingResourceProcedure()
+        {
+            return openCountTestOnCloseFailingResourceProcedure - closeCountTestOnCloseFailingResourceProcedure;
+        }
+
+        public void reset()
+        {
+            closeCountTestResourceProcedure = 0;
+            closeCountTestFailingResourceProcedure = 0;
+            closeCountTestOnCloseFailingResourceProcedure = 0;
+            openCountTestResourceProcedure = 0;
+            openCountTestFailingResourceProcedure = 0;
+            openCountTestOnCloseFailingResourceProcedure = 0;
+        }
+    }
+
+    public static ComponentRegistry.Provider<Counters> countersProvider(Counters counters1)
+    {
+        return context -> counters1;
+    }
+
+    public class Output
+    {
+        public Long value;
+
+        public Output( Long value )
+        {
+            this.value = value;
+        }
+    }
+
+    @Procedure( name = "org.neo4j.test.testResourceProcedure", mode = Mode.READ )
+    @Description( "Returns a stream of integers from 1 to the given argument" )
+    public Stream<Output> testResourceProcedure( @Name( value = "resultCount", defaultValue = "4" ) long resultCount ) throws Exception
+    {
+        Stream<Output> stream = Stream.iterate( 1L, (i) -> i + 1 ).limit( resultCount ).map( Output::new );
+        stream.onClose( () ->
+        {
+            counters.closeCountTestResourceProcedure++;
+        } );
+        counters.openCountTestResourceProcedure++;
+        return stream;
+    }
+
+    @Procedure( name = "org.neo4j.test.testFailingResourceProcedure", mode = Mode.READ )
+    @Description( "Returns a stream of integers from 1 to the given argument, but throws an exception when reaching the last element" )
+    public Stream<Output> testFailingResourceProcedure( @Name( value = "failCount", defaultValue = "3" ) long failCount ) throws Exception
+    {
+        Iterator<Output> failingIterator = new Iterator<Output>()
+        {
+            private long step = 1;
+
+            @Override
+            public boolean hasNext()
+            {
+                return step <= failCount;
+            }
+
+            @Override
+            public Output next()
+            {
+                if ( step == failCount )
+                {
+                    throw new SimulateFailureException();
+                }
+                step++;
+                return new Output(step);
+            }
+        };
+        Iterable<Output> failingIterable = () -> failingIterator;
+        Stream<Output> stream = StreamSupport.stream(failingIterable.spliterator(), false);
+        stream.onClose( () ->
+        {
+            counters.closeCountTestFailingResourceProcedure++;
+        } );
+        counters.openCountTestFailingResourceProcedure++;
+        return stream;
+    }
+
+    @Procedure( name = "org.neo4j.test.testOnCloseFailingResourceProcedure", mode = Mode.READ )
+    @Description( "Returns a stream of integers from 1 to the given argument. Throws an exception on close." )
+    public Stream<Output> testOnCloseFailingResourceProcedure( @Name( value = "resultCount", defaultValue = "4" ) long resultCount ) throws Exception
+    {
+        Stream<Output> stream = Stream.iterate( 1L, (i) -> i + 1 ).limit( resultCount ).map( Output::new );
+        stream.onClose( () ->
+        {
+            counters.closeCountTestOnCloseFailingResourceProcedure++;
+            throw new SimulateFailureOnCloseException();
+        } );
+        counters.openCountTestOnCloseFailingResourceProcedure++;
+        return stream;
+    }
+
+    @UserFunction( name = "org.neo4j.test.fail" )
+    @Description( "org.neo4j.test.fail" )
+    public String fail( @Name( value = "input" ) String input )
+    {
+        throw new SimulateFailureException();
+    }
+}

--- a/community/cypher/acceptance-spec-suite/src/test/java/org/neo4j/internal/cypher/acceptance/TestResourceProcedure.java
+++ b/community/cypher/acceptance-spec-suite/src/test/java/org/neo4j/internal/cypher/acceptance/TestResourceProcedure.java
@@ -88,9 +88,9 @@ public class TestResourceProcedure
         }
     }
 
-    public static ComponentRegistry.Provider<Counters> countersProvider(Counters counters1)
+    public static ComponentRegistry.Provider<Counters> countersProvider( Counters counters )
     {
-        return context -> counters1;
+        return context -> counters;
     }
 
     public class Output
@@ -137,8 +137,7 @@ public class TestResourceProcedure
                 {
                     throw new SimulateFailureException();
                 }
-                step++;
-                return new Output(step);
+                return new Output(step++);
             }
         };
         Iterable<Output> failingIterable = () -> failingIterator;

--- a/community/cypher/acceptance-spec-suite/src/test/java/org/neo4j/internal/cypher/acceptance/TestResourceProcedure.java
+++ b/community/cypher/acceptance-spec-suite/src/test/java/org/neo4j/internal/cypher/acceptance/TestResourceProcedure.java
@@ -34,7 +34,7 @@ import org.neo4j.procedure.UserFunction;
 
 public class TestResourceProcedure
 {
-    public static abstract class SimulateFailureBaseException extends RuntimeException
+    abstract static class SimulateFailureBaseException extends RuntimeException
     {
     }
 

--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
@@ -181,7 +181,7 @@ class EagerizationAcceptanceTest
       builder.mode(Mode.WRITE)
       new BasicProcedure(builder.build) {
         override def apply(ctx: Context, input: Array[AnyRef],
-                           resourceTracker: ResourceTracker[_<:AutoCloseable]): RawIterator[Array[AnyRef], ProcedureException] = {
+                           resourceTracker: ResourceTracker): RawIterator[Array[AnyRef], ProcedureException] = {
           val transaction = ctx.get(proc.Context.KERNEL_TRANSACTION)
           val statement = transaction.acquireStatement()
           try {
@@ -219,7 +219,7 @@ class EagerizationAcceptanceTest
       builder.mode(Mode.WRITE)
       new BasicProcedure(builder.build) {
         override def apply(ctx: Context, input: Array[AnyRef],
-                           resourceTracker: ResourceTracker[_<:AutoCloseable]): RawIterator[Array[AnyRef], ProcedureException] = {
+                           resourceTracker: ResourceTracker): RawIterator[Array[AnyRef], ProcedureException] = {
           val transaction = ctx.get(proc.Context.KERNEL_TRANSACTION)
           val statement = transaction.acquireStatement()
           try {
@@ -256,7 +256,7 @@ class EagerizationAcceptanceTest
       builder.out("relId", Neo4jTypes.NTInteger)
       new BasicProcedure(builder.build) {
         override def apply(ctx: Context, input: Array[AnyRef],
-                           resourceTracker: ResourceTracker[_<:AutoCloseable]): RawIterator[Array[AnyRef], ProcedureException] = {
+                           resourceTracker: ResourceTracker): RawIterator[Array[AnyRef], ProcedureException] = {
           val transaction = ctx.get(proc.Context.KERNEL_TRANSACTION)
           val statement = transaction.acquireStatement()
           try {
@@ -305,7 +305,7 @@ class EagerizationAcceptanceTest
       builder.out(org.neo4j.kernel.api.proc.ProcedureSignature.VOID)
       new BasicProcedure(builder.build) {
         override def apply(ctx: Context, input: Array[AnyRef],
-                           resourceTracker: ResourceTracker[_<:AutoCloseable]): RawIterator[Array[AnyRef], ProcedureException] = {
+                           resourceTracker: ResourceTracker): RawIterator[Array[AnyRef], ProcedureException] = {
           val transaction = ctx.get(proc.Context.KERNEL_TRANSACTION)
           val statement = transaction.acquireStatement()
           try {

--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v3_1.test_helpers.CreateTempFileTestSu
 import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport, QueryStatisticsTestSupport}
 import org.neo4j.graphdb.Node
 import org.neo4j.kernel.api.exceptions.ProcedureException
-import org.neo4j.kernel.api.proc
+import org.neo4j.kernel.api.{ResourceTracker, proc}
 import org.neo4j.kernel.api.proc.CallableProcedure.BasicProcedure
 import org.neo4j.kernel.api.proc.{Context, Neo4jTypes}
 import org.neo4j.procedure.Mode
@@ -180,7 +180,8 @@ class EagerizationAcceptanceTest
       builder.out("relId", Neo4jTypes.NTInteger)
       builder.mode(Mode.WRITE)
       new BasicProcedure(builder.build) {
-        override def apply(ctx: Context, input: Array[AnyRef]): RawIterator[Array[AnyRef], ProcedureException] = {
+        override def apply(ctx: Context, input: Array[AnyRef],
+                           resourceTracker: ResourceTracker[_<:AutoCloseable]): RawIterator[Array[AnyRef], ProcedureException] = {
           val transaction = ctx.get(proc.Context.KERNEL_TRANSACTION)
           val statement = transaction.acquireStatement()
           try {
@@ -217,7 +218,8 @@ class EagerizationAcceptanceTest
       builder.out(org.neo4j.kernel.api.proc.ProcedureSignature.VOID)
       builder.mode(Mode.WRITE)
       new BasicProcedure(builder.build) {
-        override def apply(ctx: Context, input: Array[AnyRef]): RawIterator[Array[AnyRef], ProcedureException] = {
+        override def apply(ctx: Context, input: Array[AnyRef],
+                           resourceTracker: ResourceTracker[_<:AutoCloseable]): RawIterator[Array[AnyRef], ProcedureException] = {
           val transaction = ctx.get(proc.Context.KERNEL_TRANSACTION)
           val statement = transaction.acquireStatement()
           try {
@@ -253,7 +255,8 @@ class EagerizationAcceptanceTest
       builder.in("y", Neo4jTypes.NTNode)
       builder.out("relId", Neo4jTypes.NTInteger)
       new BasicProcedure(builder.build) {
-        override def apply(ctx: Context, input: Array[AnyRef]): RawIterator[Array[AnyRef], ProcedureException] = {
+        override def apply(ctx: Context, input: Array[AnyRef],
+                           resourceTracker: ResourceTracker[_<:AutoCloseable]): RawIterator[Array[AnyRef], ProcedureException] = {
           val transaction = ctx.get(proc.Context.KERNEL_TRANSACTION)
           val statement = transaction.acquireStatement()
           try {
@@ -301,7 +304,8 @@ class EagerizationAcceptanceTest
       builder.in("y", Neo4jTypes.NTNode)
       builder.out(org.neo4j.kernel.api.proc.ProcedureSignature.VOID)
       new BasicProcedure(builder.build) {
-        override def apply(ctx: Context, input: Array[AnyRef]): RawIterator[Array[AnyRef], ProcedureException] = {
+        override def apply(ctx: Context, input: Array[AnyRef],
+                           resourceTracker: ResourceTracker[_<:AutoCloseable]): RawIterator[Array[AnyRef], ProcedureException] = {
           val transaction = ctx.get(proc.Context.KERNEL_TRANSACTION)
           val statement = transaction.acquireStatement()
           try {

--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProcedureCallAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProcedureCallAcceptanceTest.scala
@@ -42,7 +42,7 @@ abstract class ProcedureCallAcceptanceTest extends ExecutionEngineFunSuite {
 
       new BasicProcedure(builder.build) {
         override def apply(ctx: Context, input: Array[AnyRef],
-                           resourceTracker: ResourceTracker[_<:AutoCloseable]): RawIterator[Array[AnyRef], ProcedureException] =
+                           resourceTracker: ResourceTracker): RawIterator[Array[AnyRef], ProcedureException] =
           RawIterator.of[Array[AnyRef], ProcedureException](input)
       }
   }
@@ -54,7 +54,7 @@ abstract class ProcedureCallAcceptanceTest extends ExecutionEngineFunSuite {
 
       new BasicProcedure(builder.build) {
         override def apply(ctx: Context, input: Array[AnyRef],
-                           resourceTracker: ResourceTracker[_<:AutoCloseable]): RawIterator[Array[AnyRef], ProcedureException] =
+                           resourceTracker: ResourceTracker): RawIterator[Array[AnyRef], ProcedureException] =
           RawIterator.of[Array[AnyRef], ProcedureException](Array(value))
       }
     }
@@ -75,7 +75,7 @@ abstract class ProcedureCallAcceptanceTest extends ExecutionEngineFunSuite {
 
       new BasicProcedure(builder.build) {
         override def apply(ctx: Context, input: Array[AnyRef],
-                           resourceTracker: ResourceTracker[_<:AutoCloseable]): RawIterator[Array[AnyRef], ProcedureException] =
+                           resourceTracker: ResourceTracker): RawIterator[Array[AnyRef], ProcedureException] =
           RawIterator.empty()
       }
     }
@@ -84,7 +84,7 @@ abstract class ProcedureCallAcceptanceTest extends ExecutionEngineFunSuite {
     registerProcedure("dbms.return_nothing") { builder =>
       new BasicProcedure(builder.build) {
         override def apply(ctx: Context, input: Array[AnyRef],
-                           resourceTracker: ResourceTracker[_<:AutoCloseable]): RawIterator[Array[AnyRef], ProcedureException] =
+                           resourceTracker: ResourceTracker): RawIterator[Array[AnyRef], ProcedureException] =
           RawIterator.empty()
       }
     }

--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProcedureCallAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProcedureCallAcceptanceTest.scala
@@ -21,6 +21,7 @@ package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.collection.RawIterator
 import org.neo4j.cypher._
+import org.neo4j.kernel.api.ResourceTracker
 import org.neo4j.kernel.api.exceptions.ProcedureException
 import org.neo4j.kernel.api.proc.CallableProcedure.BasicProcedure
 import org.neo4j.kernel.api.proc.CallableUserFunction.BasicUserFunction
@@ -40,7 +41,8 @@ abstract class ProcedureCallAcceptanceTest extends ExecutionEngineFunSuite {
       }
 
       new BasicProcedure(builder.build) {
-        override def apply(ctx: Context, input: Array[AnyRef]): RawIterator[Array[AnyRef], ProcedureException] =
+        override def apply(ctx: Context, input: Array[AnyRef],
+                           resourceTracker: ResourceTracker[_<:AutoCloseable]): RawIterator[Array[AnyRef], ProcedureException] =
           RawIterator.of[Array[AnyRef], ProcedureException](input)
       }
   }
@@ -51,7 +53,8 @@ abstract class ProcedureCallAcceptanceTest extends ExecutionEngineFunSuite {
       builder.out("out", Neo4jTypes.NTAny)
 
       new BasicProcedure(builder.build) {
-        override def apply(ctx: Context, input: Array[AnyRef]): RawIterator[Array[AnyRef], ProcedureException] =
+        override def apply(ctx: Context, input: Array[AnyRef],
+                           resourceTracker: ResourceTracker[_<:AutoCloseable]): RawIterator[Array[AnyRef], ProcedureException] =
           RawIterator.of[Array[AnyRef], ProcedureException](Array(value))
       }
     }
@@ -71,7 +74,8 @@ abstract class ProcedureCallAcceptanceTest extends ExecutionEngineFunSuite {
       builder.out(ProcedureSignature.VOID)
 
       new BasicProcedure(builder.build) {
-        override def apply(ctx: Context, input: Array[AnyRef]): RawIterator[Array[AnyRef], ProcedureException] =
+        override def apply(ctx: Context, input: Array[AnyRef],
+                           resourceTracker: ResourceTracker[_<:AutoCloseable]): RawIterator[Array[AnyRef], ProcedureException] =
           RawIterator.empty()
       }
     }
@@ -79,7 +83,8 @@ abstract class ProcedureCallAcceptanceTest extends ExecutionEngineFunSuite {
   protected def registerProcedureReturningNoRowsOrColumns() =
     registerProcedure("dbms.return_nothing") { builder =>
       new BasicProcedure(builder.build) {
-        override def apply(ctx: Context, input: Array[AnyRef]): RawIterator[Array[AnyRef], ProcedureException] =
+        override def apply(ctx: Context, input: Array[AnyRef],
+                           resourceTracker: ResourceTracker[_<:AutoCloseable]): RawIterator[Array[AnyRef], ProcedureException] =
           RawIterator.empty()
       }
     }

--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ReflectiveProcedureCallAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ReflectiveProcedureCallAcceptanceTest.scala
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import java.io.PrintWriter
+
+import org.apache.commons.lang3.exception.ExceptionUtils
+import org.neo4j.cypher._
+import org.neo4j.cypher.internal.compiler.v3_1.test_helpers.CreateTempFileTestSupport
+import org.neo4j.graphdb.{QueryExecutionException, TransactionFailureException}
+import org.neo4j.internal.cypher.acceptance.TestResourceProcedure.{SimulateFailureException, SimulateFailureOnCloseException}
+import org.neo4j.kernel.api.KernelTransaction
+import org.neo4j.kernel.api.security.SecurityContext.AUTH_DISABLED
+import org.neo4j.kernel.impl.proc.Procedures
+
+import scala.collection.mutable.ArrayBuffer
+
+class ReflectiveProcedureCallAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFileTestSupport {
+
+  def query(resultCount: Long, failCount: Long) =
+    s"""
+      |CALL org.neo4j.test.testOnCloseFailingResourceProcedure($resultCount) YIELD value as v1
+      |WITH v1
+      |CALL org.neo4j.test.testResourceProcedure($resultCount) YIELD value as v2
+      |WITH v1, v2
+      |CALL org.neo4j.test.testOnCloseFailingResourceProcedure($resultCount) YIELD value as v3
+      |WITH v1, v2, v3
+      |CALL org.neo4j.test.testFailingResourceProcedure($failCount) YIELD value as v4
+      |WITH v1, v2, v3, v4
+      |CALL org.neo4j.test.testResourceProcedure($resultCount) YIELD value as v5
+      |RETURN v1, v2, v3, v4, v5
+    """.stripMargin
+
+  val defaultQuery = query(resultCount = 4, failCount = 3)
+
+  private def setUpProcedures(): TestResourceProcedure.Counters = {
+    val procedures = graph.getDependencyResolver.resolveDependency(classOf[Procedures])
+    val counters = new TestResourceProcedure.Counters
+    procedures.registerComponent(classOf[TestResourceProcedure.Counters], TestResourceProcedure.countersProvider(counters))
+
+    procedures.registerProcedure(classOf[TestResourceProcedure])
+    procedures.registerFunction(classOf[TestResourceProcedure])
+
+    counters
+  }
+
+  test("should close resources on failure") {
+    val counters = setUpProcedures()
+
+    val caught = intercept[QueryExecutionException] {
+      val result = graph.execute(defaultQuery)
+      result.resultAsString()
+    }
+    val rootCause = ExceptionUtils.getRootCause(caught)
+    rootCause shouldBe a[SimulateFailureException]
+
+    val suppressed = collectSuppressed(caught)
+    suppressed.head shouldBe a[CypherExecutionException]
+    ExceptionUtils.getRootCause(suppressed.head) shouldBe a[SimulateFailureOnCloseException]
+
+    counters.liveCountTestResourceProcedure() shouldEqual 0
+    counters.liveCountTestFailingResourceProcedure() shouldEqual 0
+    counters.liveCountTestOnCloseFailingResourceProcedure() shouldEqual 0
+
+    counters.closeCountTestResourceProcedure shouldEqual 3 // 1 close from exhausting into v5 + 2 closes on failure
+    counters.closeCountTestFailingResourceProcedure shouldEqual 1
+    counters.closeCountTestOnCloseFailingResourceProcedure shouldEqual 2
+  }
+
+  test("should close resources on mid-stream transaction close") {
+    val counters = setUpProcedures()
+
+    val tx = graph.beginTransaction(KernelTransaction.Type.`implicit`, AUTH_DISABLED)
+    val result = graph.execute(defaultQuery)
+
+    // Pull one row and then close the transaction
+    result.next()
+
+    // Close transaction while the result is still open
+    val caught = intercept[TransactionFailureException] {
+      tx.close()
+    }
+    val rootCause = ExceptionUtils.getRootCause(caught)
+    rootCause shouldBe a[SimulateFailureOnCloseException]
+
+    val suppressed = collectSuppressed(caught)
+    suppressed.head shouldBe a[SimulateFailureOnCloseException]
+
+    counters.liveCountTestResourceProcedure() shouldEqual 0
+    counters.liveCountTestFailingResourceProcedure() shouldEqual 0
+    counters.liveCountTestOnCloseFailingResourceProcedure() shouldEqual 0
+
+    counters.closeCountTestResourceProcedure shouldEqual 2
+    counters.closeCountTestFailingResourceProcedure shouldEqual 1
+    counters.closeCountTestOnCloseFailingResourceProcedure shouldEqual 2
+  }
+
+  test("should not leave any resources open on transaction close before pulling on the result") {
+    val counters = setUpProcedures()
+
+    val tx = graph.beginTransaction(KernelTransaction.Type.`implicit`, AUTH_DISABLED)
+    val result = graph.execute(defaultQuery)
+
+    // Close the transaction directly without pulling the result
+    tx.close()
+
+    counters.liveCountTestResourceProcedure() shouldEqual 0
+    counters.liveCountTestFailingResourceProcedure() shouldEqual 0
+    counters.liveCountTestOnCloseFailingResourceProcedure() shouldEqual 0
+  }
+
+  test("should handle tracking many closeable resources without stockpiling them until the end of the transaction") {
+    val counters = setUpProcedures()
+    val numberOfRows = 100
+
+    val tx = graph.beginTransaction(KernelTransaction.Type.`implicit`, AUTH_DISABLED)
+    val result = graph.execute(s"UNWIND range(1,$numberOfRows) as i CALL org.neo4j.test.testResourceProcedure(1) YIELD value RETURN value")
+
+    // Pull one row and then close the transaction
+    var i = 0
+    while (i < numberOfRows - 1 && result.hasNext) {
+      result.next()
+      i += 1
+    }
+    val counterBeforeTxClose = counters.closeCountTestResourceProcedure
+    tx.close()
+    val counterAfterTxClose = counters.closeCountTestResourceProcedure
+
+    counters.liveCountTestResourceProcedure() shouldEqual 0
+    counters.closeCountTestResourceProcedure shouldEqual numberOfRows
+    (counterAfterTxClose - counterBeforeTxClose) shouldEqual 1 // Only the last open stream should need to be closed at transaction closure
+  }
+
+  test("should close resources on failure with periodic commit") {
+    val counters = setUpProcedures()
+
+    val url = createTempCSVFile(10)
+    val periodicCommitQuery =
+      s"""USING PERIODIC COMMIT 3
+         |LOAD CSV FROM '$url' AS line
+         |CREATE ()
+         |WITH line
+         |CALL org.neo4j.test.testResourceProcedure(4) YIELD value as v1
+         |WITH line, v1,
+         |  CASE line
+         |    WHEN ['8'] THEN org.neo4j.test.fail("8")
+         |    ELSE 'ok'
+         |  END as ok
+         |RETURN line, v1, ok
+         |""".stripMargin
+
+    val caught = intercept[QueryExecutionException] {
+      val result = graph.execute(periodicCommitQuery)
+      result.resultAsString()
+    }
+    val rootCause = ExceptionUtils.getRootCause(caught)
+    rootCause shouldBe a[SimulateFailureException]
+
+    counters.liveCountTestResourceProcedure() shouldEqual 0
+    counters.liveCountTestFailingResourceProcedure() shouldEqual 0
+    counters.liveCountTestOnCloseFailingResourceProcedure() shouldEqual 0
+
+    counters.closeCountTestResourceProcedure shouldEqual 8
+    counters.closeCountTestFailingResourceProcedure shouldEqual 0 // Unused
+    counters.closeCountTestOnCloseFailingResourceProcedure shouldEqual 0 // Unused
+  }
+
+  private def collectSuppressed(t: Throwable): Seq[Throwable] = {
+    val suppressed = ArrayBuffer[Throwable](t.getSuppressed:_*)
+    var cause = t.getCause
+    while (cause != null) {
+      suppressed ++= cause.getSuppressed
+      val nextCause = cause.getCause
+      cause = if (nextCause == null || cause == nextCause) null else nextCause
+    }
+    suppressed
+  }
+
+  def createTempCSVFile(numberOfLines: Int): String =
+    createTempFileURL("file", ".csv") { writer: PrintWriter =>
+      1.to(numberOfLines).foreach { n: Int => writer.println(n.toString) }
+    }
+
+}

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ResultIterator.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ResultIterator.scala
@@ -94,7 +94,16 @@ class ClosingIterator(inner: Iterator[collection.Map[String, Any]],
       f
     } catch {
       case t: Throwable =>
-        close(success = false)
+        try {
+          close(success = false)
+        } catch {
+          case thrownDuringClose: Throwable =>
+            try {
+              t.addSuppressed(thrownDuringClose)
+            } catch {
+              case _: Throwable => // Ignore
+            }
+        }
         throw t
     }
   })

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/TransactionalContextWrapperv3_0.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/TransactionalContextWrapperv3_0.scala
@@ -64,5 +64,5 @@ case class TransactionalContextWrapperv3_0(tc: TransactionalContext) extends Que
 
   def securityContext: SecurityContext = tc.securityContext
 
-  def resourceTracker: ResourceTracker[_<:AutoCloseable] = tc.resourceTracker
+  def resourceTracker: ResourceTracker = tc.resourceTracker
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/TransactionalContextWrapperv3_0.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/TransactionalContextWrapperv3_0.scala
@@ -26,7 +26,7 @@ import org.neo4j.kernel.api.KernelTransaction.Revertable
 import org.neo4j.kernel.api.dbms.DbmsOperations
 import org.neo4j.kernel.api.security.{AccessMode, SecurityContext}
 import org.neo4j.kernel.api.txstate.TxStateHolder
-import org.neo4j.kernel.api.{ReadOperations, Statement}
+import org.neo4j.kernel.api.{ReadOperations, ResourceTracker, Statement}
 import org.neo4j.kernel.impl.query.TransactionalContext
 
 case class TransactionalContextWrapperv3_0(tc: TransactionalContext) extends QueryTransactionalContext {
@@ -63,4 +63,6 @@ case class TransactionalContextWrapperv3_0(tc: TransactionalContext) extends Que
   def restrictCurrentTransaction(context: SecurityContext): Revertable = tc.restrictCurrentTransaction(context)
 
   def securityContext: SecurityContext = tc.securityContext
+
+  def resourceTracker: ResourceTracker[_<:AutoCloseable] = tc.resourceTracker
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/TransactionalContextWrapperv3_1.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/TransactionalContextWrapperv3_1.scala
@@ -26,7 +26,7 @@ import org.neo4j.kernel.api.KernelTransaction.Revertable
 import org.neo4j.kernel.api.dbms.DbmsOperations
 import org.neo4j.kernel.api.security.{AccessMode, SecurityContext}
 import org.neo4j.kernel.api.txstate.TxStateHolder
-import org.neo4j.kernel.api.{ReadOperations, Statement}
+import org.neo4j.kernel.api.{ReadOperations, ResourceTracker, Statement}
 import org.neo4j.kernel.impl.query.TransactionalContext
 
 case class TransactionalContextWrapperv3_1(tc: TransactionalContext) extends QueryTransactionalContext {
@@ -63,4 +63,6 @@ case class TransactionalContextWrapperv3_1(tc: TransactionalContext) extends Que
   def restrictCurrentTransaction(context: SecurityContext): Revertable = tc.restrictCurrentTransaction(context)
 
   def securityContext: SecurityContext = tc.securityContext
+
+  def resourceTracker: ResourceTracker[_<:AutoCloseable] = tc.resourceTracker
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/TransactionalContextWrapperv3_1.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/TransactionalContextWrapperv3_1.scala
@@ -64,5 +64,5 @@ case class TransactionalContextWrapperv3_1(tc: TransactionalContext) extends Que
 
   def securityContext: SecurityContext = tc.securityContext
 
-  def resourceTracker: ResourceTracker[_<:AutoCloseable] = tc.resourceTracker
+  def resourceTracker: ResourceTracker = tc.resourceTracker
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/ExceptionTranslationSupport.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/ExceptionTranslationSupport.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.spi.TokenContext
 import org.neo4j.cypher.{ConstraintValidationException, CypherExecutionException}
 import org.neo4j.graphdb.{ConstraintViolationException => KernelConstraintViolationException}
 import org.neo4j.kernel.api.TokenNameLookup
-import org.neo4j.kernel.api.exceptions.KernelException
+import org.neo4j.kernel.api.exceptions.{KernelException, ResourceCloseFailureException}
 
 trait ExceptionTranslationSupport {
   inner: TokenContext =>
@@ -39,6 +39,7 @@ trait ExceptionTranslationSupport {
       def relationshipTypeGetName(relTypeId: Int): String = inner.getRelTypeName(relTypeId)
     }), e)
     case e : KernelConstraintViolationException => throw new ConstraintValidationException(e.getMessage, e)
+    case e : ResourceCloseFailureException => throw new CypherExecutionException(e.getMessage, e)
   }
 
   protected def translateIterator[A](iteratorFactory: => Iterator[A]): Iterator[A] = {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
@@ -625,7 +625,9 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
     callProcedure(name, args, transactionalContext.statement.procedureCallOperations().procedureCallWrite)
 
   override def callDbmsProcedure(name: QualifiedProcedureName, args: Seq[Any]) =
-    callProcedure(name, args, transactionalContext.dbmsOperations.procedureCallDbms(_,_,transactionalContext.securityContext))
+    callProcedure(name, args,
+                  transactionalContext.dbmsOperations.procedureCallDbms(_,_,transactionalContext.securityContext,
+                                                                        transactionalContext.resourceTracker))
 
   private def callProcedure(name: QualifiedProcedureName, args: Seq[Any],
                             call: (QualifiedName, Array[AnyRef]) => RawIterator[Array[AnyRef], ProcedureException]) = {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/ExceptionTranslationSupport.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/ExceptionTranslationSupport.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.compiler.v3_1.spi.TokenContext
 import org.neo4j.cypher.{ConstraintValidationException, CypherExecutionException}
 import org.neo4j.graphdb.{ConstraintViolationException => KernelConstraintViolationException}
 import org.neo4j.kernel.api.TokenNameLookup
-import org.neo4j.kernel.api.exceptions.KernelException
+import org.neo4j.kernel.api.exceptions.{KernelException, ResourceCloseFailureException}
 
 trait ExceptionTranslationSupport {
   inner: TokenContext =>
@@ -39,6 +39,7 @@ trait ExceptionTranslationSupport {
       def relationshipTypeGetName(relTypeId: Int): String = inner.getRelTypeName(relTypeId)
     }), e)
     case e : KernelConstraintViolationException => throw new ConstraintValidationException(e.getMessage, e)
+    case e : ResourceCloseFailureException => throw new CypherExecutionException(e.getMessage, e)
   }
 
   protected def translateIterator[A](iteratorFactory: => Iterator[A]): Iterator[A] = {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundQueryContext.scala
@@ -626,7 +626,9 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
   }
 
   override def callDbmsProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]) = {
-    callProcedure(name, args, transactionalContext.dbmsOperations.procedureCallDbms(_,_,transactionalContext.securityContext))
+    callProcedure(name, args,
+                  transactionalContext.dbmsOperations.procedureCallDbms(_,_,transactionalContext.securityContext,
+                                                                        transactionalContext.resourceTracker))
   }
 
   private def callProcedure(name: QualifiedName, args: Seq[Any], call: KernelProcedureCall) = {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineIT.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineIT.scala
@@ -700,7 +700,7 @@ class ExecutionEngineIT extends CypherFunSuite with GraphIcing {
     }.asJava
 
     override def apply(context: Context, objects: Array[AnyRef],
-                       resourceTracker: ResourceTracker[_<:AutoCloseable]): RawIterator[Array[AnyRef], ProcedureException] = {
+                       resourceTracker: ResourceTracker): RawIterator[Array[AnyRef], ProcedureException] = {
       val statement: Statement = context.get(KERNEL_TRANSACTION).acquireStatement
       val readOperations = statement.readOperations
       val nodes = readOperations.nodesGetAll()

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineIT.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineIT.scala
@@ -29,7 +29,7 @@ import org.neo4j.graphdb.Result.{ResultRow, ResultVisitor}
 import org.neo4j.graphdb.factory.GraphDatabaseSettings
 import org.neo4j.kernel.GraphDatabaseQueryService
 import org.neo4j.kernel.api.proc._
-import org.neo4j.kernel.api.Statement
+import org.neo4j.kernel.api.{ResourceTracker, Statement}
 import org.neo4j.kernel.api.exceptions.ProcedureException
 import Context.KERNEL_TRANSACTION
 import org.neo4j.kernel.api.proc._
@@ -699,7 +699,8 @@ class ExecutionEngineIT extends CypherFunSuite with GraphIcing {
       fields :+ new FieldSignature(entry, results(entry).asInstanceOf[Neo4jTypes.AnyType])
     }.asJava
 
-    override def apply(context: Context, objects: Array[AnyRef]): RawIterator[Array[AnyRef], ProcedureException] = {
+    override def apply(context: Context, objects: Array[AnyRef],
+                       resourceTracker: ResourceTracker[_<:AutoCloseable]): RawIterator[Array[AnyRef], ProcedureException] = {
       val statement: Statement = context.get(KERNEL_TRANSACTION).acquireStatement
       val readOperations = statement.readOperations
       val nodes = readOperations.nodesGetAll()

--- a/community/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/SpecSuiteSteps.scala
+++ b/community/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/SpecSuiteSteps.scala
@@ -202,7 +202,7 @@ trait SpecSuiteSteps extends FunSuiteLike with Matchers with TCKCucumberTemplate
     val kernelSignature = asKernelSignature(parsedSignature)
     val kernelProcedure = new BasicProcedure(kernelSignature) {
       override def apply(ctx: Context, input: Array[AnyRef],
-                         resourceTracker: ResourceTracker[_<:AutoCloseable]): RawIterator[Array[AnyRef], ProcedureException] = {
+                         resourceTracker: ResourceTracker): RawIterator[Array[AnyRef], ProcedureException] = {
         val scalaIterator = tableValues
           .filter { row => input.indices.forall { index => row(index) == input(index) } }
           .map { row => row.drop(input.length).clone() }

--- a/community/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/SpecSuiteSteps.scala
+++ b/community/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/SpecSuiteSteps.scala
@@ -30,7 +30,7 @@ import org.neo4j.collection.RawIterator
 import org.neo4j.cypher.internal.frontend.v3_1.symbols.{CypherType, _}
 import org.neo4j.graphdb.factory.{GraphDatabaseFactory, GraphDatabaseSettings}
 import org.neo4j.graphdb.{GraphDatabaseService, QueryStatistics, Result, Transaction}
-import org.neo4j.kernel.api.KernelAPI
+import org.neo4j.kernel.api.{KernelAPI, ResourceTracker}
 import org.neo4j.kernel.api.exceptions.ProcedureException
 import org.neo4j.kernel.api.proc.CallableProcedure.BasicProcedure
 import org.neo4j.kernel.api.proc.{Context, Neo4jTypes}
@@ -201,7 +201,8 @@ trait SpecSuiteSteps extends FunSuiteLike with Matchers with TCKCucumberTemplate
       )
     val kernelSignature = asKernelSignature(parsedSignature)
     val kernelProcedure = new BasicProcedure(kernelSignature) {
-      override def apply(ctx: Context, input: Array[AnyRef]): RawIterator[Array[AnyRef], ProcedureException] = {
+      override def apply(ctx: Context, input: Array[AnyRef],
+                         resourceTracker: ResourceTracker[_<:AutoCloseable]): RawIterator[Array[AnyRef], ProcedureException] = {
         val scalaIterator = tableValues
           .filter { row => input.indices.forall { index => row(index) == input(index) } }
           .map { row => row.drop(input.length).clone() }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ResourceManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ResourceManager.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api;
+
+public interface ResourceManager<T extends AutoCloseable> extends ResourceTracker<T>
+{
+    /**
+     * Closes and unregisters all the registered resources
+     */
+    void closeAllCloseableResources();
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ResourceManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ResourceManager.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.kernel.api;
 
-public interface ResourceManager<T extends AutoCloseable> extends ResourceTracker<T>
+public interface ResourceManager extends ResourceTracker
 {
     /**
      * Closes and unregisters all the registered resources

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ResourceTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ResourceTracker.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.kernel.api;
 
-public interface ResourceTracker<T extends AutoCloseable>
+public interface ResourceTracker
 {
     /**
      * Register a closeable resource that needs to be closed on statement cleanup.
@@ -27,10 +27,10 @@ public interface ResourceTracker<T extends AutoCloseable>
      * If the given resource can be closed elsewhere, e.g. by exhausting an iterator,
      * the close() method of the resource should be idempotent.
      */
-    void registerCloseableResource( T closeableResource );
+    void registerCloseableResource( AutoCloseable closeableResource );
 
     /**
      * @see #registerCloseableResource
      */
-    void unregisterCloseableResource( T closeableResource );
+    void unregisterCloseableResource( AutoCloseable closeableResource );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ResourceTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ResourceTracker.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api;
+
+public interface ResourceTracker<T extends AutoCloseable>
+{
+    /**
+     * Register a closeable resource that needs to be closed on statement cleanup.
+     *
+     * If the given resource can be closed elsewhere, e.g. by exhausting an iterator,
+     * the close() method of the resource should be idempotent.
+     */
+    void registerCloseableResource( T closeableResource );
+
+    /**
+     * @see #registerCloseableResource
+     */
+    void unregisterCloseableResource( T closeableResource );
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/Statement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/Statement.java
@@ -33,7 +33,7 @@ import org.neo4j.kernel.api.exceptions.InvalidTransactionTypeKernelException;
  * or {@link #schemaWriteOperations()}, otherwise if already decided, verified so that it's
  * of the same type.
  */
-public interface Statement extends Resource
+public interface Statement extends Resource, ResourceManager<AutoCloseable>
 {
     /**
      * @return interface exposing all read operations.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/Statement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/Statement.java
@@ -33,7 +33,7 @@ import org.neo4j.kernel.api.exceptions.InvalidTransactionTypeKernelException;
  * or {@link #schemaWriteOperations()}, otherwise if already decided, verified so that it's
  * of the same type.
  */
-public interface Statement extends Resource, ResourceManager<AutoCloseable>
+public interface Statement extends Resource, ResourceManager
 {
     /**
      * @return interface exposing all read operations.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/dbms/DbmsOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/dbms/DbmsOperations.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.api.dbms;
 
 import org.neo4j.collection.RawIterator;
 import org.neo4j.kernel.api.KernelAPI;
+import org.neo4j.kernel.api.ResourceTracker;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.QualifiedName;
 import org.neo4j.kernel.api.security.SecurityContext;
@@ -39,7 +40,8 @@ public interface DbmsOperations
     RawIterator<Object[],ProcedureException> procedureCallDbms(
             QualifiedName name,
             Object[] input,
-            SecurityContext securityContext
+            SecurityContext securityContext,
+            ResourceTracker resourceTracker
     ) throws ProcedureException;
 
     /** Invoke a DBMS function by name */

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/ResourceCloseFailureException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/ResourceCloseFailureException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.exceptions;
+
+import org.neo4j.graphdb.Resource;
+
+/**
+ * This exception is thrown when a checked exception occurs inside {@link Resource#close()}.
+ * It is a RuntimeException since {@link Resource#close()} is not allowed to throw checked exceptions.
+ */
+public class ResourceCloseFailureException extends RuntimeException
+{
+    public ResourceCloseFailureException( String message, Throwable cause )
+    {
+        super( message, cause );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/CallableProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/CallableProcedure.java
@@ -20,12 +20,13 @@
 package org.neo4j.kernel.api.proc;
 
 import org.neo4j.collection.RawIterator;
+import org.neo4j.kernel.api.ResourceTracker;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 
 public interface CallableProcedure
 {
     ProcedureSignature signature();
-    RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException;
+    RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input, ResourceTracker resourceTracker ) throws ProcedureException;
 
     abstract class BasicProcedure implements CallableProcedure
     {
@@ -43,6 +44,6 @@ public interface CallableProcedure
         }
 
         @Override
-        public abstract RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException;
+        public abstract RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input, ResourceTracker resourceTracker ) throws ProcedureException;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/JmxQueryProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/JmxQueryProcedure.java
@@ -37,6 +37,7 @@ import javax.management.openmbean.TabularData;
 
 import org.neo4j.collection.RawIterator;
 import org.neo4j.helpers.collection.Pair;
+import org.neo4j.kernel.api.ResourceTracker;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.proc.CallableProcedure;
@@ -66,7 +67,7 @@ public class JmxQueryProcedure extends CallableProcedure.BasicProcedure
     }
 
     @Override
-    public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
+    public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input, ResourceTracker resourceTracker ) throws ProcedureException
     {
         String query = input[0].toString();
         try

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ListComponentsProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ListComponentsProcedure.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.builtinprocs;
 
 import org.neo4j.collection.RawIterator;
+import org.neo4j.kernel.api.ResourceTracker;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.Context;
@@ -65,7 +66,7 @@ public class ListComponentsProcedure extends CallableProcedure.BasicProcedure
     }
 
     @Override
-    public RawIterator<Object[],ProcedureException> apply( Context ctx, Object[] input )
+    public RawIterator<Object[],ProcedureException> apply( Context ctx, Object[] input, ResourceTracker resourceTracker )
             throws ProcedureException
     {
         return asRawIterator( singletonList(

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CloseableResourceManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CloseableResourceManager.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.neo4j.io.IOUtils;
+import org.neo4j.kernel.api.ResourceManager;
+import org.neo4j.kernel.api.exceptions.ResourceCloseFailureException;
+
+public class CloseableResourceManager implements ResourceManager<AutoCloseable>
+{
+    private Collection<AutoCloseable> closeableResources;
+
+    // ResourceTracker
+
+    @Override
+    public final void registerCloseableResource( AutoCloseable closeable )
+    {
+        if ( closeableResources == null )
+        {
+            closeableResources = new ArrayList<>( 8 );
+        }
+        closeableResources.add( closeable );
+    }
+
+    @Override
+    public final void unregisterCloseableResource( AutoCloseable closeable )
+    {
+        if ( closeableResources != null )
+        {
+            closeableResources.remove( closeable );
+        }
+    }
+
+    // ResourceManager
+
+    @Override
+    public final void closeAllCloseableResources()
+    {
+        if ( closeableResources != null )
+        {
+            // Make sure we reset closeableResource before doing anything which may throw an exception that
+            // _may_ result in a recursive call to this close-method
+            Collection<AutoCloseable> resourcesToClose = closeableResources;
+            closeableResources = null;
+
+            IOUtils.closeAll( ResourceCloseFailureException.class, resourcesToClose.toArray( new AutoCloseable[0] ) );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CloseableResourceManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CloseableResourceManager.java
@@ -26,7 +26,7 @@ import org.neo4j.io.IOUtils;
 import org.neo4j.kernel.api.ResourceManager;
 import org.neo4j.kernel.api.exceptions.ResourceCloseFailureException;
 
-public class CloseableResourceManager implements ResourceManager<AutoCloseable>
+public class CloseableResourceManager implements ResourceManager
 {
     private Collection<AutoCloseable> closeableResources;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
@@ -62,7 +62,7 @@ import org.neo4j.storageengine.api.StorageStatement;
  * instance again, when it's initialized.</li>
  * </ol>
  */
-public class KernelStatement implements TxStateHolder, Statement, AssertOpen
+public class KernelStatement extends CloseableResourceManager implements TxStateHolder, Statement, AssertOpen
 {
     private final TxStateHolder txStateHolder;
     private final StorageStatement storeStatement;
@@ -243,6 +243,7 @@ public class KernelStatement implements TxStateHolder, Statement, AssertOpen
         // closing is done by KTI
         storeStatement.release();
         executingQueryList = ExecutingQueryList.EMPTY;
+        closeAllCloseableResources();
     }
 
     public KernelTransactionImplementation getTransaction()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -1585,7 +1585,7 @@ public class OperationsFacade
             ctx.put( Context.KERNEL_TRANSACTION, tx );
             ctx.put( Context.THREAD, Thread.currentThread() );
             ctx.put( Context.SECURITY_CONTEXT, procedureSecurityContext );
-            procedureCall = procedures.callProcedure( ctx, name, input );
+            procedureCall = procedures.callProcedure( ctx, name, input, statement );
         }
         return new RawIterator<Object[],ProcedureException>()
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/dbms/NonTransactionalDbmsOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/dbms/NonTransactionalDbmsOperations.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.api.dbms;
 
 import org.neo4j.collection.RawIterator;
+import org.neo4j.kernel.api.ResourceTracker;
 import org.neo4j.kernel.api.dbms.DbmsOperations;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.BasicContext;
@@ -43,12 +44,13 @@ public class NonTransactionalDbmsOperations implements DbmsOperations
     public RawIterator<Object[],ProcedureException> procedureCallDbms(
             QualifiedName name,
             Object[] input,
-            SecurityContext securityContext
+            SecurityContext securityContext,
+            ResourceTracker resourceTracker
     ) throws ProcedureException
     {
         BasicContext ctx = new BasicContext();
         ctx.put( Context.SECURITY_CONTEXT, securityContext );
-        return procedures.callProcedure( ctx, name, input );
+        return procedures.callProcedure( ctx, name, input, resourceTracker );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureRegistry.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureRegistry.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.neo4j.collection.RawIterator;
+import org.neo4j.kernel.api.ResourceTracker;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.proc.CallableProcedure;
@@ -148,7 +149,7 @@ public class ProcedureRegistry
         return Optional.of( func.signature() );
     }
 
-    public RawIterator<Object[],ProcedureException> callProcedure( Context ctx, QualifiedName name, Object[] input )
+    public RawIterator<Object[],ProcedureException> callProcedure( Context ctx, QualifiedName name, Object[] input, ResourceTracker resourceTracker )
             throws ProcedureException
     {
         CallableProcedure proc = procedures.get( name );
@@ -156,7 +157,7 @@ public class ProcedureRegistry
         {
             throw noSuchProcedure( name );
         }
-        return proc.apply( ctx, input );
+        return proc.apply( ctx, input, resourceTracker );
     }
 
     public Object callFunction( Context ctx, QualifiedName name, Object[] input )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import org.neo4j.collection.RawIterator;
 import org.neo4j.function.ThrowingConsumer;
+import org.neo4j.kernel.api.ResourceTracker;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.CallableProcedure;
@@ -187,9 +188,9 @@ public class Procedures extends LifecycleAdapter
     }
 
     public RawIterator<Object[], ProcedureException> callProcedure( Context ctx, QualifiedName name,
-                                                           Object[] input ) throws ProcedureException
+                                                           Object[] input, ResourceTracker resourceTracker ) throws ProcedureException
     {
-        return registry.callProcedure( ctx, name, input );
+        return registry.callProcedure( ctx, name, input, resourceTracker );
     }
 
     public Object callFunction( Context ctx, QualifiedName name,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
@@ -34,8 +34,12 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.neo4j.collection.RawIterator;
+import org.neo4j.graphdb.Resource;
+import org.neo4j.io.IOUtils;
+import org.neo4j.kernel.api.ResourceTracker;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
+import org.neo4j.kernel.api.exceptions.ResourceCloseFailureException;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.CallableUserFunction;
@@ -338,7 +342,7 @@ public class ReflectiveProcedureCompiler
         }
 
         @Override
-        public RawIterator<Object[],ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
+        public RawIterator<Object[],ProcedureException> apply( Context ctx, Object[] input, ResourceTracker resourceTracker ) throws ProcedureException
         {
             // For now, create a new instance of the class for each invocation. In the future, we'd like to keep
             // instances local to
@@ -370,33 +374,27 @@ public class ReflectiveProcedureCompiler
                 }
                 else
                 {
-                    return new MappingIterator( ((Stream<?>) rs).iterator(), () -> ((Stream<?>) rs).close() );
+                    return new MappingIterator( ((Stream<?>) rs).iterator(), ((Stream<?>) rs)::close, resourceTracker );
                 }
             }
             catch ( Throwable throwable )
             {
-                if ( throwable instanceof Status.HasStatus )
-                {
-                    throw new ProcedureException( ((Status.HasStatus) throwable).status(), throwable,
-                            throwable.getMessage() );
-                }
-                else
-                {
-                    throw new ProcedureException( Status.Procedure.ProcedureCallFailed, throwable,
-                            "Failed to invoke procedure `%s`: %s", signature.name(), "Caused by: " + throwable );
-                }
+                throw newProcedureException( throwable );
             }
         }
 
-        private class MappingIterator implements RawIterator<Object[],ProcedureException>, AutoCloseable
+        private class MappingIterator implements RawIterator<Object[],ProcedureException>, Resource
         {
             private final Iterator<?> out;
-            private Closeable closeable;
+            private Resource closeableResource;
+            private ResourceTracker resourceTracker;
 
-            MappingIterator( Iterator<?> out, Closeable closeable )
+            MappingIterator( Iterator<?> out, Resource closeableResource, ResourceTracker resourceTracker )
             {
                 this.out = out;
-                this.closeable = closeable;
+                this.closeableResource = closeableResource;
+                this.resourceTracker = resourceTracker;
+                resourceTracker.registerCloseableResource( closeableResource );
             }
 
             @Override
@@ -407,14 +405,13 @@ public class ReflectiveProcedureCompiler
                     boolean hasNext = out.hasNext();
                     if ( !hasNext )
                     {
-                        closeable.close();
+                        close();
                     }
                     return hasNext;
                 }
-                catch ( RuntimeException | IOException e )
+                catch ( Throwable throwable )
                 {
-                    throw new ProcedureException( Status.Procedure.ProcedureCallFailed, e,
-                            "Failed to call procedure `%s`: %s", signature, e.getMessage() );
+                    throw closeAndCreateProcedureException( throwable );
                 }
             }
 
@@ -426,22 +423,66 @@ public class ReflectiveProcedureCompiler
                     Object record = out.next();
                     return outputMapper.apply( record );
                 }
-                catch ( RuntimeException e )
+                catch ( Throwable throwable )
                 {
-                    throw new ProcedureException( Status.Procedure.ProcedureCallFailed, e,
-                            "Failed to call procedure `%s`: %s", signature, e.getMessage() );
+                    throw closeAndCreateProcedureException( throwable );
                 }
             }
 
             @Override
-            public void close() throws Exception
+            public void close()
             {
-                if ( closeable != null )
+                if ( closeableResource != null )
                 {
-                    closeable.close();
-                    closeable = null;
+                    // Make sure we reset closeableResource before doing anything which may throw an exception that may
+                    // result in a recursive call to this close-method
+                    Resource resourceToClose = closeableResource;
+                    closeableResource = null;
+
+                    IOUtils.closeAll( ResourceCloseFailureException.class,
+                            () -> resourceTracker.unregisterCloseableResource( resourceToClose ),
+                            resourceToClose::close );
                 }
             }
+
+            private ProcedureException closeAndCreateProcedureException( Throwable t )
+            {
+                ProcedureException procedureException = newProcedureException( t );
+
+                try
+                {
+                    close();
+                }
+                catch ( Exception exceptionDuringClose )
+                {
+                    try
+                    {
+                        procedureException.addSuppressed( exceptionDuringClose );
+                    }
+                    catch ( Throwable ignore )
+                    {
+                    }
+                }
+                return procedureException;
+            }
+        }
+
+        private ProcedureException newProcedureException( Throwable throwable )
+        {
+            ProcedureException procedureException;
+
+            if ( throwable instanceof Status.HasStatus )
+            {
+                procedureException = new ProcedureException( ((Status.HasStatus) throwable).status(), throwable,
+                        throwable.getMessage() );
+            }
+            else
+            {
+                procedureException = new ProcedureException( Status.Procedure.ProcedureCallFailed, throwable,
+                        "Failed to invoke procedure `%s`: %s", signature.name(), "Caused by: " + throwable );
+            }
+
+            return procedureException;
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
@@ -469,20 +469,10 @@ public class ReflectiveProcedureCompiler
 
         private ProcedureException newProcedureException( Throwable throwable )
         {
-            ProcedureException procedureException;
-
-            if ( throwable instanceof Status.HasStatus )
-            {
-                procedureException = new ProcedureException( ((Status.HasStatus) throwable).status(), throwable,
-                        throwable.getMessage() );
-            }
-            else
-            {
-                procedureException = new ProcedureException( Status.Procedure.ProcedureCallFailed, throwable,
-                        "Failed to invoke procedure `%s`: %s", signature.name(), "Caused by: " + throwable );
-            }
-
-            return procedureException;
+            return throwable instanceof Status.HasStatus ?
+                   new ProcedureException( ((Status.HasStatus) throwable).status(), throwable, throwable.getMessage() ) :
+                   new ProcedureException( Status.Procedure.ProcedureCallFailed, throwable,
+                           "Failed to invoke procedure `%s`: %s", signature.name(), "Caused by: " + throwable );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/Neo4jTransactionalContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/Neo4jTransactionalContext.java
@@ -267,6 +267,14 @@ public class Neo4jTransactionalContext implements TransactionalContext
         return securityContext;
     }
 
+    @Override
+    public ResourceTracker resourceTracker()
+    {
+        // We use the current statement as resourceTracker since it is attached to the KernelTransaction
+        // and is guaranteed to be cleaned up on transaction failure.
+        return statement;
+    }
+
     interface Creator {
         Neo4jTransactionalContext create(
             Supplier<Statement> statementSupplier,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/TransactionalContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/TransactionalContext.java
@@ -25,6 +25,7 @@ import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.kernel.api.ExecutingQuery;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.ResourceTracker;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.dbms.DbmsOperations;
 import org.neo4j.kernel.api.security.SecurityContext;
@@ -78,4 +79,6 @@ public interface TransactionalContext
     SecurityContext securityContext();
 
     KernelTransaction.Revertable restrictCurrentTransaction( SecurityContext context );
+
+    ResourceTracker resourceTracker();
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/StubResourceManager.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/StubResourceManager.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.kernel.api;
 
-public class StubResourceManager implements ResourceManager<AutoCloseable>
+public class StubResourceManager implements ResourceManager
 {
     @Override
     public void registerCloseableResource( AutoCloseable closeable )

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/StubResourceManager.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/StubResourceManager.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api;
+
+public class StubResourceManager implements ResourceManager<AutoCloseable>
+{
+    @Override
+    public void registerCloseableResource( AutoCloseable closeable )
+    {
+    }
+
+    @Override
+    public void unregisterCloseableResource( AutoCloseable closeable )
+    {
+    }
+
+    @Override
+    public void closeAllCloseableResources()
+    {
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -37,7 +37,9 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.ResourceTracker;
 import org.neo4j.kernel.api.Statement;
+import org.neo4j.kernel.api.StubResourceManager;
 import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
@@ -89,6 +91,7 @@ public class BuiltInProceduresTest
     private final GraphDatabaseAPI graphDatabaseAPI = mock(GraphDatabaseAPI.class);
 
     private final Procedures procs = new Procedures();
+    private final ResourceTracker resourceTracker = new StubResourceManager();
 
     @Test
     public void shouldListAllIndexes() throws Throwable
@@ -408,7 +411,7 @@ public class BuiltInProceduresTest
         ctx.put( SECURITY_CONTEXT, SecurityContext.AUTH_DISABLED );
         when( graphDatabaseAPI.getDependencyResolver() ).thenReturn( resolver );
         when( resolver.resolveDependency( Procedures.class ) ).thenReturn( procs );
-        return Iterators.asList( procs.callProcedure( ctx, ProcedureSignature.procedureName( name.split( "\\." ) ), args ) );
+        return Iterators.asList( procs.callProcedure( ctx, ProcedureSignature.procedureName( name.split( "\\." ) ), args, resourceTracker ) );
     }
 
     private static final Key<DependencyResolver> DEPENDENCY_RESOLVER =

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/JmxQueryProcedureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/JmxQueryProcedureTest.java
@@ -34,6 +34,8 @@ import javax.management.openmbean.OpenType;
 import javax.management.openmbean.SimpleType;
 
 import org.neo4j.collection.RawIterator;
+import org.neo4j.kernel.api.ResourceTracker;
+import org.neo4j.kernel.api.StubResourceManager;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.ProcedureSignature;
 
@@ -52,6 +54,7 @@ public class JmxQueryProcedureTest
     private MBeanServer jmxServer;
     private ObjectName beanName;
     private String attributeName;
+    private final ResourceTracker resourceTracker = new StubResourceManager();
 
     @Test
     public void shouldHandleBasicMBean() throws Throwable
@@ -61,7 +64,7 @@ public class JmxQueryProcedureTest
         JmxQueryProcedure procedure = new JmxQueryProcedure( ProcedureSignature.procedureName( "bob" ), jmxServer );
 
         // when
-        RawIterator<Object[],ProcedureException> result = procedure.apply( null, new Object[]{"*:*"} );
+        RawIterator<Object[],ProcedureException> result = procedure.apply( null, new Object[]{"*:*"}, resourceTracker );
 
         // then
         assertThat( asList( result ), contains(
@@ -89,7 +92,7 @@ public class JmxQueryProcedureTest
         JmxQueryProcedure procedure = new JmxQueryProcedure( ProcedureSignature.procedureName( "bob" ), jmxServer );
 
         // when
-        RawIterator<Object[],ProcedureException> result = procedure.apply( null, new Object[]{"*:*"} );
+        RawIterator<Object[],ProcedureException> result = procedure.apply( null, new Object[]{"*:*"}, resourceTracker );
 
         // then
         assertThat( asList( result ), contains(
@@ -133,7 +136,7 @@ public class JmxQueryProcedureTest
         JmxQueryProcedure procedure = new JmxQueryProcedure( ProcedureSignature.procedureName( "bob" ), jmxServer );
 
         // when
-        RawIterator<Object[],ProcedureException> result = procedure.apply( null, new Object[]{"*:*"} );
+        RawIterator<Object[],ProcedureException> result = procedure.apply( null, new Object[]{"*:*"}, resourceTracker );
 
         // then
         assertThat( asList( result ), contains(
@@ -158,7 +161,7 @@ public class JmxQueryProcedureTest
         JmxQueryProcedure procedure = new JmxQueryProcedure( ProcedureSignature.procedureName( "bob" ), jmxServer );
 
         // when
-        RawIterator<Object[],ProcedureException> result = procedure.apply( null, new Object[]{"*:*"} );
+        RawIterator<Object[],ProcedureException> result = procedure.apply( null, new Object[]{"*:*"}, resourceTracker );
 
         // then we verify that we respond with the expected number of beans without error
         //      .. we don't assert more than this, this is more of a smoke test to ensure

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/StubStatement.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/StubStatement.java
@@ -25,10 +25,11 @@ import org.neo4j.kernel.api.QueryRegistryOperations;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.Statement;
+import org.neo4j.kernel.api.StubResourceManager;
 import org.neo4j.kernel.api.TokenWriteOperations;
 import org.neo4j.kernel.api.exceptions.InvalidTransactionTypeKernelException;
 
-public class StubStatement implements Statement
+public class StubStatement extends StubResourceManager implements Statement
 {
     private final ReadOperations readOperations;
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
@@ -25,7 +25,9 @@ import org.junit.rules.ExpectedException;
 import org.neo4j.collection.RawIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.api.DataWriteOperations;
+import org.neo4j.kernel.api.ResourceTracker;
 import org.neo4j.kernel.api.SchemaWriteOperations;
+import org.neo4j.kernel.api.StubResourceManager;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.security.AnonymousContext;
 import org.neo4j.kernel.internal.Version;
@@ -44,6 +46,8 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
 {
     @Rule
     public ExpectedException exception = ExpectedException.none();
+
+    private final ResourceTracker resourceTracker = new StubResourceManager();
 
     @Test
     public void listAllLabels() throws Throwable
@@ -150,7 +154,7 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
         {
             // When
             dbmsOperations().procedureCallDbms( procedureName( "dbms", "iDoNotExist" ), new Object[0],
-                    AnonymousContext.none() );
+                    AnonymousContext.none(), resourceTracker );
             fail( "This should never get here" );
         }
         catch ( Exception e )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ProceduresKernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ProceduresKernelIT.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import org.neo4j.collection.RawIterator;
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.api.ResourceTracker;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.Context;
@@ -131,7 +132,7 @@ public class ProceduresKernelIT extends KernelIntegrationTest
         kernel.registerProcedure( new CallableProcedure.BasicProcedure( signature )
         {
             @Override
-            public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
+            public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input, ResourceTracker resourceTracker ) throws ProcedureException
             {
                 return RawIterator.<Object[], ProcedureException>of( new Object[]{ ctx.get( Context.KERNEL_TRANSACTION ).acquireStatement().readOperations() } );
             }
@@ -149,7 +150,7 @@ public class ProceduresKernelIT extends KernelIntegrationTest
         return new CallableProcedure.BasicProcedure( signature )
         {
             @Override
-            public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input )
+            public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input, ResourceTracker resourceTracker )
             {
                 return RawIterator.<Object[], ProcedureException>of( input );
             }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureJarLoaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureJarLoaderTest.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Stream;
 
+import org.neo4j.kernel.api.ResourceTracker;
+import org.neo4j.kernel.api.StubResourceManager;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.BasicContext;
 import org.neo4j.kernel.api.proc.CallableProcedure;
@@ -58,6 +60,7 @@ public class ProcedureJarLoaderTest
     private final ProcedureJarLoader jarloader =
             new ProcedureJarLoader( new ReflectiveProcedureCompiler( new TypeMappers(), new ComponentRegistry(),
                     NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT ), NullLog.getInstance() );
+    private final ResourceTracker resourceTracker = new StubResourceManager();
 
     @Test
     public void shouldLoadProcedureFromJar() throws Throwable
@@ -73,7 +76,7 @@ public class ProcedureJarLoaderTest
         assertThat( signatures, contains(
                 procedureSignature( "org","neo4j", "kernel", "impl", "proc", "myProcedure" ).out( "someNumber", NTInteger ).build() ));
 
-        assertThat( asList( procedures.get( 0 ).apply( new BasicContext(), new Object[0] ) ),
+        assertThat( asList( procedures.get( 0 ).apply( new BasicContext(), new Object[0], resourceTracker ) ),
                 contains( IsEqual.equalTo( new Object[]{1337L} )) );
     }
 
@@ -94,7 +97,7 @@ public class ProcedureJarLoaderTest
                         .out( "someNumber", NTInteger )
                         .build() ));
 
-        assertThat( asList(procedures.get( 0 ).apply( new BasicContext(), new Object[]{42L} ) ),
+        assertThat( asList(procedures.get( 0 ).apply( new BasicContext(), new Object[]{42L}, resourceTracker ) ),
                 contains( IsEqual.equalTo( new Object[]{42L} )) );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProceduresTest.java
@@ -27,6 +27,8 @@ import java.util.List;
 
 import org.neo4j.collection.RawIterator;
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.api.ResourceTracker;
+import org.neo4j.kernel.api.StubResourceManager;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.BasicContext;
 import org.neo4j.kernel.api.proc.CallableProcedure;
@@ -56,6 +58,7 @@ public class ProceduresTest
     private final Procedures procs = new Procedures();
     private final ProcedureSignature signature = procedureSignature( "org", "myproc" ).out( "name", NTString ).build();
     private final CallableProcedure procedure = procedure( signature );
+    private final ResourceTracker resourceTracker = new StubResourceManager();
 
     @Test
     public void shouldGetRegisteredProcedure() throws Throwable
@@ -90,7 +93,8 @@ public class ProceduresTest
         procs.register( procedure );
 
         // When
-        RawIterator<Object[], ProcedureException> result = procs.callProcedure( new BasicContext(), signature.name(), new Object[]{1337} );
+        RawIterator<Object[], ProcedureException> result =
+                procs.callProcedure( new BasicContext(), signature.name(), new Object[]{1337}, resourceTracker );
 
         // Then
         assertThat( asList( result ), contains( equalTo( new Object[]{1337} ) ) );
@@ -106,7 +110,7 @@ public class ProceduresTest
                                  "procedure name correctly and that the procedure is properly deployed." );
 
         // When
-        procs.callProcedure( new BasicContext(), signature.name(), new Object[]{1337} );
+        procs.callProcedure( new BasicContext(), signature.name(), new Object[]{1337}, resourceTracker );
     }
 
     @Test
@@ -171,7 +175,7 @@ public class ProceduresTest
         procs.register( new CallableProcedure.BasicProcedure(signature)
         {
             @Override
-            public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
+            public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input, ResourceTracker resourceTracker ) throws ProcedureException
             {
                 return RawIterator.<Object[], ProcedureException>of( new Object[]{ctx.get( someKey )} );
             }
@@ -181,7 +185,7 @@ public class ProceduresTest
         ctx.put( someKey, "hello, world" );
 
         // When
-        RawIterator<Object[], ProcedureException> result = procs.callProcedure( ctx, signature.name(), new Object[0] );
+        RawIterator<Object[], ProcedureException> result = procs.callProcedure( ctx, signature.name(), new Object[0], resourceTracker );
 
         // Then
         assertThat( asList( result ), contains( equalTo( new Object[]{ "hello, world" } ) ) );
@@ -260,7 +264,7 @@ public class ProceduresTest
         return new CallableProcedure.BasicProcedure(signature)
         {
             @Override
-            public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
+            public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input, ResourceTracker resourceTracker ) throws ProcedureException
             {
                 return null;
             }
@@ -272,7 +276,7 @@ public class ProceduresTest
         return new CallableProcedure.BasicProcedure( signature )
         {
             @Override
-            public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input )
+            public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input, ResourceTracker resourceTracker )
             {
                 return RawIterator.<Object[], ProcedureException>of( input );
             }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureWithArgumentsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureWithArgumentsTest.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import org.neo4j.collection.RawIterator;
+import org.neo4j.kernel.api.ResourceTracker;
+import org.neo4j.kernel.api.StubResourceManager;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.BasicContext;
@@ -49,6 +51,8 @@ public class ReflectiveProcedureWithArgumentsTest
 {
     @Rule
     public ExpectedException exception = ExpectedException.none();
+
+    private final ResourceTracker resourceTracker = new StubResourceManager();
 
     @Test
     public void shouldCompileSimpleProcedure() throws Throwable
@@ -73,7 +77,7 @@ public class ReflectiveProcedureWithArgumentsTest
         CallableProcedure procedure = compile( ClassWithProcedureWithSimpleArgs.class ).get( 0 );
 
         // When
-        RawIterator<Object[],ProcedureException> out = procedure.apply( new BasicContext(), new Object[]{"Pontus", 35L} );
+        RawIterator<Object[],ProcedureException> out = procedure.apply( new BasicContext(), new Object[]{"Pontus", 35L}, resourceTracker );
 
         // Then
         List<Object[]> collect = asList( out );
@@ -89,7 +93,7 @@ public class ReflectiveProcedureWithArgumentsTest
         // When
         RawIterator<Object[],ProcedureException> out = procedure.apply( new BasicContext(), new Object[]{
                 Arrays.asList( "Roland", "Eddie", "Susan", "Jake" ),
-                Arrays.asList( 1000L, 23L, 29L, 12L )} );
+                Arrays.asList( 1000L, 23L, 29L, 12L )}, resourceTracker );
 
         // Then
         List<Object[]> collect = asList( out );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ResourceInjectionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ResourceInjectionTest.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import org.neo4j.helpers.collection.Iterators;
+import org.neo4j.kernel.api.ResourceTracker;
+import org.neo4j.kernel.api.StubResourceManager;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.BasicContext;
@@ -45,6 +47,8 @@ public class ResourceInjectionTest
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
+    private final ResourceTracker resourceTracker = new StubResourceManager();
+
     @Test
     public void shouldCompileAndRunProcedure() throws Throwable
     {
@@ -52,7 +56,7 @@ public class ResourceInjectionTest
         CallableProcedure proc = compile( ProcedureWithInjectedAPI.class ).get( 0 );
 
         // Then
-        List<Object[]> out = Iterators.asList( proc.apply( new BasicContext(), new Object[0] ) );
+        List<Object[]> out = Iterators.asList( proc.apply( new BasicContext(), new Object[0], resourceTracker ) );
 
         // Then
         assertThat( out.get( 0 ), equalTo( (new Object[]{"Bonnie"}) ) );

--- a/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.api.ResourceTracker;
+import org.neo4j.kernel.api.StubResourceManager;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.security.AnonymousContext;
 import org.neo4j.kernel.impl.api.integrationtest.KernelIntegrationTest;
@@ -35,6 +37,8 @@ public class AuthProceduresTest extends KernelIntegrationTest
 {
     @Rule
     public ExpectedException exception = ExpectedException.none();
+
+    private final ResourceTracker<AutoCloseable> resourceTracker = new StubResourceManager();
 
     @Test
     public void shouldFailWhenDeprecatedChangePasswordWithStaticAccessModeInDbmsMode() throws Throwable
@@ -49,7 +53,10 @@ public class AuthProceduresTest extends KernelIntegrationTest
 
         // When
         dbmsOperations()
-                .procedureCallDbms( procedureName( "dbms", "changePassword" ), inputArray, AnonymousContext.none() );
+                .procedureCallDbms( procedureName( "dbms", "changePassword" ),
+                                    inputArray,
+                                    AnonymousContext.none(),
+                                    resourceTracker );
     }
 
     @Test
@@ -64,7 +71,10 @@ public class AuthProceduresTest extends KernelIntegrationTest
         exception.expectMessage( "Anonymous cannot change password" );
 
         // When
-        dbmsOperations().procedureCallDbms( procedureName( "dbms", "security", "changePassword" ), inputArray, AnonymousContext.none() );
+        dbmsOperations().procedureCallDbms( procedureName( "dbms", "security", "changePassword" ),
+                                            inputArray,
+                                            AnonymousContext.none(),
+                                            resourceTracker );
     }
 
     @Override

--- a/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresTest.java
@@ -38,7 +38,7 @@ public class AuthProceduresTest extends KernelIntegrationTest
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
-    private final ResourceTracker<AutoCloseable> resourceTracker = new StubResourceManager();
+    private final ResourceTracker resourceTracker = new StubResourceManager();
 
     @Test
     public void shouldFailWhenDeprecatedChangePasswordWithStaticAccessModeInDbmsMode() throws Throwable

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedure.java
@@ -36,6 +36,7 @@ import org.neo4j.causalclustering.discovery.CoreTopologyService;
 import org.neo4j.causalclustering.discovery.ReadReplicaAddresses;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.collection.RawIterator;
+import org.neo4j.kernel.api.ResourceTracker;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.Context;
@@ -70,7 +71,8 @@ public class ClusterOverviewProcedure extends CallableProcedure.BasicProcedure
     }
 
     @Override
-    public RawIterator<Object[],ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
+    public RawIterator<Object[],ProcedureException> apply(
+            Context ctx, Object[] input, ResourceTracker resourceTracker ) throws ProcedureException
     {
         List<ReadWriteEndPoint> endpoints = new ArrayList<>();
         CoreTopology coreTopology = discoveryService.coreServers();

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/GetServersProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/GetServersProcedure.java
@@ -36,6 +36,7 @@ import org.neo4j.causalclustering.discovery.CoreTopologyService;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.collection.RawIterator;
 import org.neo4j.helpers.AdvertisedSocketAddress;
+import org.neo4j.kernel.api.ResourceTracker;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.Context;
@@ -86,7 +87,8 @@ public class GetServersProcedure extends CallableProcedure.BasicProcedure
     }
 
     @Override
-    public RawIterator<Object[],ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
+    public RawIterator<Object[],ProcedureException> apply(
+            Context ctx, Object[] input, ResourceTracker resourceTracker ) throws ProcedureException
     {
         List<ReadWriteRouteEndPoint> writeEndpoints = writeEndpoints();
         List<ReadWriteRouteEndPoint> readEndpoints = readEndpoints();

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/RoleProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/RoleProcedure.java
@@ -20,6 +20,7 @@
 package org.neo4j.causalclustering.discovery.procedures;
 
 import org.neo4j.collection.RawIterator;
+import org.neo4j.kernel.api.ResourceTracker;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.Context;
@@ -43,7 +44,8 @@ abstract class RoleProcedure extends CallableProcedure.BasicProcedure
     }
 
     @Override
-    public RawIterator<Object[],ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
+    public RawIterator<Object[],ProcedureException> apply(
+            Context ctx, Object[] input, ResourceTracker resourceTracker ) throws ProcedureException
     {
         return RawIterator.<Object[],ProcedureException>of( new Object[]{role().name()} );
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedureTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedureTest.java
@@ -74,7 +74,7 @@ public class ClusterOverviewProcedureTest
                 NullLogProvider.getInstance() );
 
         // when
-        final List<Object[]> members = asList( procedure.apply( null, new Object[0] ) );
+        final List<Object[]> members = asList( procedure.apply( null, new Object[0], null ) );
 
         // then
         assertThat( members, IsIterableContainingInOrder.contains(

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/procedures/GetServersProcedureRoutingTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/procedures/GetServersProcedureRoutingTest.java
@@ -109,7 +109,7 @@ public class GetServersProcedureRoutingTest
     private Object[] getEndpoints( GetServersProcedure proc )
             throws org.neo4j.kernel.api.exceptions.ProcedureException
     {
-        List<Object[]> results = asList( proc.apply( null, new Object[0] ) );
+        List<Object[]> results = asList( proc.apply( null, new Object[0], null ) );
         Object[] rows = results.get( 0 );
         List<Map<String,Object[]>> servers = (List<Map<String,Object[]>>) rows[1];
         Map<String,Object[]> endpoints = servers.get( serverClass );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/procedures/GetServersProcedureTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/procedures/GetServersProcedureTest.java
@@ -115,7 +115,7 @@ public class GetServersProcedureTest
                 new GetServersProcedure( coreTopologyService, leaderLocator, config, getInstance() );
 
         // when
-        List<Object[]> results = asList( proc.apply( null, new Object[0] ) );
+        List<Object[]> results = asList( proc.apply( null, new Object[0], null ) );
 
         // then
         Object[] rows = results.get( 0 );
@@ -361,7 +361,7 @@ public class GetServersProcedureTest
     @SuppressWarnings( "unchecked" )
     private ClusterView run( GetServersProcedure proc ) throws ProcedureException
     {
-        final Object[] rows = asList( proc.apply( null, new Object[0] ) ).get( 0 );
+        final Object[] rows = asList( proc.apply( null, new Object[0], null ) ).get( 0 );
         assertEquals( config.get( cluster_routing_ttl ) / 1000, /* ttl */(long) rows[0] );
         return ClusterView.parse( (List<Map<String,Object>>) rows[1] );
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/procedures/RoleProcedureTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/procedures/RoleProcedureTest.java
@@ -43,7 +43,7 @@ public class RoleProcedureTest
         RoleProcedure proc = new CoreRoleProcedure( raft );
 
         // when
-        RawIterator<Object[], ProcedureException> result = proc.apply( null, null );
+        RawIterator<Object[], ProcedureException> result = proc.apply( null, null, null );
 
         // then
         assertEquals( Role.LEADER.name(), single( result )[0]);
@@ -58,7 +58,7 @@ public class RoleProcedureTest
         RoleProcedure proc = new CoreRoleProcedure( raft );
 
         // when
-        RawIterator<Object[], ProcedureException> result = proc.apply( null, null );
+        RawIterator<Object[], ProcedureException> result = proc.apply( null, null, null );
 
         // then
         assertEquals( Role.FOLLOWER.name(), single( result )[0]);
@@ -71,7 +71,7 @@ public class RoleProcedureTest
         RoleProcedure proc = new ReadReplicaRoleProcedure();
 
         // when
-        RawIterator<Object[], ProcedureException> result = proc.apply( null, null );
+        RawIterator<Object[], ProcedureException> result = proc.apply( null, null, null );
 
         // then
         assertEquals( Role.READ_REPLICA.name(), single( result )[0]);

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -422,9 +422,8 @@ public class ProcedureIT
             // Expect
             exception.expect( QueryExecutionException.class );
             exception.expectMessage(
-                    "Failed to call procedure `org.neo4j.procedure.throwsExceptionInStream() :: (someVal :: INTEGER?)" +
-                    "`: " +
-                    "Kaboom" );
+                    "Failed to invoke procedure `org.neo4j.procedure.throwsExceptionInStream`: " +
+                            "Caused by: java.lang.RuntimeException: Kaboom" );
 
             // When
             result.next();


### PR DESCRIPTION
Make sure we call any close handlers attached to procedure
streams on exceptions. Exceptions that occur during close are
collected as ResourceCloseFailureException and attached as suppressed.

Introduces a ResourceManager/ResourceTracker on KernelStatement to
keep track of active resources so that any non-exhausted procedure
streams are always closed if the transaction is closed during query
execution without closing the query result first.

The ResourceManager implementation is separated into a
class CloseableResourceManager so we can easily move it if we
will not keep KernelStatement in the future.

Also improves the error message.

Doc are adapted to this change with https://github.com/neo4j/neo4j-documentation/pull/185.