### PR TITLE
Fixes bug with unsupported default value for explicit.remove procedures

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
@@ -574,12 +574,14 @@ public class BuiltInProcedures
         return Stream.of( new BooleanResult( true ) );
     }
 
+    private static final String DEFAULT_KEY = " <[9895b15e-8693-4a21-a58b-4b7b87e09b8e]> ";
+
     @Description( "Remove a node from an explicit index with an optional key" )
     @Procedure( name = "db.index.explicit.removeNode", mode = WRITE )
     public Stream<BooleanResult> nodeManualIndexRemove( @Name( "indexName" ) String explicitIndexName,
-            @Name( "node" ) Node node, @Name( "key" ) String key )
+            @Name( "node" ) Node node, @Name( value = "key", defaultValue = DEFAULT_KEY ) String key )
     {
-        if ( key.equals( Name.DEFAULT_VALUE ) )
+        if ( key.equals( DEFAULT_KEY ) )
         {
             graphDatabaseAPI.index().forNodes( explicitIndexName ).remove( node );
         }
@@ -595,9 +597,9 @@ public class BuiltInProcedures
     @Procedure( name = "db.index.explicit.removeRelationship", mode = WRITE )
     public Stream<BooleanResult> relationshipManualIndexRemove( @Name( "indexName" ) String explicitIndexName,
             @Name( "relationship" ) Relationship relationship,
-            @Name( "key" ) String key )
+            @Name( value = "key", defaultValue = DEFAULT_KEY ) String key )
     {
-        if ( key.equals( Name.DEFAULT_VALUE ) )
+        if ( key.equals( DEFAULT_KEY ) )
         {
             graphDatabaseAPI.index().forRelationships( explicitIndexName ).remove( relationship );
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -272,10 +272,12 @@ public class BuiltInProceduresTest
                         "(success :: BOOLEAN?)",
                         "Add a relationship to an explicit index based on a specified key and value"),
                 record( "db.index.explicit.removeNode",
-                        "db.index.explicit.removeNode(indexName :: STRING?, node :: NODE?, key :: STRING?) :: (success :: BOOLEAN?)",
+                        "db.index.explicit.removeNode(indexName :: STRING?, node :: NODE?, " +
+                        "key =  <[9895b15e-8693-4a21-a58b-4b7b87e09b8e]>  :: STRING?) :: (success :: BOOLEAN?)",
                         "Remove a node from an explicit index with an optional key"),
                 record( "db.index.explicit.removeRelationship",
-                        "db.index.explicit.removeRelationship(indexName :: STRING?, relationship :: RELATIONSHIP?, key :: STRING?) :: " +
+                        "db.index.explicit.removeRelationship(indexName :: STRING?, relationship :: RELATIONSHIP?, " +
+                        "key =  <[9895b15e-8693-4a21-a58b-4b7b87e09b8e]>  :: STRING?) :: " +
                         "(success :: BOOLEAN?)",
                         "Remove a relationship from an explicit index with an optional key"),
                 record( "db.index.explicit.drop",

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
@@ -207,11 +207,12 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
                         "(success :: BOOLEAN?)",
                         "Add a relationship to an explicit index based on a specified key and value"} ),
                 equalTo( new Object[]{ "db.index.explicit.removeNode",
-                        "db.index.explicit.removeNode(indexName :: STRING?, node :: NODE?, key :: STRING?) :: (success :: BOOLEAN?)",
+                        "db.index.explicit.removeNode(indexName :: STRING?, node :: NODE?, " +
+                        "key =  <[9895b15e-8693-4a21-a58b-4b7b87e09b8e]>  :: STRING?) :: (success :: BOOLEAN?)",
                         "Remove a node from an explicit index with an optional key"} ),
                 equalTo( new Object[]{ "db.index.explicit.removeRelationship",
-                        "db.index.explicit.removeRelationship(indexName :: STRING?, relationship :: RELATIONSHIP?, key :: STRING?) :: " +
-                        "(success :: BOOLEAN?)",
+                        "db.index.explicit.removeRelationship(indexName :: STRING?, relationship :: RELATIONSHIP?, " +
+                        "key =  <[9895b15e-8693-4a21-a58b-4b7b87e09b8e]>  :: STRING?) :: (success :: BOOLEAN?)",
                         "Remove a relationship from an explicit index with an optional key"} ),
                 equalTo( new Object[]{ "db.index.explicit.drop",
                         "db.index.explicit.drop(indexName :: STRING?) :: " +

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ManualIndexProcsIT.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ManualIndexProcsIT.scala
@@ -441,6 +441,30 @@ class ManualIndexProcsIT extends ExecutionEngineFunSuite {
     emptyResult should equal(List.empty)
   }
 
+  test("Should able to add and remove a node from manual index using default parameter") {
+    val node = createNode(Map("name" -> "Neo"))
+
+    val addResult = execute(
+      """MATCH (n) WITH n CALL db.index.explicit.addNode('usernames', n, 'name', 'Neo') YIELD success as s RETURN s"""
+        .stripMargin).toList
+
+    addResult should be(List(Map("s" -> true)))
+
+    val seekResult = execute("CALL db.index.explicit.seekNodes('usernames', 'name', 'Neo') YIELD node AS n ").toList
+
+    seekResult should equal(List(Map("n" -> node)))
+
+    val result = execute(
+      """MATCH (n) WITH n CALL db.index.explicit.removeNode('usernames', n) YIELD success as s RETURN s"""
+        .stripMargin).toList
+
+    result should equal(List(Map("s" -> true)))
+
+    val emptyResult = execute("CALL db.index.explicit.seekNodes('usernames', 'name', 'Neo') YIELD node AS n ").toList
+
+    emptyResult should equal(List.empty)
+  }
+
   test("Should able to add and remove a relationship from manual index") {
     val a = createNode(Map("name" -> "Neo"))
     val b = createNode()
@@ -458,6 +482,32 @@ class ManualIndexProcsIT extends ExecutionEngineFunSuite {
 
     val result = execute(
       """MATCH (n)-[r]-(m) WHERE n.name = 'Neo' WITH r CALL db.index.explicit.removeRelationship('relIndex', r, 'distance') YIELD success as s RETURN s"""
+        .stripMargin).toList
+
+    result should equal(List(Map("s" -> true)))
+
+    val emptyResult = execute("CALL db.index.explicit.seekRelationships('relIndex', 'distance', '12') YIELD relationship AS r ").toList
+
+    emptyResult should equal(List.empty)
+  }
+
+  test("Should able to add and remove a relationship from manual index using default parameter") {
+    val a = createNode(Map("name" -> "Neo"))
+    val b = createNode()
+    val rel = relate(a, b, "distance" -> 12)
+
+    val addResult = execute(
+      """MATCH (n)-[r]-(m) WHERE n.name = 'Neo' WITH r CALL db.index.explicit.addRelationship('relIndex', r, 'distance', 12) YIELD success as s RETURN s"""
+        .stripMargin).toList
+
+    addResult should be(List(Map("s" -> true)))
+
+    val seekResult = execute("CALL db.index.explicit.seekRelationships('relIndex', 'distance', '12') YIELD relationship AS r ").toList
+
+    seekResult should equal(List(Map("r" -> rel)))
+
+    val result = execute(
+      """MATCH (n)-[r]-(m) WHERE n.name = 'Neo' WITH r CALL db.index.explicit.removeRelationship('relIndex', r) YIELD success as s RETURN s"""
         .stripMargin).toList
 
     result should equal(List(Map("s" -> true)))


### PR DESCRIPTION
The neo4j documentation and the original design indicates that is should be possible to not pass the third parameter to removeNode and removeRelationship procedures, however that did not work. The implementation had a misunderstanding of how optional parameters worked, and there were no tests for that specific case. This PR fixes that behaviour so the third parameter is now truly optional.