### PR TITLE
Support for temporal types in Bolt

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltMessageRouter.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltMessageRouter.java
@@ -35,7 +35,7 @@ import org.neo4j.values.virtual.MapValue;
  * This class is responsible for routing incoming request messages to a worker
  * as well as handling outgoing response messages via appropriate handlers.
  */
-public class BoltMessageRouter implements BoltRequestMessageHandler<RuntimeException>
+public class BoltMessageRouter implements BoltRequestMessageHandler
 {
     private final BoltMessageLogger messageLogger;
 
@@ -63,22 +63,21 @@ public class BoltMessageRouter implements BoltRequestMessageHandler<RuntimeExcep
     }
 
     @Override
-    public void onInit( String userAgent, Map<String,Object> authToken ) throws RuntimeException
+    public void onInit( String userAgent, Map<String,Object> authToken )
     {
-        // TODO: make the client transmit the version for now it is hardcoded to -1 to ensure current behaviour
         messageLogger.logInit(userAgent );
         worker.enqueue( session -> session.init( userAgent, authToken, initHandler ) );
     }
 
     @Override
-    public void onAckFailure() throws RuntimeException
+    public void onAckFailure()
     {
         messageLogger.logAckFailure();
         worker.enqueue( session -> session.ackFailure( defaultHandler ) );
     }
 
     @Override
