### PR TITLE
Traversal endpoint script execution is now disabled by default, by introducing the `unsupported.dbms.security.script_enabled` setting, and making it `false` by default.

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -77,6 +77,7 @@ import org.neo4j.server.rest.transactional.TransactionHandleRegistry;
 import org.neo4j.server.rest.transactional.TransactionRegistry;
 import org.neo4j.server.rest.transactional.TransitionalPeriodTransactionMessContainer;
 import org.neo4j.server.rest.web.DatabaseActions;
+import org.neo4j.server.rest.web.ScriptExecutionMode;
 import org.neo4j.server.web.AsyncRequestLog;
 import org.neo4j.server.web.SimpleUriBuilder;
 import org.neo4j.server.web.WebServer;
@@ -225,7 +226,7 @@ public abstract class AbstractNeoServer implements NeoServer
     {
         return new DatabaseActions(
                 new LeaseManager( Clocks.systemClock() ),
-                config.get( ServerSettings.script_sandboxing_enabled ), database.getGraph() );
+                ScriptExecutionMode.getConfiguredMode( config ), database.getGraph() );
     }
 
     private TransactionFacade createTransactionalActions()

--- a/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
@@ -194,7 +194,7 @@ public class ServerSettings implements LoadableConfig
                   "endpoints. This setting is in the 'unsupported' namespace, because the scripting feature might be " +
                   "removed entirely in a future release." )
     public static final Setting<Boolean> script_enabled =
-            setting("unsupported.dbms.security.script_enabled", BOOLEAN, TRUE );
+            setting("unsupported.dbms.security.script_enabled", BOOLEAN, FALSE );
 
     @Deprecated
     @Internal

--- a/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
@@ -189,6 +189,14 @@ public class ServerSettings implements LoadableConfig
     @Internal
     public static final Setting<URI> browser_path = setting( "unsupported.dbms.uris.browser", Settings.URI, "/browser/" );
 
+    @Deprecated
+    @Description( "Whether to allow executing scripts inside the server, from external sources, e.g. via traversal " +
+                  "endpoints. This setting is in the 'unsupported' namespace, because the scripting feature might be " +
+                  "removed entirely in a future release." )
+    public static final Setting<Boolean> script_enabled =
+            setting("unsupported.dbms.security.script_enabled", BOOLEAN, TRUE );
+
+    @Deprecated
     @Internal
     public static final Setting<Boolean> script_sandboxing_enabled = setting("unsupported.dbms.security.script_sandboxing_enabled",
             BOOLEAN, TRUE );

--- a/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
@@ -191,10 +191,10 @@ public class ServerSettings implements LoadableConfig
 
     @Deprecated
     @Description( "Whether to allow executing scripts inside the server, from external sources, e.g. via traversal " +
-                  "endpoints. This setting is in the 'unsupported' namespace, because the scripting feature might be " +
+                  "endpoints. This setting is in the 'unsupported' namespace, because the scripting feature will be " +
                   "removed entirely in a future release." )
     public static final Setting<Boolean> script_enabled =
-            setting("unsupported.dbms.security.script_enabled", BOOLEAN, FALSE );
+            setting( "unsupported.dbms.security.script_enabled", BOOLEAN, FALSE );
 
     @Deprecated
     @Internal

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/EvaluatorFactory.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/EvaluatorFactory.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.traversal.Evaluation;
 import org.neo4j.graphdb.traversal.Evaluator;
+import org.neo4j.server.rest.web.ScriptExecutionMode;
 import org.neo4j.server.scripting.ScriptExecutor;
 import org.neo4j.server.scripting.ScriptExecutorFactoryRepository;
 import org.neo4j.server.scripting.javascript.JavascriptExecutor;
@@ -45,10 +46,10 @@ public class EvaluatorFactory
 
     private final ScriptExecutorFactoryRepository factoryRepo;
 
