### PR TITLE
Add cursor tracking and close assertions to assist in debugging.

### DIFF
--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/TaskCloser.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/TaskCloser.scala
@@ -37,7 +37,7 @@ class TaskCloser {
     if (!closed) {
       closed = true
       var foundException: Option[Throwable] = None
-      _tasks foreach {
+      _tasks.reverse foreach {
         f =>
           try {
             f(success)

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/TaskCloser.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/TaskCloser.scala
@@ -16,11 +16,11 @@
  */
 package org.neo4j.cypher.internal.util.v3_4
 
-import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.ArrayBuffer
 
 class TaskCloser {
 
-  private val _tasks: ListBuffer[Boolean => Unit] = ListBuffer.empty
+  private val _tasks: ArrayBuffer[Boolean => Unit] = ArrayBuffer.empty
   private var closed = false
 
   /**
@@ -41,11 +41,13 @@ class TaskCloser {
         f =>
           try {
             f(success)
-            None
           } catch {
-            case e: Throwable => foundException = Some(e)
+            case e: Throwable =>
+              foundException match {
+                case Some(first) => first.addSuppressed(e)
+                case None => foundException = Some(e)
+              }
           }
-
       }
 
       foundException.forall(throwable => throw throwable)

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/AutoCloseablePlus.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/AutoCloseablePlus.java
@@ -20,29 +20,13 @@
 package org.neo4j.internal.kernel.api;
 
 /**
- * This interface is package-private because it is not generically useful. All use cases should use the explicit cursor
- * types. It is however useful to define this interface to ensure that the generic usage pattern (as outlined by the
- * example code snippet below) aligns across all cursor interfaces.
- * <p>
- * Generic usage:
- * <code><pre>
- * SomeCursor cursor = allocateCursorOfAppropriateType();
- * store.positionCursor( cursor );
- * while ( cursor.next() )
- * {
- *     do
- *     {
- *         // access data here ...
- *         // also make sure that data read here is considered valid until `shouldRetry()` is false.
- *     }
- *     while ( cursor.shouldRetry() );
- *     // use accessed data here ...
- * }
- * </pre></code>
+ * Enriches AutoCloseable with isClosed(). This method can be used to query whether a resource was closed or
+ * to make sure that it is only closed once.
  */
-interface Cursor extends AutoCloseablePlus
+public interface AutoCloseablePlus extends AutoCloseable
 {
-    boolean next();
+    @Override
+    void close();
 
-    boolean shouldRetry();
+    boolean isClosed();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
@@ -694,6 +694,7 @@ public class Operations implements Write, ExplicitIndexWrite
             relationshipCursor = null;
         }
 
+        cursors.assertClosed();
         cursors.release();
     }
 


### PR DESCRIPTION
Add some tracking code and close assertions to DefaultCursor to add in detecting leaking cursors. This is turned of be default, but could later be turned on, or converted into an auto-close.

~~Builds on #11041, first commit is 7fdc50d.~~