-    public void onReset() throws RuntimeException
+    public void onReset()
     {
         messageLogger.clientEvent("INTERRUPT");
         messageLogger.logReset();

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageHandler.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageHandler.java
@@ -25,25 +25,21 @@ import org.neo4j.bolt.v1.runtime.Neo4jError;
 import org.neo4j.values.virtual.MapValue;
 
 /**
- * Interface defining simple handler methods for each defined
- * Bolt request message.
- *
- * @param <E> an exception that may be thrown by each handler method
+ * Interface defining simple handler methods for each defined Bolt request message.
  */
-public interface BoltRequestMessageHandler<E extends Exception>
+public interface BoltRequestMessageHandler
 {
-    void onInit( String userAgent, Map<String,Object> authToken ) throws E;
+    void onInit( String userAgent, Map<String,Object> authToken );
 
-    void onAckFailure() throws E;
+    void onAckFailure();
 
-    void onReset() throws E;
+    void onReset();
 
-    void onRun( String statement, MapValue params ) throws E;
+    void onRun( String statement, MapValue params );
 
-    void onDiscardAll() throws E;
+    void onDiscardAll();
 
-    void onPullAll() throws E;
+    void onPullAll();
 
-    void onExternalError( Neo4jError error ) throws E;
-
+    void onExternalError( Neo4jError error );
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageReader.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageReader.java
@@ -47,7 +47,7 @@ public class BoltRequestMessageReader
      *
      * @param handler handler for request messages
      */
-    public <E extends Exception> void read( BoltRequestMessageHandler<E> handler ) throws IOException, E
+    public void read( BoltRequestMessageHandler handler ) throws IOException
     {
         try
         {

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/transport/BoltV1Dechunker.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/transport/BoltV1Dechunker.java
@@ -31,7 +31,7 @@ public class BoltV1Dechunker
 {
     private final ChunkedInput input;
     private final BoltRequestMessageReader unpacker;
-    private final BoltRequestMessageHandler<RuntimeException> onMessage;
+    private final BoltRequestMessageHandler onMessage;
     private final Runnable onMessageStarted;
 
     public enum State
@@ -45,8 +45,7 @@ public class BoltV1Dechunker
     private State state = State.AWAITING_CHUNK;
     private int chunkSize;
 
-    public BoltV1Dechunker( Neo4jPack neo4jPack, BoltRequestMessageHandler<RuntimeException> messageHandler,
-            Runnable onMessageStarted )
+    public BoltV1Dechunker( Neo4jPack neo4jPack, BoltRequestMessageHandler messageHandler, Runnable onMessageStarted )
     {
         this.onMessage = messageHandler;
         this.onMessageStarted = onMessageStarted;

--- a/community/bolt/src/main/java/org/neo4j/bolt/v2/messaging/Neo4jPackV2.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v2/messaging/Neo4jPackV2.java
@@ -20,6 +20,8 @@
 package org.neo4j.bolt.v2.messaging;
 
 import java.io.IOException;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 
 import org.neo4j.bolt.v1.messaging.Neo4jPack;
@@ -28,8 +30,20 @@ import org.neo4j.bolt.v1.packstream.PackInput;
 import org.neo4j.bolt.v1.packstream.PackOutput;
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.storable.CoordinateReferenceSystem;
+import org.neo4j.values.storable.DateTimeValue;
+import org.neo4j.values.storable.DateValue;
+import org.neo4j.values.storable.DurationValue;
+import org.neo4j.values.storable.LocalDateTimeValue;
+import org.neo4j.values.storable.LocalTimeValue;
 import org.neo4j.values.storable.PointValue;
+import org.neo4j.values.storable.TimeValue;
 
+import static org.neo4j.values.storable.DateTimeValue.datetime;
+import static org.neo4j.values.storable.DateValue.epochDate;
+import static org.neo4j.values.storable.DurationValue.duration;
+import static org.neo4j.values.storable.LocalDateTimeValue.localDateTime;
+import static org.neo4j.values.storable.LocalTimeValue.localTime;
+import static org.neo4j.values.storable.TimeValue.time;
 import static org.neo4j.values.storable.Values.pointValue;
 
 public class Neo4jPackV2 extends Neo4jPackV1
@@ -38,6 +52,14 @@ public class Neo4jPackV2 extends Neo4jPackV1
 
     public static final byte POINT_2D = 'X';
     public static final byte POINT_3D = 'Y';
+
+    public static final byte DATE = 'D';
+    public static final byte TIME = 'T';
+    public static final byte LOCAL_TIME = 't';
+    public static final byte LOCAL_DATE_TIME = 'd';
+    public static final byte DATE_TIME_WITH_ZONE_OFFSET = 'F';
+    public static final byte DATE_TIME_WITH_ZONE_NAME = 'f';
+    public static final byte DURATION = 'E';
 
     @Override
     public Neo4jPack.Packer newPacker( PackOutput output )
@@ -88,6 +110,64 @@ public class Neo4jPackV2 extends Neo4jPackV1
                                                     "got crs=" + crs + ", coordinate=" + Arrays.toString( coordinate ) );
             }
         }
+
+        @Override
+        public void writeDuration( long months, long days, long seconds, int nanos ) throws IOException
+        {
+            packStructHeader( 4, DURATION );
+            pack( months );
+            pack( days );
+            pack( seconds );
+            pack( nanos );
+        }
+
+        @Override
+        public void writeDate( long epochDay ) throws IOException
+        {
+            packStructHeader( 1, DATE );
+            pack( epochDay );
+        }
+
+        @Override
+        public void writeLocalTime( long nanoOfDay ) throws IOException
+        {
+            packStructHeader( 1, LOCAL_TIME );
+            pack( nanoOfDay );
+        }
+
+        @Override
+        public void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws IOException
+        {
+            packStructHeader( 2, TIME );
+            pack( nanosOfDayUTC );
+            pack( offsetSeconds );
+        }
+
+        @Override
+        public void writeLocalDateTime( long epochSecond, int nano ) throws IOException
+        {
+            packStructHeader( 2, LOCAL_DATE_TIME );
+            pack( epochSecond );
+            pack( nano );
+        }
+
+        @Override
+        public void writeDateTime( long epochSecondUTC, int nano, int offsetSeconds ) throws IOException
+        {
+            packStructHeader( 3, DATE_TIME_WITH_ZONE_OFFSET );
+            pack( epochSecondUTC );
+            pack( nano );
+            pack( offsetSeconds );
+        }
+
+        @Override
+        public void writeDateTime( long epochSecondUTC, int nano, String zoneId ) throws IOException
+        {
+            packStructHeader( 3, DATE_TIME_WITH_ZONE_NAME );
+            pack( epochSecondUTC );
+            pack( nano );
+            pack( zoneId );
+        }
     }
 
     private static class UnpackerV2 extends Neo4jPackV1.UnpackerV1
@@ -100,16 +180,27 @@ public class Neo4jPackV2 extends Neo4jPackV1
         @Override
         protected AnyValue unpackStruct( char signature ) throws IOException
         {
-            if ( signature == POINT_2D )
+            switch ( signature )
             {
+            case POINT_2D:
                 return unpackPoint2D();
-            }
-            else if ( signature == POINT_3D )
-            {
+            case POINT_3D:
                 return unpackPoint3D();
-            }
-            else
-            {
+            case DURATION:
+                return unpackDuration();
+            case DATE:
+                return unpackDate();
+            case LOCAL_TIME:
+                return unpackLocalTime();
+            case TIME:
+                return unpackTime();
+            case LOCAL_DATE_TIME:
+                return unpackLocalDateTime();
+            case DATE_TIME_WITH_ZONE_OFFSET:
+                return unpackDateTimeWithZoneOffset();
+            case DATE_TIME_WITH_ZONE_NAME:
+                return unpackDateTimeWithZoneName();
+            default:
                 return super.unpackStruct( signature );
             }
         }
@@ -128,6 +219,57 @@ public class Neo4jPackV2 extends Neo4jPackV1
             CoordinateReferenceSystem crs = CoordinateReferenceSystem.get( crsCode );
             double[] coordinates = {unpackDouble(), unpackDouble(), unpackDouble()};
             return pointValue( crs, coordinates );
+        }
+
+        private DurationValue unpackDuration() throws IOException
+        {
+            long months = unpackLong();
+            long days = unpackLong();
+            long seconds = unpackLong();
+            long nanos = unpackInteger();
+            return duration( months, days, seconds, nanos );
+        }
+
+        private DateValue unpackDate() throws IOException
+        {
+            long epochDay = unpackLong();
+            return epochDate( epochDay );
+        }
+
+        private LocalTimeValue unpackLocalTime() throws IOException
+        {
+            long nanoOfDay = unpackLong();
+            return localTime( nanoOfDay );
+        }
+
+        private TimeValue unpackTime() throws IOException
+        {
+            long nanosOfDayUTC = unpackLong();
+            int offsetSeconds = unpackInteger();
+            return time( nanosOfDayUTC, ZoneOffset.ofTotalSeconds( offsetSeconds ) );
+        }
+
+        private LocalDateTimeValue unpackLocalDateTime() throws IOException
+        {
+            long epochSecond = unpackLong();
+            long nano = unpackLong();
+            return localDateTime( epochSecond, nano );
+        }
+
+        private DateTimeValue unpackDateTimeWithZoneOffset() throws IOException
+        {
+            long epochSecondUTC = unpackLong();
+            long nano = unpackLong();
+            int offsetSeconds = unpackInteger();
+            return datetime( epochSecondUTC, nano, ZoneOffset.ofTotalSeconds( offsetSeconds ) );
+        }
+
+        private DateTimeValue unpackDateTimeWithZoneName() throws IOException
+        {
+            long epochSecondUTC = unpackLong();
+            long nano = unpackLong();
+            String zoneId = unpackString();
+            return datetime( epochSecondUTC, nano, ZoneId.of( zoneId ) );
         }
     }
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageRecorder.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageRecorder.java
@@ -32,22 +32,22 @@ import static org.neo4j.bolt.v1.messaging.message.PullAllMessage.pullAll;
 import static org.neo4j.bolt.v1.messaging.message.ResetMessage.reset;
 import static org.neo4j.bolt.v1.messaging.message.RunMessage.run;
 