-    public EvaluatorFactory( boolean enableSandboxing )
+    public EvaluatorFactory( ScriptExecutionMode executionMode )
     {
         Map<String,ScriptExecutor.Factory> languages = new HashMap<>();
-        languages.put( "javascript", new JavascriptExecutor.Factory( enableSandboxing ) );
+        languages.put( "javascript", new JavascriptExecutor.Factory( executionMode ) );
 
         factoryRepo = new ScriptExecutorFactoryRepository( languages );
     }

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/TraversalDescriptionBuilder.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/TraversalDescriptionBuilder.java
@@ -31,6 +31,7 @@ import org.neo4j.graphdb.traversal.Evaluators;
 import org.neo4j.graphdb.traversal.TraversalDescription;
 import org.neo4j.graphdb.traversal.Uniqueness;
 import org.neo4j.kernel.impl.traversal.MonoDirectionalTraversalDescription;
+import org.neo4j.server.rest.web.ScriptExecutionMode;
 
 import static org.neo4j.graphdb.traversal.Evaluators.excludeStartPosition;
 
@@ -38,9 +39,9 @@ public class TraversalDescriptionBuilder
 {
     private final EvaluatorFactory evaluatorFactory;
 
-    public TraversalDescriptionBuilder( boolean enableSandboxing )
+    public TraversalDescriptionBuilder( ScriptExecutionMode executionMode )
     {
-        this.evaluatorFactory = new EvaluatorFactory( enableSandboxing );
+        this.evaluatorFactory = new EvaluatorFactory( executionMode );
     }
 
     public TraversalDescription from( Map<String, Object> description )

--- a/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseActions.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseActions.java
@@ -140,18 +140,21 @@ public class DatabaseActions
     private final Function<ConstraintDefinition,Representation> CONSTRAINT_DEF_TO_REPRESENTATION =
             ConstraintDefinitionRepresentation::new;
 
-    public DatabaseActions( LeaseManager leaseManager, boolean enableScriptSandboxing,
+    public DatabaseActions( LeaseManager leaseManager, ScriptExecutionMode executionMode,
             GraphDatabaseAPI graphDatabaseAPI )
     {
         this.leases = leaseManager;
         this.graphDb = graphDatabaseAPI;
-        this.traversalDescriptionBuilder = new TraversalDescriptionBuilder( enableScriptSandboxing );
+        this.traversalDescriptionBuilder = new TraversalDescriptionBuilder( executionMode );
         this.propertySetter = new PropertySettingStrategy( graphDb );
     }
 
+    /**
+     * This method is only meant for testing.
+     */
     public DatabaseActions( LeaseManager leaseManager, GraphDatabaseAPI graphDatabaseAPI )
     {
-        this( leaseManager, true, graphDatabaseAPI );
+        this( leaseManager, ScriptExecutionMode.SANDBOXED, graphDatabaseAPI );
     }
 
     private Node node( long id ) throws NodeNotFoundException

--- a/community/server/src/main/java/org/neo4j/server/rest/web/RestfulGraphDatabase.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/RestfulGraphDatabase.java
@@ -161,9 +161,6 @@ public class RestfulGraphDatabase
     private static final String UNIQUENESS_MODE_GET_OR_CREATE = "get_or_create";
     private static final String UNIQUENESS_MODE_CREATE_OR_FAIL = "create_or_fail";
 
-    // TODO Obviously change name/content on this
-    private static final String HEADER_TRANSACTION = "Transaction";
-
     private final DatabaseActions actions;
     private Configuration config;
     private final OutputFormat output;

--- a/community/server/src/main/java/org/neo4j/server/rest/web/ScriptExecutionMode.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/ScriptExecutionMode.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.web;
+
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.server.configuration.ServerSettings;
+
+/**
+ * The mode of execution allowed for scripting inside the server.
+ * <p>
+ * Currently only traversal endpoints expose scripting, but this scripting feature for those endpoints can be disabled
+ * by specifying the {@link #DISABLED} mode when constructing the {@link DatabaseActions}.
+ */
+public enum ScriptExecutionMode
+{
+    /**
+     * Scripting is not allowed, and any attempt at invoking a script will raise an exception.
+     */
+    DISABLED,
+    /**
+     * Allow scripts to run in a sandboxed environment.
+     */
+    SANDBOXED,
+    /**
+     * Allow scripts to run without any restrictions at all. This should only be used in fully controlled environments,
+     * where it can be guaranteed that no malicious scripts will make their way into the server.
+     */
+    UNRESTRICTED;
+
+    /**
+     * Get the execution mode that matches the given configuration.
+     */
+    public static ScriptExecutionMode getConfiguredMode( Config config )
+    {
+        if ( config.get( ServerSettings.script_enabled ) )
+        {
+            boolean sandboxed = config.get( ServerSettings.script_sandboxing_enabled );
+            return sandboxed ? SANDBOXED : UNRESTRICTED;
+        }
+        return DISABLED;
+    }
+}

--- a/community/server/src/main/java/org/neo4j/server/scripting/javascript/GlobalJavascriptInitializer.java
+++ b/community/server/src/main/java/org/neo4j/server/scripting/javascript/GlobalJavascriptInitializer.java
@@ -23,6 +23,7 @@ import org.mozilla.javascript.ClassShutter;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 
+import org.neo4j.server.rest.web.ScriptExecutionMode;
 import org.neo4j.server.scripting.UserScriptClassWhiteList;
 
 /**
@@ -41,70 +42,54 @@ import org.neo4j.server.scripting.UserScriptClassWhiteList;
  */
 public class GlobalJavascriptInitializer
 {
+    private static ScriptExecutionMode initializationMode;
 
-    private static Mode initializationMode;
-
-    public enum Mode
-    {
-        SANDBOXED,
-        UNSAFE
-    }
-
-    public static synchronized void initialize(Mode requestedMode)
+    public static synchronized void initialize( ScriptExecutionMode executionMode )
     {
         if ( initializationMode != null )
         {
-            if ( initializationMode == requestedMode )
+            if ( initializationMode == executionMode )
             {
                 return;
             }
             else
             {
                 throw new RuntimeException(
-                        "Cannot initialize javascript context twice, " + "system is currently initialized as: '" +
+                        "Cannot initialize javascript context twice, system is currently initialized as: '" +
                                 initializationMode.name() + "'." );
             }
         }
+        initializationMode = executionMode;
 
-        initializationMode = requestedMode;
-
-        ContextFactory contextFactory;
-        switch ( requestedMode )
+        if ( executionMode == ScriptExecutionMode.UNRESTRICTED )
         {
-            case UNSAFE:
-                contextFactory = new ContextFactory()
+            ContextFactory.initGlobal( new ContextFactory()
+            {
+                protected Context makeContext()
                 {
-                    protected Context makeContext()
-                    {
-                        Context cx = super.makeContext();
-                        cx.setLanguageVersion( Context.VERSION_1_7 );
-                        // TODO: This goes up to 9, do performance tests to determine appropriate level of optimization
-                        cx.setOptimizationLevel( 4 );
-                        return cx;
-                    }
-                };
-                break;
-            default:
-                contextFactory = new ContextFactory()
-                {
-                    protected Context makeContext()
-                    {
-                        Context cx = super.makeContext();
-
-                        ClassShutter shutter = new WhiteListClassShutter( UserScriptClassWhiteList.getWhiteList() );
-
-                        cx.setLanguageVersion( Context.VERSION_1_7 );
-                        // TODO: This goes up to 9, do performance tests to determine appropriate level of optimization
-                        cx.setOptimizationLevel( 4 );
-                        cx.setClassShutter( shutter );
-                        cx.setWrapFactory( new WhiteListJavaWrapper( shutter ) );
-                        return cx;
-                    }
-                };
-                break;
+                    Context cx = super.makeContext();
+                    cx.setLanguageVersion( Context.VERSION_1_7 );
+                    cx.setOptimizationLevel( 4 );
+                    return cx;
+                }
+            } );
         }
-
-        ContextFactory.initGlobal( contextFactory );
+        else if ( executionMode == ScriptExecutionMode.SANDBOXED )
+        {
+            ContextFactory.initGlobal( new ContextFactory()
+            {
+                protected Context makeContext()
+                {
+                    Context cx = super.makeContext();
+                    cx.setLanguageVersion( Context.VERSION_1_7 );
+                    cx.setOptimizationLevel( 4 );
+                    ClassShutter shutter = new WhiteListClassShutter( UserScriptClassWhiteList.getWhiteList() );
+                    cx.setClassShutter( shutter );
+                    cx.setWrapFactory( new WhiteListJavaWrapper( shutter ) );
+                    return cx;
+                }
+            } );
+        }
     }
 
 }

--- a/community/server/src/main/java/org/neo4j/server/scripting/javascript/JavascriptExecutor.java
+++ b/community/server/src/main/java/org/neo4j/server/scripting/javascript/JavascriptExecutor.java
@@ -29,7 +29,9 @@ import org.mozilla.javascript.Undefined;
 
 import java.util.Map;
 
+import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.rest.domain.EvaluationException;
+import org.neo4j.server.rest.web.ScriptExecutionMode;
 import org.neo4j.server.scripting.ScriptExecutor;
 
 public class JavascriptExecutor implements ScriptExecutor
@@ -39,28 +41,27 @@ public class JavascriptExecutor implements ScriptExecutor
 
     public static class Factory implements ScriptExecutor.Factory
     {
+        private final ScriptExecutionMode executionMode;
+
         /**
          * Note that you can set sandbox/no sandbox once, after that it is globally defined
          * for the JVM. If you create a new factory with a different sandboxing setting, an
          * exception will be thrown.
-         *
-         * @param enableSandboxing
          */
-        public Factory(boolean enableSandboxing)
+        public Factory( ScriptExecutionMode executionMode )
         {
-            if ( enableSandboxing )
-            {
-                GlobalJavascriptInitializer.initialize( GlobalJavascriptInitializer.Mode.SANDBOXED );
-            }
-            else
-            {
-                GlobalJavascriptInitializer.initialize( GlobalJavascriptInitializer.Mode.UNSAFE );
-            }
+            this.executionMode = executionMode;
+            GlobalJavascriptInitializer.initialize( executionMode );
         }
 
         @Override
         public ScriptExecutor createExecutorForScript( String script ) throws EvaluationException
         {
+            if ( executionMode == ScriptExecutionMode.DISABLED )
+            {
+                throw new EvaluationException( "Script execution is DISABLED via the " +
+                                               ServerSettings.script_enabled.name() + " setting." );
+            }
             return new JavascriptExecutor( script );
         }
     }

--- a/community/server/src/test/java/org/neo4j/server/BaseBootstrapperTest.java
+++ b/community/server/src/test/java/org/neo4j/server/BaseBootstrapperTest.java
@@ -30,11 +30,9 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.neo4j.bolt.BoltKernelExtension;
 import org.neo4j.graphdb.config.Setting;
-import org.neo4j.kernel.configuration.ssl.SslPolicyConfig;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.server.configuration.ConfigLoader;
-import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.test.server.ExclusiveServerTestBase;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -46,6 +44,7 @@ import static org.neo4j.graphdb.factory.GraphDatabaseSettings.forced_kernel_id;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.logs_directory;
 import static org.neo4j.helpers.collection.MapUtil.store;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.server.configuration.ServerSettings.script_enabled;
 import static org.neo4j.test.assertion.Assert.assertEventually;
 
 public abstract class BaseBootstrapperTest extends ExclusiveServerTestBase
@@ -80,6 +79,9 @@ public abstract class BaseBootstrapperTest extends ExclusiveServerTestBase
                 "--home-dir", tempDir.newFolder( "home-dir" ).getAbsolutePath(),
                 "-c", configOption( data_directory, tempDir.getRoot().getAbsolutePath() ),
                 "-c", configOption( logs_directory, tempDir.getRoot().getAbsolutePath() ),
+                // The `script_enabled=true` setting is needed because the global javascript context must be
+                // initialised in sandboxed mode to allow testing traversal endpoint scripting:
+                "-c", configOption( script_enabled, Settings.TRUE ),
                 "-c", "dbms.connector.http.type=HTTP",
                 "-c", "dbms.connector.http.enabled=true"
         );

