### PR TITLE
Spatial index cleanup

### DIFF
--- a/community/collections/src/main/java/org/neo4j/helpers/collection/CombiningIterable.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/CombiningIterable.java
@@ -32,9 +32,10 @@ public class CombiningIterable<T> implements Iterable<T>
 {
     private Iterable<Iterable<T>> iterables;
 
-    public CombiningIterable( Iterable<Iterable<T>> iterables )
+    @SuppressWarnings( "unchecked" )
+    public <INNER extends Iterable<T>> CombiningIterable( Iterable<INNER> iterables )
     {
-        this.iterables = iterables;
+        this.iterables = (Iterable) iterables;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SamplingUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SamplingUtil.java
@@ -26,11 +26,11 @@ import org.neo4j.storageengine.api.schema.IndexSampler;
 /**
  * Utilities for implementing {@link IndexSampler sampling}.
  */
-class SamplingUtil
+public class SamplingUtil
 {
     private static final String DELIMITER = "\u001F";
 
-    static String encodedStringValuesForSampling( Object... values )
+    public static String encodedStringValuesForSampling( Object... values )
     {
         return StringUtils.join( values, DELIMITER );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialCRSSchemaIndex.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialCRSSchemaIndex.java
@@ -552,9 +552,9 @@ public class SpatialCRSSchemaIndex
         FAILED
     }
 
-    public interface Factory
+    public interface Supplier
     {
-        SpatialCRSSchemaIndex selectAndCreate( IndexDescriptor descriptor,
+        SpatialCRSSchemaIndex get( IndexDescriptor descriptor,
                 Map<CoordinateReferenceSystem,SpatialCRSSchemaIndex> indexMap, long indexId,
                 CoordinateReferenceSystem crs );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialSchemaIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialSchemaIndexReader.java
@@ -34,12 +34,10 @@ import org.neo4j.internal.kernel.api.IndexOrder;
 import org.neo4j.internal.kernel.api.IndexQuery;
 import org.neo4j.internal.kernel.api.IndexQuery.ExactPredicate;
 import org.neo4j.internal.kernel.api.IndexQuery.GeometryRangePredicate;
-import org.neo4j.kernel.api.exceptions.index.IndexNotApplicableKernelException;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.kernel.impl.index.schema.fusion.BridgingIndexProgressor;
 import org.neo4j.storageengine.api.schema.IndexProgressor;
-import org.neo4j.values.storable.PointValue;
 import org.neo4j.values.storable.Value;
 
 import static java.lang.String.format;
@@ -128,7 +126,7 @@ public class SpatialSchemaIndexReader<KEY extends SpatialSchemaKey, VALUE extend
             BridgingIndexProgressor multiProgressor = new BridgingIndexProgressor( client, descriptor.schema().getPropertyIds() );
             client.initialize( descriptor, multiProgressor, query );
             SpaceFillingCurve curve = spatial.getSpaceFillingCurve();
-            Envelope completeEnvelope = SpatialKnownIndex.envelopeFromCRS( spatial.crs );
+            Envelope completeEnvelope = SpatialCRSSchemaIndex.envelopeFromCRS( spatial.crs );
             double[] from = rangePredicate.from() == null ? completeEnvelope.getMin() : rangePredicate.from().coordinate();
             double[] to = rangePredicate.to() == null ? completeEnvelope.getMax() : rangePredicate.to().coordinate();
             Envelope envelope = new Envelope( from, to );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexAccessor.java
@@ -63,7 +63,7 @@ class SpatialFusionIndexAccessor implements IndexAccessor
         this.indexFactory = indexFactory;
         for ( SpatialCRSSchemaIndex index : indexMap.values() )
         {
-            index.takeOnline( samplingConfig );
+            index.takeOnline();
         }
     }
 
@@ -77,7 +77,7 @@ class SpatialFusionIndexAccessor implements IndexAccessor
     @Override
     public IndexUpdater newUpdater( IndexUpdateMode mode )
     {
-        return SpatialFusionIndexUpdater.updaterForAccessor( indexMap, indexId, indexFactory, descriptor, samplingConfig );
+        return SpatialFusionIndexUpdater.updaterForAccessor( indexMap, indexId, indexFactory, descriptor );
     }
 
     @Override
@@ -142,7 +142,7 @@ class SpatialFusionIndexAccessor implements IndexAccessor
             @Override
             public Iterator<Long> iterator()
             {
-                return new CombiningIterable( allEntriesReader ).iterator();
+                return new CombiningIterable<>( allEntriesReader ).iterator();
             }
         };
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexAccessor.java
@@ -51,10 +51,10 @@ class SpatialFusionIndexAccessor implements IndexAccessor
     private final long indexId;
     private final IndexDescriptor descriptor;
     private final IndexSamplingConfig samplingConfig;
-    private final SpatialCRSSchemaIndex.Factory indexFactory;
+    private final SpatialCRSSchemaIndex.Supplier indexFactory;
 
     SpatialFusionIndexAccessor( Map<CoordinateReferenceSystem,SpatialCRSSchemaIndex> indexMap, long indexId, IndexDescriptor descriptor,
-            IndexSamplingConfig samplingConfig, SpatialCRSSchemaIndex.Factory indexFactory ) throws IOException
+            IndexSamplingConfig samplingConfig, SpatialCRSSchemaIndex.Supplier indexFactory ) throws IOException
     {
         this.indexMap = indexMap;
         this.indexId = indexId;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexPopulator.java
@@ -46,17 +46,17 @@ class SpatialFusionIndexPopulator implements IndexPopulator
     private final long indexId;
     private final IndexDescriptor descriptor;
     private final IndexSamplingConfig samplingConfig;
-    private final SpatialCRSSchemaIndex.Factory indexFactory;
+    private final SpatialCRSSchemaIndex.Supplier indexSupplier;
     private final Map<CoordinateReferenceSystem,SpatialCRSSchemaIndex> indexMap;
 
     SpatialFusionIndexPopulator( Map<CoordinateReferenceSystem,SpatialCRSSchemaIndex> indexMap, long indexId, IndexDescriptor descriptor,
-            IndexSamplingConfig samplingConfig, SpatialCRSSchemaIndex.Factory indexFactory )
+            IndexSamplingConfig samplingConfig, SpatialCRSSchemaIndex.Supplier indexSupplier )
     {
         this.indexMap = indexMap;
         this.indexId = indexId;
         this.descriptor = descriptor;
         this.samplingConfig = samplingConfig;
-        this.indexFactory = indexFactory;
+        this.indexSupplier = indexSupplier;
     }
 
     @Override
@@ -87,7 +87,7 @@ class SpatialFusionIndexPopulator implements IndexPopulator
         }
         for ( CoordinateReferenceSystem crs : batchMap.keySet() )
         {
-            SpatialCRSSchemaIndex index = indexFactory.selectAndCreate( descriptor, indexMap, indexId, crs );
+            SpatialCRSSchemaIndex index = indexSupplier.get( descriptor, indexMap, indexId, crs );
             index.startPopulation( samplingConfig );
             index.add( batchMap.get( crs ) );
         }
@@ -110,7 +110,7 @@ class SpatialFusionIndexPopulator implements IndexPopulator
     @Override
     public IndexUpdater newPopulatingUpdater( PropertyAccessor accessor )
     {
-        return SpatialFusionIndexUpdater.updaterForPopulator( indexMap, indexId, indexFactory, descriptor, samplingConfig );
+        return SpatialFusionIndexUpdater.updaterForPopulator( indexMap, indexId, indexSupplier, descriptor, samplingConfig );
     }
 
     @Override
@@ -131,7 +131,7 @@ class SpatialFusionIndexPopulator implements IndexPopulator
         Value[] values = update.values();
         assert values.length == 1;
         CoordinateReferenceSystem crs = ((PointValue) values[0]).getCoordinateReferenceSystem();
-        SpatialCRSSchemaIndex index = indexFactory.selectAndCreate( descriptor, indexMap, indexId, crs );
+        SpatialCRSSchemaIndex index = indexSupplier.get( descriptor, indexMap, indexId, crs );
         index.init( samplingConfig );
         index.includeSample( update );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexUpdater.java
@@ -27,7 +27,6 @@ import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
-import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.kernel.impl.index.schema.SpatialCRSSchemaIndex;
 import org.neo4j.values.storable.CoordinateReferenceSystem;
 import org.neo4j.values.storable.PointValue;
@@ -42,33 +41,30 @@ class SpatialFusionIndexUpdater implements IndexUpdater
     private final long indexId;
     private final SpatialCRSSchemaIndex.Supplier indexSupplier;
     private final IndexDescriptor descriptor;
-    private final IndexSamplingConfig samplingConfig;
     private final boolean populating;
 
     static SpatialFusionIndexUpdater updaterForAccessor( Map<CoordinateReferenceSystem,SpatialCRSSchemaIndex> indexMap, long indexId,
-            SpatialCRSSchemaIndex.Supplier indexFactory, IndexDescriptor descriptor, IndexSamplingConfig samplingConfig )
+            SpatialCRSSchemaIndex.Supplier indexFactory, IndexDescriptor descriptor )
     {
-        return new SpatialFusionIndexUpdater( indexMap, indexId, indexFactory, descriptor, samplingConfig, false );
+        return new SpatialFusionIndexUpdater( indexMap, indexId, indexFactory, descriptor, false );
     }
 
     static SpatialFusionIndexUpdater updaterForPopulator( Map<CoordinateReferenceSystem,SpatialCRSSchemaIndex> indexMap, long indexId,
-            SpatialCRSSchemaIndex.Supplier indexFactory, IndexDescriptor descriptor, IndexSamplingConfig samplingConfig )
+            SpatialCRSSchemaIndex.Supplier indexFactory, IndexDescriptor descriptor )
     {
-        return new SpatialFusionIndexUpdater( indexMap, indexId, indexFactory, descriptor, samplingConfig, true );
+        return new SpatialFusionIndexUpdater( indexMap, indexId, indexFactory, descriptor, true );
     }
 
     private SpatialFusionIndexUpdater( Map<CoordinateReferenceSystem,SpatialCRSSchemaIndex> indexMap,
                                        long indexId,
                                        SpatialCRSSchemaIndex.Supplier indexSupplier,
                                        IndexDescriptor descriptor,
-                                       IndexSamplingConfig samplingConfig,
                                        boolean populating )
     {
         this.indexMap = indexMap;
         this.indexId = indexId;
         this.indexSupplier = indexSupplier;
         this.descriptor = descriptor;
-        this.samplingConfig = samplingConfig;
         this.populating = populating;
     }
 
