### PR TITLE
Don't use MethodHandle#invokeWithArguments for procedures et al

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
@@ -101,31 +101,31 @@ class ReflectiveProcedureCompiler
     {
         try
         {
-            List<Method> procedureMethods = Arrays.stream( fcnDefinition.getDeclaredMethods() )
+            List<Method> functionMethods = Arrays.stream( fcnDefinition.getDeclaredMethods() )
                     .filter( m -> m.isAnnotationPresent( UserFunction.class ) )
                     .collect( Collectors.toList() );
 
-            if ( procedureMethods.isEmpty() )
+            if ( functionMethods.isEmpty() )
             {
                 return emptyList();
             }
 
             MethodHandle constructor = constructor( fcnDefinition );
 
-            ArrayList<CallableUserFunction> out = new ArrayList<>( procedureMethods.size() );
-            for ( Method method : procedureMethods )
+            ArrayList<CallableUserFunction> out = new ArrayList<>( functionMethods.size() );
+            for ( Method method : functionMethods )
             {
                 String valueName = method.getAnnotation( UserFunction.class ).value();
                 String definedName = method.getAnnotation( UserFunction.class ).name();
-                QualifiedName procName = extractName( fcnDefinition, method, valueName, definedName );
-                if ( config.isWhitelisted( procName.toString() ) )
+                QualifiedName funcName = extractName( fcnDefinition, method, valueName, definedName );
+                if ( config.isWhitelisted( funcName.toString() ) )
                 {
-                    out.add( compileFunction( fcnDefinition, constructor, method,procName ) );
+                    out.add( compileFunction( fcnDefinition, constructor, method, funcName ) );
                 }
                 else
                 {
                     log.warn( String.format( "The function '%s' is not on the whitelist and won't be loaded.",
-                            procName.toString() ) );
+                            funcName.toString() ) );
                 }
             }
             out.sort( Comparator.comparing( a -> a.signature().name().toString() ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
@@ -697,23 +697,29 @@ class ReflectiveProcedureCompiler
 
         private ProcedureException newProcedureException( Throwable throwable )
         {
-            if (throwable instanceof Status.HasStatus )
+            Throwable cause = rootCause( throwable );
+            if ( cause instanceof Status.HasStatus )
             {
-                return new ProcedureException( ((Status.HasStatus) throwable).status(), throwable, throwable.getMessage() );
+                return new ProcedureException( ((Status.HasStatus) cause).status(), cause,
+                        cause.getMessage() );
             }
             else
             {
-                Throwable cause = ExceptionUtils.getRootCause( throwable );
-                return new ProcedureException( Status.Procedure.ProcedureCallFailed, throwable,
+                return new ProcedureException( Status.Procedure.ProcedureCallFailed, cause,
                         "Failed to invoke procedure `%s`: %s", signature.name(),
-                        "Caused by: " + (cause != null ? cause : throwable) );
+                        "Caused by: " + cause );
             }
         }
     }
 
+    private static Throwable rootCause( Throwable throwable )
+    {
+        Throwable rootCause = ExceptionUtils.getRootCause( throwable );
+        return rootCause != null ? rootCause : throwable;
+    }
+
     private static class ReflectiveUserFunction extends ReflectiveBase implements CallableUserFunction
     {
-
         private final TypeMappers.NeoValueConverter valueConverter;
         private final UserFunctionSignature signature;
         private final MethodHandle constructor;
@@ -764,17 +770,17 @@ class ReflectiveProcedureCompiler
             }
             catch ( Throwable throwable )
             {
-                if ( throwable instanceof Status.HasStatus )
+                Throwable cause = rootCause( throwable );
+                if ( cause instanceof Status.HasStatus )
                 {
-                    throw new ProcedureException( ((Status.HasStatus) throwable).status(), throwable,
-                            throwable.getMessage(), throwable );
+                    throw new ProcedureException( ((Status.HasStatus) cause).status(), cause,
+                            cause.getMessage(), cause );
                 }
                 else
                 {
-                    Throwable cause = ExceptionUtils.getRootCause( throwable );
                     throw new ProcedureException( Status.Procedure.ProcedureCallFailed, throwable,
                             "Failed to invoke function `%s`: %s", signature.name(),
-                            "Caused by: " + (cause != null ? cause : throwable) );
+                            "Caused by: " + cause );
                 }
             }
         }