--- a/community/server/src/test/java/org/neo4j/server/ServerConfigIT.java
+++ b/community/server/src/test/java/org/neo4j/server/ServerConfigIT.java
@@ -19,16 +19,17 @@
  */
 package org.neo4j.server;
 
-import java.io.IOException;
-import javax.ws.rs.core.MediaType;
-
 import org.junit.After;
 import org.junit.Test;
+
+import java.io.IOException;
+import javax.ws.rs.core.MediaType;
 
 import org.neo4j.helpers.ListenSocketAddress;
 import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.rest.JaxRsResponse;
 import org.neo4j.server.rest.RestRequest;
+import org.neo4j.server.rest.web.ScriptExecutionMode;
 import org.neo4j.server.scripting.javascript.GlobalJavascriptInitializer;
 import org.neo4j.test.server.ExclusiveServerTestBase;
 
@@ -36,7 +37,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-
 import static org.neo4j.server.helpers.CommunityServerBuilder.server;
 import static org.neo4j.test.server.HTTP.POST;
 
@@ -202,7 +202,7 @@ public class ServerConfigIT extends ExclusiveServerTestBase
     {
         // NOTE: This has to be initialized to sandboxed, because it can only be initialized once per JVM session,
         // and all other tests depend on it being sandboxed.
-        GlobalJavascriptInitializer.initialize( GlobalJavascriptInitializer.Mode.SANDBOXED );
+        GlobalJavascriptInitializer.initialize( ScriptExecutionMode.SANDBOXED );
 
         server = server().withProperty( ServerSettings.script_sandboxing_enabled.name(), "false" )
                 .usingDataDir( folder.directory( name.getMethodName() ).getAbsolutePath() )

--- a/community/server/src/test/java/org/neo4j/server/ServerTestUtils.java
+++ b/community/server/src/test/java/org/neo4j/server/ServerTestUtils.java
@@ -36,7 +36,9 @@ import java.util.Random;
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.configuration.ssl.LegacySslPolicyConfig;
+import org.neo4j.server.configuration.ServerSettings;
 
 public class ServerTestUtils
 {
@@ -90,6 +92,9 @@ public class ServerTestUtils
         addRelativeProperty( temporaryFolder, properties, GraphDatabaseSettings.logs_directory );
         addRelativeProperty( temporaryFolder, properties, LegacySslPolicyConfig.certificates_directory );
         properties.put( GraphDatabaseSettings.pagecache_memory.name(), "8m" );
+        // Needed to allow testing traversal endpoint scripting, which needs the JVM-wide "global" javascript context
+        // to be initialised to sandboxed mode:
+        properties.put( ServerSettings.script_enabled.name(), Settings.TRUE );
     }
 
     private static void addRelativeProperty( File temporaryFolder, Map<String,String> properties,

--- a/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
@@ -51,6 +51,7 @@ import org.neo4j.server.database.LifecycleManagingDatabase;
 import org.neo4j.server.preflight.PreFlightTasks;
 import org.neo4j.server.rest.paging.LeaseManager;
 import org.neo4j.server.rest.web.DatabaseActions;
+import org.neo4j.server.rest.web.ScriptExecutionMode;
 import org.neo4j.test.ImpermanentGraphDatabase;
 import org.neo4j.time.Clocks;
 
@@ -324,7 +325,7 @@ public class CommunityServerBuilder
 
         return new DatabaseActions(
                 new LeaseManager( clockToUse ),
-                config.get( ServerSettings.script_sandboxing_enabled ), database.getGraph() );
+                ScriptExecutionMode.getConfiguredMode( config ), database.getGraph() );
     }
 
     protected Optional<File> buildBefore() throws IOException

