### PR TITLE
Flaky rest integration test

### DIFF
--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/QueryResultsSerializationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/QueryResultsSerializationTest.java
@@ -584,7 +584,7 @@ public class QueryResultsSerializationTest extends AbstractRestFunctionalTestBas
      * This matcher is hardcoded to check for a list containing one deleted node and one map with a
      * deleted node mapped to the key `someKey`.
      */
-    public static Matcher<? super Response> restContainsNestedDeleted()
+    private static Matcher<? super Response> restContainsNestedDeleted()
     {
         return new TypeSafeMatcher<Response>()
         {

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionMatchers.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionMatchers.java
@@ -39,6 +39,7 @@ import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.server.rest.repr.util.RFC1123;
 import org.neo4j.test.server.HTTP;
 
+import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -409,18 +410,18 @@ public class TransactionMatchers
                 try
                 {
                     Iterator<JsonNode> nodes = getJsonNodeWithName( response, "graph" ).get( "nodes" ).iterator();
-
-                    for ( int i = 0; i < amount; ++i )
-                    {
-                        assertTrue( nodes.hasNext() );
-                        JsonNode node = nodes.next();
-                        assertThat( node.get( "deleted" ).asBoolean(), equalTo( Boolean.TRUE ) );
-                    }
+                    int deleted = 0;
                     while ( nodes.hasNext() )
                     {
                         JsonNode node = nodes.next();
-                        assertNull( node.get( "deleted" ) );
+                        if ( node.get( "deleted" ) != null )
+                        {
+                            assertTrue( node.get( "deleted" ).asBoolean() );
+                            deleted++;
+                        }
                     }
+                    assertEquals( format( "Expected to see %d deleted elements but %d was encountered.", amount, deleted ),
+                            amount, deleted );
                     return true;
                 }
                 catch ( JsonParseException e )

--- a/community/server/src/test/java/org/neo4j/test/server/SharedServerTestBase.java
+++ b/community/server/src/test/java/org/neo4j/test/server/SharedServerTestBase.java
@@ -51,6 +51,7 @@ public class SharedServerTestBase
         suppressAll().call( (Callable<Void>) () ->
         {
             ServerHolder.setServerBuilderProperty( GraphDatabaseSettings.cypher_hints_error.name(), "true" );
+            ServerHolder.setServerBuilderProperty( GraphDatabaseSettings.transaction_timeout.name(), "120s" );
             server = ServerHolder.allocate();
             ServerHelper.cleanTheDatabase( server );
             return null;


### PR DESCRIPTION
Increase transaction inactivity timeout to 2 minutes.
Make deleted node matcher order independent.