### PR TITLE
Fix regressions for nodeGetDegree

### DIFF
--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledExpandUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledExpandUtils.java
@@ -23,7 +23,6 @@ import org.neo4j.graphdb.Direction;
 import org.neo4j.internal.kernel.api.CursorFactory;
 import org.neo4j.internal.kernel.api.NodeCursor;
 import org.neo4j.internal.kernel.api.Read;
-import org.neo4j.internal.kernel.api.RelationshipGroupCursor;
 import org.neo4j.internal.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.internal.kernel.api.helpers.RelationshipSelectionCursor;
 
@@ -33,63 +32,35 @@ import static org.neo4j.internal.kernel.api.helpers.Nodes.countOutgoing;
 
 public abstract class CompiledExpandUtils
 {
+
+    private static final int NOT_DENSE_DEGREE = -1;
+
     public static RelationshipSelectionCursor connectingRelationships( Read read, CursorFactory cursors,
             NodeCursor nodeCursor,
             long fromNode, Direction direction, long toNode )
     {
-
-
-        int fromDegree = nodeGetDegree( read, fromNode, nodeCursor, cursors, direction );
+        //Check from
+        int fromDegree = nodeGetDegreeIfDense( read, fromNode, nodeCursor, cursors, direction );
         if ( fromDegree == 0 )
         {
             return RelationshipSelectionCursor.EMPTY;
         }
+        boolean fromNodeIsDense = fromDegree != NOT_DENSE_DEGREE;
 
-        int toDegree = nodeGetDegree( read, toNode, nodeCursor, cursors, direction.reverse() );
-        if ( toDegree == 0 )
+        //Check to
+        read.singleNode( toNode, nodeCursor );
+        if ( !nodeCursor.next() )
         {
             return RelationshipSelectionCursor.EMPTY;
         }
+        boolean toNodeIsDense = nodeCursor.isDense();
 
-        long startNode;
-        long endNode;
-        Direction relDirection;
-        if ( fromDegree < toDegree )
+
+        //Both are dense, start with the one with the lesser degree
+        if ( fromNodeIsDense && toNodeIsDense )
         {
-            startNode = fromNode;
-            endNode = toNode;
-            relDirection = direction;
-        }
-        else
-        {
-            startNode = toNode;
-            endNode = fromNode;
-            relDirection = direction.reverse();
-        }
-
-        RelationshipSelectionCursor selectionCursor = CompiledCursorUtils
-                .nodeGetRelationships( read, cursors, nodeCursor, startNode, relDirection );
-
-        return connectingRelationshipsIterator( selectionCursor, endNode );
-    }
-
-    public static RelationshipSelectionCursor connectingRelationships( Read read, CursorFactory cursors,
-            NodeCursor nodeCursor, long fromNode, Direction direction, long toNode, int[] relTypes )
-    {
-        try
-        {
-            int fromDegree = calculateTotalDegree( read, fromNode, nodeCursor, direction, relTypes, cursors );
-            if ( fromDegree == 0 )
-            {
-                return RelationshipSelectionCursor.EMPTY;
-            }
-
-            int toDegree = calculateTotalDegree( read, toNode, nodeCursor, direction.reverse(), relTypes, cursors );
-            if ( toDegree == 0 )
-            {
-                return RelationshipSelectionCursor.EMPTY;
-            }
-
+            //Note that we have already position the cursor at toNode
+            int toDegree = nodeGetDegree( nodeCursor, cursors, direction );
             long startNode;
             long endNode;
             Direction relDirection;
@@ -106,18 +77,77 @@ public abstract class CompiledExpandUtils
                 relDirection = direction.reverse();
             }
 
-            RelationshipSelectionCursor selectionCursor = CompiledCursorUtils
-                    .nodeGetRelationships( read, cursors, nodeCursor, startNode, relDirection, relTypes );
-
-            return connectingRelationshipsIterator( selectionCursor, endNode );
+            return connectingRelationshipsIterator( CompiledCursorUtils
+                    .nodeGetRelationships( read, cursors, nodeCursor, startNode, relDirection ), endNode );
         }
-        catch ( EntityNotFoundException ignore )
+        else if ( fromNodeIsDense )
         {
-            return RelationshipSelectionCursor.EMPTY;
+            return connectingRelationshipsIterator( CompiledCursorUtils
+                    .nodeGetRelationships( read, cursors, nodeCursor, toNode, direction.reverse() ), fromNode );
+        }
+        else//either only toNode is dense or none of them, just go with what we got
+        {
+            return connectingRelationshipsIterator( CompiledCursorUtils
+                    .nodeGetRelationships( read, cursors, nodeCursor, fromNode, direction ), toNode );
         }
     }
 