--- a/community/server/src/test/java/org/neo4j/server/rest/domain/TraversalDescriptionBuilderTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/domain/TraversalDescriptionBuilderTest.java
@@ -19,13 +19,14 @@
  */
 package org.neo4j.server.rest.domain;
 
-import static org.neo4j.helpers.collection.MapUtil.map;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 
-import org.junit.Test;
+import static org.neo4j.helpers.collection.MapUtil.map;
+import static org.neo4j.server.rest.web.ScriptExecutionMode.SANDBOXED;
 
 public class TraversalDescriptionBuilderTest
 {
@@ -33,7 +34,7 @@ public class TraversalDescriptionBuilderTest
     public void throwsIllegalArgumentOnUnknownExpanderType() throws Exception
     {
         // Given
-        TraversalDescriptionBuilder builder = new TraversalDescriptionBuilder( true );
+        TraversalDescriptionBuilder builder = new TraversalDescriptionBuilder( SANDBOXED );
         Collection<Map<String,Object>> rels = new ArrayList<Map<String, Object>>();
         rels.add( map( "type", "blah" ) );
 
@@ -47,7 +48,7 @@ public class TraversalDescriptionBuilderTest
     public void throwsIllegalArgumentOnNonStringExpanderType() throws Exception
     {
         // Given
-        TraversalDescriptionBuilder builder = new TraversalDescriptionBuilder( true );
+        TraversalDescriptionBuilder builder = new TraversalDescriptionBuilder( SANDBOXED );
         Collection<Map<String,Object>> rels = new ArrayList<Map<String, Object>>();
         rels.add( map( "type", "blah" ) );
 

--- a/community/server/src/test/java/org/neo4j/server/rest/paging/PagedTraverserIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/paging/PagedTraverserIT.java
@@ -47,6 +47,7 @@ import org.neo4j.server.rest.RESTRequestGenerator;
 import org.neo4j.server.rest.RESTRequestGenerator.ResponseEntity;
 import org.neo4j.server.rest.RestRequest;
 import org.neo4j.server.rest.domain.JsonHelper;
+import org.neo4j.server.rest.web.ScriptExecutionMode;
 import org.neo4j.server.scripting.javascript.GlobalJavascriptInitializer;
 import org.neo4j.test.TestData;
 import org.neo4j.test.server.ExclusiveServerTestBase;
@@ -294,7 +295,7 @@ public class PagedTraverserIT extends ExclusiveServerTestBase
     @Test
     public void shouldRespondWith400OnScriptErrors()
     {
-        GlobalJavascriptInitializer.initialize( GlobalJavascriptInitializer.Mode.SANDBOXED );
+        GlobalJavascriptInitializer.initialize( ScriptExecutionMode.SANDBOXED );
 
         theStartNode = createLinkedList( 1, server.getDatabase() );
 

--- a/community/server/src/test/java/org/neo4j/server/rest/web/PagingTraversalTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/PagingTraversalTest.java
@@ -70,7 +70,7 @@ public class PagingTraversalTest
         leaseManager = new LeaseManager( Clocks.fakeClock() );
         service = new RestfulGraphDatabase( new JsonFormat(),
                 output,
-                new DatabaseActions( leaseManager, true, database.getGraph() ), null );
+                new DatabaseActions( leaseManager, ScriptExecutionMode.SANDBOXED, database.getGraph() ), null );
         service = new TransactionWrappingRestfulGraphDatabase( graph, service );
     }
 

--- a/community/server/src/test/java/org/neo4j/server/rest/web/RestfulGraphDatabasePagedTraversalTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/RestfulGraphDatabasePagedTraversalTest.java
@@ -69,7 +69,7 @@ public class RestfulGraphDatabasePagedTraversalTest
         output = new EntityOutputFormat( new JsonFormat(), URI.create( BASE_URI ), null );
         leaseManager = new LeaseManager( Clocks.fakeClock() );
         service = new RestfulGraphDatabase( new JsonFormat(), output,
-                new DatabaseActions( leaseManager, true, database.getGraph() ), null );
+                new DatabaseActions( leaseManager, ScriptExecutionMode.SANDBOXED, database.getGraph() ), null );
         service = new TransactionWrappingRestfulGraphDatabase( graph, service );
     }
 

