### PR TITLE
Fix default value lookup in config to return the original string

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
@@ -596,8 +596,8 @@ public class Config implements DiagnosticsProvider, Configuration
 
         synchronized ( params )
         {
-            boolean oldDefault = false;
-            boolean newDefault = false;
+            boolean oldValueIsDefault = false;
+            boolean newValueIsDefault = false;
             String oldValue;
             String newValue;
             if ( update == null || update.isEmpty() )
@@ -607,7 +607,7 @@ public class Config implements DiagnosticsProvider, Configuration
                 boolean hasDefault = overriddenDefault != null;
                 oldValue = hasDefault ? params.put( setting, overriddenDefault ) : params.remove( setting );
                 newValue = getDefaultValueOf( setting );
-                newDefault = true;
+                newValueIsDefault = true;
             }
             else
             {
@@ -621,16 +621,21 @@ public class Config implements DiagnosticsProvider, Configuration
                     validator.validate( newEntry, ignore -> {} ); // Throws if invalid
                 }
 
-                oldValue = getDefaultValueOf( setting );
-                if ( params.put( setting, update ) == null )
+                String previousValue = params.put( setting, update );
+                if ( previousValue != null )
                 {
-                    oldDefault = true;
+                    oldValue = previousValue;
+                }
+                else
+                {
+                    oldValue = getDefaultValueOf( setting );
+                    oldValueIsDefault = true;
                 }
                 newValue = update;
             }
             log.info( "Setting changed: '%s' changed from '%s' to '%s'",
-                    setting, oldDefault ? "default (" + oldValue + ")" : oldValue,
-                    newDefault ? "default (" + newValue + ")" : newValue );
+                    setting, oldValueIsDefault ? "default (" + oldValue + ")" : oldValue,
+                    newValueIsDefault ? "default (" + newValue + ")" : newValue );
             updateListeners.getOrDefault( setting, emptyList() ).forEach( l -> l.accept( oldValue, newValue ) );
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
@@ -44,6 +44,7 @@ import javax.annotation.Nullable;
 import org.neo4j.configuration.ConfigOptions;
 import org.neo4j.configuration.ConfigValue;
 import org.neo4j.configuration.LoadableConfig;
+import org.neo4j.graphdb.config.BaseSetting;
 import org.neo4j.graphdb.config.Configuration;
 import org.neo4j.graphdb.config.InvalidSettingException;
 import org.neo4j.graphdb.config.Setting;
@@ -85,6 +86,7 @@ public class Config implements DiagnosticsProvider, Configuration
     private final ConfigurationMigrator migrator;
     private final List<ConfigurationValidator> validators = new ArrayList<>();
     private final Map<String,String> overriddenDefaults = new CopyOnWriteHashMap<>();
+    private final Map<String,BaseSetting<?>> settingsMap; // Only contains fixed settings and not groups
 
     // Messages to this log get replayed into a real logger once logging has been instantiated.
     private Log log = new BufferingLog();
@@ -381,6 +383,13 @@ public class Config implements DiagnosticsProvider, Configuration
                 .flatMap( List::stream )
                 .collect( Collectors.toList() );
 
+        settingsMap = new HashMap<>();
+        configOptions.stream()
+                .map( ConfigOptions::settingGroup )
+                .filter( BaseSetting.class::isInstance )
+                .map( BaseSetting.class::cast )
+                .forEach( setting -> settingsMap.put( setting.name(), setting ) );
+
         validators.addAll( additionalValidators );
         migrator = new AnnotationBasedConfigurationMigrator( settingsClasses );
         this.overriddenDefaults.putAll( overriddenDefaults );
@@ -587,6 +596,8 @@ public class Config implements DiagnosticsProvider, Configuration
 
         synchronized ( params )
         {
+            boolean oldDefault = false;
+            boolean newDefault = false;
             String oldValue;
             String newValue;
             if ( update == null || update.isEmpty() )
@@ -596,6 +607,7 @@ public class Config implements DiagnosticsProvider, Configuration
                 boolean hasDefault = overriddenDefault != null;
                 oldValue = hasDefault ? params.put( setting, overriddenDefault ) : params.remove( setting );
                 newValue = getDefaultValueOf( setting );
+                newDefault = true;
             }
             else
             {
@@ -610,10 +622,15 @@ public class Config implements DiagnosticsProvider, Configuration
                 }
 
                 oldValue = getDefaultValueOf( setting );
-                params.put( setting, update );
+                if ( params.put( setting, update ) == null )
+                {
+                    oldDefault = true;
+                }
                 newValue = update;
             }
-            log.info( "Setting changed: '%s' changed from '%s' to '%s'", setting, oldValue, newValue );
+            log.info( "Setting changed: '%s' changed from '%s' to '%s'",
+                    setting, oldDefault ? "default (" + oldValue + ")" : oldValue,
+                    newDefault ? "default (" + newValue + ")" : newValue );
             updateListeners.getOrDefault( setting, emptyList() ).forEach( l -> l.accept( oldValue, newValue ) );
         }
     }
@@ -636,7 +653,15 @@ public class Config implements DiagnosticsProvider, Configuration
 
     private String getDefaultValueOf( String setting )
     {
-        return getValue( setting ).map( Object::toString ).orElse( "<no default>" );
+        if ( overriddenDefaults.containsKey( setting ) )
+        {
+            return overriddenDefaults.get( setting );
+        }
+        if ( settingsMap.containsKey( setting ) )
+        {
+            return settingsMap.get( setting ).getDefaultValue();
+        }
+        return "<no default>";
     }
 
     private Optional<ConfigValue> findConfigValue( String setting )

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/ConfigTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/ConfigTest.java
@@ -384,9 +384,9 @@ public class ConfigTest
         config.updateDynamicSetting( settingName, "" );
 
         InOrder order = inOrder( log );
-        order.verify( log ).info( changedMessage, settingName, "true", "false" );
+        order.verify( log ).info( changedMessage, settingName, "default (true)", "false" );
         order.verify( log ).info( changedMessage, settingName, "false", "true" );
-        order.verify( log ).info( changedMessage, settingName, "true", "true" );
+        order.verify( log ).info( changedMessage, settingName, "true", "default (true)" );
         verifyNoMoreInteractions( log );
     }
 


### PR DESCRIPTION
Previously we returned the setting with type and called `toString` to get the original value out. This does not work for settings that uses java lang types such as `Duration` where the `toString` cannot be overridden.