-    static int nodeGetDegree( Read read, long node, NodeCursor nodeCursor, CursorFactory cursors,
+    public static RelationshipSelectionCursor connectingRelationships( Read read, CursorFactory cursors,
+            NodeCursor nodeCursor, long fromNode, Direction direction, long toNode, int[] relTypes )
+    {
+        //Check from
+        int fromDegree = calculateTotalDegreeIfDense( read, fromNode, nodeCursor, direction, relTypes, cursors );
+        if ( fromDegree == 0 )
+        {
+            return RelationshipSelectionCursor.EMPTY;
+        }
+        boolean fromNodeIsDense = fromDegree != NOT_DENSE_DEGREE;
+
+        //Check to
+        read.singleNode( toNode, nodeCursor );
+        if ( !nodeCursor.next() )
+        {
+            return RelationshipSelectionCursor.EMPTY;
+        }
+        boolean toNodeIsDense = nodeCursor.isDense();
+
+        //Both are dense, start with the one with the lesser degree
+        if ( fromNodeIsDense && toNodeIsDense )
+        {
+            //Note that we have already position the cursor at toNode
+            int toDegree = calculateTotalDegree( nodeCursor, direction, relTypes, cursors );
+            long startNode;
+            long endNode;
+            Direction relDirection;
+            if ( fromDegree < toDegree )
+            {
+                startNode = fromNode;
+                endNode = toNode;
+                relDirection = direction;
+            }
+            else
+            {
+                startNode = toNode;
+                endNode = fromNode;
+                relDirection = direction.reverse();
+            }
+
+            return connectingRelationshipsIterator( CompiledCursorUtils
+                    .nodeGetRelationships( read, cursors, nodeCursor, startNode, relDirection ), endNode );
+        }
+        else if ( fromNodeIsDense )
+        {
+            return connectingRelationshipsIterator( CompiledCursorUtils
+                    .nodeGetRelationships( read, cursors, nodeCursor, toNode, direction.reverse() ), fromNode );
+        }
+        else//either only toNode is dense or none of them, just go with what we got
+        {
+            return connectingRelationshipsIterator( CompiledCursorUtils
+                    .nodeGetRelationships( read, cursors, nodeCursor, fromNode, direction ), toNode );
+        }
+    }
+
+    static int nodeGetDegreeIfDense( Read read, long node, NodeCursor nodeCursor, CursorFactory cursors,
             Direction direction )
     {
         read.singleNode( node, nodeCursor );
@@ -125,6 +155,17 @@ public abstract class CompiledExpandUtils
         {
             return 0;
         }
+        if ( !nodeCursor.isDense() )
+        {
+            return NOT_DENSE_DEGREE;
+        }
+
+        return nodeGetDegree( nodeCursor, cursors, direction );
+    }
+
+    private static int nodeGetDegree( NodeCursor nodeCursor, CursorFactory cursors,
+            Direction direction )
+    {
         switch ( direction )
         {
         case OUTGOING:
@@ -138,7 +179,7 @@ public abstract class CompiledExpandUtils
         }
     }
 
-    static int nodeGetDegree( Read read, long node, NodeCursor nodeCursor, CursorFactory cursors,
+    static int nodeGetDegreeIfDense( Read read, long node, NodeCursor nodeCursor, CursorFactory cursors,
             Direction direction, int type )
     {
         read.singleNode( node, nodeCursor );
@@ -146,6 +187,17 @@ public abstract class CompiledExpandUtils
         {
             return 0;
         }
+        if ( !nodeCursor.isDense() )
+        {
+            return NOT_DENSE_DEGREE;
+        }
+
+        return nodeGetDegree( nodeCursor, cursors, direction, type );
+    }
+
+    private static int nodeGetDegree( NodeCursor nodeCursor, CursorFactory cursors,
+            Direction direction, int type )
+    {
         switch ( direction )
         {
         case OUTGOING:
@@ -159,14 +211,29 @@ public abstract class CompiledExpandUtils
         }
     }
 
-    private static int calculateTotalDegree( Read read, long fromNode, NodeCursor nodeCursor, Direction direction,
-            int[] relTypes, CursorFactory cursors ) throws EntityNotFoundException
-    {
 
+    private static int calculateTotalDegreeIfDense( Read read, long node, NodeCursor nodeCursor, Direction direction,
+            int[] relTypes, CursorFactory cursors )
+    {
+        read.singleNode( node, nodeCursor );
+        if ( !nodeCursor.next() )
+        {
+            return 0;
+        }
+        if ( !nodeCursor.isDense() )
+        {
+            return NOT_DENSE_DEGREE;
+        }
+        return calculateTotalDegree( nodeCursor, direction, relTypes, cursors );
+    }
+
+    private static int calculateTotalDegree( NodeCursor nodeCursor, Direction direction, int[] relTypes,
+            CursorFactory cursors )
+    {
         int degree = 0;
         for ( int relType : relTypes )
         {
-            degree += nodeGetDegree( read, fromNode, nodeCursor, cursors, direction, relType );
+            degree += nodeGetDegree( nodeCursor, cursors, direction, relType );
         }
 
         return degree;

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledExpandUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledExpandUtils.java
@@ -30,9 +30,9 @@ import static org.neo4j.internal.kernel.api.helpers.Nodes.countAll;
 import static org.neo4j.internal.kernel.api.helpers.Nodes.countIncoming;
 import static org.neo4j.internal.kernel.api.helpers.Nodes.countOutgoing;
 
+@SuppressWarnings( "unused" )
 public abstract class CompiledExpandUtils
 {
-
     private static final int NOT_DENSE_DEGREE = -1;
 
     public static RelationshipSelectionCursor connectingRelationships( Read read, CursorFactory cursors,
@@ -54,7 +54,6 @@ public abstract class CompiledExpandUtils
             return RelationshipSelectionCursor.EMPTY;
         }
         boolean toNodeIsDense = nodeCursor.isDense();
-
 
         //Both are dense, start with the one with the lesser degree
         if ( fromNodeIsDense && toNodeIsDense )
@@ -85,8 +84,8 @@ public abstract class CompiledExpandUtils
             return connectingRelationshipsIterator( CompiledCursorUtils
                     .nodeGetRelationships( read, cursors, nodeCursor, toNode, direction.reverse() ), fromNode );
         }
-        else//either only toNode is dense or none of them, just go with what we got
-        {
+        else
+        {   //either only toNode is dense or none of them, just go with what we got
             return connectingRelationshipsIterator( CompiledCursorUtils
                     .nodeGetRelationships( read, cursors, nodeCursor, fromNode, direction ), toNode );
         }
@@ -140,8 +139,8 @@ public abstract class CompiledExpandUtils
             return connectingRelationshipsIterator( CompiledCursorUtils
                     .nodeGetRelationships( read, cursors, nodeCursor, toNode, direction.reverse() ), fromNode );
         }
-        else//either only toNode is dense or none of them, just go with what we got
-        {
+        else
+        {   //either only toNode is dense or none of them, just go with what we got
             return connectingRelationshipsIterator( CompiledCursorUtils
                     .nodeGetRelationships( read, cursors, nodeCursor, fromNode, direction ), toNode );
         }
@@ -210,7 +209,6 @@ public abstract class CompiledExpandUtils
             throw new IllegalStateException( "Unknown direction " + direction );
         }
     }
-
 
     private static int calculateTotalDegreeIfDense( Read read, long node, NodeCursor nodeCursor, Direction direction,
             int[] relTypes, CursorFactory cursors )

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/CompiledExpandUtilsTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/CompiledExpandUtilsTest.java
@@ -82,13 +82,11 @@ public class CompiledExpandUtilsTest
         {
             Read read = tx.dataRead();
             CursorFactory cursors = tx.cursors();
-            try ( NodeCursor nodes = cursors.allocateNodeCursor();
-                  RelationshipGroupCursor group = cursors.allocateRelationshipGroupCursor() )
+            try ( NodeCursor nodes = cursors.allocateNodeCursor() )
             {
-
-                assertThat( nodeGetDegree( read, node, nodes, group, OUTGOING ), equalTo( 3 ) );
-                assertThat( nodeGetDegree( read, node, nodes, group, INCOMING ), equalTo( 2 ) );
-                assertThat( nodeGetDegree( read, node, nodes, group, BOTH ), equalTo( 4 ) );
+                assertThat( nodeGetDegree( read, node, nodes, cursors, OUTGOING ), equalTo( 3 ) );
+                assertThat( nodeGetDegree( read, node, nodes, cursors, INCOMING ), equalTo( 2 ) );
+                assertThat( nodeGetDegree( read, node, nodes, cursors, BOTH ), equalTo( 4 ) );
             }
         }
     }
@@ -122,20 +120,19 @@ public class CompiledExpandUtilsTest
         {
             Read read = tx.dataRead();
             CursorFactory cursors = tx.cursors();
-            try ( NodeCursor nodes = cursors.allocateNodeCursor();
-                  RelationshipGroupCursor group = cursors.allocateRelationshipGroupCursor() )
+            try ( NodeCursor nodes = cursors.allocateNodeCursor() )
             {
-                assertThat( nodeGetDegree( read, node, nodes, group, OUTGOING, out ), equalTo( 2 ) );
-                assertThat( nodeGetDegree( read, node, nodes, group, OUTGOING, in ), equalTo( 0 ) );
-                assertThat( nodeGetDegree( read, node, nodes, group, OUTGOING, loop ), equalTo( 1 ) );
+                assertThat( nodeGetDegree( read, node, nodes, cursors, OUTGOING, out ), equalTo( 2 ) );
+                assertThat( nodeGetDegree( read, node, nodes, cursors, OUTGOING, in ), equalTo( 0 ) );
+                assertThat( nodeGetDegree( read, node, nodes, cursors, OUTGOING, loop ), equalTo( 1 ) );
 
-                assertThat( nodeGetDegree( read, node, nodes, group, INCOMING, out ), equalTo( 0 ) );
-                assertThat( nodeGetDegree( read, node, nodes, group, INCOMING, in ), equalTo( 1 ) );
-                assertThat( nodeGetDegree( read, node, nodes, group, INCOMING, loop ), equalTo( 1 ) );
+                assertThat( nodeGetDegree( read, node, nodes, cursors, INCOMING, out ), equalTo( 0 ) );
+                assertThat( nodeGetDegree( read, node, nodes, cursors, INCOMING, in ), equalTo( 1 ) );
+                assertThat( nodeGetDegree( read, node, nodes, cursors, INCOMING, loop ), equalTo( 1 ) );
 
-                assertThat( nodeGetDegree( read, node, nodes, group, BOTH, out ), equalTo( 2 ) );
-                assertThat( nodeGetDegree( read, node, nodes, group, BOTH, in ), equalTo( 1 ) );
-                assertThat( nodeGetDegree( read, node, nodes, group, BOTH, loop ), equalTo( 1 ) );
+                assertThat( nodeGetDegree( read, node, nodes, cursors, BOTH, out ), equalTo( 2 ) );
+                assertThat( nodeGetDegree( read, node, nodes, cursors, BOTH, in ), equalTo( 1 ) );
+                assertThat( nodeGetDegree( read, node, nodes, cursors, BOTH, loop ), equalTo( 1 ) );
             }
         }
     }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
@@ -497,35 +497,28 @@ sealed class TransactionBoundQueryContext(val transactionalContext: Transactiona
 
   override def nodeGetDegree(node: Long, dir: SemanticDirection): Int = {
     val cursor = nodeCursor
-    val group = transactionalContext.cursors.allocateRelationshipGroupCursor()
-    try {
       reads().singleNode(node, cursor)
       if (!cursor.next()) 0
       else {
         dir match {
-          case OUTGOING => Nodes.countOutgoing(cursor, group)
-          case INCOMING => Nodes.countIncoming(cursor, group)
-          case BOTH => Nodes.countAll(cursor, group)
+          case OUTGOING => Nodes.countOutgoing(cursor, transactionalContext.cursors)
+          case INCOMING => Nodes.countIncoming(cursor, transactionalContext.cursors)
+          case BOTH => Nodes.countAll(cursor, transactionalContext.cursors)
         }
       }
-    }
-    finally group.close()
   }
 
   override def nodeGetDegree(node: Long, dir: SemanticDirection, relTypeId: Int): Int = {
     val cursor = nodeCursor
-    val group = transactionalContext.cursors.allocateRelationshipGroupCursor()
-    try {
-      reads().singleNode(node, cursor)
-      if (!cursor.next()) 0
-      else {
-        dir match {
-          case OUTGOING => Nodes.countOutgoing(cursor, group, relTypeId)
-          case INCOMING => Nodes.countIncoming(cursor, group, relTypeId)
-          case BOTH => Nodes.countAll(cursor, group, relTypeId)
-        }
+    reads().singleNode(node, cursor)
+    if (!cursor.next()) 0
+    else {
+      dir match {
+        case OUTGOING => Nodes.countOutgoing(cursor, transactionalContext.cursors, relTypeId)
+        case INCOMING => Nodes.countIncoming(cursor, transactionalContext.cursors, relTypeId)
+        case BOTH => Nodes.countAll(cursor, transactionalContext.cursors, relTypeId)
       }
-    } finally group.close()
+    }
   }
 
   override def nodeIsDense(node: Long): Boolean = {

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
@@ -524,7 +524,8 @@ sealed class TransactionBoundQueryContext(val transactionalContext: Transactiona
   override def nodeIsDense(node: Long): Boolean = {
     val cursor = nodeCursor
     reads().singleNode(node, cursor)
-    cursor.isDense
+    if (!cursor.next()) false
+    else cursor.isDense
   }
 
   override def asObject(value: AnyValue): Any = {

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/Nodes.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/Nodes.java
@@ -131,7 +131,7 @@ public final class Nodes
         {
             if ( group.type() == type )
             {
-                count += group.incomingCount() + group.loopCount();
+                return group.incomingCount() + group.loopCount();
             }
         }
         return count;
@@ -153,7 +153,7 @@ public final class Nodes
         {
             if ( group.type() == type )
             {
-                count += group.totalCount();
+                return group.totalCount();
             }
         }
         return count;

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/NodesTest.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/NodesTest.java
@@ -21,6 +21,8 @@ package org.neo4j.internal.kernel.api.helpers;
 
 import org.junit.Test;
 
+import org.neo4j.internal.kernel.api.CursorFactory;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.neo4j.internal.kernel.api.helpers.Nodes.countAll;
@@ -42,9 +44,10 @@ public class NodesTest
                 group().withOutCount( 3 ).withInCount( 1 ).withLoopCount( 1 ),
                 group().withOutCount( 5 ).withInCount( 1 ).withLoopCount( 1 )
         );
+        StubCursorFactory cursors = new StubCursorFactory().withGroupCursors( groupCursor );
 
         // When
-        int count = countOutgoing( NODE, groupCursor );
+        int count = countOutgoing( NODE, cursors );
 
         // Then
         assertThat( count, equalTo( 24 ) );
@@ -61,9 +64,10 @@ public class NodesTest
                 group().withOutCount( 3 ).withInCount( 1 ).withLoopCount( 1 ),
                 group().withOutCount( 5 ).withInCount( 1 ).withLoopCount( 1 )
         );
+        StubCursorFactory cursors = new StubCursorFactory().withGroupCursors( groupCursor );
 
         // When
-        int count = countIncoming( new StubNodeCursor(), groupCursor );
+        int count = countIncoming( new StubNodeCursor(), cursors );
 
         // Then
         assertThat( count, equalTo( 17 ) );
@@ -80,9 +84,10 @@ public class NodesTest
                 group().withOutCount( 3 ).withInCount( 1 ).withLoopCount( 1 ),
                 group().withOutCount( 5 ).withInCount( 1 ).withLoopCount( 1 )
         );
+        StubCursorFactory cursors = new StubCursorFactory().withGroupCursors( groupCursor );
 
         // When
-        int count = countAll( new StubNodeCursor(), groupCursor );
+        int count = countAll( new StubNodeCursor(), cursors );
 
         // Then
         assertThat( count, equalTo( 29 ) );
@@ -96,10 +101,11 @@ public class NodesTest
                 group( 1 ).withOutCount( 1 ).withInCount( 1 ).withLoopCount( 5 ),
                 group( 2 ).withOutCount( 1 ).withInCount( 1 ).withLoopCount( 3 )
         );
+        StubCursorFactory cursors = new StubCursorFactory().withGroupCursors( groupCursor, groupCursor );
 
         // Then
-        assertThat( countOutgoing( new StubNodeCursor(), groupCursor, 1 ), equalTo( 6 ) );
-        assertThat( countOutgoing( new StubNodeCursor(), groupCursor, 2 ), equalTo( 4 ) );
+        assertThat( countOutgoing( new StubNodeCursor(), cursors, 1 ), equalTo( 6 ) );
+        assertThat( countOutgoing( new StubNodeCursor(), cursors, 2 ), equalTo( 4 ) );
     }
 
     @Test
@@ -110,10 +116,11 @@ public class NodesTest
                 group( 1 ).withOutCount( 1 ).withInCount( 1 ).withLoopCount( 5 ),
                 group( 2 ).withOutCount( 1 ).withInCount( 1 ).withLoopCount( 3 )
         );