--- a/community/server/src/test/java/org/neo4j/server/rest/web/RestfulGraphDatabaseTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/RestfulGraphDatabaseTest.java
@@ -40,7 +40,6 @@ import javax.ws.rs.core.Response.Status;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.index.IndexHits;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.api.exceptions.Status.Request;
@@ -48,7 +47,6 @@ import org.neo4j.kernel.api.exceptions.Status.Schema;
 import org.neo4j.kernel.api.exceptions.Status.Statement;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
-import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.database.Database;
 import org.neo4j.server.database.WrappedDatabase;
 import org.neo4j.server.plugins.ConfigAdapter;
@@ -68,7 +66,6 @@ import org.neo4j.test.server.EntityOutputFormat;
 import org.neo4j.time.Clocks;
 
 import static java.lang.Long.parseLong;
-import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -102,12 +99,14 @@ public class RestfulGraphDatabaseTest
         database = new WrappedDatabase( graph );
         helper = new GraphDbHelper( database );
         output = new EntityOutputFormat( new JsonFormat(), URI.create( BASE_URI ), null );
+        DatabaseActions databaseActions = new DatabaseActions(
+                new LeaseManager( Clocks.fakeClock() ), ScriptExecutionMode.SANDBOXED, database.getGraph() );
         service = new TransactionWrappingRestfulGraphDatabase(
                 graph,
                 new RestfulGraphDatabase(
                         new JsonFormat(),
                         output,
-                        new DatabaseActions( new LeaseManager( Clocks.fakeClock() ), true, database.getGraph() ),
+                        databaseActions,
                         new ConfigAdapter( Config.embeddedDefaults() )
                 )
         );