-public class BoltRequestMessageRecorder extends MessageRecorder<RequestMessage> implements BoltRequestMessageHandler<RuntimeException>
+public class BoltRequestMessageRecorder extends MessageRecorder<RequestMessage> implements BoltRequestMessageHandler
 {
     @Override
-    public void onInit( String clientName, Map<String, Object> credentials ) throws RuntimeException
+    public void onInit( String clientName, Map<String,Object> credentials )
     {
         messages.add( init( clientName, credentials ) );
     }
 
     @Override
-    public void onAckFailure() throws RuntimeException
+    public void onAckFailure()
     {
         messages.add( ackFailure() );
     }
 
     @Override
-    public void onReset() throws RuntimeException
+    public void onReset()
     {
         messages.add( reset() );
     }
@@ -71,7 +71,7 @@ public class BoltRequestMessageRecorder extends MessageRecorder<RequestMessage> 
     }
 
     @Override
-    public void onExternalError( Neo4jError error ) throws RuntimeException
+    public void onExternalError( Neo4jError error )
     {
         //ignore
     }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageWriter.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageWriter.java
@@ -20,6 +20,7 @@
 package org.neo4j.bolt.v1.messaging;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Map;
 
 import org.neo4j.bolt.v1.messaging.message.RequestMessage;
@@ -34,10 +35,8 @@ import static org.neo4j.bolt.v1.messaging.BoltRequestMessage.PULL_ALL;
 import static org.neo4j.bolt.v1.messaging.BoltRequestMessage.RESET;
 import static org.neo4j.bolt.v1.messaging.BoltRequestMessage.RUN;
 
-
-public class BoltRequestMessageWriter implements BoltRequestMessageHandler<IOException>
+public class BoltRequestMessageWriter implements BoltRequestMessageHandler
 {
-
     private final Neo4jPack.Packer packer;
     private final BoltResponseMessageBoundaryHook onMessageComplete;
 
@@ -54,57 +53,106 @@ public class BoltRequestMessageWriter implements BoltRequestMessageHandler<IOExc
     }
 
     @Override