@@ -117,7 +113,7 @@ class SpatialFusionIndexUpdater implements IndexUpdater
             return updater;
         }
         SpatialCRSSchemaIndex index = indexSupplier.get( descriptor, indexMap, indexId, crs );
-        IndexUpdater indexUpdater = index.updaterWithCreate( samplingConfig, populating );
+        IndexUpdater indexUpdater = index.updaterWithCreate( populating );
         return remember( crs, indexUpdater );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexUpdater.java
@@ -40,29 +40,33 @@ class SpatialFusionIndexUpdater implements IndexUpdater
     private final Map<CoordinateReferenceSystem,SpatialCRSSchemaIndex> indexMap;
     private final Map<CoordinateReferenceSystem,IndexUpdater> currentUpdaters = new HashMap<>();
     private final long indexId;
-    private final SpatialCRSSchemaIndex.Factory indexFactory;
+    private final SpatialCRSSchemaIndex.Supplier indexSupplier;
     private final IndexDescriptor descriptor;
     private final IndexSamplingConfig samplingConfig;
     private final boolean populating;
 
     static SpatialFusionIndexUpdater updaterForAccessor( Map<CoordinateReferenceSystem,SpatialCRSSchemaIndex> indexMap, long indexId,
-            SpatialCRSSchemaIndex.Factory indexFactory, IndexDescriptor descriptor, IndexSamplingConfig samplingConfig )
+            SpatialCRSSchemaIndex.Supplier indexFactory, IndexDescriptor descriptor, IndexSamplingConfig samplingConfig )
     {
         return new SpatialFusionIndexUpdater( indexMap, indexId, indexFactory, descriptor, samplingConfig, false );
     }
 
     static SpatialFusionIndexUpdater updaterForPopulator( Map<CoordinateReferenceSystem,SpatialCRSSchemaIndex> indexMap, long indexId,
-            SpatialCRSSchemaIndex.Factory indexFactory, IndexDescriptor descriptor, IndexSamplingConfig samplingConfig )
+            SpatialCRSSchemaIndex.Supplier indexFactory, IndexDescriptor descriptor, IndexSamplingConfig samplingConfig )
     {
         return new SpatialFusionIndexUpdater( indexMap, indexId, indexFactory, descriptor, samplingConfig, true );
     }
 