--- a/community/server/src/test/java/org/neo4j/server/rest/web/ScriptExecutionModeTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/ScriptExecutionModeTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.web;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.configuration.Settings;
+import org.neo4j.server.configuration.ServerSettings;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
+public class ScriptExecutionModeTest
+{
+    @Test
+    public void unrestrictedConfiguration() throws Exception
+    {
+        Config config = Config.defaults().augment( stringMap(
+                ServerSettings.script_enabled.name(), Settings.TRUE,
+                ServerSettings.script_sandboxing_enabled.name(), Settings.FALSE ) );
+        assertThat( ScriptExecutionMode.getConfiguredMode( config ), is( ScriptExecutionMode.UNRESTRICTED ) );
+    }
+
+    @Test
+    public void sandboxedConfiguration() throws Exception
+    {
+        Config config = Config.defaults().augment( stringMap(
+                ServerSettings.script_enabled.name(), Settings.TRUE,
+                ServerSettings.script_sandboxing_enabled.name(), Settings.TRUE ) );
+        assertThat( ScriptExecutionMode.getConfiguredMode( config ), is( ScriptExecutionMode.SANDBOXED ) );
+    }
+
+    @Test
+    public void disabledConfiguration() throws Exception
+    {
+        Config config = Config.defaults().augment( stringMap(
+                ServerSettings.script_enabled.name(), Settings.FALSE,
+                ServerSettings.script_sandboxing_enabled.name(), Settings.TRUE ) );
+        assertThat( ScriptExecutionMode.getConfiguredMode( config ), is( ScriptExecutionMode.DISABLED ) );
+
+        config = Config.defaults().augment( stringMap(
+                ServerSettings.script_enabled.name(), Settings.FALSE,
+                ServerSettings.script_sandboxing_enabled.name(), Settings.FALSE ) );
+        assertThat( ScriptExecutionMode.getConfiguredMode( config ), is( ScriptExecutionMode.DISABLED ) );
+
+        config = Config.defaults().augment( stringMap(
+                ServerSettings.script_enabled.name(), Settings.FALSE ) );
+        assertThat( ScriptExecutionMode.getConfiguredMode( config ), is( ScriptExecutionMode.DISABLED ) );
+    }
+}