+        StubCursorFactory cursors = new StubCursorFactory().withGroupCursors( groupCursor, groupCursor );
 
         // Then
-        assertThat( countIncoming( new StubNodeCursor(), groupCursor, 1 ), equalTo( 6 ) );
-        assertThat( countIncoming( new StubNodeCursor(), groupCursor, 2 ), equalTo( 4 ) );
+        assertThat( countIncoming( new StubNodeCursor(), cursors, 1 ), equalTo( 6 ) );
+        assertThat( countIncoming( new StubNodeCursor(), cursors, 2 ), equalTo( 4 ) );
     }
 
     @Test
@@ -124,10 +131,11 @@ public class NodesTest
                 group( 1 ).withOutCount( 1 ).withInCount( 1 ).withLoopCount( 5 ),
                 group( 2 ).withOutCount( 1 ).withInCount( 1 ).withLoopCount( 3 )
         );
+        StubCursorFactory cursors = new StubCursorFactory().withGroupCursors( groupCursor, groupCursor );
 
         // Then
-        assertThat( countAll( new StubNodeCursor(), groupCursor, 1 ), equalTo( 7 ) );
-        assertThat( countAll( new StubNodeCursor(), groupCursor, 2 ), equalTo( 5 ) );
+        assertThat( countAll( new StubNodeCursor(), cursors, 1 ), equalTo( 7 ) );
+        assertThat( countAll( new StubNodeCursor(), cursors, 2 ), equalTo( 5 ) );
     }
 
     private StubGroupCursor.GroupData group()

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubCursorFactory.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubCursorFactory.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.neo4j.internal.kernel.api.helpers;
 
 import java.util.Arrays;

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubCursorFactory.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubCursorFactory.java
@@ -1,0 +1,90 @@
+package org.neo4j.internal.kernel.api.helpers;
+
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.Queue;
+
+import org.neo4j.internal.kernel.api.CursorFactory;
+import org.neo4j.internal.kernel.api.NodeCursor;
+import org.neo4j.internal.kernel.api.NodeExplicitIndexCursor;
+import org.neo4j.internal.kernel.api.NodeLabelIndexCursor;
+import org.neo4j.internal.kernel.api.NodeValueIndexCursor;
+import org.neo4j.internal.kernel.api.PropertyCursor;
+import org.neo4j.internal.kernel.api.RelationshipExplicitIndexCursor;
+import org.neo4j.internal.kernel.api.RelationshipGroupCursor;
+import org.neo4j.internal.kernel.api.RelationshipScanCursor;
+import org.neo4j.internal.kernel.api.RelationshipTraversalCursor;
+
+public class StubCursorFactory implements CursorFactory
+{
+    private Queue<NodeCursor> nodeCursors = new LinkedList<>(  );
+    private Queue<RelationshipScanCursor> relationshipScanCursors = new LinkedList<>(  );
+    private Queue<RelationshipTraversalCursor> relationshiTraversalCursors = new LinkedList<>(  );
+    private Queue<PropertyCursor> propertyCursors = new LinkedList<>(  );
+    private Queue<RelationshipGroupCursor> groupCursors = new LinkedList<>(  );
+    private Queue<NodeValueIndexCursor> nodeValueIndexCursors = new LinkedList<>(  );
+    private Queue<NodeLabelIndexCursor> nodeLabelIndexCursors = new LinkedList<>(  );
+    private Queue<NodeExplicitIndexCursor> nodeExplicitIndexCursors = new LinkedList<>(  );
+    private Queue<RelationshipExplicitIndexCursor> relationshipExplicitIndexCursors = new LinkedList<>(  );
+
+    @Override
+    public NodeCursor allocateNodeCursor()
+    {
+        return nodeCursors.poll();
+    }
+
+    @Override
+    public RelationshipScanCursor allocateRelationshipScanCursor()
+    {
+        return relationshipScanCursors.poll();
+    }
+
+    @Override
+    public RelationshipTraversalCursor allocateRelationshipTraversalCursor()
+    {
+        return relationshiTraversalCursors.poll();
+    }
+
+    @Override
+    public PropertyCursor allocatePropertyCursor()
+    {
+        return propertyCursors.poll();
+    }
+
+    @Override
+    public RelationshipGroupCursor allocateRelationshipGroupCursor()
+    {
+        return groupCursors.poll();
+    }
+
+    @Override
+    public NodeValueIndexCursor allocateNodeValueIndexCursor()
+    {
+        return nodeValueIndexCursors.poll();
+    }
+
+    @Override
+    public NodeLabelIndexCursor allocateNodeLabelIndexCursor()
+    {
+        return nodeLabelIndexCursors.poll();
+    }
+
+    @Override
+    public NodeExplicitIndexCursor allocateNodeExplicitIndexCursor()
+    {
+        return nodeExplicitIndexCursors.poll();
+    }
+
+    @Override
+    public RelationshipExplicitIndexCursor allocateRelationshipExplicitIndexCursor()
+    {
+        return relationshipExplicitIndexCursors.poll();
+    }
+
+    StubCursorFactory withGroupCursors( RelationshipGroupCursor...cursors )
+    {
+        groupCursors.addAll( Arrays.asList( cursors ) );
+        return this;
+    }
+}

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubNodeCursor.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubNodeCursor.java
@@ -34,7 +34,18 @@ import org.neo4j.values.storable.Value;
 public class StubNodeCursor implements NodeCursor
 {
     private int offset = -1;
+    private boolean dense;
     private List<NodeData> nodes = new ArrayList<>();
+
+    public StubNodeCursor()
+    {
+        this( true );
+    }
+
+    public StubNodeCursor( boolean dense )
+    {
+        this.dense = dense;
+    }
 
     void single( long reference )
     {
@@ -136,7 +147,7 @@ public class StubNodeCursor implements NodeCursor
     @Override
     public boolean isDense()
     {
-        return false;
+        return dense;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -669,13 +669,12 @@ public class NodeProxy implements Node
     {
         KernelTransaction transaction = safeAcquireTransaction();
 
-        try ( Statement ignore = transaction.acquireStatement();
-              RelationshipGroupCursor group = transaction.cursors().allocateRelationshipGroupCursor();)
+        try ( Statement ignore = transaction.acquireStatement() )
         {
             NodeCursor nodes = transaction.nodeCursor();
             singleNode( transaction, nodes );
 
-            return Nodes.countAll( nodes, group );
+            return Nodes.countAll( nodes, transaction.cursors() );
         }
     }
 
@@ -689,13 +688,12 @@ public class NodeProxy implements Node
             return 0;
         }
 
-        try ( Statement ignore = transaction.acquireStatement();
-              RelationshipGroupCursor group = transaction.cursors().allocateRelationshipGroupCursor();)
+        try ( Statement ignore = transaction.acquireStatement() )
         {
             NodeCursor nodes = transaction.nodeCursor();
             singleNode( transaction, nodes );
 
-            return Nodes.countAll( nodes, group, typeId );
+            return Nodes.countAll( nodes, transaction.cursors(), typeId );
         }
     }
 
@@ -703,8 +701,7 @@ public class NodeProxy implements Node
     public int getDegree( Direction direction )
     {
         KernelTransaction transaction = safeAcquireTransaction();
-        try ( Statement ignore = transaction.acquireStatement();
-              RelationshipGroupCursor group = transaction.cursors().allocateRelationshipGroupCursor();)
+        try ( Statement ignore = transaction.acquireStatement() )
         {
             NodeCursor nodes = transaction.nodeCursor();
             singleNode( transaction, nodes );
@@ -712,11 +709,11 @@ public class NodeProxy implements Node
             switch ( direction )
             {
             case OUTGOING:
-                return Nodes.countOutgoing( nodes, group );
+                return Nodes.countOutgoing( nodes, transaction.cursors() );
             case INCOMING:
-                return Nodes.countIncoming( nodes, group );
+                return Nodes.countIncoming( nodes, transaction.cursors() );
             case BOTH:
-                return Nodes.countAll( nodes, group );
+                return Nodes.countAll( nodes, transaction.cursors() );
             default:
                 throw new IllegalStateException( "Unknown direction " + direction );
             }
@@ -737,15 +734,14 @@ public class NodeProxy implements Node
         {
             NodeCursor nodes = transaction.nodeCursor();
             singleNode( transaction, nodes );
-            RelationshipGroupCursor group = transaction.cursors().allocateRelationshipGroupCursor();
             switch ( direction )
             {
             case OUTGOING:
-                return Nodes.countOutgoing( nodes, group, typeId );
+                return Nodes.countOutgoing( nodes, transaction.cursors(), typeId );
             case INCOMING:
-                return Nodes.countIncoming( nodes, group, typeId );
+                return Nodes.countIncoming( nodes, transaction.cursors(), typeId );
             case BOTH:
-                return Nodes.countAll( nodes, group, typeId );
+                return Nodes.countAll( nodes, transaction.cursors(), typeId );
             default:
                 throw new IllegalStateException( "Unknown direction " + direction );
             }


### PR DESCRIPTION
This includes four separate fixes:
- Fix bug in `nodeIsDense` which caused it to always return `false`
- abort early when computing degree for a given type, a type can belong to one-and-only-one group
- Use a traversal cursor directly for non-dense nodes instead of relying on the buffering done by the group cursor
- For `Expand(Into)`: Be smarter when to compute degrees for nodes in the compiled runtime, we should only compute the degree if both nodes are dense like we do in interpreted runtime