### PR TITLE
3.1 Fixed bug RE:log rotation during backup recovery

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointerImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointerImpl.java
@@ -214,7 +214,7 @@ public class CheckPointerImpl extends LifecycleAdapter implements CheckPointer
             msgLog.info( prefix + " Check pointing completed" );
             /*
              * Prune up to the version pointed from the latest check point,
-             * since it might be an earlier version than the current log version.
+             * since it might be an earlier version than the current log version (tx could have been received during checkpoint).
              */
             logPruning.pruneLogs( logPosition.getLogVersion() );
             lastCheckPointedTx = lastClosedTransactionId;

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/DatabaseHealth.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/DatabaseHealth.java
@@ -27,8 +27,7 @@ import static org.neo4j.helpers.Exceptions.withCause;
 
 public class DatabaseHealth
 {
-    private static final String panicMessage = "Database has encountered some problem, "
-            + "please perform necessary action (tx recovery/restart)";
+    private static final String panicMessage = "Database has encountered some problem, please perform necessary action (tx recovery/restart)";
 
     // Keep that cozy name for legacy purposes
     private volatile boolean tmOk = true; // TODO rather skip volatile if possible here.

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -157,7 +157,7 @@ class BackupService
             storeCopier.copyStore(
                     storeCopyRequester,
                     CancellationRequest.NEVER_CANCELLED,
-                    MoveAfterCopy.moveReplaceExisting() );
+                    MoveAfterCopy.moveReplaceExisting(), false );
 
             bumpDebugDotLogFileVersion( targetDirectory, timestamp );
             boolean consistent = false;
@@ -187,7 +187,7 @@ class BackupService
             throw new RuntimeException( targetDirectory + " doesn't contain a database" );
         }
 
-        Map<String,String> temporaryDbConfig = getTemporaryDbConfig( config );
+        Map<String,String> temporaryDbConfig = getTemporaryDbConfig();
         config = config.with( temporaryDbConfig );
         try ( PageCache pageCache = createPageCache( new DefaultFileSystemAbstraction(), config ) )
         {
@@ -212,13 +212,12 @@ class BackupService
         }
     }
 
-    private Map<String,String> getTemporaryDbConfig( Config userConfig )
+    private Map<String,String> getTemporaryDbConfig()
     {
         Map<String,String> tempDbConfig = new HashMap<>();
         tempDbConfig.put( OnlineBackupSettings.online_backup_enabled.name(), Settings.FALSE );
-
-        // In case someone deleted the logical log from a full backup
         tempDbConfig.put( GraphDatabaseSettings.keep_logical_logs.name(), "1 txs" );
+        tempDbConfig.put( GraphDatabaseSettings.logical_log_rotation_threshold.name(), "1M" );
         return tempDbConfig;
     }
 

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -187,7 +187,7 @@ class BackupService
             throw new RuntimeException( targetDirectory + " doesn't contain a database" );
         }
 
-        Map<String,String> temporaryDbConfig = getTemporaryDbConfig();
+        Map<String,String> temporaryDbConfig = getTemporaryDbConfig( config );
         config = config.with( temporaryDbConfig );
         try ( PageCache pageCache = createPageCache( new DefaultFileSystemAbstraction(), config ) )
         {
@@ -212,12 +212,13 @@ class BackupService
         }
     }
 
-    private Map<String,String> getTemporaryDbConfig()
+    private Map<String,String> getTemporaryDbConfig( Config userConfig )
     {
         Map<String,String> tempDbConfig = new HashMap<>();
         tempDbConfig.put( OnlineBackupSettings.online_backup_enabled.name(), Settings.FALSE );
+
         // In case someone deleted the logical log from a full backup
-        tempDbConfig.put( GraphDatabaseSettings.keep_logical_logs.name(), Settings.TRUE );
+        tempDbConfig.put( GraphDatabaseSettings.keep_logical_logs.name(), "1 txs" );
         return tempDbConfig;
     }
 

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -217,7 +217,6 @@ class BackupService
         Map<String,String> tempDbConfig = new HashMap<>();
         tempDbConfig.put( OnlineBackupSettings.online_backup_enabled.name(), Settings.FALSE );
         tempDbConfig.put( GraphDatabaseSettings.keep_logical_logs.name(), "1 txs" );
