### PR TITLE
Explicitly reserve key bit for future use

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/DynamicSizeUtil.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/DynamicSizeUtil.java
@@ -21,6 +21,7 @@ package org.neo4j.index.internal.gbptree;
 
 import org.neo4j.io.pagecache.PageCursor;
 
+import static java.lang.String.format;
 import static org.neo4j.index.internal.gbptree.PageCursorUtil.getUnsignedShort;
 import static org.neo4j.index.internal.gbptree.PageCursorUtil.putUnsignedShort;
 
@@ -60,15 +61,18 @@ import static org.neo4j.index.internal.gbptree.PageCursorUtil.putUnsignedShort;
  * [0,0,1,k,k,k,k,k][1,v,v,v,v,v,v,v][v,v,v,v,v,v,v,v]
  *
  * Two byte key, no value
- * [0,1,0,k,k,k,k,k][k,k,k,k,k,k,k,k]
+ * [0,1,0,k,k,k,k,k][0,k,k,k,k,k,k,k]
  *
  * Two byte key, one byte value
- * [0,1,1,k,k,k,k,k][k,k,k,k,k,k,k,k][0,v,v,v,v,v,v,v]
+ * [0,1,1,k,k,k,k,k][0,k,k,k,k,k,k,k][0,v,v,v,v,v,v,v]
  *
  * Two byte key, two byte value
- * [0,1,1,k,k,k,k,k][k,k,k,k,k,k,k,k][1,v,v,v,v,v,v,v][v,v,v,v,v,v,v,v]
+ * [0,1,1,k,k,k,k,k][0,k,k,k,k,k,k,k][1,v,v,v,v,v,v,v][v,v,v,v,v,v,v,v]
  * </pre>
  * This key/value size format is used, both for leaves and internal nodes even though internal nodes can never have values.
+ *
+ * The most significant key bit in the second byte (shown as 0) is not needed for the discrete key sizes for our 8k page size
+ * and is to be considered reserved for future use.
  *
  * Relative layout of key and key_value
  * KeyOffset points to the exact offset where key entry or key_value entry
@@ -89,7 +93,9 @@ class DynamicSizeUtil
     private static final int FLAG_FIRST_BYTE_TOMBSTONE = 0x80;
     private static final long FLAG_READ_TOMBSTONE = 0x80000000_00000000L;
     static final int MASK_ONE_BYTE_KEY_SIZE = 0x1F;
+    static final int MASK_TWO_BYTE_KEY_SIZE = 0xFFF;
     static final int MASK_ONE_BYTE_VALUE_SIZE = 0x7F;
+    static final int MASK_TWO_BYTE_VALUE_SIZE = 0x7FFF;
     private static final int FLAG_HAS_VALUE_SIZE = 0x20;
     private static final int FLAG_ADDITIONAL_KEY_SIZE = 0x40;
     private static final int FLAG_ADDITIONAL_VALUE_SIZE = 0x80;
@@ -122,6 +128,11 @@ class DynamicSizeUtil
             if ( hasAdditionalKeySize )
             {
                 firstByte |= FLAG_ADDITIONAL_KEY_SIZE;
+                if ( keySize > MASK_TWO_BYTE_KEY_SIZE )
+                {
+                    throw new IllegalArgumentException(
+                            format( "Max supported key size is %d, but tried to store key of size %d", MASK_TWO_BYTE_KEY_SIZE, keySize ) );
+                }
             }
             if ( hasValueSize )
             {
@@ -144,6 +155,11 @@ class DynamicSizeUtil
                 byte firstByte = (byte) (valueSize & MASK_ONE_BYTE_VALUE_SIZE); // Least significant 7 bits
                 if ( needsAdditionalValueSize )
                 {
+                    if ( valueSize > MASK_TWO_BYTE_VALUE_SIZE )
+                    {
+                        throw new IllegalArgumentException(
+                                format( "Max supported value size is %d, but tried to store value of size %d", MASK_TWO_BYTE_VALUE_SIZE, valueSize ) );
+                    }
                     firstByte |= FLAG_ADDITIONAL_VALUE_SIZE;
                 }
                 cursor.putByte( firstByte );

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/DynamicSizeUtil.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/DynamicSizeUtil.java
@@ -92,10 +92,14 @@ class DynamicSizeUtil
 
     private static final int FLAG_FIRST_BYTE_TOMBSTONE = 0x80;
     private static final long FLAG_READ_TOMBSTONE = 0x80000000_00000000L;
+    // mask for one-byte key size to map to the k's in [_,_,_,k,k,k,k,k]
     static final int MASK_ONE_BYTE_KEY_SIZE = 0x1F;
-    static final int MASK_TWO_BYTE_KEY_SIZE = 0xFFF;
+    // max two-byte key size to map to the k's in [_,_,_,k,k,k,k,k][_,k,k,k,k,k,k,k]
+    private static final int MAX_TWO_BYTE_KEY_SIZE = 0xFFF;
+    // mask for one-byte value size to map to the v's in [_,v,v,v,v,v,v,v]
     static final int MASK_ONE_BYTE_VALUE_SIZE = 0x7F;
-    static final int MASK_TWO_BYTE_VALUE_SIZE = 0x7FFF;
+    // max two-byte value size to map to the v's in [_,v,v,v,v,v,v,v][v,v,v,v,v,v,v,v]
+    private static final int MAX_TWO_BYTE_VALUE_SIZE = 0x7FFF;
     private static final int FLAG_HAS_VALUE_SIZE = 0x20;
     private static final int FLAG_ADDITIONAL_KEY_SIZE = 0x40;
     private static final int FLAG_ADDITIONAL_VALUE_SIZE = 0x80;
@@ -128,10 +132,10 @@ class DynamicSizeUtil
             if ( hasAdditionalKeySize )
             {
                 firstByte |= FLAG_ADDITIONAL_KEY_SIZE;
-                if ( keySize > MASK_TWO_BYTE_KEY_SIZE )
+                if ( keySize > MAX_TWO_BYTE_KEY_SIZE )
                 {
                     throw new IllegalArgumentException(
-                            format( "Max supported key size is %d, but tried to store key of size %d", MASK_TWO_BYTE_KEY_SIZE, keySize ) );
+                            format( "Max supported key size is %d, but tried to store key of size %d", MAX_TWO_BYTE_KEY_SIZE, keySize ) );
                 }
             }
             if ( hasValueSize )
@@ -155,10 +159,10 @@ class DynamicSizeUtil
                 byte firstByte = (byte) (valueSize & MASK_ONE_BYTE_VALUE_SIZE); // Least significant 7 bits
                 if ( needsAdditionalValueSize )
                 {
-                    if ( valueSize > MASK_TWO_BYTE_VALUE_SIZE )
+                    if ( valueSize > MAX_TWO_BYTE_VALUE_SIZE )
                     {
                         throw new IllegalArgumentException(
-                                format( "Max supported value size is %d, but tried to store value of size %d", MASK_TWO_BYTE_VALUE_SIZE, valueSize ) );
+                                format( "Max supported value size is %d, but tried to store value of size %d", MAX_TWO_BYTE_VALUE_SIZE, valueSize ) );
                     }
                     firstByte |= FLAG_ADDITIONAL_VALUE_SIZE;
                 }


### PR DESCRIPTION
One of the bits in the key/value header is now explicitly reserved
for future use. This reduces max key size to 4905, but in reality
this limit is even lower anyway.