-    public void onInit( String clientName, Map<String,Object> credentials ) throws IOException
+    public void onInit( String clientName, Map<String,Object> credentials )
     {
-        packer.packStructHeader( 2, INIT.signature() );
-        packer.pack( clientName );
-        packer.pack( ValueUtils.asMapValue( credentials ) );
-        onMessageComplete.onMessageComplete();
+        try
+        {
+            packer.packStructHeader( 2, INIT.signature() );
+            packer.pack( clientName );
+            packer.pack( ValueUtils.asMapValue( credentials ) );
+            onMessageComplete.onMessageComplete();
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
     }
 
     @Override
-    public void onAckFailure() throws IOException
+    public void onAckFailure()
     {
-        packer.packStructHeader( 0, ACK_FAILURE.signature() );
-        onMessageComplete.onMessageComplete();
+        try
+        {
+            packer.packStructHeader( 0, ACK_FAILURE.signature() );
+            onMessageComplete.onMessageComplete();
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
     }
 
     @Override
-    public void onReset() throws IOException
+    public void onReset()
     {
-        packer.packStructHeader( 0, RESET.signature() );
-        onMessageComplete.onMessageComplete();
+        try
+        {
+            packer.packStructHeader( 0, RESET.signature() );
+            onMessageComplete.onMessageComplete();
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
     }
 
     @Override
     public void onRun( String statement, MapValue params )
-            throws IOException
+
     {
-        packer.packStructHeader( 2, RUN.signature() );
-        packer.pack( statement );
-        packer.pack( params );
-        onMessageComplete.onMessageComplete();
+        try
+        {
+            packer.packStructHeader( 2, RUN.signature() );
+            packer.pack( statement );
+            packer.pack( params );
+            onMessageComplete.onMessageComplete();
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
     }
 
     @Override
     public void onDiscardAll()
-            throws IOException
+
     {
-        packer.packStructHeader( 0, DISCARD_ALL.signature() );
-        onMessageComplete.onMessageComplete();
+        try
+        {
+            packer.packStructHeader( 0, DISCARD_ALL.signature() );
+            onMessageComplete.onMessageComplete();
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
     }
 
     @Override
     public void onPullAll()
-            throws IOException
+
     {
-        packer.packStructHeader( 0, PULL_ALL.signature() );
-        onMessageComplete.onMessageComplete();
+        try
+        {
+            packer.packStructHeader( 0, PULL_ALL.signature() );
+            onMessageComplete.onMessageComplete();
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
     }
 
-    public void flush() throws IOException
+    public void flush()
     {
-        packer.flush();
+        try
+        {
+            packer.flush();
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
     }
 
     @Override

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/AckFailureMessage.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/AckFailureMessage.java
@@ -23,7 +23,7 @@ import org.neo4j.bolt.v1.messaging.BoltRequestMessageHandler;
 
 public class AckFailureMessage implements RequestMessage
 {
-    private static AckFailureMessage INSTANCE = new AckFailureMessage();
+    private static final AckFailureMessage INSTANCE = new AckFailureMessage();
 
     /**
      * Factory method for obtaining ACK_FAILURE messages.
@@ -38,7 +38,7 @@ public class AckFailureMessage implements RequestMessage
     }
 
     @Override
-    public <E extends Exception> void dispatch( BoltRequestMessageHandler<E> consumer ) throws E
+    public void dispatch( BoltRequestMessageHandler consumer )
     {
         consumer.onAckFailure();
     }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/DiscardAllMessage.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/DiscardAllMessage.java
@@ -23,7 +23,7 @@ import org.neo4j.bolt.v1.messaging.BoltRequestMessageHandler;
 
 public class DiscardAllMessage implements RequestMessage
 {
-    private static DiscardAllMessage INSTANCE = new DiscardAllMessage();
+    private static final DiscardAllMessage INSTANCE = new DiscardAllMessage();
 
     /**
      * Factory method for obtaining DISCARD_ALL messages.
@@ -38,7 +38,7 @@ public class DiscardAllMessage implements RequestMessage
     }
 
     @Override
-    public <E extends Exception> void dispatch( BoltRequestMessageHandler<E> consumer ) throws E
+    public void dispatch( BoltRequestMessageHandler consumer )
     {
         consumer.onDiscardAll();
     }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/InitMessage.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/InitMessage.java
@@ -48,7 +48,7 @@ public class InitMessage implements RequestMessage
     }
 
     @Override
-    public <E extends Exception> void dispatch( BoltRequestMessageHandler<E> consumer ) throws E
+    public void dispatch( BoltRequestMessageHandler consumer )
     {
         consumer.onInit( userAgent, authToken );
     }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/PullAllMessage.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/PullAllMessage.java
@@ -23,7 +23,7 @@ import org.neo4j.bolt.v1.messaging.BoltRequestMessageHandler;
 
 public class PullAllMessage implements RequestMessage
 {
-    private static PullAllMessage INSTANCE = new PullAllMessage();
+    private static final PullAllMessage INSTANCE = new PullAllMessage();
 
     public static PullAllMessage pullAll()
     {
@@ -35,7 +35,7 @@ public class PullAllMessage implements RequestMessage
     }
 
     @Override
-    public <E extends Exception> void dispatch( BoltRequestMessageHandler<E> consumer ) throws E
+    public void dispatch( BoltRequestMessageHandler consumer )
     {
         consumer.onPullAll();
     }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/RequestMessage.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/RequestMessage.java
@@ -23,5 +23,5 @@ import org.neo4j.bolt.v1.messaging.BoltRequestMessageHandler;
 
 public interface RequestMessage
 {
-    <E extends Exception> void dispatch( BoltRequestMessageHandler<E> consumer ) throws E;
+    void dispatch( BoltRequestMessageHandler consumer );
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/ResetMessage.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/ResetMessage.java
@@ -23,7 +23,7 @@ import org.neo4j.bolt.v1.messaging.BoltRequestMessageHandler;
 
 public class ResetMessage implements RequestMessage
 {
-    private static ResetMessage INSTANCE = new ResetMessage();
+    private static final ResetMessage INSTANCE = new ResetMessage();
 
     /**
      * Factory method for obtaining RESET messages.
@@ -38,7 +38,7 @@ public class ResetMessage implements RequestMessage
     }
 
     @Override
-    public <E extends Exception> void dispatch( BoltRequestMessageHandler<E> consumer ) throws E
+    public void dispatch( BoltRequestMessageHandler consumer )
     {
         consumer.onReset();
     }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/RunMessage.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/message/RunMessage.java
@@ -25,7 +25,7 @@ import org.neo4j.values.virtual.VirtualValues;
 
 public class RunMessage implements RequestMessage
 {
-    private static MapValue EMPTY_PARAMETERS = VirtualValues.EMPTY_MAP;
+    private static final MapValue EMPTY_PARAMETERS = VirtualValues.EMPTY_MAP;
 
     /**
      * Factory method for obtaining RUN messages.
@@ -64,7 +64,7 @@ public class RunMessage implements RequestMessage
     }
 
     @Override
-    public <E extends Exception> void dispatch( BoltRequestMessageHandler<E> consumer ) throws E
+    public void dispatch( BoltRequestMessageHandler consumer )
     {
         consumer.onRun( statement, params );
     }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v2/messaging/Neo4jPackV2Test.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v2/messaging/Neo4jPackV2Test.java
@@ -22,23 +22,50 @@ package org.neo4j.bolt.v2.messaging;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.List;
+import java.io.UncheckedIOException;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoField;
+import java.time.temporal.ValueRange;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
 import org.neo4j.bolt.v1.messaging.Neo4jPack;
 import org.neo4j.bolt.v1.packstream.PackedInputArray;
 import org.neo4j.bolt.v1.packstream.PackedOutputArray;
+import org.neo4j.kernel.impl.store.TimeZoneMapping;
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.storable.CoordinateReferenceSystem;
+import org.neo4j.values.storable.DateTimeValue;
+import org.neo4j.values.storable.DateValue;
+import org.neo4j.values.storable.DurationValue;
+import org.neo4j.values.storable.LocalDateTimeValue;
+import org.neo4j.values.storable.LocalTimeValue;
 import org.neo4j.values.storable.PointValue;
+import org.neo4j.values.storable.TimeValue;
 import org.neo4j.values.virtual.ListValue;
 
-import static java.util.stream.Collectors.toList;
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.EPOCH_DAY;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.NANO_OF_DAY;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+import static java.time.temporal.ChronoField.YEAR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.neo4j.values.storable.CoordinateReferenceSystem.Cartesian;
 import static org.neo4j.values.storable.CoordinateReferenceSystem.WGS84;
+import static org.neo4j.values.storable.DateTimeValue.datetime;
+import static org.neo4j.values.storable.DateValue.epochDate;
+import static org.neo4j.values.storable.DurationValue.duration;
+import static org.neo4j.values.storable.LocalDateTimeValue.localDateTime;
+import static org.neo4j.values.storable.LocalTimeValue.localTime;
+import static org.neo4j.values.storable.TimeValue.time;
 import static org.neo4j.values.storable.Values.doubleValue;
 import static org.neo4j.values.storable.Values.intValue;
 import static org.neo4j.values.storable.Values.pointValue;
@@ -46,8 +73,14 @@ import static org.neo4j.values.virtual.VirtualValues.list;
 
 public class Neo4jPackV2Test
 {
+    private static final String[] TIME_ZONE_NAMES = TimeZoneMapping.supportedTimeZones().toArray( new String[0] );
+
+    private static final int RANDOM_VALUES_TO_TEST = 1_000;
+    private static final int RANDOM_LISTS_TO_TEST = 1_000;
+    private static final int RANDOM_LIST_MAX_SIZE = 500;
+
     @Test
-    public void shouldFailToPackPointWithIllegalDimensions() throws IOException
+    public void shouldFailToPackPointWithIllegalDimensions()
     {
         testPackingPointsWithWrongDimensions( 0 );
         testPackingPointsWithWrongDimensions( 1 );
@@ -71,7 +104,7 @@ public class Neo4jPackV2Test
             unpack( output );
             fail( "Exception expected" );
         }
-        catch ( IOException ignore )
+        catch ( UncheckedIOException ignore )
         {
         }
     }
@@ -93,62 +126,136 @@ public class Neo4jPackV2Test
             unpack( output );
             fail( "Exception expected" );
         }
-        catch ( IOException ignore )
+        catch ( UncheckedIOException ignore )
         {
         }
     }
 
     @Test
-    public void shouldPackAndUnpack2DPoints() throws IOException
+    public void shouldPackAndUnpack2DPoints()
     {
-        testPackingAndUnpackingOfPoints( 2 );
+        testPackingAndUnpacking( this::randomPoint2D );
     }
 
     @Test
-    public void shouldPackAndUnpack3DPoints() throws IOException
+    public void shouldPackAndUnpack3DPoints()
     {
-        testPackingAndUnpackingOfPoints( 3 );
+        testPackingAndUnpacking( this::randomPoint3D );
     }
 
     @Test
-    public void shouldPackAndUnpackListsOf2DPoints() throws IOException
+    public void shouldPackAndUnpackListsOf2DPoints()
     {
-        testPackingAndUnpackingOfListsOfPoints( 2 );
+        testPackingAndUnpacking( () -> randomList( this::randomPoint2D ) );
     }
 
     @Test
-    public void shouldPackAndUnpackListsOf3DPoints() throws IOException
+    public void shouldPackAndUnpackListsOf3DPoints()
     {
-        testPackingAndUnpackingOfListsOfPoints( 3 );
+        testPackingAndUnpacking( () -> randomList( this::randomPoint3D ) );
     }
 
-    private static void testPackingAndUnpackingOfListsOfPoints( int pointDimension ) throws IOException
+    @Test
+    public void shouldPackAndUnpackDuration()
     {
-        List<ListValue> pointLists = IntStream.range( 0, 1000 )
-                .mapToObj( index -> randomListOfPoints( index, pointDimension ) )
-                .collect( toList() );
-
-        for ( ListValue original : pointLists )
-        {
-            ListValue unpacked = packAndUnpack( original );
-            assertEquals( "Failed on " + original, original, unpacked );
-        }
+        testPackingAndUnpacking( this::randomDuration );
     }
 
-    private static void testPackingAndUnpackingOfPoints( int dimension ) throws IOException
+    @Test
+    public void shouldPackAndUnpackListsOfDuration()
     {
-        List<PointValue> points = IntStream.range( 0, 1000 )
-                .mapToObj( index -> randomPoint( index, dimension ) )
-                .collect( toList() );
-
-        for ( PointValue original : points )
-        {
-            PointValue unpacked = packAndUnpack( original );
-            assertEquals( "Failed on " + original, original, unpacked );
-        }
+        testPackingAndUnpacking( () -> randomList( this::randomDuration ) );
     }
 
-    private static void testPackingPointsWithWrongDimensions( int dimensions ) throws IOException
+    @Test
+    public void shouldPackAndUnpackDate()
+    {
+        testPackingAndUnpacking( this::randomDate );
+    }
+
+    @Test
+    public void shouldPackAndUnpackListsOfDate()
+    {
+        testPackingAndUnpacking( () -> randomList( this::randomDate ) );
+    }
+
+    @Test
+    public void shouldPackAndUnpackLocalTime()
+    {
+        testPackingAndUnpacking( this::randomLocalTime );
+    }
+
+    @Test
+    public void shouldPackAndUnpackListsOfLocalTime()
+    {
+        testPackingAndUnpacking( () -> randomList( this::randomLocalTime ) );
+    }
+
+    @Test
+    public void shouldPackAndUnpackTime()
+    {
+        testPackingAndUnpacking( this::randomTime );
+    }
+
+    @Test
+    public void shouldPackAndUnpackListsOfTime()
+    {
+        testPackingAndUnpacking( () -> randomList( this::randomTime ) );
+    }
+
+    @Test
+    public void shouldPackAndUnpackLocalDateTime()
+    {
+        testPackingAndUnpacking( this::randomLocalDateTime );
+    }
+
+    @Test
+    public void shouldPackAndUnpackListsOfLocalDateTime()
+    {
+        testPackingAndUnpacking( () -> randomList( this::randomLocalDateTime ) );
+    }
+
+    @Test
+    public void shouldPackAndUnpackDateTimeWithTimeZoneName()
+    {
+        testPackingAndUnpacking( this::randomDateTimeWithTimeZoneName );
+    }
+
+    @Test
+    public void shouldPackAndUnpackListsOfDateTimeWithTimeZoneName()
+    {
+        testPackingAndUnpacking( () -> randomList( this::randomDateTimeWithTimeZoneName ) );
+    }
+
+    @Test
+    public void shouldPackAndUnpackDateTimeWithTimeZoneOffset()
+    {
+        testPackingAndUnpacking( this::randomDateTimeWithTimeZoneOffset );
+    }
+
+    @Test
+    public void shouldPackAndUnpackListsOfDateTimeWithTimeZoneOffset()
+    {
+        testPackingAndUnpacking( () -> randomList( this::randomDateTimeWithTimeZoneOffset ) );
+    }
+
+    private static <T extends AnyValue> void testPackingAndUnpacking( Supplier<T> randomValueGenerator )
+    {
+        testPackingAndUnpacking( index -> randomValueGenerator.get() );
+    }
+
+    private static <T extends AnyValue> void testPackingAndUnpacking( Function<Integer,T> randomValueGenerator )
+    {
+        IntStream.range( 0, RANDOM_VALUES_TO_TEST )
+                .mapToObj( index -> randomValueGenerator.apply( index ) )
+                .forEach( originalValue ->
+                {
+                    T unpackedValue = packAndUnpack( originalValue );
+                    assertEquals( originalValue, unpackedValue );
+                } );
+    }
+
+    private static void testPackingPointsWithWrongDimensions( int dimensions )
     {
         PointValue point = randomPoint( 0, dimensions );
         try
@@ -161,43 +268,142 @@ public class Neo4jPackV2Test
         }
     }
 
-    private static <T extends AnyValue> T packAndUnpack( T value ) throws IOException
+    private static <T extends AnyValue> T packAndUnpack( T value )
     {
         return unpack( pack( value ) );
     }
 
-    private static PackedOutputArray pack( AnyValue value ) throws IOException
+    private static PackedOutputArray pack( AnyValue value )
     {
-        Neo4jPackV2 neo4jPack = new Neo4jPackV2();
-        PackedOutputArray output = new PackedOutputArray();
-        Neo4jPack.Packer packer = neo4jPack.newPacker( output );
-        packer.pack( value );
-        return output;
+        try
+        {
+            Neo4jPackV2 neo4jPack = new Neo4jPackV2();
+            PackedOutputArray output = new PackedOutputArray();
+            Neo4jPack.Packer packer = neo4jPack.newPacker( output );
+            packer.pack( value );
+            return output;
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
     }
 
     @SuppressWarnings( "unchecked" )
-    private static <T extends AnyValue> T unpack( PackedOutputArray output ) throws IOException
+    private static <T extends AnyValue> T unpack( PackedOutputArray output )
     {
-        Neo4jPackV2 neo4jPack = new Neo4jPackV2();
-        PackedInputArray input = new PackedInputArray( output.bytes() );
-        Neo4jPack.Unpacker unpacker = neo4jPack.newUnpacker( input );
-        AnyValue unpack = unpacker.unpack();
-        return (T) unpack;
+        try
+        {
+            Neo4jPackV2 neo4jPack = new Neo4jPackV2();
+            PackedInputArray input = new PackedInputArray( output.bytes() );
+            Neo4jPack.Unpacker unpacker = neo4jPack.newUnpacker( input );
+            AnyValue unpack = unpacker.unpack();
+            return (T) unpack;
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
     }
 
-    private static ListValue randomListOfPoints( int index, int pointDimension )
+    private static <T extends AnyValue> ListValue randomList( Supplier<T> randomValueGenerator )
     {
-        PointValue[] pointValues = ThreadLocalRandom.current()
-                .ints( 100, 1, 100 )
-                .mapToObj( i -> randomPoint( index, pointDimension ) )
-                .toArray( PointValue[]::new );
+        return randomList( index -> randomValueGenerator.get() );
+    }
 
-        return list( pointValues );
+    private static <T extends AnyValue> ListValue randomList( Function<Integer,T> randomValueGenerator )
+    {
+        AnyValue[] values = random().ints( RANDOM_LISTS_TO_TEST, 1, RANDOM_LIST_MAX_SIZE )
+                .mapToObj( index -> randomValueGenerator.apply( index ) )
+                .toArray( AnyValue[]::new );
+
+        return list( values );
+    }
+
+    private PointValue randomPoint2D( int index )
+    {
+        return randomPoint( index, 2 );
+    }
+
+    private PointValue randomPoint3D( int index )
+    {
+        return randomPoint( index, 3 );
     }
 
     private static PointValue randomPoint( int index, int dimension )
     {
         CoordinateReferenceSystem crs = index % 2 == 0 ? WGS84 : Cartesian;
-        return pointValue( crs, ThreadLocalRandom.current().doubles( dimension, Double.MIN_VALUE, Double.MAX_VALUE ).toArray() );
+        return pointValue( crs, random().doubles( dimension, Double.MIN_VALUE, Double.MAX_VALUE ).toArray() );
+    }
+
+    private DurationValue randomDuration( int index )
+    {
+        return duration( randomLong( index ), randomLong( index ), randomLong( index ), randomLong( index ) );
+    }
+
+    private DateValue randomDate()
+    {
+        return epochDate( random( EPOCH_DAY ) );
+    }
+
+    private LocalTimeValue randomLocalTime()
+    {
+        return localTime( random( NANO_OF_DAY ) );
+    }
+
+    private TimeValue randomTime()
+    {
+        return time( random( NANO_OF_DAY ), randomZoneOffset() );
+    }
+
+    private LocalDateTimeValue randomLocalDateTime()
+    {
+        return localDateTime( random( YEAR ), random( MONTH_OF_YEAR ), random( DAY_OF_MONTH ), random( HOUR_OF_DAY ),
+                random( MINUTE_OF_HOUR ), random( SECOND_OF_MINUTE ), random( NANO_OF_SECOND ) );
+    }
+
+    private DateTimeValue randomDateTimeWithTimeZoneName()
+    {
+        return datetime( random( YEAR ), random( MONTH_OF_YEAR ), random( DAY_OF_MONTH ), random( HOUR_OF_DAY ),
+                random( MINUTE_OF_HOUR ), random( SECOND_OF_MINUTE ), random( NANO_OF_SECOND ), randomZoneIdWithName() );
+    }
+
+    private DateTimeValue randomDateTimeWithTimeZoneOffset()
+    {
+        return datetime( random( YEAR ), random( MONTH_OF_YEAR ), random( DAY_OF_MONTH ), random( HOUR_OF_DAY ),
+                random( MINUTE_OF_HOUR ), random( SECOND_OF_MINUTE ), random( NANO_OF_SECOND ), randomZoneOffset() );
+    }
+
+    private static long randomLong( long origin )
+    {
+        return random().nextLong( origin, Long.MAX_VALUE );
+    }
+
+    private static int random( ChronoField chronoField )
+    {
+        ValueRange range = chronoField.range();
+        int min = (int) range.getMinimum();
+        int max = (int) range.getSmallestMaximum();
+        if ( max != range.getSmallestMaximum() )
+        {
+            max = Integer.MAX_VALUE;
+        }
+        return random().nextInt( min, max );
+    }
+
+    private static ZoneOffset randomZoneOffset()
+    {
+        return ZoneOffset.ofTotalSeconds( random().nextInt( ZoneOffset.MIN.getTotalSeconds(), ZoneOffset.MAX.getTotalSeconds() + 1 ) );
+    }
+
+    private static ZoneId randomZoneIdWithName()
+    {
+        String timeZoneName = TIME_ZONE_NAMES[random().nextInt( TIME_ZONE_NAMES.length )];
+        return ZoneId.of( timeZoneName );
+    }
+
+    private static ThreadLocalRandom random()
+    {
+        return ThreadLocalRandom.current();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TimeZoneMapping.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TimeZoneMapping.java
@@ -23,12 +23,14 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static java.util.Collections.unmodifiableSet;
 
 public class TimeZoneMapping
 {
@@ -61,9 +63,9 @@ public class TimeZoneMapping
         return TIME_ZONE_SHORT_TO_STRING.get( offset );
     }
 
-    static Collection<String> supportedTimeZones()
+    public static Set<String> supportedTimeZones()
     {
-        return TIME_ZONE_STRING_TO_SHORT.keySet();
+        return unmodifiableSet( TIME_ZONE_STRING_TO_SHORT.keySet() );
     }
 
     static

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TimeZoneMappingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TimeZoneMappingTest.java
@@ -30,7 +30,6 @@ import java.net.URL;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -124,7 +123,7 @@ public class TimeZoneMappingTest
         } );
 
         // TODO assertion for removals
-        Collection<String> neo4jSupportedTzs = TimeZoneMapping.supportedTimeZones();
+        Set<String> neo4jSupportedTzs = TimeZoneMapping.supportedTimeZones();
         Set<String> removedTzs = new HashSet<>( neo4jSupportedTzs );
         removedTzs.removeAll( ianaSupportedTzs );
         //assertThat( "There were removals from the IANA database. Please upgrade manually.", removedTzs, empty() );


### PR DESCRIPTION
This PR makes Bolt version 2 aware of six new temporal types: DateTime, LocalDateTime, Date, Time, LocalTime and Duration. Bolt server will now be able to serialize and deserialize these types.

DateTime type contains time zone information either as an offset or as a zone name. That is why it is presented as two distinct types in Bolt. First contains offset as integer and second contains zone name as string.