### PR TITLE
Handle active tx state from Cypher

### DIFF
--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ActiveRead.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/ActiveRead.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.v3_4.logical.plans
+
+import org.neo4j.cypher.internal.util.v3_4.attribution.IdGen
+
+/**
+  * Change the reads of all source plans to target the active tx-state instead of the stable. This is used for MERGE
+  * to make sure that each merge row can observe the writes of previous rows.
+  */
+case class ActiveRead(source: LogicalPlan)(implicit idGen: IdGen) extends LogicalPlan(idGen) with LazyLogicalPlan {
+
+  val lhs = Some(source)
+  val rhs = None
+
+  override val availableSymbols: Set[String] = source.availableSymbols
+}

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Eager.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Eager.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.v3_4.logical.plans
 import org.neo4j.cypher.internal.util.v3_4.attribution.IdGen
 
 /**
-  * Consumes and buffers all source rows, and then produces them.
+  * Consumes and buffers all source rows, marks the transaction as stable, and then produces all rows.
   */
 case class Eager(source: LogicalPlan)(implicit idGen: IdGen) extends LogicalPlan(idGen) with EagerLogicalPlan {
 

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/LogicalPlanProducer.scala
@@ -318,6 +318,11 @@ case class LogicalPlanProducer(cardinalityModel: CardinalityModel, solveds: Solv
     annotate(Optional(inputPlan, ids), solved, context)
   }
 
+  def planActiveRead(inputPlan: LogicalPlan, context: LogicalPlanningContext): LogicalPlan = {
+    val solved = solveds.get(inputPlan.id)
+    annotate(ActiveRead(inputPlan), solved, context)
+  }
+
   def planLeftOuterHashJoin(nodes: Set[String], left: LogicalPlan, right: LogicalPlan, hints: Set[UsingJoinHint], context: LogicalPlanningContext): LogicalPlan = {
     val solved = solveds.get(left.id).amendQueryGraph(_.withAddedOptionalMatch(solveds.get(right.id).queryGraph.addHints(hints)))
     annotate(LeftOuterHashJoin(nodes, left, right), solved, context)

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/MergeNodePlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/MergeNodePlanningIntegrationTest.scala
@@ -31,7 +31,7 @@ class MergeNodePlanningIntegrationTest extends CypherFunSuite with LogicalPlanni
 
   test("should plan single merge node") {
     val allNodesScan = AllNodesScan(aId, Set.empty)
-    val optional = Optional(allNodesScan)
+    val optional = Optional(ActiveRead(allNodesScan))
     val onCreate = MergeCreateNode(Argument(), aId, Seq.empty, None)
 
     val mergeNode = AntiConditionalApply(optional, onCreate, Seq(aId))
@@ -43,7 +43,7 @@ class MergeNodePlanningIntegrationTest extends CypherFunSuite with LogicalPlanni
   test("should plan single merge node from a label scan") {
 
     val labelScan = NodeByLabelScan(aId, lblName("X"), Set.empty)
-    val optional = Optional(labelScan)
+    val optional = Optional(ActiveRead(labelScan))
     val onCreate = MergeCreateNode(Argument(), aId, Seq(lblName("X")), None)
 
     val mergeNode = AntiConditionalApply(optional, onCreate, Seq(aId))
@@ -63,7 +63,7 @@ class MergeNodePlanningIntegrationTest extends CypherFunSuite with LogicalPlanni
     val propertyValue = SignedDecimalIntegerLiteral("42")(pos)
     val selection = Selection(Seq(In(Property(Variable("a")(pos), propertyKeyName)(pos),
                                      ListLiteral(Seq(propertyValue))(pos))(pos)), allNodesScan)
-    val optional = Optional(selection)
+    val optional = Optional(ActiveRead(selection))
 
     val onCreate = MergeCreateNode(Argument(), aId, Seq.empty,
       Some(MapExpression(List((PropertyKeyName("prop")(pos),
@@ -78,7 +78,7 @@ class MergeNodePlanningIntegrationTest extends CypherFunSuite with LogicalPlanni
   test("should plan create followed by merge") {
     val createNode = CreateNode(Argument(), aId, Seq.empty, None)
     val allNodesScan = AllNodesScan(bId, Set.empty)
-    val optional = Optional(allNodesScan)
+    val optional = Optional(ActiveRead(allNodesScan))
     val onCreate = MergeCreateNode(Argument(), bId, Seq.empty, None)
     val mergeNode = AntiConditionalApply(optional, onCreate, Seq(bId))
     val apply = Apply(createNode, mergeNode)
@@ -89,7 +89,7 @@ class MergeNodePlanningIntegrationTest extends CypherFunSuite with LogicalPlanni
 
   test("should plan merge followed by create") {
     val allNodesScan = AllNodesScan(aId, Set.empty)
-    val optional = Optional(allNodesScan)
+    val optional = Optional(ActiveRead(allNodesScan))
     val onCreate = MergeCreateNode(Argument(), aId, Seq.empty, None)
     val mergeNode = AntiConditionalApply(optional, onCreate, Seq(aId))
     val eager = Eager(mergeNode)
@@ -133,7 +133,7 @@ class MergeNodePlanningIntegrationTest extends CypherFunSuite with LogicalPlanni
    */
   test("should plan merge node with on create and on match ") {
     val allNodesScan = AllNodesScan(aId, Set.empty)
-    val optional = Optional(allNodesScan)
+    val optional = Optional(ActiveRead(allNodesScan))
     val argument1 = Argument(Set(aId))
     val setLabels = SetLabels(argument1, aId, Seq(lblName("L")))
     val onMatch = ConditionalApply(optional, setLabels, Seq(aId))

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/MergeRelationshipPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/MergeRelationshipPlanningIntegrationTest.scala
@@ -36,7 +36,7 @@ class MergeRelationshipPlanningIntegrationTest extends CypherFunSuite with Logic
     val nodeByLabelScan = NodeByLabelScan(aId, LabelName("A")(pos), Set.empty)
     val expand = Expand(nodeByLabelScan, aId, OUTGOING, Seq(RelTypeName("R")(pos)), bId, rId)
 
-    val optional = Optional(expand)
+    val optional = Optional(ActiveRead(expand))
     val argument = Argument()
     val createNodeA = MergeCreateNode(argument, aId, Seq(LabelName("A")(pos)), None)
     val createNodeB = MergeCreateNode(createNodeA, bId, Seq.empty, None)
@@ -56,7 +56,7 @@ class MergeRelationshipPlanningIntegrationTest extends CypherFunSuite with Logic
     val selection = Selection(Seq(In(Property(Variable("a")(pos), PropertyKeyName("p")(pos))(pos), ListLiteral(Seq(Variable("arg")(pos)))(pos))(pos)), nodeByLabelScan)
     val expand = Expand(selection, aId, OUTGOING, Seq(RelTypeName("R")(pos)), bId, rId)
 
-    val optional = Optional(expand, Set(argId))
+    val optional = Optional(ActiveRead(expand), Set(argId))
     val argument = Argument(Set(argId))
     val createNodeA = MergeCreateNode(argument, aId, Seq(LabelName("A")(pos)), Some(MapExpression(Seq((PropertyKeyName("p")(pos), Variable("arg")(pos))))(pos)))
     val createNodeB = MergeCreateNode(createNodeA, bId, Seq.empty, None)
@@ -97,14 +97,16 @@ class MergeRelationshipPlanningIntegrationTest extends CypherFunSuite with Logic
           AntiConditionalApply(
             AntiConditionalApply(
               Optional(
-                Expand(
-                  Argument(Set("n")),
-                  "n", OUTGOING, List(RelTypeName("T")(pos)), "b", "r", ExpandAll),
+                ActiveRead(
+                  Expand(
+                    Argument(Set("n")),
+                    "n", OUTGOING, List(RelTypeName("T")(pos)), "b", "r", ExpandAll)),
                 Set("n")),
               Optional(
-                Expand(
-                  LockNodes(Argument(Set("n")), Set("n")),
-                  "n", OUTGOING, List(RelTypeName("T")(pos)), "b", "r", ExpandAll),
+                ActiveRead(
+                  Expand(
+                    LockNodes(Argument(Set("n")), Set("n")),
+                    "n", OUTGOING, List(RelTypeName("T")(pos)), "b", "r", ExpandAll)),
                 Set("n")),
               Seq("b", "r")),
             MergeCreateRelationship(
@@ -129,16 +131,18 @@ class MergeRelationshipPlanningIntegrationTest extends CypherFunSuite with Logic
         AntiConditionalApply(
           AntiConditionalApply(
             Optional(
-              Expand(
-                Argument(Set("n", "m")),
-                "n", OUTGOING, List(RelTypeName("T")(pos)), "m", "r", ExpandInto),
+              ActiveRead(
+                Expand(
+                  Argument(Set("n", "m")),
+                  "n", OUTGOING, List(RelTypeName("T")(pos)), "m", "r", ExpandInto)),
               Set("n", "m")),
             Optional(
-              Expand(
-                LockNodes(
-                  Argument(Set("n", "m")),
-                  Set("n", "m")),
-                "n", OUTGOING, List(RelTypeName("T")(pos)), "m", "r", ExpandInto),
+              ActiveRead(
+                Expand(
+                  LockNodes(
+                    Argument(Set("n", "m")),
+                    Set("n", "m")),
+                  "n", OUTGOING, List(RelTypeName("T")(pos)), "m", "r", ExpandInto)),
               Set("n", "m")),
             Vector("r")),
           MergeCreateRelationship(
@@ -164,16 +168,18 @@ class MergeRelationshipPlanningIntegrationTest extends CypherFunSuite with Logic
           AntiConditionalApply(
             AntiConditionalApply(
               Optional(
-                Expand(
-                  Argument(Set("a", "b")),
-                  "a", OUTGOING, List(RelTypeName("T")(pos)), "b", "r", ExpandInto),
+                ActiveRead(
+                  Expand(
+                    Argument(Set("a", "b")),
+                    "a", OUTGOING, List(RelTypeName("T")(pos)), "b", "r", ExpandInto)),
                 Set("a", "b")
               ),
               Optional(
-                Expand(
-                  LockNodes(
-                    Argument(Set("a", "b")), Set("a", "b")),
-                  "a", OUTGOING, List(RelTypeName("T")(pos)), "b", "r", ExpandInto),
+                ActiveRead(
+                  Expand(
+                    LockNodes(
+                      Argument(Set("a", "b")), Set("a", "b")),
+                    "a", OUTGOING, List(RelTypeName("T")(pos)), "b", "r", ExpandInto)),
                 Set("a", "b")
               ),
               Vector("r")),
@@ -197,15 +203,17 @@ class MergeRelationshipPlanningIntegrationTest extends CypherFunSuite with Logic
           AntiConditionalApply(
             AntiConditionalApply(
               Optional(
-                Expand(
-                  Argument(Set("a")),
-                  "a", OUTGOING, List(RelTypeName("T")(pos)), "b", "r", ExpandAll),
+                ActiveRead(
+                  Expand(
+                    Argument(Set("a")),
+                    "a", OUTGOING, List(RelTypeName("T")(pos)), "b", "r", ExpandAll)),
                 Set("a")
               ),
               Optional(
-                Expand(
-                  LockNodes(Argument(Set("a")), Set("a")),
-                  "a", OUTGOING, List(RelTypeName("T")(pos)), "b", "r", ExpandAll),
+                ActiveRead(
+                  Expand(
+                    LockNodes(Argument(Set("a")), Set("a")),
+                    "a", OUTGOING, List(RelTypeName("T")(pos)), "b", "r", ExpandAll)),
                 Set("a")
               ),
               Seq("b", "r")),

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/ExceptionTranslatingQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/ExceptionTranslatingQueryContext.scala
@@ -41,6 +41,8 @@ class ExceptionTranslatingQueryContext(val inner: QueryContext) extends QueryCon
 
   override def entityAccessor: EmbeddedProxySPI = inner.entityAccessor
 
+  override def withActiveRead: QueryContext = inner.withActiveRead
+
   override def resources: CloseableResource = inner.resources
 
   override def transactionalContext =

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/CommunityPipeBuilder.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/CommunityPipeBuilder.scala
@@ -160,6 +160,9 @@ case class CommunityPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe
         VarLengthExpandPipe(source, fromName, relName, toName, dir, projectedDir,
           LazyTypes(types.toArray), min, max, nodeInScope, predicate)(id = id)
 
+      case ActiveRead(_) =>
+        ActiveReadPipe(source)(id = id)
+
       case Optional(inner, protectedSymbols) =>
         OptionalPipe((inner.availableSymbols -- protectedSymbols), source)(id = id)
 

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/DelegatingQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/DelegatingQueryContext.scala
@@ -302,6 +302,8 @@ class DelegatingQueryTransactionalContext(val inner: QueryTransactionalContext) 
 
   override def stableDataRead: Read = inner.stableDataRead
 
+  override def markAsStable(): Unit = inner.markAsStable()
+
   override def tokenRead: TokenRead = inner.tokenRead
 
   override def schemaRead: SchemaRead = inner.schemaRead

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/DelegatingQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/DelegatingQueryContext.scala
@@ -53,6 +53,8 @@ abstract class DelegatingQueryContext(val inner: QueryContext) extends QueryCont
 
   override def entityAccessor: EmbeddedProxySPI = inner.entityAccessor
 
+  override def withActiveRead: QueryContext = inner.withActiveRead
+
   override def setLabelsOnNode(node: Long, labelIds: Iterator[Int]): Int =
     singleDbHit(inner.setLabelsOnNode(node, labelIds))
 
@@ -297,6 +299,8 @@ class DelegatingQueryTransactionalContext(val inner: QueryTransactionalContext) 
   override def cursors: CursorFactory = inner.cursors
 
   override def dataRead: Read = inner.dataRead
+
+  override def stableDataRead: Read = inner.stableDataRead
 
   override def tokenRead: TokenRead = inner.tokenRead
 

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionalContextWrapper.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionalContextWrapper.scala
@@ -57,6 +57,8 @@ case class TransactionalContextWrapper(tc: TransactionalContext) extends QueryTr
 
   override def dataRead: Read = tc.kernelTransaction().dataRead()
 
+  override def stableDataRead: Read = tc.kernelTransaction().stableDataRead()
+
   override def tokenRead: TokenRead = tc.kernelTransaction().tokenRead()
 
   override def schemaRead: SchemaRead = tc.kernelTransaction().schemaRead()

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionalContextWrapper.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionalContextWrapper.scala
@@ -59,6 +59,8 @@ case class TransactionalContextWrapper(tc: TransactionalContext) extends QueryTr
 
   override def stableDataRead: Read = tc.kernelTransaction().stableDataRead()
 
+  override def markAsStable(): Unit = tc.kernelTransaction().markAsStable()
+
   override def tokenRead: TokenRead = tc.kernelTransaction().tokenRead()
 
   override def schemaRead: SchemaRead = tc.kernelTransaction().schemaRead()

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ActiveReadPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ActiveReadPipe.scala
@@ -25,9 +25,10 @@ import org.neo4j.cypher.internal.util.v3_4.attribution.Id
 case class ActiveReadPipe(source: Pipe)(val id: Id = Id.INVALID_ID) extends Pipe {
 
   override def createResults(state: QueryState): Iterator[ExecutionContext] = {
-    val sourceResult = source.createResults(state)
+    val activeState = state.withQueryContext(state.query.withActiveRead)
+    val sourceResult = source.createResults(activeState)
 
-    val decoratedState = state.decorator.decorate(this, state)
+    state.decorator.decorate(this, state)
     state.decorator.decorate(this, sourceResult)
   }
 

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ActiveReadPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ActiveReadPipe.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.runtime.interpreted.pipes
+
+import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
+import org.neo4j.cypher.internal.util.v3_4.attribution.Id
+
+case class ActiveReadPipe(source: Pipe)(val id: Id = Id.INVALID_ID) extends Pipe {
+
+  override def createResults(state: QueryState): Iterator[ExecutionContext] = {
+    val sourceResult = source.createResults(state)
+
+    val decoratedState = state.decorator.decorate(this, state)
+    state.decorator.decorate(this, sourceResult)
+  }
+
+  override protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] =
+    throw new UnsupportedOperationException("This method should never be called on ActiveReadPipe")
+}

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/EagerPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/EagerPipe.scala
@@ -25,6 +25,9 @@ import org.neo4j.cypher.internal.util.v3_4.attribution.Id
 case class EagerPipe(src: Pipe)(val id: Id = Id.INVALID_ID)
   extends PipeWithSource(src) {
 
-  protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] =
-    input.toIndexedSeq.toIterator
+  protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
+    val buffer = input.toIndexedSeq
+    state.query.transactionalContext.markAsStable()
+    buffer.toIterator
+  }
 }

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/QueryContextAdaptation.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/QueryContextAdaptation.scala
@@ -82,6 +82,8 @@ trait QueryContextAdaptation {
 
   override def entityAccessor: EmbeddedProxySPI = ???
 
+  override def withActiveRead: QueryContext = ???
+
   override def resources: CloseableResource = ???
 
   override def getOrCreatePropertyKeyId(propertyKey: String): Int = ???

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryContext.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryContext.scala
@@ -248,6 +248,8 @@ trait QueryTransactionalContext extends CloseableResource {
 
   def stableDataRead: Read
 
+  def markAsStable(): Unit
+
   def tokenRead: TokenRead
 
   def schemaRead: SchemaRead

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryContext.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryContext.scala
@@ -58,6 +58,8 @@ trait QueryContext extends TokenContext {
 
   def transactionalContext: QueryTransactionalContext
 
+  def withActiveRead: QueryContext
+
   def resources: CloseableResource
 
   def nodeOps: Operations[NodeValue]
@@ -243,6 +245,8 @@ trait QueryTransactionalContext extends CloseableResource {
   def cursors : CursorFactory
 
   def dataRead: Read
+
+  def stableDataRead: Read
 
   def tokenRead: TokenRead
 

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/planDescription/LogicalPlan2PlanDescription.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/planDescription/LogicalPlan2PlanDescription.scala
@@ -228,6 +228,9 @@ case class LogicalPlan2PlanDescription(readOnly: Boolean, cardinalities: Cardina
       case _: MergeCreateRelationship =>
         PlanDescriptionImpl(id, "MergeCreateRelationship", children, Seq.empty, variables)
 
+      case _: ActiveRead =>
+        PlanDescriptionImpl(id, "ActiveRead", children, Seq.empty, variables)
+
       case _: Optional =>
         PlanDescriptionImpl(id, "Optional", children, Seq.empty, variables)
 

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
@@ -338,7 +338,8 @@ object SlotAllocation {
            _: Limit |
            _: Skip |
            _: Sort |
-           _: Top
+           _: Top |
+           _: ActiveRead
       =>
         source
 


### PR DESCRIPTION
To support the 2-layer tx-state, this PR injects a new logical plan operator: `ActiveRead`. 

This logical plan operator ensures that all source reads are performed on
the active tx layer. This means that any writes are immediately visible
without the need for a Transaction#markAsStable call, and is used in
the read part of merge plans to ensure that different rows in the same
merge clause see previous writes.

Further the `Eager` operator is augmented to mark the transaction as stable after buffering all source rows.