-        tempDbConfig.put( GraphDatabaseSettings.logical_log_rotation_threshold.name(), "1M" );
         return tempDbConfig;
     }
 

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupImplTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupImplTest.java
@@ -61,13 +61,6 @@ public class BackupImplTest
 
     private static Supplier<StoreId> defaultStoreIdSupplier()
     {
-        return new Supplier<StoreId>()
-        {
-            @Override
-            public StoreId get()
-            {
-                return StoreId.DEFAULT;
-            }
-        };
+        return () -> StoreId.DEFAULT;
     }
 }

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
@@ -172,7 +172,7 @@ public class StoreCopyClient
     }
 
     public void copyStore( StoreCopyRequester requester, CancellationRequest cancellationRequest,
-                           MoveAfterCopy moveAfterCopy, boolean isProduction ) throws Exception
+                           MoveAfterCopy moveAfterCopy, boolean keepTxLogs ) throws Exception
     {
         // Create a temp directory (or clean if present)
         File tempStore = new File( storeDir, StoreUtil.TEMP_COPY_DIRECTORY_NAME );
@@ -205,7 +205,7 @@ public class StoreCopyClient
 
             // Run recovery, so that the transactions we just wrote into the active log will be applied.
             monitor.startRecoveringStore();
-            GraphDatabaseService graphDatabaseService = newTempDatabase( tempStore, isProduction );
+            GraphDatabaseService graphDatabaseService = newTempDatabase( tempStore, keepTxLogs );
             graphDatabaseService.shutdown();
             monitor.finishRecoveringStore();
 
@@ -335,7 +335,7 @@ public class StoreCopyClient
         }
     }
 
-    private GraphDatabaseService newTempDatabase( File tempStore, boolean isProduction )
+    private GraphDatabaseService newTempDatabase( File tempStore, boolean keepTxLogs )
     {
         ExternallyManagedPageCache.GraphDatabaseFactoryWithPageCacheFactory factory =
                 ExternallyManagedPageCache.graphDatabaseFactoryWithPageCache( pageCache );
@@ -345,7 +345,7 @@ public class StoreCopyClient
                 .newEmbeddedDatabaseBuilder( tempStore.getAbsoluteFile() )
                 .setConfig( "dbms.backup.enabled", Settings.FALSE )
                 .setConfig( GraphDatabaseSettings.logs_directory, tempStore.getAbsolutePath() )
-                .setConfig( GraphDatabaseSettings.keep_logical_logs, isProduction ? Settings.TRUE : Settings.FALSE )
+                .setConfig( GraphDatabaseSettings.keep_logical_logs, keepTxLogs ? Settings.TRUE : Settings.FALSE )
                 .setConfig( GraphDatabaseSettings.allow_store_upgrade,
                         config.get( GraphDatabaseSettings.allow_store_upgrade ).toString() )
                 .newGraphDatabase();

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 
 import org.neo4j.com.Response;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.CancellationRequest;
 import org.neo4j.helpers.collection.Visitor;
@@ -171,7 +172,7 @@ public class StoreCopyClient
     }
 
     public void copyStore( StoreCopyRequester requester, CancellationRequest cancellationRequest,
-                           MoveAfterCopy moveAfterCopy ) throws Exception
+                           MoveAfterCopy moveAfterCopy, boolean isProduction ) throws Exception
     {
         // Create a temp directory (or clean if present)
         File tempStore = new File( storeDir, StoreUtil.TEMP_COPY_DIRECTORY_NAME );
@@ -204,7 +205,7 @@ public class StoreCopyClient
 
             // Run recovery, so that the transactions we just wrote into the active log will be applied.
             monitor.startRecoveringStore();
-            GraphDatabaseService graphDatabaseService = newTempDatabase( tempStore );
+            GraphDatabaseService graphDatabaseService = newTempDatabase( tempStore, isProduction );
             graphDatabaseService.shutdown();
             monitor.finishRecoveringStore();
 
@@ -334,7 +335,7 @@ public class StoreCopyClient
         }
     }
 