--- a/community/server/src/test/java/org/neo4j/server/scripting/javascript/TestGlobalJavascriptInitializer.java
+++ b/community/server/src/test/java/org/neo4j/server/scripting/javascript/TestGlobalJavascriptInitializer.java
@@ -21,6 +21,8 @@ package org.neo4j.server.scripting.javascript;
 
 import org.junit.Test;
 
+import org.neo4j.server.rest.web.ScriptExecutionMode;
+
 public class TestGlobalJavascriptInitializer
 {
 
@@ -28,20 +30,20 @@ public class TestGlobalJavascriptInitializer
     public void shouldNotAllowChangingMode() throws Exception
     {
         // Given
-        GlobalJavascriptInitializer.initialize( GlobalJavascriptInitializer.Mode.SANDBOXED );
+        GlobalJavascriptInitializer.initialize( ScriptExecutionMode.SANDBOXED );
 
         // When
-        GlobalJavascriptInitializer.initialize( GlobalJavascriptInitializer.Mode.UNSAFE );
+        GlobalJavascriptInitializer.initialize( ScriptExecutionMode.UNRESTRICTED );
     }
 
     @Test
     public void initializingTheSameModeTwiceIsFine() throws Exception
     {
         // Given
-        GlobalJavascriptInitializer.initialize( GlobalJavascriptInitializer.Mode.SANDBOXED );
+        GlobalJavascriptInitializer.initialize( ScriptExecutionMode.SANDBOXED );
 
         // When
-        GlobalJavascriptInitializer.initialize( GlobalJavascriptInitializer.Mode.SANDBOXED );
+        GlobalJavascriptInitializer.initialize( ScriptExecutionMode.SANDBOXED );
 
         // Then
         // no exception should have been thrown.

--- a/community/server/src/test/java/org/neo4j/server/scripting/javascript/TestJavascriptSecurityRestrictions.java
+++ b/community/server/src/test/java/org/neo4j/server/scripting/javascript/TestJavascriptSecurityRestrictions.java
@@ -19,15 +19,17 @@
  */
 package org.neo4j.server.scripting.javascript;
 
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.neo4j.graphdb.traversal.Evaluation;
+import org.neo4j.server.rest.domain.EvaluationException;
+import org.neo4j.server.rest.web.ScriptExecutionMode;
+import org.neo4j.server.scripting.ScriptExecutor;
+
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.neo4j.graphdb.traversal.Evaluation;
-import org.neo4j.server.rest.domain.EvaluationException;
-import org.neo4j.server.scripting.ScriptExecutor;
 
 public class TestJavascriptSecurityRestrictions
 {
@@ -40,7 +42,7 @@ public class TestJavascriptSecurityRestrictions
     @BeforeClass
     public static void doBullshitGlobalStateCrap()
     {
-        GlobalJavascriptInitializer.initialize( GlobalJavascriptInitializer.Mode.SANDBOXED );
+        GlobalJavascriptInitializer.initialize( ScriptExecutionMode.SANDBOXED );
     }
 
     @Test

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/EnterpriseBootstrapperTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/EnterpriseBootstrapperTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.kernel.GraphDatabaseDependencies;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.server.BaseBootstrapperTest;
 import org.neo4j.server.NeoServer;
@@ -51,6 +52,7 @@ import static org.neo4j.helpers.collection.MapUtil.store;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.configuration.ssl.LegacySslPolicyConfig.certificates_directory;
 import static org.neo4j.server.ServerTestUtils.getRelativePath;
+import static org.neo4j.server.configuration.ServerSettings.script_enabled;
 import static org.neo4j.test.assertion.Assert.assertEventually;
 
 public class EnterpriseBootstrapperTest extends BaseBootstrapperTest
@@ -80,6 +82,9 @@ public class EnterpriseBootstrapperTest extends BaseBootstrapperTest
                 "-c", configOption( data_directory, getRelativePath( folder.getRoot(), data_directory ) ),
                 "-c", configOption( logs_directory, tempDir.getRoot().getAbsolutePath() ),
                 "-c", configOption( certificates_directory, getRelativePath( folder.getRoot(), certificates_directory ) ),
+                // The `script_enabled=true` setting is needed because the global javascript context must be
+                // initialised in sandboxed mode to allow testing traversal endpoint scripting:
+                "-c", configOption( script_enabled, Settings.TRUE ),
                 "-c", "dbms.connector.1.type=HTTP",
                 "-c", "dbms.connector.1.encryption=NONE",
                 "-c", "dbms.connector.1.enabled=true" );
@@ -101,6 +106,9 @@ public class EnterpriseBootstrapperTest extends BaseBootstrapperTest
                 "-c", configOption( data_directory, getRelativePath( folder.getRoot(), data_directory ) ),
                 "-c", configOption( logs_directory, tempDir.getRoot().getAbsolutePath() ),
                 "-c", configOption( certificates_directory, getRelativePath( folder.getRoot(), certificates_directory ) ),
+                // The `script_enabled=true` setting is needed because the global javascript context must be
+                // initialised in sandboxed mode to allow testing traversal endpoint scripting:
+                "-c", configOption( script_enabled, Settings.TRUE ),
                 "-c", "dbms.connector.1.type=HTTP",
                 "-c", "dbms.connector.1.encryption=NONE",
                 "-c", "dbms.connector.1.enabled=true" );


### PR DESCRIPTION
This resolves the #6155 issue.