-    private SpatialFusionIndexUpdater( Map<CoordinateReferenceSystem,SpatialCRSSchemaIndex> indexMap, long indexId, SpatialCRSSchemaIndex.Factory indexFactory,
-            IndexDescriptor descriptor, IndexSamplingConfig samplingConfig, boolean populating )
+    private SpatialFusionIndexUpdater( Map<CoordinateReferenceSystem,SpatialCRSSchemaIndex> indexMap,
+                                       long indexId,
+                                       SpatialCRSSchemaIndex.Supplier indexSupplier,
+                                       IndexDescriptor descriptor,
+                                       IndexSamplingConfig samplingConfig,
+                                       boolean populating )
     {
         this.indexMap = indexMap;
         this.indexId = indexId;
-        this.indexFactory = indexFactory;
+        this.indexSupplier = indexSupplier;
         this.descriptor = descriptor;
         this.samplingConfig = samplingConfig;
         this.populating = populating;
@@ -112,7 +116,7 @@ class SpatialFusionIndexUpdater implements IndexUpdater
         {
             return updater;
         }
-        SpatialCRSSchemaIndex index = indexFactory.selectAndCreate( descriptor, indexMap, indexId, crs );
+        SpatialCRSSchemaIndex index = indexSupplier.get( descriptor, indexMap, indexId, crs );
         IndexUpdater indexUpdater = index.updaterWithCreate( samplingConfig, populating );
         return remember( crs, indexUpdater );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexUpdater.java
@@ -28,7 +28,7 @@ import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
-import org.neo4j.kernel.impl.index.schema.SpatialKnownIndex;
+import org.neo4j.kernel.impl.index.schema.SpatialCRSSchemaIndex;
 import org.neo4j.values.storable.CoordinateReferenceSystem;
 import org.neo4j.values.storable.PointValue;
 import org.neo4j.values.storable.Value;
@@ -37,27 +37,27 @@ import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexUtils.forAll;
 
 class SpatialFusionIndexUpdater implements IndexUpdater
 {
-    private final Map<CoordinateReferenceSystem,SpatialKnownIndex> indexMap;
+    private final Map<CoordinateReferenceSystem,SpatialCRSSchemaIndex> indexMap;
     private final Map<CoordinateReferenceSystem,IndexUpdater> currentUpdaters = new HashMap<>();
     private final long indexId;
-    private final SpatialKnownIndex.Factory indexFactory;
+    private final SpatialCRSSchemaIndex.Factory indexFactory;
     private final IndexDescriptor descriptor;
     private final IndexSamplingConfig samplingConfig;
     private final boolean populating;
 
-    static SpatialFusionIndexUpdater updaterForAccessor( Map<CoordinateReferenceSystem,SpatialKnownIndex> indexMap, long indexId,
-            SpatialKnownIndex.Factory indexFactory, IndexDescriptor descriptor, IndexSamplingConfig samplingConfig )
+    static SpatialFusionIndexUpdater updaterForAccessor( Map<CoordinateReferenceSystem,SpatialCRSSchemaIndex> indexMap, long indexId,
+            SpatialCRSSchemaIndex.Factory indexFactory, IndexDescriptor descriptor, IndexSamplingConfig samplingConfig )
     {
         return new SpatialFusionIndexUpdater( indexMap, indexId, indexFactory, descriptor, samplingConfig, false );
     }
 
-    static SpatialFusionIndexUpdater updaterForPopulator( Map<CoordinateReferenceSystem,SpatialKnownIndex> indexMap, long indexId,
-            SpatialKnownIndex.Factory indexFactory, IndexDescriptor descriptor, IndexSamplingConfig samplingConfig )
+    static SpatialFusionIndexUpdater updaterForPopulator( Map<CoordinateReferenceSystem,SpatialCRSSchemaIndex> indexMap, long indexId,
+            SpatialCRSSchemaIndex.Factory indexFactory, IndexDescriptor descriptor, IndexSamplingConfig samplingConfig )
     {
         return new SpatialFusionIndexUpdater( indexMap, indexId, indexFactory, descriptor, samplingConfig, true );
     }
 
-    private SpatialFusionIndexUpdater( Map<CoordinateReferenceSystem,SpatialKnownIndex> indexMap, long indexId, SpatialKnownIndex.Factory indexFactory,
+    private SpatialFusionIndexUpdater( Map<CoordinateReferenceSystem,SpatialCRSSchemaIndex> indexMap, long indexId, SpatialCRSSchemaIndex.Factory indexFactory,
             IndexDescriptor descriptor, IndexSamplingConfig samplingConfig, boolean populating )
     {
         this.indexMap = indexMap;
@@ -112,8 +112,8 @@ class SpatialFusionIndexUpdater implements IndexUpdater
         {
             return updater;
         }
-        SpatialKnownIndex index = indexFactory.selectAndCreate( indexMap, indexId, crs );
-        IndexUpdater indexUpdater = index.updaterWithCreate( descriptor, samplingConfig, populating );
+        SpatialCRSSchemaIndex index = indexFactory.selectAndCreate( descriptor, indexMap, indexId, crs );
+        IndexUpdater indexUpdater = index.updaterWithCreate( samplingConfig, populating );
         return remember( crs, indexUpdater );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionSchemaIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionSchemaIndexProvider.java
@@ -45,7 +45,7 @@ import org.neo4j.values.storable.CoordinateReferenceSystem;
 /**
  * Schema index provider for native indexes backed by e.g. {@link GBPTree}.
  */
-public class SpatialFusionSchemaIndexProvider extends SchemaIndexProvider implements SpatialCRSSchemaIndex.Factory
+public class SpatialFusionSchemaIndexProvider extends SchemaIndexProvider implements SpatialCRSSchemaIndex.Supplier
 {
     public static final String KEY = "spatial";
     public static final Descriptor SPATIAL_PROVIDER_DESCRIPTOR = new Descriptor( KEY, "1.0" );
@@ -163,7 +163,7 @@ public class SpatialFusionSchemaIndexProvider extends SchemaIndexProvider implem
     }
 
     @Override
-    public SpatialCRSSchemaIndex selectAndCreate( IndexDescriptor descriptor,
+    public SpatialCRSSchemaIndex get( IndexDescriptor descriptor,
             Map<CoordinateReferenceSystem,SpatialCRSSchemaIndex> indexMap, long indexId, CoordinateReferenceSystem crs )
     {
         return indexMap.computeIfAbsent( crs,
@@ -192,7 +192,7 @@ public class SpatialFusionSchemaIndexProvider extends SchemaIndexProvider implem
                         int tableId = Integer.parseInt( m.group( 1 ) );
                         int code = Integer.parseInt( m.group( 2 ) );
                         CoordinateReferenceSystem crs = CoordinateReferenceSystem.get( tableId, code );
-                        SpatialCRSSchemaIndex index = selectAndCreate( descriptor, indexMap, indexId, crs );
+                        SpatialCRSSchemaIndex index = get( descriptor, indexMap, indexId, crs );
                         if ( !index.indexExists() )
                         {
                             index.markAsFailed( "Index file was not found" );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialKnownIndexTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialKnownIndexTest.java
@@ -89,26 +89,13 @@ public class SpatialKnownIndexTest
     }
 
     @Test
-    public void shouldNotCreateFileOnInit()
-    {
-        // given
-        assertThat( fs.listFiles( storeDir ).length, equalTo( 0 ) );
-
-        // when
-        index.init( samplingConfig );
-
-        // then
-        assertThat( fs.listFiles( storeDir ).length, equalTo( 0 ) );
-    }
-
-    @Test
     public void shouldCreateFileOnCreate() throws IOException
     {
         // given
         assertThat( fs.listFiles( storeDir ).length, equalTo( 0 ) );
 
         // when
-        index.startPopulation( samplingConfig );
+        index.startPopulation();
 
         // then
         assertThat( fs.listFiles( indexDir ).length, equalTo( 1 ) );
@@ -123,7 +110,7 @@ public class SpatialKnownIndexTest
         try
         {
             // when
-            index.takeOnline( samplingConfig );
+            index.takeOnline();
             fail("should have thrown exception");
         }
         catch ( IOException e )
@@ -139,12 +126,12 @@ public class SpatialKnownIndexTest
     {
         // given
         assertThat( fs.listFiles( storeDir ).length, equalTo( 0 ) );
-        index.startPopulation( samplingConfig );
+        index.startPopulation();
 
         // when
         try
         {
-            index.takeOnline( samplingConfig );
+            index.takeOnline();
             fail( "Should have thrown exception." );
         }
         catch ( IllegalStateException e )
@@ -160,11 +147,11 @@ public class SpatialKnownIndexTest
     {
         // given
         assertThat( fs.listFiles( storeDir ).length, equalTo( 0 ) );
-        index.startPopulation( samplingConfig );
+        index.startPopulation();
         index.finishPopulation( true );
 
         // when
-        index.takeOnline( samplingConfig );
+        index.takeOnline();
         index.close();
     }
 
@@ -174,7 +161,7 @@ public class SpatialKnownIndexTest
         assertThat( fs.listFiles( storeDir ).length, equalTo( 0 ) );
 
         // when
-        IndexUpdater updater = index.updaterWithCreate( samplingConfig, false );
+        IndexUpdater updater = index.updaterWithCreate( false );
 
         // then
         assertThat( fs.listFiles( indexDir ).length, equalTo( 1 ) );
@@ -189,7 +176,7 @@ public class SpatialKnownIndexTest
         assertThat( fs.listFiles( storeDir ).length, equalTo( 0 ) );
 
         // when
-        IndexUpdater updater = index.updaterWithCreate( samplingConfig, true );
+        IndexUpdater updater = index.updaterWithCreate( true );
 
         // then
         assertThat( fs.listFiles( indexDir ).length, equalTo( 1 ) );
@@ -203,7 +190,7 @@ public class SpatialKnownIndexTest
     {
         // given
         assertThat( fs.listFiles( storeDir ).length, equalTo( 0 ) );
-        index.startPopulation( samplingConfig );
+        index.startPopulation();
         assertThat( fs.listFiles( indexDir ).length, equalTo( 1 ) );
 
         // when

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialKnownIndexTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialKnownIndexTest.java
@@ -63,7 +63,7 @@ public class SpatialKnownIndexTest
     @Rule
     public final RuleChain rules = outerRule( fsRule ).around( directory ).around( pageCacheRule ).around( random );
 
-    private SpatialKnownIndex index;
+    private SpatialCRSSchemaIndex index;
     private IndexDescriptor descriptor;
     private IndexSamplingConfig samplingConfig;
     private FileSystemAbstraction fs;
@@ -82,9 +82,9 @@ public class SpatialKnownIndexTest
         String crsDir = String.format("%s-%s", crs.getTable().getTableId(), crs.getCode() );
         indexDir = new File( new File( new File( new File( new File( storeDir, "schema" ), "index" ), "spatial-1.0" ), "1" ), crsDir );
         IndexDirectoryStructure dirStructure = IndexDirectoryStructure.directoriesByProvider( storeDir ).forProvider( SPATIAL_PROVIDER_DESCRIPTOR );
-        index = new SpatialKnownIndex( dirStructure, crs, 1L, pageCacheRule.getPageCache( fs ), fs,
-                SchemaIndexProvider.Monitor.EMPTY, RecoveryCleanupWorkCollector.IMMEDIATE );
         descriptor = IndexDescriptorFactory.forLabel( 42, 1337 );
+        index = new SpatialCRSSchemaIndex( descriptor, dirStructure, crs, 1L, pageCacheRule.getPageCache( fs ), fs,
+                SchemaIndexProvider.Monitor.EMPTY, RecoveryCleanupWorkCollector.IMMEDIATE );
         samplingConfig = mock( IndexSamplingConfig.class );
     }
 
@@ -95,7 +95,7 @@ public class SpatialKnownIndexTest
         assertThat( fs.listFiles( storeDir ).length, equalTo( 0 ) );
 
         // when
-        index.init( descriptor, samplingConfig );
+        index.init( samplingConfig );
 
         // then
         assertThat( fs.listFiles( storeDir ).length, equalTo( 0 ) );
@@ -108,7 +108,7 @@ public class SpatialKnownIndexTest
         assertThat( fs.listFiles( storeDir ).length, equalTo( 0 ) );
 
         // when
-        index.startPopulation( descriptor, samplingConfig );
+        index.startPopulation( samplingConfig );
 
         // then
         assertThat( fs.listFiles( indexDir ).length, equalTo( 1 ) );
@@ -123,7 +123,7 @@ public class SpatialKnownIndexTest
         try
         {
             // when
-            index.takeOnline( descriptor, samplingConfig );
+            index.takeOnline( samplingConfig );
             fail("should have thrown exception");
         }
         catch ( IOException e )
@@ -139,12 +139,12 @@ public class SpatialKnownIndexTest
     {
         // given
         assertThat( fs.listFiles( storeDir ).length, equalTo( 0 ) );
-        index.startPopulation( descriptor, samplingConfig );
+        index.startPopulation( samplingConfig );
 
         // when
         try
         {
-            index.takeOnline( descriptor, samplingConfig );
+            index.takeOnline( samplingConfig );
             fail( "Should have thrown exception." );
         }
         catch ( IllegalStateException e )
@@ -160,11 +160,11 @@ public class SpatialKnownIndexTest
     {
         // given
         assertThat( fs.listFiles( storeDir ).length, equalTo( 0 ) );
-        index.startPopulation( descriptor, samplingConfig );
+        index.startPopulation( samplingConfig );
         index.finishPopulation( true );
 
         // when
-        index.takeOnline( descriptor, samplingConfig );
+        index.takeOnline( samplingConfig );
         index.close();
     }
 
@@ -174,7 +174,7 @@ public class SpatialKnownIndexTest
         assertThat( fs.listFiles( storeDir ).length, equalTo( 0 ) );
 
         // when
-        IndexUpdater updater = index.updaterWithCreate( descriptor, samplingConfig, false );
+        IndexUpdater updater = index.updaterWithCreate( samplingConfig, false );
 
         // then
         assertThat( fs.listFiles( indexDir ).length, equalTo( 1 ) );
@@ -189,7 +189,7 @@ public class SpatialKnownIndexTest
         assertThat( fs.listFiles( storeDir ).length, equalTo( 0 ) );
 
         // when
-        IndexUpdater updater = index.updaterWithCreate( descriptor, samplingConfig, true );
+        IndexUpdater updater = index.updaterWithCreate( samplingConfig, true );
 
         // then
         assertThat( fs.listFiles( indexDir ).length, equalTo( 1 ) );
@@ -203,7 +203,7 @@ public class SpatialKnownIndexTest
     {
         // given
         assertThat( fs.listFiles( storeDir ).length, equalTo( 0 ) );
-        index.startPopulation( descriptor, samplingConfig );
+        index.startPopulation( samplingConfig );
         assertThat( fs.listFiles( indexDir ).length, equalTo( 1 ) );
 
         // when

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexAccessorTest.java
@@ -68,7 +68,7 @@ public class SpatialFusionIndexAccessorTest
     @Before
     public void setup() throws Exception
     {
-        SpatialCRSSchemaIndex.Factory indexFactory = mock( SpatialCRSSchemaIndex.Factory.class );
+        SpatialCRSSchemaIndex.Supplier indexFactory = mock( SpatialCRSSchemaIndex.Supplier.class );
 
         for ( CoordinateReferenceSystem crs : asList( WGS84, Cartesian ) )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexAccessorTest.java
@@ -35,7 +35,7 @@ import java.util.Set;
 import org.neo4j.helpers.collection.BoundedIterable;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
-import org.neo4j.kernel.impl.index.schema.SpatialKnownIndex;
+import org.neo4j.kernel.impl.index.schema.SpatialCRSSchemaIndex;
 import org.neo4j.values.storable.CoordinateReferenceSystem;
 
 import static java.util.Arrays.asList;
@@ -63,16 +63,16 @@ public class SpatialFusionIndexAccessorTest
 {
 
     private SpatialFusionIndexAccessor fusionIndexAccessor;
-    private Map<CoordinateReferenceSystem,SpatialKnownIndex> indexMap = new HashMap<>();
+    private Map<CoordinateReferenceSystem,SpatialCRSSchemaIndex> indexMap = new HashMap<>();
 
     @Before
     public void setup() throws Exception
     {
-        SpatialKnownIndex.Factory indexFactory = mock( SpatialKnownIndex.Factory.class );
+        SpatialCRSSchemaIndex.Factory indexFactory = mock( SpatialCRSSchemaIndex.Factory.class );
 
         for ( CoordinateReferenceSystem crs : asList( WGS84, Cartesian ) )
         {
-            indexMap.put( crs, mock( SpatialKnownIndex.class ) );
+            indexMap.put( crs, mock( SpatialCRSSchemaIndex.class ) );
         }
 
         fusionIndexAccessor = new SpatialFusionIndexAccessor( indexMap, 0, mock( IndexDescriptor.class ), null, indexFactory );
@@ -83,7 +83,7 @@ public class SpatialFusionIndexAccessorTest
     {
         fusionIndexAccessor.drop();
 
-        for ( SpatialKnownIndex spatialKnownIndex : indexMap.values() )
+        for ( SpatialCRSSchemaIndex spatialKnownIndex : indexMap.values() )
         {
             verify( spatialKnownIndex, times( 1 ) ).drop();
         }
@@ -126,7 +126,7 @@ public class SpatialFusionIndexAccessorTest
     {
         fusionIndexAccessor.close();
 
-        for ( SpatialKnownIndex spatialKnownIndex : indexMap.values() )
+        for ( SpatialCRSSchemaIndex spatialKnownIndex : indexMap.values() )
         {
             verify( spatialKnownIndex, times( 1 ) ).close();
         }
@@ -135,7 +135,7 @@ public class SpatialFusionIndexAccessorTest
     @Test
     public void closeMustCloseOthersIfCloseOneFail() throws Exception
     {
-        for ( SpatialKnownIndex failingIndex : indexMap.values() )
+        for ( SpatialCRSSchemaIndex failingIndex : indexMap.values() )
         {
             IOException failure = new IOException( "fail" );
             doThrow( failure ).when( failingIndex ).close();
@@ -151,7 +151,7 @@ public class SpatialFusionIndexAccessorTest
             }
 
             // then
-            for ( SpatialKnownIndex successfulIndex : indexMap.values() )
+            for ( SpatialCRSSchemaIndex successfulIndex : indexMap.values() )
             {
                 if ( failingIndex != successfulIndex )
                 {
@@ -165,7 +165,7 @@ public class SpatialFusionIndexAccessorTest
     @Test
     public void closeMustThrowIfCloseOneFail() throws Exception
     {
-        for ( SpatialKnownIndex index : indexMap.values() )
+        for ( SpatialCRSSchemaIndex index : indexMap.values() )
         {
             IOException expectedFailure = new IOException( "fail" );
             doThrow( expectedFailure ).when( index ).close();
@@ -187,7 +187,7 @@ public class SpatialFusionIndexAccessorTest
     {
         // given
         List<IOException> failures = new ArrayList<>();
-        for ( SpatialKnownIndex index : indexMap.values() )
+        for ( SpatialCRSSchemaIndex index : indexMap.values() )
         {
             IOException exception = new IOException( "unknown" );
             failures.add( exception );
@@ -354,7 +354,7 @@ public class SpatialFusionIndexAccessorTest
         assertThat( fusionAllEntriesReader.maxCount(), is( 9L ) );
     }
 
-    private void verifyFailOnSingleDropFailure( SpatialKnownIndex spatialKnownIndex ) throws IOException
+    private void verifyFailOnSingleDropFailure( SpatialCRSSchemaIndex spatialKnownIndex ) throws IOException
     {
         IOException expectedFailure = new IOException( "fail" );
         doThrow( expectedFailure ).when( spatialKnownIndex ).drop();
@@ -369,14 +369,14 @@ public class SpatialFusionIndexAccessorTest
         }
     }
 
-    private BoundedIterable<Long> mockSingleAllEntriesReader( SpatialKnownIndex spatialKnownIndex, long[] entries )
+    private BoundedIterable<Long> mockSingleAllEntriesReader( SpatialCRSSchemaIndex spatialKnownIndex, long[] entries )
     {
         BoundedIterable<Long> allEntriesReader = mockedAllEntriesReader( entries );
         when( spatialKnownIndex.newAllEntriesReader() ).thenReturn( allEntriesReader );
         return allEntriesReader;
     }
 
-    private void mockSingleAllEntriesReaderWithUnknownMaxCount( SpatialKnownIndex spatialKnownIndex, long[] entries )
+    private void mockSingleAllEntriesReaderWithUnknownMaxCount( SpatialCRSSchemaIndex spatialKnownIndex, long[] entries )
     {
         BoundedIterable<Long> allEntriesReader = mockedAllEntriesReaderUnknownMaxCount( entries );
         when( spatialKnownIndex.newAllEntriesReader() ).thenReturn( allEntriesReader );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexPopulatorTest.java
@@ -61,17 +61,17 @@ public class SpatialFusionIndexPopulatorTest
     @Before
     public void setup() throws Exception
     {
-        SpatialCRSSchemaIndex.Factory indexFactory = mock( SpatialCRSSchemaIndex.Factory.class );
+        SpatialCRSSchemaIndex.Supplier indexSupplier = mock( SpatialCRSSchemaIndex.Supplier.class );
         IndexDescriptor descriptor = mock( IndexDescriptor.class );
 
         for ( CoordinateReferenceSystem crs : asList( CoordinateReferenceSystem.WGS84, CoordinateReferenceSystem.Cartesian ) )
         {
             indexMap.put( crs, mock( SpatialCRSSchemaIndex.class ) );
 
-            when( indexFactory.selectAndCreate( descriptor, indexMap, 0, crs ) ).thenReturn( indexMap.get( crs ) );
+            when( indexSupplier.get( descriptor, indexMap, 0, crs ) ).thenReturn( indexMap.get( crs ) );
         }
 
-        fusionIndexPopulator = new SpatialFusionIndexPopulator( indexMap, 0, descriptor, null, indexFactory );
+        fusionIndexPopulator = new SpatialFusionIndexPopulator( indexMap, 0, descriptor, null, indexSupplier );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexUpdaterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexUpdaterTest.java
@@ -67,14 +67,14 @@ public class SpatialFusionIndexUpdaterTest
             updaterMap.put( crs, mock( IndexUpdater.class ) );
             indexMap.put( crs, mock( SpatialCRSSchemaIndex.class ) );
             when( indexSupplier.get( descriptor, indexMap, 0, crs ) ).thenReturn( indexMap.get( crs ) );
-            when( indexMap.get( crs ).updaterWithCreate( samplingConfig, true ) ).thenReturn( updaterMap.get( crs ) );
-            when( indexMap.get( crs ).updaterWithCreate( samplingConfig, false ) ).thenReturn( updaterMap.get( crs ) );
+            when( indexMap.get( crs ).updaterWithCreate( true ) ).thenReturn( updaterMap.get( crs ) );
+            when( indexMap.get( crs ).updaterWithCreate( false ) ).thenReturn( updaterMap.get( crs ) );
         }
 
         fusionIndexAccessorUpdater = SpatialFusionIndexUpdater.updaterForAccessor(
-                indexMap, 0, indexSupplier, descriptor, samplingConfig );
+                indexMap, 0, indexSupplier, descriptor );
         fusionIndexPopulatorUpdater = SpatialFusionIndexUpdater.updaterForPopulator(
-                indexMap, 0, indexSupplier, descriptor, samplingConfig );
+                indexMap, 0, indexSupplier, descriptor );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexUpdaterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexUpdaterTest.java
@@ -58,7 +58,7 @@ public class SpatialFusionIndexUpdaterTest
     @Before
     public void setup() throws Exception
     {
-        SpatialCRSSchemaIndex.Factory indexFactory = mock( SpatialCRSSchemaIndex.Factory.class );
+        SpatialCRSSchemaIndex.Supplier indexSupplier = mock( SpatialCRSSchemaIndex.Supplier.class );
         IndexDescriptor descriptor = mock( IndexDescriptor.class );
         IndexSamplingConfig samplingConfig = mock( IndexSamplingConfig.class );
 
@@ -66,15 +66,15 @@ public class SpatialFusionIndexUpdaterTest
         {
             updaterMap.put( crs, mock( IndexUpdater.class ) );
             indexMap.put( crs, mock( SpatialCRSSchemaIndex.class ) );
-            when( indexFactory.selectAndCreate( descriptor, indexMap, 0, crs ) ).thenReturn( indexMap.get( crs ) );
+            when( indexSupplier.get( descriptor, indexMap, 0, crs ) ).thenReturn( indexMap.get( crs ) );
             when( indexMap.get( crs ).updaterWithCreate( samplingConfig, true ) ).thenReturn( updaterMap.get( crs ) );
             when( indexMap.get( crs ).updaterWithCreate( samplingConfig, false ) ).thenReturn( updaterMap.get( crs ) );
         }
 
         fusionIndexAccessorUpdater = SpatialFusionIndexUpdater.updaterForAccessor(
-                indexMap, 0, indexFactory, descriptor, samplingConfig );
+                indexMap, 0, indexSupplier, descriptor, samplingConfig );
         fusionIndexPopulatorUpdater = SpatialFusionIndexUpdater.updaterForPopulator(
-                indexMap, 0, indexFactory, descriptor, samplingConfig );
+                indexMap, 0, indexSupplier, descriptor, samplingConfig );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexUpdaterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionIndexUpdaterTest.java
@@ -32,7 +32,7 @@ import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
-import org.neo4j.kernel.impl.index.schema.SpatialKnownIndex;
+import org.neo4j.kernel.impl.index.schema.SpatialCRSSchemaIndex;
 import org.neo4j.values.storable.CoordinateReferenceSystem;
 import org.neo4j.values.storable.PointValue;
 import org.neo4j.values.storable.Value;
@@ -51,24 +51,24 @@ import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexTestHelp.remo
 public class SpatialFusionIndexUpdaterTest
 {
     private Map<CoordinateReferenceSystem,IndexUpdater> updaterMap = new HashMap<>();
-    private Map<CoordinateReferenceSystem,SpatialKnownIndex> indexMap = new HashMap<>();
+    private Map<CoordinateReferenceSystem,SpatialCRSSchemaIndex> indexMap = new HashMap<>();
     private SpatialFusionIndexUpdater fusionIndexAccessorUpdater;
     private SpatialFusionIndexUpdater fusionIndexPopulatorUpdater;
 
     @Before
     public void setup() throws Exception
     {
-        SpatialKnownIndex.Factory indexFactory = mock( SpatialKnownIndex.Factory.class );
+        SpatialCRSSchemaIndex.Factory indexFactory = mock( SpatialCRSSchemaIndex.Factory.class );
         IndexDescriptor descriptor = mock( IndexDescriptor.class );
         IndexSamplingConfig samplingConfig = mock( IndexSamplingConfig.class );
 
         for ( CoordinateReferenceSystem crs : asList( CoordinateReferenceSystem.WGS84, CoordinateReferenceSystem.Cartesian ) )
         {
             updaterMap.put( crs, mock( IndexUpdater.class ) );
-            indexMap.put( crs, mock( SpatialKnownIndex.class ) );
-            when( indexFactory.selectAndCreate( indexMap, 0, crs ) ).thenReturn( indexMap.get( crs ) );
-            when( indexMap.get( crs ).updaterWithCreate( descriptor, samplingConfig, true ) ).thenReturn( updaterMap.get( crs ) );
-            when( indexMap.get( crs ).updaterWithCreate( descriptor, samplingConfig, false ) ).thenReturn( updaterMap.get( crs ) );
+            indexMap.put( crs, mock( SpatialCRSSchemaIndex.class ) );
+            when( indexFactory.selectAndCreate( descriptor, indexMap, 0, crs ) ).thenReturn( indexMap.get( crs ) );
+            when( indexMap.get( crs ).updaterWithCreate( samplingConfig, true ) ).thenReturn( updaterMap.get( crs ) );
+            when( indexMap.get( crs ).updaterWithCreate( samplingConfig, false ) ).thenReturn( updaterMap.get( crs ) );
         }
 
         fusionIndexAccessorUpdater = SpatialFusionIndexUpdater.updaterForAccessor(

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionSchemaIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionSchemaIndexProviderTest.java
@@ -32,7 +32,7 @@ import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
-import org.neo4j.kernel.impl.index.schema.SpatialKnownIndex;
+import org.neo4j.kernel.impl.index.schema.SpatialCRSSchemaIndex;
 import org.neo4j.test.rule.RandomRule;
 import org.neo4j.values.storable.CoordinateReferenceSystem;
 import org.neo4j.values.storable.PointValue;
@@ -51,7 +51,7 @@ public class SpatialFusionSchemaIndexProviderTest
     @Rule
     public RandomRule random = new RandomRule();
 
-    private Map<CoordinateReferenceSystem, SpatialKnownIndex> indexMap;
+    private Map<CoordinateReferenceSystem,SpatialCRSSchemaIndex> indexMap;
     private SpatialFusionSchemaIndexProvider provider;
     private IndexDescriptor descriptor = IndexDescriptorFactory.forLabel( 1, 1 );
 
@@ -66,8 +66,8 @@ public class SpatialFusionSchemaIndexProviderTest
                 null,
                 false );
         indexMap = provider.indexesFor( 0 );
-        indexMap.put( CoordinateReferenceSystem.WGS84, mock( SpatialKnownIndex.class ) );
-        indexMap.put( CoordinateReferenceSystem.Cartesian, mock( SpatialKnownIndex.class ) );
+        indexMap.put( CoordinateReferenceSystem.WGS84, mock( SpatialCRSSchemaIndex.class ) );
+        indexMap.put( CoordinateReferenceSystem.Cartesian, mock( SpatialCRSSchemaIndex.class ) );
     }
 
     @Test
@@ -76,12 +76,12 @@ public class SpatialFusionSchemaIndexProviderTest
         for ( InternalIndexState state : array( InternalIndexState.ONLINE, InternalIndexState.POPULATING ) )
         {
             // when
-            for ( SpatialKnownIndex index : indexMap.values() )
+            for ( SpatialCRSSchemaIndex index : indexMap.values() )
             {
                 setInitialState( index, state );
             }
 
-            for ( SpatialKnownIndex index : indexMap.values() )
+            for ( SpatialCRSSchemaIndex index : indexMap.values() )
             {
                 setInitialState( index, InternalIndexState.POPULATING );
                 // then
@@ -96,7 +96,7 @@ public class SpatialFusionSchemaIndexProviderTest
     {
         // when
         // ... no failure
-        for ( SpatialKnownIndex index : indexMap.values() )
+        for ( SpatialCRSSchemaIndex index : indexMap.values() )
         {
             when( index.readPopulationFailure( descriptor ) ).thenReturn( null );
         }
@@ -118,14 +118,14 @@ public class SpatialFusionSchemaIndexProviderTest
         {
             PointValue point = (PointValue) spatialValue;
             CoordinateReferenceSystem crs = point.getCoordinateReferenceSystem();
-            SpatialKnownIndex index = provider.selectAndCreate( indexMap, 0, point.getCoordinateReferenceSystem() );
+            SpatialCRSSchemaIndex index = provider.selectAndCreate( descriptor, indexMap, 0, point.getCoordinateReferenceSystem() );
             assertSame( indexMap.get( crs ), index );
-            index = provider.selectAndCreate( indexMap, 0, crs );
+            index = provider.selectAndCreate( descriptor, indexMap, 0, crs );
             assertSame( indexMap.get( crs ), index );
         }
     }
 
-    private void setInitialState( SpatialKnownIndex mockedIndex, InternalIndexState state ) throws IOException
+    private void setInitialState( SpatialCRSSchemaIndex mockedIndex, InternalIndexState state ) throws IOException
     {
         when( mockedIndex.indexExists() ).thenReturn( true );
         when( mockedIndex.readState( descriptor ) ).thenReturn( state );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionSchemaIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/SpatialFusionSchemaIndexProviderTest.java
@@ -118,9 +118,9 @@ public class SpatialFusionSchemaIndexProviderTest
         {
             PointValue point = (PointValue) spatialValue;
             CoordinateReferenceSystem crs = point.getCoordinateReferenceSystem();
-            SpatialCRSSchemaIndex index = provider.selectAndCreate( descriptor, indexMap, 0, point.getCoordinateReferenceSystem() );
+            SpatialCRSSchemaIndex index = provider.get( descriptor, indexMap, 0, point.getCoordinateReferenceSystem() );
             assertSame( indexMap.get( crs ), index );
-            index = provider.selectAndCreate( descriptor, indexMap, 0, crs );
+            index = provider.get( descriptor, indexMap, 0, crs );
             assertSame( indexMap.get( crs ), index );
         }
     }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
@@ -19,10 +19,7 @@
  */
 package org.neo4j.internal.cypher.acceptance
 
-import java.util.concurrent.TimeUnit
-
 import org.neo4j.cypher.ExecutionEngineFunSuite
-import org.neo4j.graphdb.Label
 import org.neo4j.graphdb.spatial.Point
 import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
 import org.neo4j.values.storable.{CoordinateReferenceSystem, Values}


### PR DESCRIPTION
Changed to do sampling at SpatialFusion level and got rid of the need to have an init method in `SpatialCRSSchemaIndex`.