-    private GraphDatabaseService newTempDatabase( File tempStore )
+    private GraphDatabaseService newTempDatabase( File tempStore, boolean isProduction )
     {
         ExternallyManagedPageCache.GraphDatabaseFactoryWithPageCacheFactory factory =
                 ExternallyManagedPageCache.graphDatabaseFactoryWithPageCache( pageCache );
@@ -344,7 +345,7 @@ public class StoreCopyClient
                 .newEmbeddedDatabaseBuilder( tempStore.getAbsoluteFile() )
                 .setConfig( "dbms.backup.enabled", Settings.FALSE )
                 .setConfig( GraphDatabaseSettings.logs_directory, tempStore.getAbsolutePath() )
-                .setConfig( GraphDatabaseSettings.keep_logical_logs, Settings.TRUE )
+                .setConfig( GraphDatabaseSettings.keep_logical_logs, isProduction ? Settings.TRUE : Settings.FALSE )
                 .setConfig( GraphDatabaseSettings.allow_store_upgrade,
                         config.get( GraphDatabaseSettings.allow_store_upgrade ).toString() )
                 .newGraphDatabase();

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
@@ -122,7 +122,7 @@ public class StoreCopyClientTest
                 spy( new LocalStoreCopyRequester( original, originalDir, fs ) );
 
         // when
-        copier.copyStore( storeCopyRequest, cancelStoreCopy::get, MoveAfterCopy.moveReplaceExisting() );
+        copier.copyStore( storeCopyRequest, cancelStoreCopy::get, MoveAfterCopy.moveReplaceExisting(), false );
 
         // Then
         GraphDatabaseService copy = startDatabase( copyDir );
@@ -167,7 +167,7 @@ public class StoreCopyClientTest
         final GraphDatabaseAPI original = (GraphDatabaseAPI) startDatabase( originalDir, recordFormatsName );
         StoreCopyClient.StoreCopyRequester storeCopyRequest = new LocalStoreCopyRequester( original, originalDir, fs );
 
-        copier.copyStore( storeCopyRequest, CancellationRequest.NEVER_CANCELLED, MoveAfterCopy.moveReplaceExisting() );
+        copier.copyStore( storeCopyRequest, CancellationRequest.NEVER_CANCELLED, MoveAfterCopy.moveReplaceExisting(), false );
 
         assertFalse( new File( copyDir, TEMP_COPY_DIRECTORY_NAME ).exists() );
 
@@ -211,7 +211,7 @@ public class StoreCopyClientTest
                 spy( new LocalStoreCopyRequester( original, originalDir, fs ) );
 
         // when
-        copier.copyStore( storeCopyRequest, cancelStoreCopy::get, MoveAfterCopy.moveReplaceExisting() );
+        copier.copyStore( storeCopyRequest, cancelStoreCopy::get, MoveAfterCopy.moveReplaceExisting(), false );
 
         // Then
         GraphDatabaseService copy = startDatabase( copyDir );
@@ -250,7 +250,7 @@ public class StoreCopyClientTest
                 new LocalStoreCopyRequester( (GraphDatabaseAPI) initialDatabase, initialStore, fs );
 
         // WHEN
-        copier.copyStore( storeCopyRequest, falseCancellationRequest, MoveAfterCopy.moveReplaceExisting() );
+        copier.copyStore( storeCopyRequest, falseCancellationRequest, MoveAfterCopy.moveReplaceExisting(), false );
 
         // THEN
         long updatedTransactionOffset =
@@ -289,7 +289,7 @@ public class StoreCopyClientTest
         // WHEN
         try
         {
-            copier.copyStore( storeCopyRequest, falseCancellationRequest, MoveAfterCopy.moveReplaceExisting() );
+            copier.copyStore( storeCopyRequest, falseCancellationRequest, MoveAfterCopy.moveReplaceExisting(), false );
             fail( "should have thrown " );
         }
         catch ( RuntimeException ex )

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
@@ -542,7 +542,7 @@ public abstract class SwitchToSlave
                 moveAfterCopy.move( moves, fromDirectory, toDirectory );
             };
             storeCopyClient.copyStore(
-                    requester, cancellationRequest, moveAfterCopyWithLogging );
+                    requester, cancellationRequest, moveAfterCopyWithLogging, false );
 
             startServicesAgain();
             userLog.info( "Finished copying store from master" );

