### PR TITLE
3.1 Resolved inc backup debug.logs wrong location

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/StoreLogService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/StoreLogService.java
@@ -101,9 +101,10 @@ public class StoreLogService extends AbstractLogService implements Lifecycle
 
         public StoreLogService inLogsDirectory(FileSystemAbstraction fileSystem, File logsDir ) throws IOException
         {
+            File debugLogFile = new File( logsDir, INTERNAL_LOG_NAME );
             return new StoreLogService(
                     userLogProvider,
-                    fileSystem, new File( logsDir, INTERNAL_LOG_NAME ), logLevels, defaultLevel,
+                    fileSystem, debugLogFile, logLevels, defaultLevel,
                     internalLogRotationThreshold, internalLogRotationDelay, maxInternalLogArchives, rotationExecutor, rotationListener );
         }
     }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -39,6 +39,7 @@ import org.neo4j.com.storecopy.StoreCopyClient;
 import org.neo4j.com.storecopy.StoreWriter;
 import org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker;
 import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.CancellationRequest;
@@ -290,6 +291,7 @@ class BackupService
     {
         GraphDatabaseFactory factory = ExternallyManagedPageCache.graphDatabaseFactoryWithPageCache( pageCache );
         return (GraphDatabaseAPI) factory.newEmbeddedDatabaseBuilder( targetDirectory ).setConfig( config )
+                .setConfig( GraphDatabaseSettings.logs_directory, targetDirectory.toString() )
                 .newGraphDatabase();
     }
 

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ExternallyManagedPageCache.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ExternallyManagedPageCache.java
@@ -111,7 +111,7 @@ public class ExternallyManagedPageCache implements PageCache
      */
     public static GraphDatabaseFactoryWithPageCacheFactory graphDatabaseFactoryWithPageCache( final PageCache delegatePageCache )
     {
-        return new GraphDatabaseFactoryWithPageCacheFactory( delegatePageCache);
+        return new GraphDatabaseFactoryWithPageCacheFactory( delegatePageCache );
     }
 
     public static class GraphDatabaseFactoryWithPageCacheFactory extends GraphDatabaseFactory


### PR DESCRIPTION
During incremental backup debug logs were being written to a different
directory that the backup target location. This commit fixes that.