### PR TITLE
Forbid to import junit.framework package

### DIFF
--- a/build/checkstyle.xml
+++ b/build/checkstyle.xml
@@ -92,6 +92,10 @@
       <property name="max" value="160"/>
       <property name="ignorePattern" value="a href|href|http://|https://"/>
     </module>
+
+    <module name="IllegalImport">
+      <property name="illegalPkgs" value="junit.framework"/>
+    </module>
   </module>
 
 </module>

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/TwoLayerTxStateTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/TwoLayerTxStateTestBase.java
@@ -32,9 +32,9 @@ import java.util.stream.Collectors;
 
 import org.neo4j.values.storable.Value;
 
-import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.neo4j.values.storable.Values.booleanValue;
 import static org.neo4j.values.storable.Values.intValue;
 import static org.neo4j.values.storable.Values.stringValue;

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionTestBase.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 import org.neo4j.graphdb.ResourceIterator;
 
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 public abstract class RelationshipDenseSelectionTestBase<Traverser extends RelationshipDenseSelection>
         extends RelationshipSelectionTestBase

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/RelationshipSelectionTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/RelationshipSelectionTestBase.java
@@ -21,9 +21,9 @@ package org.neo4j.internal.kernel.api.helpers;
 
 import org.neo4j.graphdb.ResourceIterator;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 class RelationshipSelectionTestBase
 {

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionTestBase.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.internal.kernel.api.RelationshipTraversalCursor;
 
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 public abstract class RelationshipSparseSelectionTestBase<Traverser extends RelationshipSparseSelection>
         extends RelationshipSelectionTestBase


### PR DESCRIPTION
Adapt checkstyle to forbid usage of old junit.framework package.
Please use more analogs from recent junit's instead.