--- a/enterprise/ha/src/test/java/org/neo4j/ha/BackupHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/BackupHaIT.java
@@ -67,7 +67,7 @@ public class BackupHaIT
                 backupPath, "basic" ) ) );
 
         // Add some new data
-        DbRepresentation afterChange = createSomeData( cluster.getMaster() );
+        DbRepresentation afterChange = createSomeData( cluster.getMaster() ).get();
         cluster.sync();
 
         // Verify that backed up database can be started and compare representation
@@ -90,7 +90,7 @@ public class BackupHaIT
                     backupPath, "anyinstance" ) ) );
 
             // Add some new data
-            DbRepresentation afterChange = createSomeData( cluster.getMaster() );
+            DbRepresentation afterChange = createSomeData( cluster.getMaster() ).get();
             cluster.sync();
 
             // Verify that old data is back

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveBranchThenCopyTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveBranchThenCopyTest.java
@@ -84,6 +84,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
@@ -120,7 +121,8 @@ public class SwitchToSlaveBranchThenCopyTest
         doThrow( new RuntimeException() ).doNothing().when( storeCopyClient ).copyStore(
                 any( StoreCopyClient.StoreCopyRequester.class ),
                 any( CancellationRequest.class ),
-                any( MoveAfterCopy.class ) );
+                any( MoveAfterCopy.class ),
+                anyBoolean() );
 
         SwitchToSlaveBranchThenCopy switchToSlave = newSwitchToSlaveSpy( pageCacheMock, storeCopyClient );
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveCopyThenBranchTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveCopyThenBranchTest.java
@@ -236,7 +236,8 @@ public class SwitchToSlaveCopyThenBranchTest
         } ).when( storeCopyClient ).copyStore(
                 any( StoreCopyClient.StoreCopyRequester.class ),
                 any( CancellationRequest.class ),
-                any( MoveAfterCopy.class ), any() );
+                any( MoveAfterCopy.class ),
+                anyBoolean() );
 
         PageCache pageCacheMock = mock( PageCache.class );
         PagedFile pagedFileMock = mock( PagedFile.class );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveCopyThenBranchTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveCopyThenBranchTest.java
@@ -86,6 +86,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
@@ -122,7 +123,8 @@ public class SwitchToSlaveCopyThenBranchTest
         doThrow( new RuntimeException() ).doNothing().when( storeCopyClient ).copyStore(
                 any( StoreCopyClient.StoreCopyRequester.class ),
                 any( CancellationRequest.class ),
-                any( MoveAfterCopy.class ) );
+                any( MoveAfterCopy.class ),
+                anyBoolean() );
 
         SwitchToSlaveCopyThenBranch switchToSlave = newSwitchToSlaveSpy( pageCacheMock, storeCopyClient );
 
@@ -234,7 +236,7 @@ public class SwitchToSlaveCopyThenBranchTest
         } ).when( storeCopyClient ).copyStore(
                 any( StoreCopyClient.StoreCopyRequester.class ),
                 any( CancellationRequest.class ),
-                any( MoveAfterCopy.class ) );
+                any( MoveAfterCopy.class ), any() );
 
         PageCache pageCacheMock = mock( PageCache.class );
         PagedFile pagedFileMock = mock( PagedFile.class );
@@ -262,7 +264,7 @@ public class SwitchToSlaveCopyThenBranchTest
         InOrder inOrder = Mockito.inOrder( storeCopyClient, branchPolicy );
 
         inOrder.verify( storeCopyClient ).copyStore( any( StoreCopyClient.StoreCopyRequester.class ),
-                any( CancellationRequest.class ), any( MoveAfterCopy.class ) ) ;
+                any( CancellationRequest.class ), any( MoveAfterCopy.class ), anyBoolean() ) ;
         inOrder.verify( branchPolicy ).handle( new File(""), pageCacheMock, NullLogService.getInstance() );
     }
 


### PR DESCRIPTION
Logs are not removed during backup recovery.

This reduces the rotation policy on backups and adds a flag to network code to retain or prune transaction file logs that are being populated during catchup/incremental backup. 