@@ -845,17 +851,17 @@ class ReflectiveProcedureCompiler
                         }
                         catch ( Throwable throwable )
                         {
-                            if ( throwable instanceof Status.HasStatus )
+                            Throwable cause = rootCause( throwable );
+                            if ( cause instanceof Status.HasStatus )
                             {
-                                throw new ProcedureException( ((Status.HasStatus) throwable).status(), throwable,
-                                        throwable.getMessage() );
+                                throw new ProcedureException( ((Status.HasStatus) cause).status(), cause,
+                                        cause.getMessage() );
                             }
                             else
                             {
-                                Throwable cause = ExceptionUtils.getRootCause( throwable );
                                 throw new ProcedureException( Status.Procedure.ProcedureCallFailed, throwable,
                                         "Failed to invoke function `%s`: %s", signature.name(),
-                                        "Caused by: " + (cause != null ? cause : throwable) );
+                                        "Caused by: " + cause );
                             }
                         }
                     }
@@ -869,17 +875,17 @@ class ReflectiveProcedureCompiler
                         }
                         catch ( Throwable throwable )
                         {
-                            if ( throwable instanceof Status.HasStatus )
+                            Throwable cause = rootCause( throwable );
+                            if ( cause instanceof Status.HasStatus )
                             {
-                                throw new ProcedureException( ((Status.HasStatus) throwable).status(), throwable,
-                                        throwable.getMessage() );
+                                throw new ProcedureException( ((Status.HasStatus) cause).status(), cause,
+                                        cause.getMessage() );
                             }
                             else
                             {
-                                Throwable cause = ExceptionUtils.getRootCause( throwable );
                                 throw new ProcedureException( Status.Procedure.ProcedureCallFailed, throwable,
                                         "Failed to invoke function `%s`: %s", signature.name(),
-                                        "Caused by: " + (cause != null ? cause : throwable) );
+                                        "Caused by: " + cause );
                             }
                         }
 
@@ -890,17 +896,17 @@ class ReflectiveProcedureCompiler
             }
             catch ( Throwable throwable )
             {
-                if ( throwable instanceof Status.HasStatus )
+                Throwable cause = rootCause( throwable );
+                if ( cause instanceof Status.HasStatus )
                 {
-                    throw new ProcedureException( ((Status.HasStatus) throwable).status(), throwable,
-                            throwable.getMessage() );
+                    throw new ProcedureException( ((Status.HasStatus) cause).status(), cause,
+                            cause.getMessage() );
                 }
                 else
                 {
-                    Throwable cause = ExceptionUtils.getRootCause( throwable );
                     throw new ProcedureException( Status.Procedure.ProcedureCallFailed, throwable,
                             "Failed to invoke function `%s`: %s", signature.name(),
-                            "Caused by: " + (cause != null ? cause : throwable ) );
+                            "Caused by: " + cause );
                 }
             }
         }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
@@ -43,7 +43,6 @@ import java.util.stream.Stream;
 import org.neo4j.bolt.v1.transport.integration.TransportTestUtil;
 import org.neo4j.bolt.v1.transport.socket.client.SocketConnection;
 import org.neo4j.bolt.v1.transport.socket.client.TransportConnection;
-import org.neo4j.kernel.impl.util.BaseToObjectValueWriter;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
@@ -62,6 +61,7 @@ import org.neo4j.kernel.api.bolt.ManagedBoltStateMachine;
 import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
 import org.neo4j.kernel.enterprise.builtinprocs.EnterpriseBuiltInDbmsProcedures;
 import org.neo4j.kernel.impl.proc.Procedures;
+import org.neo4j.kernel.impl.util.BaseToObjectValueWriter;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Mode;
@@ -104,7 +104,10 @@ import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRol
 
 public abstract class ProcedureInteractionTestBase<S>
 {
-    static final String PROCEDURE_TIMEOUT_ERROR = "Procedure got: Transaction guard check failed";
+    static final String PROCEDURE_TIMEOUT_ERROR = "The transaction has been terminated. Retry your operation in a new " +
+                                                  "transaction, and you should see a successful result. The transaction " +
+                                                  "has not completed within the specified timeout. You may want to retry " +
+                                                  "with a longer timeout. ";
     protected boolean PWD_CHANGE_CHECK_FIRST;
     protected String CHANGE_PWD_ERR_MSG = AuthorizationViolationException.PERMISSION_DENIED;
     private static final String BOLT_PWD_ERR_MSG =


### PR DESCRIPTION
Turns out that `MethodHandle#invokeWithArguments` is a lot slower than normal reflection. 

These are numbers from calling a simple UDF directly, first case is with this change and the latter one is after applying change.

```
MethodHandle#invokeWithArguments 4739.831 ± 212.183  ops/ms
Method#invoke 24860.247 ± 847.512  ops/ms
```

I think there are more improvements to be done here but after applying this fix it looks like the usage of a HashMap in  in the `ProcedureRegistry` is a bigger bottleneck than the reflection.
