### PR TITLE
Increase timeout on fileMappedWithDeleteOnCloseMustNotLeakDirtyPages test.

### DIFF
--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -4142,7 +4142,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         };
     }
 
-    @Test( timeout = SHORT_TIMEOUT_MILLIS )
+    @Test( timeout = SEMI_LONG_TIMEOUT_MILLIS )
     public void fileMappedWithDeleteOnCloseMustNotLeakDirtyPages() throws Exception
     {
         configureStandardPageCache();


### PR DESCRIPTION
This test was normally taking several seconds on the build servers anyway, and occasionally exceeding the 10 second timeout.