### PR TITLE
Catch all kinds of EntityNotFoundExceptions on makeENFXSafe

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/helpers/JavaConversionSupport.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/helpers/JavaConversionSupport.scala
@@ -20,7 +20,6 @@
 package org.neo4j.cypher.internal.helpers
 
 import org.neo4j.collection.primitive.{PrimitiveIntIterator, PrimitiveLongIterator}
-import org.neo4j.cypher.internal.frontend.v3_2.EntityNotFoundException
 
 import scala.collection.JavaConversions._
 
@@ -61,8 +60,11 @@ object JavaConversionSupport {
         try {
           _next = Some(f(more()))
         } catch {
+          case _: org.neo4j.graphdb.NotFoundException => // IGNORE
           case _: org.neo4j.kernel.api.exceptions.EntityNotFoundException => // IGNORE
-          case _: EntityNotFoundException => // IGNORE
+          case _: org.neo4j.cypher.internal.frontend.v3_2.EntityNotFoundException => // IGNORE
+          case _: org.neo4j.cypher.internal.frontend.v3_1.EntityNotFoundException => // IGNORE
+          case _: org.neo4j.cypher.internal.frontend.v2_3.EntityNotFoundException => // IGNORE
         }
       }
       _next

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ApocAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ApocAcceptanceTest.scala
@@ -33,7 +33,6 @@ class ApocAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupp
     graph.getDependencyResolver.resolveDependency(classOf[Procedures]).registerProcedure(classOf[TestProcedure])
 
     graph.execute(movies)
-//    graph.execute(bigbrother)
 
     graph.execute("MATCH (c:Person) WHERE c.name in ['Clint Eastwood', 'Gene Hackman'] SET c:Western")
 
@@ -49,13 +48,11 @@ class ApocAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupp
   }
 
   def testResult(db: GraphDatabaseService, call: String, onResult: Result => Unit): Unit = {
+    val tx: Transaction = db.beginTx
     try {
-      val tx: Transaction = db.beginTx
-      try {
-        onResult(db.execute(call, Collections.emptyMap[String, AnyRef]))
-        tx.success()
-      } finally if (tx != null) tx.close()
-    }
+      onResult(db.execute(call, Collections.emptyMap[String, AnyRef]))
+      tx.success()
+    } finally if (tx != null) tx.close()
   }
 
   val movies = """

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartAcceptanceTest.scala
@@ -299,12 +299,31 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     relate(node, createNode())
 
     graph.inTx {
-      graph.index.forNodes("nodes").add(node, "key", "A")
-      graph.index.forRelationships("rels").add(rel, "key", "B")
+      graph.index().forNodes("nodes").add(node, "key", "A")
+      graph.index().forRelationships("rels").add(rel, "key", "B")
     }
 
     val result = innerExecute("START n=node:nodes(key = 'A'), r=rel:rels(key = 'B') MATCH (n)-[r]->(b) RETURN b")
     result.toList should equal(List(Map("b" -> resultNode)))
   }
 
+  test("Should not return deleted nodes from explicit index") {
+    // setup: create index, add a node
+    val node = createNode()
+    graph.inTx {
+      graph.index().forNodes("index").add(node, "key", "value")
+    }
+
+    // check if we find the node
+    innerExecute("start n=node:index(key = 'value') return n").size should equal(1)
+
+    // when
+    graph.inTx {
+      node.delete()
+    }
+
+    // nothing found in the index after deletion
+    val result = executeWithAllPlannersAndCompatibilityMode("start n=node:index(key = 'value') return n")
+    result.size should equal(0)
+  }
 }


### PR DESCRIPTION
changelog: Fix `Node X not found` exceptions arising when searching an explicit index which contains nodes that have been deleted.