### PR TITLE
Fix most of Core API LBDC regressions

### DIFF
--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ResourceManager.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ResourceManager.scala
@@ -31,9 +31,7 @@ class ResourceManager extends CloseableResource {
   private val resources: util.Set[AutoCloseable] = newSetFromMap(new util.IdentityHashMap[AutoCloseable, java.lang.Boolean]())
 
   def trace(resource: AutoCloseable): Unit =
-    if (!resources.add(resource)) {
-      throw new IllegalStateException(s"$resource is already in the resource set $resources")
-    }
+    resources.add(resource)
 
   def release(resource: AutoCloseable): Unit = {
     resource.close()

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelection.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelection.java
@@ -236,7 +236,7 @@ abstract class RelationshipDenseSelection
             break;
 
         default:
-            throw new IllegalStateException( "Lorem ipsus, Brutus" );
+            throw new IllegalStateException( "Lorem ipsus, Brutus. (could not setup cursor for Dir='" + d + "')" );
         }
     }
 

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelection.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelection.java
@@ -57,7 +57,7 @@ abstract class RelationshipDenseSelection
      * @param groupCursor Group cursor to use. Pre-initialized on node.
      * @param relationshipCursor Relationship traversal cursor to use.
      */
-    public void outgoing(
+    public final void outgoing(
             RelationshipGroupCursor groupCursor,
             RelationshipTraversalCursor relationshipCursor )
     {
@@ -71,7 +71,7 @@ abstract class RelationshipDenseSelection
      * @param relationshipCursor Relationship traversal cursor to use.
      * @param types Relationship types to traverse
      */
-    public void outgoing(
+    public final void outgoing(
             RelationshipGroupCursor groupCursor,
             RelationshipTraversalCursor relationshipCursor,
             int[] types )
@@ -94,7 +94,7 @@ abstract class RelationshipDenseSelection
      * @param groupCursor Group cursor to use. Pre-initialized on node.
      * @param relationshipCursor Relationship traversal cursor to use.
      */
-    public void incoming(
+    public final void incoming(
             RelationshipGroupCursor groupCursor,
             RelationshipTraversalCursor relationshipCursor )
     {
@@ -108,7 +108,7 @@ abstract class RelationshipDenseSelection
      * @param relationshipCursor Relationship traversal cursor to use.
      * @param types Relationship types to traverse
      */
-    public void incoming(
+    public final void incoming(
             RelationshipGroupCursor groupCursor,
             RelationshipTraversalCursor relationshipCursor,
             int[] types )
@@ -131,7 +131,7 @@ abstract class RelationshipDenseSelection
      * @param groupCursor Group cursor to use. Pre-initialized on node.
      * @param relationshipCursor Relationship traversal cursor to use.
      */
-    public void all(
+    public final void all(
             RelationshipGroupCursor groupCursor,
             RelationshipTraversalCursor relationshipCursor )
     {
@@ -145,7 +145,7 @@ abstract class RelationshipDenseSelection
      * @param relationshipCursor Relationship traversal cursor to use.
      * @param types Relationship types to traverse
      */
-    public void all(
+    public final void all(
             RelationshipGroupCursor groupCursor,
             RelationshipTraversalCursor relationshipCursor,
             int[] types )
@@ -164,8 +164,7 @@ abstract class RelationshipDenseSelection
     }
 
     /**
-     * Fetch the next valid relationship. If a valid relationship is found, will callback
-     * using {@link #setRelationship(long, long, int, long)}
+     * Fetch the next valid relationship.
      *
      * @return True is a valid relationship was found
      */
@@ -187,16 +186,7 @@ abstract class RelationshipDenseSelection
                     return false;
                 }
 
-                do
-                {
-                    onGroup = groupCursor.next();
-                } while ( onGroup && !correctRelationshipType() );
-
-                if ( onGroup )
-                {
-                    foundTypes++;
-                    currentDirection = 0;
-                }
+                loopOnRelationship();
             }
 
             if ( !onGroup )
@@ -204,46 +194,51 @@ abstract class RelationshipDenseSelection
                 return false;
             }
 
-            Dir d = directions[currentDirection];
-
-            switch ( d )
-            {
-            case OUT:
-                groupCursor.outgoing( relationshipCursor );
-                onRelationship = relationshipCursor.next();
-                break;
-
-            case IN:
-                groupCursor.incoming( relationshipCursor );
-                onRelationship = relationshipCursor.next();
-                break;
-
-            case LOOP:
-                groupCursor.loops( relationshipCursor );
-                onRelationship = relationshipCursor.next();
-                break;
-
-            default:
-                throw new IllegalStateException( "Lorem ipsus, Brutus" );
-            }
+            setupCursors();
         }
 
-        setRelationship(relationshipCursor.relationshipReference(),
-                        relationshipCursor.sourceNodeReference(),
-                        relationshipCursor.label(),
-                        relationshipCursor.targetNodeReference() );
         return true;
     }
 
-    /**
-     * Called when {@link #fetchNext()} finds a valid relationship.
-     *
-     * @param id relationship id
-     * @param sourceNode source node id
-     * @param type relationship type
-     * @param targetNode target node id
-     */
-    protected abstract void setRelationship( long id, long sourceNode, int type, long targetNode );
+    private void loopOnRelationship()
+    {
+        do
+        {
+            onGroup = groupCursor.next();
+        } while ( onGroup && !correctRelationshipType() );
+
+        if ( onGroup )
+        {
+            foundTypes++;
+            currentDirection = 0;
+        }
+    }
+
+    private void setupCursors()
+    {
+        Dir d = directions[currentDirection];
+
+        switch ( d )
+        {
+        case OUT:
+            groupCursor.outgoing( relationshipCursor );
+            onRelationship = relationshipCursor.next();
+            break;
+
+        case IN:
+            groupCursor.incoming( relationshipCursor );
+            onRelationship = relationshipCursor.next();
+            break;
+
+        case LOOP:
+            groupCursor.loops( relationshipCursor );
+            onRelationship = relationshipCursor.next();
+            break;
+
+        default:
+            throw new IllegalStateException( "Lorem ipsus, Brutus" );
+        }
+    }
 
     private boolean correctRelationshipType()
     {

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionCursor.java
@@ -65,10 +65,4 @@ public final class RelationshipDenseSelectionCursor extends RelationshipDenseSel
     {
         return relationshipCursor.targetNodeReference();
     }
-
-    @Override
-    protected void setRelationship( long id, long sourceNode, int type, long targetNode )
-    {
-        // nothing to do
-    }
 }

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionIterator.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionIterator.java
@@ -32,7 +32,7 @@ public final class RelationshipDenseSelectionIterator<R> extends RelationshipDen
     private RelationshipFactory<R> factory;
     private long next;
 
-    public RelationshipDenseSelectionIterator( RelationshipFactory<R> factory )
+    RelationshipDenseSelectionIterator( RelationshipFactory<R> factory )
     {
         this.factory = factory;
         this.next = RelationshipSelections.UNINITIALIZED;

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionIterator.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionIterator.java
@@ -66,6 +66,7 @@ public final class RelationshipDenseSelectionIterator<R> extends RelationshipDen
         R current = _next;
         if ( !fetchNext() )
         {
+            close();
             _next = null;
         }
 

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSelections.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSelections.java
@@ -30,6 +30,9 @@ import org.neo4j.internal.kernel.api.RelationshipTraversalCursor;
  */
 public final class RelationshipSelections
 {
+    static final long UNINITIALIZED = -2L;
+    static final long NO_ID = -1L;
+
     private RelationshipSelections()
     {
         throw new UnsupportedOperationException( "Do not instantiate" );

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelection.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelection.java
@@ -46,7 +46,7 @@ abstract class RelationshipSparseSelection
      *
      * @param relationshipCursor Relationship traversal cursor to use. Pre-initialized on node.
      */
-    public void outgoing( RelationshipTraversalCursor relationshipCursor )
+    public final void outgoing( RelationshipTraversalCursor relationshipCursor )
     {
         init( relationshipCursor, null, Dir.OUT );
     }
@@ -57,7 +57,7 @@ abstract class RelationshipSparseSelection
      * @param relationshipCursor Relationship traversal cursor to use. Pre-initialized on node.
      * @param types Relationship types to traverse
      */
-    public void outgoing(
+    public final void outgoing(
             RelationshipTraversalCursor relationshipCursor,
             int[] types )
     {
@@ -69,7 +69,7 @@ abstract class RelationshipSparseSelection
      *
      * @param relationshipCursor Relationship traversal cursor to use. Pre-initialized on node.
      */
-    public void incoming( RelationshipTraversalCursor relationshipCursor )
+    public final void incoming( RelationshipTraversalCursor relationshipCursor )
     {
         init( relationshipCursor, null, Dir.IN );
     }
@@ -80,7 +80,7 @@ abstract class RelationshipSparseSelection
      * @param relationshipCursor Relationship traversal cursor to use. Pre-initialized on node.
      * @param types Relationship types to traverse
      */
-    public void incoming(
+    public final void incoming(
             RelationshipTraversalCursor relationshipCursor,
             int[] types )
     {
@@ -92,7 +92,7 @@ abstract class RelationshipSparseSelection
      *
      * @param relationshipCursor Relationship traversal cursor to use. Pre-initialized on node.
      */
-    public void all( RelationshipTraversalCursor relationshipCursor )
+    public final void all( RelationshipTraversalCursor relationshipCursor )
     {
         init( relationshipCursor, null, Dir.BOTH );
     }
@@ -103,7 +103,7 @@ abstract class RelationshipSparseSelection
      * @param relationshipCursor Relationship traversal cursor to use. Pre-initialized on node.
      * @param types Relationship types to traverse
      */
-    public void all(
+    public final void all(
             RelationshipTraversalCursor relationshipCursor,
             int[] types )
     {
@@ -120,8 +120,7 @@ abstract class RelationshipSparseSelection
     }
 
     /**
-     * Fetch the next valid relationship. If a valid relationship is found, will callback
-     * using {@link #setRelationship(long, long, int, long)}
+     * Fetch the next valid relationship.
      *
      * @return True is a valid relationship was found
      */
@@ -136,25 +135,8 @@ abstract class RelationshipSparseSelection
             } while ( onRelationship && (!correctDirection() || !correctType()) );
         }
 
-        if ( onRelationship )
-        {
-           setRelationship( cursor.relationshipReference(),
-                            cursor.sourceNodeReference(),
-                            cursor.label(),
-                            cursor.targetNodeReference() );
-        }
         return onRelationship;
     }
-
-    /**
-     * Called when {@link #fetchNext()} finds a valid relationship.
-     *
-     * @param id relationship id
-     * @param sourceNode source node id
-     * @param type relationship type
-     * @param targetNode target node id
-     */
-    protected abstract void setRelationship( long id, long sourceNode, int type, long targetNode );
 
     private boolean correctDirection()
     {

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionCursor.java
@@ -65,10 +65,4 @@ public final class RelationshipSparseSelectionCursor extends RelationshipSparseS
     {
         return cursor.targetNodeReference();
     }
-
-    @Override
-    protected void setRelationship( long id, long sourceNode, int type, long targetNode )
-    {
-        // nothing to do
-    }
 }

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionIterator.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionIterator.java
@@ -67,6 +67,7 @@ public final class RelationshipSparseSelectionIterator<R> extends RelationshipSp
         R current = _next;
         if ( !fetchNext() )
         {
+            close();
             _next = null;
         }
         return current;

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionIterator.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionIterator.java
@@ -31,25 +31,24 @@ public final class RelationshipSparseSelectionIterator<R> extends RelationshipSp
 {
 
     private final RelationshipFactory<R> factory;
-    private R _next;
-    private boolean initialized;
+    private long next;
 
-    public RelationshipSparseSelectionIterator( RelationshipFactory<R> factory )
+    RelationshipSparseSelectionIterator( RelationshipFactory<R> factory )
     {
         this.factory = factory;
-        this.initialized = false;
+        this.next = RelationshipSelections.UNINITIALIZED;
     }
 
     @Override
     public boolean hasNext()
     {
-        if ( !initialized )
+        if ( next == RelationshipSelections.UNINITIALIZED )
         {
             fetchNext();
-            initialized = true;
+            next = cursor.relationshipReference();
         }
 
-        if ( _next == null )
+        if ( next == RelationshipSelections.NO_ID )
         {
             close();
             return false;
@@ -64,18 +63,21 @@ public final class RelationshipSparseSelectionIterator<R> extends RelationshipSp
         {
             throw new NoSuchElementException();
         }
-        R current = _next;
+        R current = factory.relationship( next,
+                                          cursor.sourceNodeReference(),
+                                          cursor.label(),
+                                          cursor.targetNodeReference() );
+
         if ( !fetchNext() )
         {
             close();
-            _next = null;
+            next = RelationshipSelections.NO_ID;
         }
-        return current;
-    }
+        else
+        {
+            next = cursor.relationshipReference();
+        }
 
-    @Override
-    protected void setRelationship( long id, long sourceNode, int type, long targetNode )
-    {
-        _next = factory.relationship( id, sourceNode, type, targetNode );
+        return current;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -676,7 +676,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
                 constraintIndexCreator, statementOperationParts, schemaWriteGuard, transactionHeaderInformationFactory,
                 transactionCommitProcess, indexConfigStore, explicitIndexProviderLookup, hooks, transactionMonitor,
                 availabilityGuard, tracers, storageEngine, procedures, transactionIdStore, clock,
-                cpuClockRef, heapAllocationRef, accessCapability, token, new DefaultCursors(), autoIndexing,
+                cpuClockRef, heapAllocationRef, accessCapability, token, DefaultCursors::new, autoIndexing,
                         explicitIndexStore, versionContextSupplier ) );
 
         buildTransactionMonitor( kernelTransactions, clock, config );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -96,7 +96,7 @@ public class KernelTransactions extends LifecycleAdapter implements Supplier<Ker
     private final VersionContextSupplier versionContextSupplier;
     private final ReentrantReadWriteLock newTransactionsLock = new ReentrantReadWriteLock();
     private final MonotonicCounter userTransactionIdCounter = MonotonicCounter.newAtomicMonotonicCounter();
-    private final DefaultCursors cursors;
+    private final Supplier<DefaultCursors> cursorsSupplier;
     private final KernelToken token;
     private final AutoIndexing autoIndexing;
     private final ExplicitIndexStore explicitIndexStore;
@@ -138,7 +138,7 @@ public class KernelTransactions extends LifecycleAdapter implements Supplier<Ker
             StorageEngine storageEngine, Procedures procedures, TransactionIdStore transactionIdStore,
             SystemNanoClock clock,
             AtomicReference<CpuClock> cpuClockRef, AtomicReference<HeapAllocation> heapAllocationRef, AccessCapability accessCapability,
-            KernelToken token, DefaultCursors cursors,
+            KernelToken token, Supplier<DefaultCursors> cursorsSupplier,
             AutoIndexing autoIndexing,
             ExplicitIndexStore explicitIndexStore, VersionContextSupplier versionContextSupplier )
     {
@@ -166,7 +166,7 @@ public class KernelTransactions extends LifecycleAdapter implements Supplier<Ker
         this.versionContextSupplier = versionContextSupplier;
         this.clock = clock;
         doBlockNewTransactions();
-        this.cursors = cursors;
+        this.cursorsSupplier = cursorsSupplier;
         this.token = token;
     }
 
@@ -362,7 +362,8 @@ public class KernelTransactions extends LifecycleAdapter implements Supplier<Ker
                             constraintIndexCreator, procedures, transactionHeaderInformationFactory,
                             transactionCommitProcess, transactionMonitor, explicitIndexTxStateSupplier, localTxPool,
                             clock, cpuClockRef, heapAllocationRef, tracers.transactionTracer, tracers.lockTracer,
-                            tracers.pageCursorTracerSupplier, storageEngine, accessCapability, token, cursors, autoIndexing,
+                            tracers.pageCursorTracerSupplier, storageEngine, accessCapability, token,
+                            cursorsSupplier.get(), autoIndexing,
                             explicitIndexStore, versionContextSupplier );
             this.transactions.add( tx );
             return tx;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -769,6 +769,7 @@ public class NodeProxy implements Node
         {
             throw new NotFoundException( format( "Node %d not found", nodeId ) );
         }
+
         switch ( direction )
         {
         case OUTGOING:

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -196,7 +196,11 @@ public class NodeProxy implements Node
 
     private boolean innerHasRelationships( final KernelTransaction transaction, final Direction direction, int[] typeIds )
     {
-        return getRelationshipSelectionIterator( transaction, direction, typeIds ).hasNext();
+        try ( ResourceIterator<Relationship> iterator =
+                getRelationshipSelectionIterator( transaction, direction, typeIds ) )
+        {
+            return iterator.hasNext();
+        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -223,11 +223,6 @@ public class NodeProxy implements Node
         }
     }
 
-    private void assertInUnterminatedTransaction()
-    {
-        spi.assertInUnterminatedTransaction();
-    }
-
     @Override
     public void setProperty( String key, Object value )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -150,12 +150,8 @@ public class NodeProxy implements Node
     @Override
     public ResourceIterable<Relationship> getRelationships( final Direction direction, RelationshipType... types )
     {
-        final int[] typeIds;
         KernelTransaction transaction = safeAcquireTransaction();
-        try ( Statement statement = transaction.acquireStatement() )
-        {
-            typeIds = relTypeIds( types, statement );
-        }
+        int[] typeIds = relTypeIds( types, transaction.tokenRead() );
         return innerGetRelationships( transaction, direction, typeIds );
     }
 
@@ -187,12 +183,8 @@ public class NodeProxy implements Node
     @Override
     public boolean hasRelationship( Direction direction, RelationshipType... types )
     {
-        final int[] typeIds;
         KernelTransaction transaction = safeAcquireTransaction();
-        try ( Statement statement = transaction.acquireStatement() )
-        {
-            typeIds = relTypeIds( types, statement );
-        }
+        int[] typeIds = relTypeIds( types, transaction.tokenRead() );
         return innerHasRelationships( transaction, direction, typeIds );
     }
 
@@ -791,13 +783,13 @@ public class NodeProxy implements Node
         }
     }
 
-    private int[] relTypeIds( RelationshipType[] types, Statement statement )
+    private int[] relTypeIds( RelationshipType[] types, TokenRead token )
     {
         int[] ids = new int[types.length];
         int outIndex = 0;
         for ( RelationshipType type : types )
         {
-            int id = statement.readOperations().relationshipTypeGetForName( type.name() );
+            int id = token.relationshipType( type.name() );
             if ( id != NO_SUCH_RELATIONSHIP_TYPE )
             {
                 ids[outIndex++] = id;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/ThreadToStatementContextBridge.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/ThreadToStatementContextBridge.java
@@ -72,11 +72,11 @@ public class ThreadToStatementContextBridge extends LifecycleAdapter implements 
         {
             throw new BridgeNotInTransactionException();
         }
-        Optional<Status> terminationReason = transaction.getReasonIfTerminated();
-        terminationReason.ifPresent( status ->
+        if ( transaction.isTerminated() )
         {
-            throw new TransactionTerminatedException( status );
-        } );
+            Status terminationReason = transaction.getReasonIfTerminated().orElse( Status.Transaction.Terminated );
+            throw new TransactionTerminatedException( terminationReason );
+        }
     }
 
     public void assertInUnterminatedTransaction()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultCursors.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultCursors.java
@@ -59,7 +59,7 @@ public class DefaultCursors implements CursorFactory
             @Override
             protected DefaultRelationshipTraversalCursor create()
             {
-                return new DefaultRelationshipTraversalCursor( new DefaultRelationshipGroupCursor( null ), this );
+                return new DefaultRelationshipTraversalCursor( new DefaultRelationshipGroupCursor( cursor -> {} ), this );
             }
         };
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultCursors.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultCursors.java
@@ -20,155 +20,308 @@
 package org.neo4j.kernel.impl.newapi;
 
 import org.neo4j.internal.kernel.api.CursorFactory;
-import org.neo4j.kernel.impl.util.InstanceCache;
 
 public class DefaultCursors implements CursorFactory
 {
-    private final InstanceCache<DefaultNodeCursor> nodeCursor;
-    private final InstanceCache<DefaultRelationshipScanCursor> relationshipScanCursor;
-    private final InstanceCache<DefaultRelationshipTraversalCursor> relationshipTraversalCursor;
-    private final InstanceCache<DefaultPropertyCursor> propertyCursor;
-    private final InstanceCache<DefaultRelationshipGroupCursor> relationshipGroupCursor;
-    private final InstanceCache<DefaultNodeValueIndexCursor> nodeValueIndexCursor;
-    private final InstanceCache<DefaultNodeLabelIndexCursor> nodeLabelIndexCursor;
-    private final InstanceCache<DefaultNodeExplicitIndexCursor> nodeExplicitIndexCursor;
-    private final InstanceCache<DefaultRelationshipExplicitIndexCursor> relationshipExplicitIndexCursor;
-
-    public DefaultCursors()
-    {
-        nodeCursor = new InstanceCache<DefaultNodeCursor>()
-        {
-            @Override
-            protected DefaultNodeCursor create()
-            {
-                return new DefaultNodeCursor( this );
-            }
-        };
-
-        relationshipScanCursor = new InstanceCache<DefaultRelationshipScanCursor>()
-        {
-            @Override
-            protected DefaultRelationshipScanCursor create()
-            {
-                return new DefaultRelationshipScanCursor( this );
-            }
-        };
-
-        relationshipTraversalCursor = new InstanceCache<DefaultRelationshipTraversalCursor>()
-        {
-            @Override
-            protected DefaultRelationshipTraversalCursor create()
-            {
-                return new DefaultRelationshipTraversalCursor( new DefaultRelationshipGroupCursor( cursor -> {} ), this );
-            }
-        };
-
-        propertyCursor = new InstanceCache<DefaultPropertyCursor>()
-        {
-            @Override
-            protected DefaultPropertyCursor create()
-            {
-                return new DefaultPropertyCursor( this );
-            }
-        };
-
-        relationshipGroupCursor = new InstanceCache<DefaultRelationshipGroupCursor>()
-        {
-            @Override
-            protected DefaultRelationshipGroupCursor create()
-            {
-                return new DefaultRelationshipGroupCursor( this );
-            }
-        };
-
-        nodeValueIndexCursor = new InstanceCache<DefaultNodeValueIndexCursor>()
-        {
-            @Override
-            protected DefaultNodeValueIndexCursor create()
-            {
-                return new DefaultNodeValueIndexCursor( this );
-            }
-        };
-
-        nodeLabelIndexCursor = new InstanceCache<DefaultNodeLabelIndexCursor>()
-        {
-            @Override
-            protected DefaultNodeLabelIndexCursor create()
-            {
-                return new DefaultNodeLabelIndexCursor( this );
-            }
-        };
-
-        nodeExplicitIndexCursor = new InstanceCache<DefaultNodeExplicitIndexCursor>()
-        {
-            @Override
-            protected DefaultNodeExplicitIndexCursor create()
-            {
-                return new DefaultNodeExplicitIndexCursor( this );
-            }
-        };
-
-        relationshipExplicitIndexCursor = new InstanceCache<DefaultRelationshipExplicitIndexCursor>()
-        {
-            @Override
-            protected DefaultRelationshipExplicitIndexCursor create()
-            {
-                return new DefaultRelationshipExplicitIndexCursor( this );
-            }
-        };
-    }
+    private DefaultNodeCursor nodeCursor;
+    private DefaultRelationshipScanCursor relationshipScanCursor;
+    private DefaultRelationshipTraversalCursor relationshipTraversalCursor;
+    private DefaultPropertyCursor propertyCursor;
+    private DefaultRelationshipGroupCursor relationshipGroupCursor;
+    private DefaultNodeValueIndexCursor nodeValueIndexCursor;
+    private DefaultNodeLabelIndexCursor nodeLabelIndexCursor;
+    private DefaultNodeExplicitIndexCursor nodeExplicitIndexCursor;
+    private DefaultRelationshipExplicitIndexCursor relationshipExplicitIndexCursor;
 
     @Override
     public DefaultNodeCursor allocateNodeCursor()
     {
-        return nodeCursor.get();
+        if ( nodeCursor == null )
+        {
+            return new DefaultNodeCursor( this );
+        }
+
+        try
+        {
+            return nodeCursor;
+        }
+        finally
+        {
+            nodeCursor = null;
+        }
+    }
+
+    public void accept( DefaultNodeCursor cursor )
+    {
+        if ( nodeCursor != null )
+        {
+            nodeCursor.release();
+        }
+        nodeCursor = cursor;
     }
 
     @Override
     public DefaultRelationshipScanCursor allocateRelationshipScanCursor()
     {
-        return relationshipScanCursor.get( );
+        if ( relationshipScanCursor == null )
+        {
+            return new DefaultRelationshipScanCursor( this );
+        }
+
+        try
+        {
+            return relationshipScanCursor;
+        }
+        finally
+        {
+            relationshipScanCursor = null;
+        }
+    }
+
+    public void accept( DefaultRelationshipScanCursor cursor )
+    {
+        if ( relationshipScanCursor != null )
+        {
+            relationshipScanCursor.release();
+        }
+        relationshipScanCursor = cursor;
     }
 
     @Override
     public DefaultRelationshipTraversalCursor allocateRelationshipTraversalCursor()
     {
-        return relationshipTraversalCursor.get();
+        if ( relationshipTraversalCursor == null )
+        {
+            return new DefaultRelationshipTraversalCursor( new DefaultRelationshipGroupCursor( null ), this );
+        }
+
+        try
+        {
+            return relationshipTraversalCursor;
+        }
+        finally
+        {
+            relationshipTraversalCursor = null;
+        }
+    }
+
+    public void accept( DefaultRelationshipTraversalCursor cursor )
+    {
+        if ( relationshipTraversalCursor != null )
+        {
+            relationshipTraversalCursor.release();
+        }
+        relationshipTraversalCursor = cursor;
     }
 
     @Override
     public DefaultPropertyCursor allocatePropertyCursor()
     {
-        return propertyCursor.get();
+        if ( propertyCursor == null )
+        {
+            return new DefaultPropertyCursor( this );
+        }
+
+        try
+        {
+            return propertyCursor;
+        }
+        finally
+        {
+            propertyCursor = null;
+        }
+    }
+
+    public void accept( DefaultPropertyCursor cursor )
+    {
+        if ( propertyCursor != null )
+        {
+            propertyCursor.release();
+        }
+        propertyCursor = cursor;
     }
 
     @Override
     public DefaultRelationshipGroupCursor allocateRelationshipGroupCursor()
     {
-        return relationshipGroupCursor.get();
+        if ( relationshipGroupCursor == null )
+        {
+            return new DefaultRelationshipGroupCursor( this );
+        }
+
+        try
+        {
+            return relationshipGroupCursor;
+        }
+        finally
+        {
+            relationshipGroupCursor = null;
+        }
+    }
+
+    public void accept( DefaultRelationshipGroupCursor cursor )
+    {
+        if ( relationshipGroupCursor != null )
+        {
+            relationshipGroupCursor.release();
+        }
+        relationshipGroupCursor = cursor;
     }
 
     @Override
     public DefaultNodeValueIndexCursor allocateNodeValueIndexCursor()
     {
-        return nodeValueIndexCursor.get();
+        if ( nodeValueIndexCursor == null )
+        {
+            return new DefaultNodeValueIndexCursor( this );
+        }
+
+        try
+        {
+            return nodeValueIndexCursor;
+        }
+        finally
+        {
+            nodeValueIndexCursor = null;
+        }
+    }
+
+    public void accept( DefaultNodeValueIndexCursor cursor )
+    {
+        if ( nodeValueIndexCursor != null )
+        {
+            nodeValueIndexCursor.release();
+        }
+        nodeValueIndexCursor = cursor;
     }
 
     @Override
     public DefaultNodeLabelIndexCursor allocateNodeLabelIndexCursor()
     {
-        return nodeLabelIndexCursor.get();
+        if ( nodeLabelIndexCursor == null )
+        {
+            return new DefaultNodeLabelIndexCursor( this );
+        }
+
+        try
+        {
+            return nodeLabelIndexCursor;
+        }
+        finally
+        {
+            nodeLabelIndexCursor = null;
+        }
+    }
+
+    public void accept( DefaultNodeLabelIndexCursor cursor )
+    {
+        if ( nodeLabelIndexCursor != null )
+        {
+            nodeLabelIndexCursor.release();
+        }
+        nodeLabelIndexCursor = cursor;
     }
 
     @Override
     public DefaultNodeExplicitIndexCursor allocateNodeExplicitIndexCursor()
     {
-        return nodeExplicitIndexCursor.get();
+        if ( nodeExplicitIndexCursor == null )
+        {
+            return new DefaultNodeExplicitIndexCursor( this );
+        }
+
+        try
+        {
+            return nodeExplicitIndexCursor;
+        }
+        finally
+        {
+            nodeExplicitIndexCursor = null;
+        }
+    }
+
+    public void accept( DefaultNodeExplicitIndexCursor cursor )
+    {
+        if ( nodeExplicitIndexCursor != null )
+        {
+            nodeExplicitIndexCursor.release();
+        }
+        nodeExplicitIndexCursor = cursor;
     }
 
     @Override
     public DefaultRelationshipExplicitIndexCursor allocateRelationshipExplicitIndexCursor()
     {
-        return relationshipExplicitIndexCursor.get();
+        if ( relationshipExplicitIndexCursor == null )
+        {
+            return new DefaultRelationshipExplicitIndexCursor( this );
+        }
+
+        try
+        {
+            return relationshipExplicitIndexCursor;
+        }
+        finally
+        {
+            relationshipExplicitIndexCursor = null;
+        }
+    }
+
+    public void accept( DefaultRelationshipExplicitIndexCursor cursor )
+    {
+        if ( relationshipExplicitIndexCursor != null )
+        {
+            relationshipExplicitIndexCursor.release();
+        }
+        relationshipExplicitIndexCursor = cursor;
+    }
+
+    public void release()
+    {
+        if ( nodeCursor != null )
+        {
+            nodeCursor.release();
+            nodeCursor = null;
+        }
+        if ( relationshipScanCursor != null )
+        {
+            relationshipScanCursor.release();
+            relationshipScanCursor = null;
+        }
+        if ( relationshipTraversalCursor != null )
+        {
+            relationshipTraversalCursor.release();
+            relationshipTraversalCursor = null;
+        }
+        if ( propertyCursor != null )
+        {
+            propertyCursor.release();
+            propertyCursor = null;
+        }
+        if ( relationshipGroupCursor != null )
+        {
+            relationshipGroupCursor.release();
+            relationshipGroupCursor = null;
+        }
+        if ( nodeValueIndexCursor != null )
+        {
+            nodeValueIndexCursor.release();
+            nodeValueIndexCursor = null;
+        }
+        if ( nodeLabelIndexCursor != null )
+        {
+            nodeLabelIndexCursor.release();
+            nodeLabelIndexCursor = null;
+        }
+        if ( nodeExplicitIndexCursor != null )
+        {
+            nodeExplicitIndexCursor.release();
+            nodeExplicitIndexCursor = null;
+        }
+        if ( relationshipExplicitIndexCursor != null )
+        {
+            relationshipExplicitIndexCursor.release();
+            relationshipExplicitIndexCursor = null;
+        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultCursors.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultCursors.java
@@ -20,60 +20,155 @@
 package org.neo4j.kernel.impl.newapi;
 
 import org.neo4j.internal.kernel.api.CursorFactory;
+import org.neo4j.kernel.impl.util.InstanceCache;
 
 public class DefaultCursors implements CursorFactory
 {
+    private final InstanceCache<DefaultNodeCursor> nodeCursor;
+    private final InstanceCache<DefaultRelationshipScanCursor> relationshipScanCursor;
+    private final InstanceCache<DefaultRelationshipTraversalCursor> relationshipTraversalCursor;
+    private final InstanceCache<DefaultPropertyCursor> propertyCursor;
+    private final InstanceCache<DefaultRelationshipGroupCursor> relationshipGroupCursor;
+    private final InstanceCache<DefaultNodeValueIndexCursor> nodeValueIndexCursor;
+    private final InstanceCache<DefaultNodeLabelIndexCursor> nodeLabelIndexCursor;
+    private final InstanceCache<DefaultNodeExplicitIndexCursor> nodeExplicitIndexCursor;
+    private final InstanceCache<DefaultRelationshipExplicitIndexCursor> relationshipExplicitIndexCursor;
+
+    public DefaultCursors()
+    {
+        nodeCursor = new InstanceCache<DefaultNodeCursor>()
+        {
+            @Override
+            protected DefaultNodeCursor create()
+            {
+                return new DefaultNodeCursor( this );
+            }
+        };
+
+        relationshipScanCursor = new InstanceCache<DefaultRelationshipScanCursor>()
+        {
+            @Override
+            protected DefaultRelationshipScanCursor create()
+            {
+                return new DefaultRelationshipScanCursor( this );
+            }
+        };
+
+        relationshipTraversalCursor = new InstanceCache<DefaultRelationshipTraversalCursor>()
+        {
+            @Override
+            protected DefaultRelationshipTraversalCursor create()
+            {
+                return new DefaultRelationshipTraversalCursor( new DefaultRelationshipGroupCursor( null ), this );
+            }
+        };
+
+        propertyCursor = new InstanceCache<DefaultPropertyCursor>()
+        {
+            @Override
+            protected DefaultPropertyCursor create()
+            {
+                return new DefaultPropertyCursor( this );
+            }
+        };
+
+        relationshipGroupCursor = new InstanceCache<DefaultRelationshipGroupCursor>()
+        {
+            @Override
+            protected DefaultRelationshipGroupCursor create()
+            {
+                return new DefaultRelationshipGroupCursor( this );
+            }
+        };
+
+        nodeValueIndexCursor = new InstanceCache<DefaultNodeValueIndexCursor>()
+        {
+            @Override
+            protected DefaultNodeValueIndexCursor create()
+            {
+                return new DefaultNodeValueIndexCursor( this );
+            }
+        };
+
+        nodeLabelIndexCursor = new InstanceCache<DefaultNodeLabelIndexCursor>()
+        {
+            @Override
+            protected DefaultNodeLabelIndexCursor create()
+            {
+                return new DefaultNodeLabelIndexCursor( this );
+            }
+        };
+
+        nodeExplicitIndexCursor = new InstanceCache<DefaultNodeExplicitIndexCursor>()
+        {
+            @Override
+            protected DefaultNodeExplicitIndexCursor create()
+            {
+                return new DefaultNodeExplicitIndexCursor( this );
+            }
+        };
+
+        relationshipExplicitIndexCursor = new InstanceCache<DefaultRelationshipExplicitIndexCursor>()
+        {
+            @Override
+            protected DefaultRelationshipExplicitIndexCursor create()
+            {
+                return new DefaultRelationshipExplicitIndexCursor( this );
+            }
+        };
+    }
+
     @Override
     public DefaultNodeCursor allocateNodeCursor()
     {
-        return new DefaultNodeCursor( );
+        return nodeCursor.get();
     }
 
     @Override
     public DefaultRelationshipScanCursor allocateRelationshipScanCursor()
     {
-        return new DefaultRelationshipScanCursor( );
+        return relationshipScanCursor.get( );
     }
 
     @Override
     public DefaultRelationshipTraversalCursor allocateRelationshipTraversalCursor()
     {
-        return new DefaultRelationshipTraversalCursor( allocateRelationshipGroupCursor() );
+        return relationshipTraversalCursor.get();
     }
 
     @Override
     public DefaultPropertyCursor allocatePropertyCursor()
     {
-        return new DefaultPropertyCursor( );
+        return propertyCursor.get();
     }
 
     @Override
     public DefaultRelationshipGroupCursor allocateRelationshipGroupCursor()
     {
-        return new DefaultRelationshipGroupCursor( );
+        return relationshipGroupCursor.get();
     }
 
     @Override
     public DefaultNodeValueIndexCursor allocateNodeValueIndexCursor()
     {
-        return new DefaultNodeValueIndexCursor( );
+        return nodeValueIndexCursor.get();
     }
 
     @Override
     public DefaultNodeLabelIndexCursor allocateNodeLabelIndexCursor()
     {
-        return new DefaultNodeLabelIndexCursor( );
+        return nodeLabelIndexCursor.get();
     }
 
     @Override
     public DefaultNodeExplicitIndexCursor allocateNodeExplicitIndexCursor()
     {
-        return new DefaultNodeExplicitIndexCursor( );
+        return nodeExplicitIndexCursor.get();
     }
 
     @Override
     public DefaultRelationshipExplicitIndexCursor allocateRelationshipExplicitIndexCursor()
     {
-        return new DefaultRelationshipExplicitIndexCursor( );
+        return relationshipExplicitIndexCursor.get();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeCursor.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.newapi;
 
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveIntSet;
@@ -47,9 +48,12 @@ class DefaultNodeCursor extends NodeRecord implements NodeCursor
     private HasChanges hasChanges = HasChanges.MAYBE;
     private Set<Long> addedNodes;
 
-    DefaultNodeCursor()
+    private final Consumer<DefaultNodeCursor> pool;
+
+    DefaultNodeCursor( Consumer<DefaultNodeCursor> pool )
     {
         super( NO_ID );
+        this.pool = pool;
     }
 
     void scan( Read read )
@@ -242,21 +246,27 @@ class DefaultNodeCursor extends NodeRecord implements NodeCursor
     @Override
     public void close()
     {
-        if ( pageCursor != null )
-        {
-            pageCursor.close();
-            pageCursor = null;
-        }
         read = null;
+        hasChanges = HasChanges.MAYBE;
+        addedNodes = emptySet();
+        reset();
 
         if ( labelCursor != null )
         {
             labelCursor.close();
             labelCursor = null;
         }
-        hasChanges = HasChanges.MAYBE;
-        addedNodes = emptySet();
-        reset();
+
+        if ( pageCursor != null )
+        {
+            pageCursor.close();
+            pageCursor = null;
+
+            if ( pool != null )
+            {
+                pool.accept( this );
+            }
+        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeCursor.java
@@ -262,10 +262,7 @@ class DefaultNodeCursor extends NodeRecord implements NodeCursor
             pageCursor.close();
             pageCursor = null;
 
-            if ( pool != null )
-            {
-                pool.accept( this );
-            }
+            pool.accept( this );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeExplicitIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeExplicitIndexCursor.java
@@ -103,10 +103,7 @@ class DefaultNodeExplicitIndexCursor extends IndexCursor<ExplicitIndexProgressor
             expectedSize = 0;
             read = null;
 
-            if ( pool != null )
-            {
-                pool.accept( this );
-            }
+            pool.accept( this );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeExplicitIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeExplicitIndexCursor.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.newapi;
 
-import java.util.function.Consumer;
-
 import org.neo4j.internal.kernel.api.NodeCursor;
 import org.neo4j.storageengine.api.schema.IndexProgressor.ExplicitClient;
 
@@ -34,9 +32,9 @@ class DefaultNodeExplicitIndexCursor extends IndexCursor<ExplicitIndexProgressor
     private long node;
     private float score;
 
-    private final Consumer<DefaultNodeExplicitIndexCursor> pool;
+    private final DefaultCursors pool;
 
-    DefaultNodeExplicitIndexCursor( Consumer<DefaultNodeExplicitIndexCursor> pool )
+    DefaultNodeExplicitIndexCursor( DefaultCursors pool )
     {
         this.pool = pool;
         node = NO_ID;
@@ -125,5 +123,10 @@ class DefaultNodeExplicitIndexCursor extends IndexCursor<ExplicitIndexProgressor
             return "NodeExplicitIndexCursor[node=" + node + ", expectedSize=" + expectedSize + ", score=" + score +
                     ", underlying record=" + super.toString() + " ]";
         }
+    }
+
+    public void release()
+    {
+        // nothing to do
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeLabelIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeLabelIndexCursor.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.newapi;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
@@ -43,8 +44,11 @@ class DefaultNodeLabelIndexCursor extends IndexCursor<LabelScanValueIndexProgres
     private PrimitiveLongIterator added;
     private Set<Long> removed;
 
-    DefaultNodeLabelIndexCursor()
+    private final Consumer<DefaultNodeLabelIndexCursor> pool;
+
+    DefaultNodeLabelIndexCursor( Consumer<DefaultNodeLabelIndexCursor> pool )
     {
+        this.pool = pool;
         node = NO_ID;
     }
 
@@ -140,11 +144,19 @@ class DefaultNodeLabelIndexCursor extends IndexCursor<LabelScanValueIndexProgres
     @Override
     public void close()
     {
-        super.close();
-        node = NO_ID;
-        labels = null;
-        read = null;
-        removed = null;
+        if ( !isClosed() )
+        {
+            super.close();
+            node = NO_ID;
+            labels = null;
+            read = null;
+            removed = null;
+
+            if ( pool != null )
+            {
+                pool.accept( this );
+            }
+        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeLabelIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeLabelIndexCursor.java
@@ -152,10 +152,7 @@ class DefaultNodeLabelIndexCursor extends IndexCursor<LabelScanValueIndexProgres
             read = null;
             removed = null;
 
-            if ( pool != null )
-            {
-                pool.accept( this );
-            }
+            pool.accept( this );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeLabelIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeLabelIndexCursor.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.impl.newapi;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.function.Consumer;
 
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
@@ -44,9 +43,9 @@ class DefaultNodeLabelIndexCursor extends IndexCursor<LabelScanValueIndexProgres
     private PrimitiveLongIterator added;
     private Set<Long> removed;
 
-    private final Consumer<DefaultNodeLabelIndexCursor> pool;
+    private final DefaultCursors pool;
 
-    DefaultNodeLabelIndexCursor( Consumer<DefaultNodeLabelIndexCursor> pool )
+    DefaultNodeLabelIndexCursor( DefaultCursors pool )
     {
         this.pool = pool;
         node = NO_ID;
@@ -179,5 +178,10 @@ class DefaultNodeLabelIndexCursor extends IndexCursor<LabelScanValueIndexProgres
     private boolean isRemoved( long reference )
     {
         return removed != null && removed.contains( reference );
+    }
+
+    public void release()
+    {
+        // nothing to do
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeValueIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeValueIndexCursor.java
@@ -200,10 +200,7 @@ final class DefaultNodeValueIndexCursor extends IndexCursor<IndexProgressor>
             this.added = emptyIterator();
             this.removed = PrimitiveLongCollections.emptySet();
 
-            if ( pool != null )
-            {
-                pool.accept( this );
-            }
+            pool.accept( this );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeValueIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeValueIndexCursor.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.impl.newapi;
 
 import java.util.Arrays;
-import java.util.function.Consumer;
 
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
@@ -52,9 +51,9 @@ final class DefaultNodeValueIndexCursor extends IndexCursor<IndexProgressor>
     private PrimitiveLongIterator added = emptyIterator();
     private PrimitiveLongSet removed = emptySet();
     private boolean needsValues;
-    private final Consumer<DefaultNodeValueIndexCursor> pool;
+    private final DefaultCursors pool;
 
-    DefaultNodeValueIndexCursor( Consumer<DefaultNodeValueIndexCursor> pool )
+    DefaultNodeValueIndexCursor( DefaultCursors pool )
     {
         this.pool = pool;
         node = NO_ID;
@@ -311,5 +310,10 @@ final class DefaultNodeValueIndexCursor extends IndexCursor<IndexProgressor>
         PrimitiveLongSet longSet = asSet( txState.addedAndRemovedNodes().getRemoved() );
         longSet.addAll( changes.getRemoved().iterator() );
         return longSet;
+    }
+
+    public void release()
+    {
+        // nothing to do
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeValueIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeValueIndexCursor.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.newapi;
 
 import java.util.Arrays;
+import java.util.function.Consumer;
 
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
@@ -51,9 +52,11 @@ final class DefaultNodeValueIndexCursor extends IndexCursor<IndexProgressor>
     private PrimitiveLongIterator added = emptyIterator();
     private PrimitiveLongSet removed = emptySet();
     private boolean needsValues;
+    private final Consumer<DefaultNodeValueIndexCursor> pool;
 
-    DefaultNodeValueIndexCursor()
+    DefaultNodeValueIndexCursor( Consumer<DefaultNodeValueIndexCursor> pool )
     {
+        this.pool = pool;
         node = NO_ID;
     }
 
@@ -187,13 +190,21 @@ final class DefaultNodeValueIndexCursor extends IndexCursor<IndexProgressor>
     @Override
     public void close()
     {
-        super.close();
-        this.node = NO_ID;
-        this.query = null;
-        this.values = null;
-        this.read = null;
-        this.added = emptyIterator();
-        this.removed = PrimitiveLongCollections.emptySet();
+        if ( !isClosed() )
+        {
+            super.close();
+            this.node = NO_ID;
+            this.query = null;
+            this.values = null;
+            this.read = null;
+            this.added = emptyIterator();
+            this.removed = PrimitiveLongCollections.emptySet();
+
+            if ( pool != null )
+            {
+                pool.accept( this );
+            }
+        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultPropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultPropertyCursor.java
@@ -254,10 +254,7 @@ public class DefaultPropertyCursor extends PropertyRecord implements PropertyCur
             page.close();
             page = null;
 
-            if ( pool != null )
-            {
-                pool.accept( this );
-            }
+            pool.accept( this );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipExplicitIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipExplicitIndexCursor.java
@@ -134,10 +134,7 @@ class DefaultRelationshipExplicitIndexCursor extends IndexCursor<ExplicitIndexPr
             expectedSize = 0;
             read = null;
 
-            if ( pool != null )
-            {
-                pool.accept( this );
-            }
+            pool.accept( this );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipExplicitIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipExplicitIndexCursor.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.newapi;
 
-import java.util.function.Consumer;
-
 import org.neo4j.internal.kernel.api.NodeCursor;
 import org.neo4j.internal.kernel.api.RelationshipExplicitIndexCursor;
 import org.neo4j.internal.kernel.api.RelationshipScanCursor;
@@ -36,9 +34,9 @@ class DefaultRelationshipExplicitIndexCursor extends IndexCursor<ExplicitIndexPr
     private long relationship;
     private float score;
 
-    private final Consumer<DefaultRelationshipExplicitIndexCursor> pool;
+    private final DefaultCursors pool;
 
-    DefaultRelationshipExplicitIndexCursor( Consumer<DefaultRelationshipExplicitIndexCursor> pool )
+    DefaultRelationshipExplicitIndexCursor( DefaultCursors pool )
     {
         this.pool = pool;
     }
@@ -156,5 +154,10 @@ class DefaultRelationshipExplicitIndexCursor extends IndexCursor<ExplicitIndexPr
             return "RelationshipExplicitIndexCursor[relationship=" + relationship + ", expectedSize=" + expectedSize + ", score=" + score +
                     " ,underlying record=" + super.toString() + " ]";
         }
+    }
+
+    public void release()
+    {
+        // nothing to do
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipExplicitIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipExplicitIndexCursor.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.newapi;
 
+import java.util.function.Consumer;
+
 import org.neo4j.internal.kernel.api.NodeCursor;
 import org.neo4j.internal.kernel.api.RelationshipExplicitIndexCursor;
 import org.neo4j.internal.kernel.api.RelationshipScanCursor;
@@ -33,6 +35,13 @@ class DefaultRelationshipExplicitIndexCursor extends IndexCursor<ExplicitIndexPr
     private int expectedSize;
     private long relationship;
     private float score;
+
+    private final Consumer<DefaultRelationshipExplicitIndexCursor> pool;
+
+    DefaultRelationshipExplicitIndexCursor( Consumer<DefaultRelationshipExplicitIndexCursor> pool )
+    {
+        this.pool = pool;
+    }
 
     @Override
     public void initialize( ExplicitIndexProgressor progressor, int expectedSize )
@@ -117,11 +126,19 @@ class DefaultRelationshipExplicitIndexCursor extends IndexCursor<ExplicitIndexPr
     @Override
     public void close()
     {
-        super.close();
-        relationship = NO_ID;
-        score = 0;
-        expectedSize = 0;
-        read = null;
+        if ( !isClosed() )
+        {
+            super.close();
+            relationship = NO_ID;
+            score = 0;
+            expectedSize = 0;
+            read = null;
+
+            if ( pool != null )
+            {
+                pool.accept( this );
+            }
+        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipGroupCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipGroupCursor.java
@@ -259,10 +259,7 @@ class DefaultRelationshipGroupCursor extends RelationshipGroupRecord implements 
             page.close();
             page = null;
 
-            if ( pool != null )
-            {
-                pool.accept( this );
-            }
+            pool.accept( this );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipGroupCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipGroupCursor.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.newapi;
 
-import java.util.function.Consumer;
-
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.collection.primitive.PrimitiveIntObjectMap;
@@ -46,7 +44,7 @@ class DefaultRelationshipGroupCursor extends RelationshipGroupRecord implements 
 {
     private Read read;
     private final RelationshipRecord edge = new RelationshipRecord( NO_ID );
-    private final Consumer<DefaultRelationshipGroupCursor> pool;
+    private final DefaultCursors pool;
 
     private BufferedGroup bufferedGroup;
     private PageCursor page;
@@ -55,7 +53,7 @@ class DefaultRelationshipGroupCursor extends RelationshipGroupRecord implements 
     private final PrimitiveIntSet txTypes = Primitive.intSet();
     private PrimitiveIntIterator txTypeIterator;
 
-    DefaultRelationshipGroupCursor( Consumer<DefaultRelationshipGroupCursor> pool )
+    DefaultRelationshipGroupCursor( DefaultCursors pool )
     {
         super( NO_ID );
         this.pool = pool;
@@ -243,23 +241,17 @@ class DefaultRelationshipGroupCursor extends RelationshipGroupRecord implements 
     @Override
     public void close()
     {
-        bufferedGroup = null;
-        read = null;
-        setId( NO_ID );
-        clear();
-
-        if ( edgePage != null )
+        if ( !isClosed() )
         {
-            edgePage.close();
-            edgePage = null;
-        }
+            bufferedGroup = null;
+            read = null;
+            setId( NO_ID );
+            clear();
 
-        if ( page != null )
-        {
-            page.close();
-            page = null;
-
-            pool.accept( this );
+            if ( pool != null )
+            {
+                pool.accept( this );
+            }
         }
     }
 
@@ -410,7 +402,7 @@ class DefaultRelationshipGroupCursor extends RelationshipGroupRecord implements 
     @Override
     public boolean isClosed()
     {
-        return page == null && bufferedGroup == null;
+        return read == null && bufferedGroup == null;
     }
 
     @Override
@@ -468,6 +460,21 @@ class DefaultRelationshipGroupCursor extends RelationshipGroupRecord implements 
     {
         assert relationshipId != NO_ID;
         return isBuffered() ? encodeForFiltering( relationshipId ) : encodeForTxStateFiltering( relationshipId );
+    }
+
+    public void release()
+    {
+        if ( edgePage != null )
+        {
+            edgePage.close();
+            edgePage = null;
+        }
+
+        if ( page != null )
+        {
+            page.close();
+            page = null;
+        }
     }
 
     static class BufferedGroup

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipScanCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipScanCursor.java
@@ -157,10 +157,7 @@ class DefaultRelationshipScanCursor extends RelationshipCursor implements Relati
             pageCursor.close();
             pageCursor = null;
 
-            if ( pool != null )
-            {
-                pool.accept( this );
-            }
+            pool.accept( this );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipScanCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipScanCursor.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.newapi;
 
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.neo4j.internal.kernel.api.RelationshipScanCursor;
 import org.neo4j.io.pagecache.PageCursor;
@@ -33,7 +34,14 @@ class DefaultRelationshipScanCursor extends RelationshipCursor implements Relati
     private long next;
     private long highMark;
     private PageCursor pageCursor;
-    Set<Long> addedRelationships;
+    private Set<Long> addedRelationships;
+
+    private final Consumer<DefaultRelationshipScanCursor> pool;
+
+    DefaultRelationshipScanCursor( Consumer<DefaultRelationshipScanCursor> pool )
+    {
+        this.pool = pool;
+    }
 
     void scan( int label, Read read )
     {
@@ -141,13 +149,19 @@ class DefaultRelationshipScanCursor extends RelationshipCursor implements Relati
     @Override
     public void close()
     {
+        read = null;
+        reset();
+
         if ( pageCursor != null )
         {
             pageCursor.close();
             pageCursor = null;
+
+            if ( pool != null )
+            {
+                pool.accept( this );
+            }
         }
-        read = null;
-        reset();
     }
 
     private void reset()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
@@ -183,7 +183,7 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
 
     /*
      * Grouped traversal of non-dense node. Same type and direction as first read relationship. Store relationships are
-     * all assumed to be of wanted relationship type and direction iff filterStore == true.
+     * all assumed to be of wanted relationship type and direction iff filterStore == false.
      */
     void filtered( long nodeReference, long reference, Read read, boolean filterStore )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
@@ -43,6 +43,7 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
 
     private enum FilterState
     {
+        // need filter, and need to read filter state from first store relationship
         NOT_INITIALIZED( RelationshipDirection.ERROR )
                 {
                     @Override
@@ -51,6 +52,7 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
                         throw new IllegalStateException( "Cannot call check on uninitialized filter" );
                     }
                 },
+        // allow only incoming relationships
         INCOMING( RelationshipDirection.INCOMING )
                 {
                     @Override
@@ -59,6 +61,7 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
                         return origin == target;
                     }
                 },
+        // allow only outgoing relationships
         OUTGOING( RelationshipDirection.OUTGOING )
                 {
                     @Override
@@ -67,6 +70,7 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
                         return origin == source;
                     }
                 },
+        // allow only loop relationships
         LOOP( RelationshipDirection.LOOP )
                 {
                     @Override
@@ -75,6 +79,7 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
                         return source == target;
                     }
                 },
+        // no filtering required
         NONE( RelationshipDirection.ERROR )
                 {
                     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.newapi;
 
+import java.util.function.Consumer;
+
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.internal.kernel.api.NodeCursor;
@@ -117,6 +119,7 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
     private Record buffer;
     private PageCursor pageCursor;
     private final DefaultRelationshipGroupCursor group;
+    private final Consumer<DefaultRelationshipTraversalCursor> pool;
     private GroupState groupState;
     private FilterState filterState;
     private boolean filterStore;
@@ -124,9 +127,10 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
 
     private PrimitiveLongIterator addedRelationships;
 
-    DefaultRelationshipTraversalCursor( DefaultRelationshipGroupCursor group )
+    DefaultRelationshipTraversalCursor( DefaultRelationshipGroupCursor group, Consumer<DefaultRelationshipTraversalCursor> pool )
     {
         this.group = group;
+        this.pool = pool;
     }
 
     /*
@@ -478,13 +482,19 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
     @Override
     public void close()
     {
+        read = null;
+        reset();
+
         if ( pageCursor != null )
         {
             pageCursor.close();
             pageCursor = null;
+
+            if ( pool != null )
+            {
+                pool.accept( this );
+            }
         }
-        read = null;
-        reset();
     }
 
     private void reset()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
@@ -490,10 +490,7 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
             pageCursor.close();
             pageCursor = null;
 
-            if ( pool != null )
-            {
-                pool.accept( this );
-            }
+            pool.accept( this );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
@@ -656,6 +656,8 @@ public class Operations implements Write, ExplicitIndexWrite
             propertyCursor.close();
             propertyCursor = null;
         }
+
+        cursors.release();
     }
 
     public Token token()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
@@ -656,6 +656,11 @@ public class Operations implements Write, ExplicitIndexWrite
             propertyCursor.close();
             propertyCursor = null;
         }
+        if ( relationshipCursor != null )
+        {
+            relationshipCursor.close();
+            relationshipCursor = null;
+        }
 
         cursors.release();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.newapi;
 
-import java.util.Set;
-
 import org.neo4j.internal.kernel.api.NodeCursor;
 import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.RelationshipDataAccessor;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
@@ -103,9 +103,8 @@ abstract class RelationshipCursor extends RelationshipRecord implements Relation
      */
     protected boolean hasChanges()
     {
-        switch ( hasChanges )
+        if ( hasChanges == HasChanges.MAYBE )
         {
-        case MAYBE:
             boolean changes = read.hasTxStateWithChanges();
             if ( changes )
             {
@@ -117,13 +116,9 @@ abstract class RelationshipCursor extends RelationshipRecord implements Relation
                 hasChanges = HasChanges.NO;
             }
             return changes;
-        case YES:
-            return true;
-        case NO:
-            return false;
-        default:
-            throw new IllegalStateException( "Style guide, why are you making me do this" );
         }
+
+        return hasChanges == HasChanges.YES;
     }
 
     // Load transaction state using RelationshipVisitor

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipReferenceEncoding.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipReferenceEncoding.java
@@ -44,6 +44,7 @@ enum RelationshipReferenceEncoding
     /** @see #encodeNoLoopRels(int) */
     NO_LOOP_OF_TYPE( 6 );
 
+    private static final RelationshipReferenceEncoding[] ENCODINGS = RelationshipReferenceEncoding.values();
     final long id;
     final long bits;
 
@@ -59,7 +60,7 @@ enum RelationshipReferenceEncoding
         {
             return NONE;
         }
-        return RelationshipReferenceEncoding.values()[encodingId( reference )];
+        return ENCODINGS[encodingId( reference )];
     }
 
     private static int encodingId( long reference )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.function.Supplier;
 
 import org.neo4j.graphdb.DatabaseShutdownException;
 import org.neo4j.graphdb.security.AuthorizationExpiredException;
@@ -588,7 +589,7 @@ public class KernelTransactionsTest
         return new KernelTransactions( statementLocksFactory, null, statementOperations, null, DEFAULT, commitProcess, null, null, new TransactionHooks(),
                 mock( TransactionMonitor.class ), availabilityGuard, tracers, storageEngine, new Procedures(), transactionIdStore, clock,
                 new AtomicReference<>( CpuClock.NOT_AVAILABLE ), new AtomicReference<>( HeapAllocation.NOT_AVAILABLE ), new CanWrite(),
-                new KernelToken( storageEngine.storeReadLayer() ), new DefaultCursors(), AutoIndexing.UNSUPPORTED,
+                new KernelToken( storageEngine.storeReadLayer() ), DefaultCursors::new, AutoIndexing.UNSUPPORTED,
                 mock( ExplicitIndexStore.class ), EmptyVersionContextSupplier.EMPTY );
     }
 
@@ -601,7 +602,7 @@ public class KernelTransactionsTest
                 null, DEFAULT,
                 commitProcess, null, null, new TransactionHooks(), mock( TransactionMonitor.class ),
                 availabilityGuard, tracers, storageEngine, new Procedures(), transactionIdStore, clock,
-                new CanWrite(), new KernelToken( storageEngine.storeReadLayer() ), new DefaultCursors(),
+                new CanWrite(), new KernelToken( storageEngine.storeReadLayer() ), DefaultCursors::new,
                         AutoIndexing.UNSUPPORTED, EmptyVersionContextSupplier.EMPTY );
     }
 
@@ -651,7 +652,7 @@ public class KernelTransactionsTest
                 ExplicitIndexProviderLookup explicitIndexProviderLookup, TransactionHooks hooks,
                 TransactionMonitor transactionMonitor, AvailabilityGuard availabilityGuard, Tracers tracers,
                 StorageEngine storageEngine, Procedures procedures, TransactionIdStore transactionIdStore, SystemNanoClock clock,
-                AccessCapability accessCapability, KernelToken token, DefaultCursors cursors,
+                AccessCapability accessCapability, KernelToken token, Supplier<DefaultCursors> cursors,
                 AutoIndexing autoIndexing, VersionContextSupplier versionContextSupplier  )
         {
             super( statementLocksFactory, constraintIndexCreator, statementOperations, schemaWriteGuard, txHeaderFactory, transactionCommitProcess,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueClientFilterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueClientFilterTest.java
@@ -48,6 +48,7 @@ public class NodeValueClientFilterTest implements IndexProgressor, NodeValueClie
     @Rule
     public final MockStore store = new MockStore( new DefaultCursors() );
     private final List<Event> events = new ArrayList<>();
+    private final DefaultCursors cursors = new DefaultCursors();
 
     @Test
     public void shouldAcceptAllNodesOnNoFilters()
@@ -135,7 +136,7 @@ public class NodeValueClientFilterTest implements IndexProgressor, NodeValueClie
     private NodeValueClientFilter initializeFilter( IndexQuery... filters )
     {
         NodeValueClientFilter filter = new NodeValueClientFilter(
-                this, new DefaultNodeCursor( null ), new DefaultPropertyCursor( null ), store, filters );
+                this, cursors.allocateNodeCursor(), cursors.allocatePropertyCursor(), store, filters );
         filter.initialize( IndexDescriptorFactory.forLabel( 11), this, null );
         return filter;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueClientFilterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueClientFilterTest.java
@@ -135,7 +135,7 @@ public class NodeValueClientFilterTest implements IndexProgressor, NodeValueClie
     private NodeValueClientFilter initializeFilter( IndexQuery... filters )
     {
         NodeValueClientFilter filter = new NodeValueClientFilter(
-                this, new DefaultNodeCursor(), new DefaultPropertyCursor(), store, filters );
+                this, new DefaultNodeCursor( null ), new DefaultPropertyCursor( null ), store, filters );
         filter.initialize( IndexDescriptorFactory.forLabel( 11), this, null );
         return filter;
     }


### PR DESCRIPTION
This PR contains several small optimizations and some bigger ones. Big ones are

 - Reuse Cursors in instance cache (single instance pool). 
 - Separate cursor close() and resource release into separate methods, so that resources and only released once the cursor is dropped from the pool. 
 - No unneeded txBridge interactions and statement acquires. 

The smaller optimizations were identified hotspots from async profiles. 

Beware that some code gets touched by several commits here, so unclear whether commit-by-commit or full-monkey would be the best review strategy.
