### PR TITLE
Add support for spatial point values to the batch importer

### DIFF
--- a/community/csv/pom.xml
+++ b/community/csv/pom.xml
@@ -64,6 +64,11 @@ the relevant Commercial Agreement.
       <artifactId>neo4j-collections</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-values</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <!-- test dependencies -->
     <dependency>

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
@@ -90,7 +90,7 @@ public class Extractors
     private final Extractor<long[]> longArray;
     private final Extractor<float[]> floatArray;
     private final Extractor<double[]> doubleArray;
-    private final PointExtractor point_;
+    private final PointExtractor point;
 
     public Extractors( char arrayDelimiter )
     {
@@ -141,7 +141,7 @@ public class Extractors
             add( longArray = new LongArrayExtractor( arrayDelimiter ) );
             add( floatArray = new FloatArrayExtractor( arrayDelimiter ) );
             add( doubleArray = new DoubleArrayExtractor( arrayDelimiter ) );
-            add( point_ = new PointExtractor() );
+            add( point = new PointExtractor() );
         }
         catch ( IllegalAccessException e )
         {
@@ -249,9 +249,9 @@ public class Extractors
         return doubleArray;
     }
 
-    public PointExtractor point_()
+    public PointExtractor point()
     {
-        return point_;
+        return point;
     }
 
     private abstract static class AbstractExtractor<T> implements Extractor<T>

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/MapSupport.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/MapSupport.scala
@@ -71,7 +71,13 @@ class LazyMap[T](ctx: QueryContext, ops: Operations[T], id: Long)
 
   override def putAll(m: util.Map[_ <: String, _ <: AnyValue]): Unit = throw new UnsupportedOperationException()
 
-  override def get(key: scala.Any): AnyValue = ops.getProperty(id, ctx.getPropertyKeyId(key.asInstanceOf[String]))
+  override def get(key: scala.Any): AnyValue =
+    ctx.getOptPropertyKeyId(key.asInstanceOf[String]) match {
+      case Some(keyId) =>
+        ops.getProperty(id, keyId)
+      case None =>
+        null
+    }
 
   override def keySet(): util.Set[String] = allProps.keySet()
 

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/PointFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/PointFunction.scala
@@ -22,12 +22,11 @@ package org.neo4j.cypher.internal.runtime.interpreted.commands.expressions
 import java.util.function.BiConsumer
 
 import org.neo4j.cypher.internal.util.v3_4.CypherTypeException
-import org.neo4j.kernel.impl.util.ValueUtils
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.IsMap
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.QueryState
 import org.neo4j.values.AnyValue
-import org.neo4j.values.storable.Values
+import org.neo4j.values.storable.{PointValue, Values}
 import org.neo4j.values.virtual.MapValue
 
 case class PointFunction(data: Expression) extends NullInNullOutExpression(data) {
@@ -35,7 +34,7 @@ case class PointFunction(data: Expression) extends NullInNullOutExpression(data)
     case IsMap(mapCreator) =>
       val map = mapCreator(state.query)
       if (containsNull(map)) Values.NO_VALUE
-      else ValueUtils.pointFromMap(map)
+      else PointValue.fromMap(map)
     case x => throw new CypherTypeException(s"Expected a map but got $x")
   }
 

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ContainerIndexTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ContainerIndexTest.scala
@@ -86,8 +86,8 @@ class ContainerIndexTest extends CypherFunSuite {
     val node = mock[Node]
     when(node.getId).thenReturn(0)
     implicit val expression = Literal(node)
-    when(qtx.getPropertyKeyId("v")).thenReturn(0)
-    when(qtx.getPropertyKeyId("c")).thenReturn(1)
+    when(qtx.getOptPropertyKeyId("v")).thenReturn(Some(0))
+    when(qtx.getOptPropertyKeyId("c")).thenReturn(Some(1))
     val nodeOps = mock[Operations[NodeValue]]
     when(nodeOps.getProperty(0, 0)).thenAnswer(new Answer[Value] {
       override def answer(invocation: InvocationOnMock): Value = Values.longValue(1)
@@ -105,8 +105,8 @@ class ContainerIndexTest extends CypherFunSuite {
     val rel = mock[Relationship]
     when(rel.getId).thenReturn(0)
     implicit val expression = Literal(rel)
-    when(qtx.getPropertyKeyId("v")).thenReturn(0)
-    when(qtx.getPropertyKeyId("c")).thenReturn(1)
+    when(qtx.getOptPropertyKeyId("v")).thenReturn(Some(0))
+    when(qtx.getOptPropertyKeyId("c")).thenReturn(Some(1))
     val relOps = mock[Operations[RelationshipValue]]
     when(relOps.getProperty(0, 0)).thenAnswer(new Answer[Value] {
       override def answer(invocation: InvocationOnMock): Value = Values.longValue(1)

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ValueUtils.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ValueUtils.java
@@ -278,7 +278,8 @@ public final class ValueUtils
     /**
      * Creates a {@link Value} from the given object, or if it is already a Value it is returned as it is.
      * <p>
-     * This is different from {@link Values#of} which explicitly fails if given a Value.
+     * This is different from {@link Values#of} which often explicitly fails or creates a new copy
+     * if given a Value.
      */
     public static Value asValue( Object value )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ValueUtils.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ValueUtils.java
@@ -254,70 +254,6 @@ public final class ValueUtils
         return map( mapValues( map ) );
     }
 
-    public static PointValue pointFromMap( MapValue map )
-    {
-        CoordinateReferenceSystem crs;
-        double[] coordinates;
-        if ( map.containsKey( "crs" ) )
-        {
-            TextValue crsName = (TextValue) map.get( "crs" );
-            crs = CoordinateReferenceSystem.byName( crsName.stringValue() );
-            if ( crs == null )
-            {
-                throw new IllegalArgumentException( "Unknown coordinate reference system: " + crsName.stringValue() );
-            }
-        }
-        else
-        {
-            crs = null;
-        }
-        if ( map.containsKey( "x" ) && map.containsKey( "y" ) )
-        {
-            double x = ((NumberValue) map.get( "x" )).doubleValue();
-            double y = ((NumberValue) map.get( "y" )).doubleValue();
-            coordinates = map.containsKey( "z" ) ? new double[]{x, y, ((NumberValue) map.get( "z" )).doubleValue()} : new double[]{x, y};
-            if ( crs == null )
-            {
-                crs = coordinates.length == 3 ? CoordinateReferenceSystem.Cartesian_3D : CoordinateReferenceSystem.Cartesian;
-            }
-        }
-        else if ( map.containsKey( "latitude" ) && map.containsKey( "longitude" ) )
-        {
-            double x = ((NumberValue) map.get( "longitude" )).doubleValue();
-            double y = ((NumberValue) map.get( "latitude" )).doubleValue();
-            // TODO Consider supporting key 'height'
-            if ( map.containsKey( "z" ) )
-            {
-                coordinates = new double[]{x, y, ((NumberValue) map.get( "z" )).doubleValue()};
-            }
-            else if ( map.containsKey( "height" ) )
-            {
-                coordinates = new double[]{x, y, ((NumberValue) map.get( "height" )).doubleValue()};
-            }
-            else
-            {
-                coordinates = new double[]{x, y};
-            }
-            if ( crs == null )
-            {
-                crs = coordinates.length == 3 ? CoordinateReferenceSystem.WGS84_3D : CoordinateReferenceSystem.WGS84;
-            }
-            if ( !crs.isGeographic() )
-            {
-                throw new IllegalArgumentException( "Geographic points does not support coordinate reference system: " + crs );
-            }
-        }
-        else
-        {
-            throw new IllegalArgumentException( "A point must contain either 'x' and 'y' or 'latitude' and 'longitude'" );
-        }
-        if ( crs.getDimension() != coordinates.length )
-        {
-            throw new IllegalArgumentException( "Cannot create " + crs.getDimension() + "D point with " + coordinates.length + " coordinates" );
-        }
-        return Values.pointValue( crs, coordinates );
-    }
-
     private static Map<String,AnyValue> mapValues( Map<String,Object> map )
     {
         HashMap<String,AnyValue> newMap = new HashMap<>( map.size() );
@@ -337,5 +273,19 @@ public final class ValueUtils
     public static RelationshipValue fromRelationshipProxy( Relationship relationship )
     {
         return new RelationshipProxyWrappingValue( relationship );
+    }
+
+    /**
+     * Creates a {@link Value} from the given object, or if it is already a Value it is returned as it is.
+     * <p>
+     * This is different from {@link Values#of} which explicitly fails if given a Value.
+     */
+    public static Value asValue( Object value )
+    {
+        if ( value instanceof Value )
+        {
+            return (Value) value;
+        }
+        return Values.of( value );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
@@ -148,6 +148,7 @@ import org.neo4j.kernel.impl.transaction.state.RelationshipCreator;
 import org.neo4j.kernel.impl.transaction.state.RelationshipGroupGetter;
 import org.neo4j.kernel.impl.transaction.state.storeview.NeoStoreIndexStoreView;
 import org.neo4j.kernel.impl.util.Dependencies;
+import org.neo4j.kernel.impl.util.ValueUtils;
 import org.neo4j.kernel.internal.EmbeddedGraphDatabase;
 import org.neo4j.kernel.internal.locker.GlobalStoreLocker;
 import org.neo4j.kernel.internal.locker.StoreLocker;
@@ -161,7 +162,6 @@ import org.neo4j.storageengine.api.schema.SchemaRule;
 import org.neo4j.unsafe.batchinsert.BatchInserter;
 import org.neo4j.unsafe.batchinsert.BatchRelationship;
 import org.neo4j.values.storable.Value;
-import org.neo4j.values.storable.Values;
 
 import static java.lang.Boolean.parseBoolean;
 import static java.util.Collections.emptyIterator;
@@ -408,7 +408,7 @@ public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvide
         int propertyKey = getOrCreatePropertyKeyId( propertyName );
         RecordAccess<PropertyRecord,PrimitiveRecord> propertyRecords = recordAccess.getPropertyRecords();
 
-        propertyCreator.primitiveSetProperty( primitiveRecord, propertyKey, Values.of( propertyValue ), propertyRecords );
+        propertyCreator.primitiveSetProperty( primitiveRecord, propertyKey, ValueUtils.asValue( propertyValue ), propertyRecords );
     }
 
     private void validateIndexCanBeCreated( int labelId, int[] propertyKeyIds )
@@ -773,7 +773,7 @@ public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvide
             protected PropertyBlock underlyingObjectToObject( Entry<String, Object> property )
             {
                 return propertyCreator.encodePropertyValue(
-                        getOrCreatePropertyKeyId( property.getKey() ), Values.of( property.getValue() ) );
+                        getOrCreatePropertyKeyId( property.getKey() ), ValueUtils.asValue( property.getValue() ) );
             }
         };
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/EntityImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/EntityImporter.java
@@ -29,11 +29,11 @@ import org.neo4j.kernel.impl.store.record.PrimitiveRecord;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.store.record.PropertyRecord;
 import org.neo4j.kernel.impl.store.record.Record;
+import org.neo4j.kernel.impl.util.ValueUtils;
 import org.neo4j.unsafe.impl.batchimport.DataImporter.Monitor;
 import org.neo4j.unsafe.impl.batchimport.input.InputEntityVisitor;
 import org.neo4j.unsafe.impl.batchimport.store.BatchingNeoStores;
 import org.neo4j.unsafe.impl.batchimport.store.BatchingTokenRepository.BatchingPropertyKeyTokenRepository;
-import org.neo4j.values.storable.Values;
 
 /**
  * Abstract class containing logic for importing properties for an entity (node/relationship).
@@ -119,7 +119,7 @@ abstract class EntityImporter extends InputEntityVisitor.Adapter
 
     private void encodeProperty( PropertyBlock block, int key, Object value )
     {
-        PropertyStore.encodeValue( block, key, Values.of( value ), dynamicStringRecordAllocator, dynamicArrayRecordAllocator,
+        PropertyStore.encodeValue( block, key, ValueUtils.asValue( value ), dynamicStringRecordAllocator, dynamicArrayRecordAllocator,
                 propertyStore.allowStorePointsAndTemporal() );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Inputs.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Inputs.java
@@ -21,12 +21,12 @@ package org.neo4j.unsafe.impl.batchimport.input;
 
 import java.util.function.ToIntFunction;
 
+import org.neo4j.kernel.impl.util.ValueUtils;
 import org.neo4j.unsafe.impl.batchimport.InputIterable;
 import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
 import org.neo4j.unsafe.impl.batchimport.input.Input.Estimates;
 import org.neo4j.values.storable.Value;
-import org.neo4j.values.storable.Values;
 
 public class Inputs
 {
@@ -133,7 +133,7 @@ public class Inputs
             Value[] values = new Value[propertyCount];
             for ( int i = 0; i < propertyCount; i++ )
             {
-                values[i] = Values.of( entity.propertyValue( i ) );
+                values[i] = ValueUtils.asValue( entity.propertyValue( i ) );
             }
             size += valueSizeCalculator.applyAsInt( values );
         }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
@@ -482,7 +482,7 @@ public class CsvInputBatchImportIT
             for ( int i = 0; i < node.propertyCount(); i++ )
             {
                 final Object expectedValue = node.propertyValue( i );
-                Consumer verify = (actualValue) ->
+                Consumer verify = actualValue ->
                 {
                     assertEquals( expectedValue, actualValue );
                 };
@@ -490,7 +490,7 @@ public class CsvInputBatchImportIT
             }
 
             // Special verifier for point property
-            Consumer verifyPoint = (actualValue) ->
+            Consumer verifyPoint = actualValue ->
             {
                 // The y-coordinate should match the node number
                 PointValue v = (PointValue) actualValue;

--- a/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
@@ -447,7 +447,8 @@ public class PointValue extends ScalarValue implements Point, Comparable<PointVa
             }
             else if ( crs == CoordinateReferenceSystem.WGS84_3D )
             {
-                throw new IllegalArgumentException( "A " + CoordinateReferenceSystem.WGS84_3D.getName() + " point must contain 'latitude', 'longitude' and 'height'" );
+                throw new IllegalArgumentException( "A " + CoordinateReferenceSystem.WGS84_3D.getName() +
+                                                    " point must contain 'latitude', 'longitude' and 'height'" );
             }
             throw new IllegalArgumentException( "A point must contain either 'x' and 'y' or 'latitude' and 'longitude'" );
         }
@@ -459,22 +460,31 @@ public class PointValue extends ScalarValue implements Point, Comparable<PointVa
         return Values.pointValue( crs, coordinates );
     }
 
-    private static enum PointValueField
+    private enum PointValueField
     {
         X
                 {
                     @Override
-                    ValueGroup valueType() { return NUMBER; }
+                    ValueGroup valueType()
+                    {
+                        return NUMBER;
+                    }
                 },
         Y
                 {
                     @Override
-                    ValueGroup valueType() { return NUMBER; }
+                    ValueGroup valueType()
+                    {
+                        return NUMBER;
+                    }
                 },
         Z
                 {
                     @Override
-                    ValueGroup valueType() { return NUMBER; }
+                    ValueGroup valueType()
+                    {
+                        return NUMBER;
+                    }
                 },
         LATITUDE
                 {
@@ -495,15 +505,24 @@ public class PointValue extends ScalarValue implements Point, Comparable<PointVa
         HEIGHT
                 {
                     @Override
-                    ValueGroup valueType() { return NUMBER; }
+                    ValueGroup valueType()
+                    {
+                        return NUMBER;
+                    }
                 },
         CRS
                 {
                     @Override
-                    ValueGroup valueType() { return TEXT; }
+                    ValueGroup valueType()
+                    {
+                        return TEXT;
+                    }
                 },
-        __MAX_VALUE__;
+        __MAX_VALUE__; // This is just used to define array boundaries
 
-        ValueGroup valueType() { return ValueGroup.NO_VALUE; }
+        ValueGroup valueType()
+        {
+            return ValueGroup.NO_VALUE;
+        }
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
@@ -264,14 +264,11 @@ public class PointValue extends ScalarValue implements Point, Comparable<PointVa
 
     public static PointValue fromMap( MapValue map )
     {
-        AnyValue[] fields = new Value[PointValueField.__MAX_VALUE__.ordinal()];
+        AnyValue[] fields = new Value[PointValueField.values().length];
         for ( PointValueField f : PointValueField.values() )
         {
-            if ( f != PointValueField.__MAX_VALUE__ )
-            {
-                AnyValue fieldValue = map.get( f.name().toLowerCase() );
-                fields[f.ordinal()] = fieldValue != Values.NO_VALUE ? fieldValue : null;
-            }
+            AnyValue fieldValue = map.get( f.name().toLowerCase() );
+            fields[f.ordinal()] = fieldValue != Values.NO_VALUE ? fieldValue : null;
         }
         return fromInputFields( fields );
     }
@@ -305,7 +302,7 @@ public class PointValue extends ScalarValue implements Point, Comparable<PointVa
             throw new IllegalArgumentException( errorMessage );
         }
 
-        Value[] fields = new Value[PointValueField.__MAX_VALUE__.ordinal()];
+        Value[] fields = new Value[PointValueField.values().length];
 
         do
         {
@@ -462,67 +459,24 @@ public class PointValue extends ScalarValue implements Point, Comparable<PointVa
 
     private enum PointValueField
     {
-        X
-                {
-                    @Override
-                    ValueGroup valueType()
-                    {
-                        return NUMBER;
-                    }
-                },
-        Y
-                {
-                    @Override
-                    ValueGroup valueType()
-                    {
-                        return NUMBER;
-                    }
-                },
-        Z
-                {
-                    @Override
-                    ValueGroup valueType()
-                    {
-                        return NUMBER;
-                    }
-                },
-        LATITUDE
-                {
-                    @Override
-                    ValueGroup valueType()
-                    {
-                        return NUMBER;
-                    }
-                },
-        LONGITUDE
-                {
-                    @Override
-                    ValueGroup valueType()
-                    {
-                        return NUMBER;
-                    }
-                },
-        HEIGHT
-                {
-                    @Override
-                    ValueGroup valueType()
-                    {
-                        return NUMBER;
-                    }
-                },
-        CRS
-                {
-                    @Override
-                    ValueGroup valueType()
-                    {
-                        return TEXT;
-                    }
-                },
-        __MAX_VALUE__; // This is just used to define array boundaries
+        X( NUMBER ),
+        Y( NUMBER ),
+        Z( NUMBER ),
+        LATITUDE( NUMBER ),
+        LONGITUDE( NUMBER ),
+        HEIGHT( NUMBER ),
+        CRS( TEXT );
+
+        PointValueField( ValueGroup valueType )
+        {
+            this.valueType = valueType;
+        }
 
         ValueGroup valueType()
         {
-            return ValueGroup.NO_VALUE;
+            return valueType;
         }
+
+        private ValueGroup valueType;
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
@@ -21,15 +21,21 @@ package org.neo4j.values.storable;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.neo4j.graphdb.spatial.CRS;
 import org.neo4j.graphdb.spatial.Coordinate;
 import org.neo4j.graphdb.spatial.Point;
+import org.neo4j.values.AnyValue;
 import org.neo4j.values.ValueMapper;
 import org.neo4j.values.utils.PrettyPrinter;
+import org.neo4j.values.virtual.MapValue;
 
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
+import static org.neo4j.values.storable.ValueGroup.NUMBER;
+import static org.neo4j.values.storable.ValueGroup.TEXT;
 
 public class PointValue extends ScalarValue implements Point, Comparable<PointValue>
 {
@@ -254,5 +260,241 @@ public class PointValue extends ScalarValue implements Point, Comparable<PointVa
             }
         }
         return true;
+    }
+
+    public static PointValue fromMap( MapValue map )
+    {
+        AnyValue[] fields = new Value[PointValueField.__MAX_VALUE__.ordinal()];
+        for ( PointValueField f : PointValueField.values() )
+        {
+            if ( f != PointValueField.__MAX_VALUE__ )
+            {
+                AnyValue fieldValue = map.get( f.name().toLowerCase() );
+                fields[f.ordinal()] = fieldValue != Values.NO_VALUE ? fieldValue : null;
+            }
+        }
+        return fromInputFields( fields );
+    }
+
+//    private static Pattern keyValuePattern = Pattern.compile(
+//            "\\s*+((?<x>x)|(?<y>y)|(?<long>longitude)|(?<lat>latitude))\\s*+:\\s*+(?<dblVal>\\S+)|((?<crs>crs)\\s*+:\\s*+(?<crsVal>\\S+))" );
+//    private static Pattern keyValuePattern = Pattern.compile( "(?<k>[a-z_A-Z]\\w*+)\\s*:\\s*(?<v>\\S+)" );
+    private static Pattern mapPattern = Pattern.compile( "\\{(.*)\\}" );
+    private static Pattern keyValuePattern =
+        Pattern.compile( "(?:\\A|,)\\s*+(?<k>[a-z_A-Z]\\w*+)\\s*:\\s*(?<v>[^\\s,]+)" );
+
+    private static Pattern quotesPattern = Pattern.compile( "^[\"']|[\"']$" );
+
+    public static PointValue parse( CharSequence text )
+    {
+        Matcher mapMatcher = mapPattern.matcher( text );
+        if ( !(mapMatcher.find() && mapMatcher.groupCount() == 1  ) )
+        {
+            String errorMessage = format( "Failed to parse point value: '%s'", text );
+            throw new IllegalArgumentException( errorMessage );
+        }
+
+        String mapContents = mapMatcher.group( 1 );
+        if ( mapContents.isEmpty() )
+        {
+            String errorMessage = format( "Failed to parse point value: '%s'", text );
+            throw new IllegalArgumentException( errorMessage );
+        }
+
+        Matcher matcher = keyValuePattern.matcher( mapContents );
+        if ( !(matcher.find() ) )
+        {
+            String errorMessage = format( "Failed to parse point value: '%s'", text );
+            throw new IllegalArgumentException( errorMessage );
+        }
+
+        Value[] fields = new Value[PointValueField.__MAX_VALUE__.ordinal()];
+
+        do
+        {
+            String key = matcher.group( "k" );
+            if ( key != null )
+            {
+                try
+                {
+                    // NOTE: We let the key be case-insensitive here
+                    PointValueField field = PointValueField.valueOf( PointValueField.class, key.toUpperCase() );
+
+                    String value = matcher.group( "v" );
+                    if ( value != null )
+                    {
+                        switch ( field.valueType() )
+                        {
+                        case NUMBER:
+                        {
+                            DoubleValue doubleValue = Values.doubleValue( Double.parseDouble( value ) );
+                            fields[field.ordinal()] = doubleValue;
+                            break;
+                        }
+
+                        case TEXT:
+                        {
+                            // Eliminate any quoutes
+                            String unquotedValue = quotesPattern.matcher( value ).replaceAll( "" );
+                            fields[field.ordinal()] = Values.stringValue( unquotedValue );
+                            break;
+                        }
+
+                        default:
+                            // Just ignore unknown fields
+                        }
+                    }
+                }
+                catch ( IllegalArgumentException e )
+                {
+                    // Ignore unknown fields
+                }
+            }
+        } while ( matcher.find() );
+
+        return fromInputFields( fields );
+    }
+
+    /**
+     * This contains the logic to decide the default coordinate reference system based on the input fields
+     */
+    private static PointValue fromInputFields( AnyValue[] fields )
+    {
+        CoordinateReferenceSystem crs;
+        double[] coordinates;
+
+        AnyValue crsValue = fields[PointValueField.CRS.ordinal()];
+        if ( crsValue != null )
+        {
+            TextValue crsName = (TextValue) crsValue;
+            crs = CoordinateReferenceSystem.byName( crsName.stringValue() );
+            if ( crs == null )
+            {
+                throw new IllegalArgumentException( "Unknown coordinate reference system: " + crsName.stringValue() );
+            }
+        }
+        else
+        {
+            crs = null;
+        }
+
+        AnyValue xValue = fields[PointValueField.X.ordinal()];
+        AnyValue yValue = fields[PointValueField.Y.ordinal()];
+        AnyValue latitudeValue = fields[PointValueField.LATITUDE.ordinal()];
+        AnyValue longitudeValue = fields[PointValueField.LONGITUDE.ordinal()];
+
+        if ( xValue != null && yValue != null )
+        {
+            double x = ((NumberValue) xValue).doubleValue();
+            double y = ((NumberValue) yValue).doubleValue();
+            AnyValue zValue = fields[PointValueField.Z.ordinal()];
+
+            coordinates = zValue != null ? new double[]{x, y, ((NumberValue) zValue).doubleValue()} : new double[]{x, y};
+            if ( crs == null )
+            {
+                crs = coordinates.length == 3 ? CoordinateReferenceSystem.Cartesian_3D : CoordinateReferenceSystem.Cartesian;
+            }
+        }
+        else if ( latitudeValue != null && longitudeValue != null )
+        {
+            double x = ((NumberValue) longitudeValue).doubleValue();
+            double y = ((NumberValue) latitudeValue).doubleValue();
+            AnyValue zValue = fields[PointValueField.Z.ordinal()];
+            AnyValue heightValue = fields[PointValueField.HEIGHT.ordinal()];
+            if ( zValue != null )
+            {
+                coordinates = new double[]{x, y, ((NumberValue) zValue).doubleValue()};
+            }
+            else if ( heightValue != null )
+            {
+                coordinates = new double[]{x, y, ((NumberValue) heightValue).doubleValue()};
+            }
+            else
+            {
+                coordinates = new double[]{x, y};
+            }
+            if ( crs == null )
+            {
+                crs = coordinates.length == 3 ? CoordinateReferenceSystem.WGS84_3D : CoordinateReferenceSystem.WGS84;
+            }
+            if ( !crs.isGeographic() )
+            {
+                throw new IllegalArgumentException( "Geographic points does not support coordinate reference system: " + crs );
+            }
+        }
+        else
+        {
+            if ( crs == CoordinateReferenceSystem.Cartesian )
+            {
+                throw new IllegalArgumentException( "A " + CoordinateReferenceSystem.Cartesian.getName() + " point must contain 'x' and 'y'" );
+            }
+            else if ( crs == CoordinateReferenceSystem.Cartesian_3D )
+            {
+                throw new IllegalArgumentException( "A " + CoordinateReferenceSystem.Cartesian_3D.getName() + " point must contain 'x', 'y' and 'z'" );
+            }
+            else if ( crs == CoordinateReferenceSystem.WGS84 )
+            {
+                throw new IllegalArgumentException( "A " + CoordinateReferenceSystem.WGS84.getName() + " point must contain 'latitude' and 'longitude'" );
+            }
+            else if ( crs == CoordinateReferenceSystem.WGS84_3D )
+            {
+                throw new IllegalArgumentException( "A " + CoordinateReferenceSystem.WGS84_3D.getName() + " point must contain 'latitude', 'longitude' and 'height'" );
+            }
+            throw new IllegalArgumentException( "A point must contain either 'x' and 'y' or 'latitude' and 'longitude'" );
+        }
+
+        if ( crs.getDimension() != coordinates.length )
+        {
+            throw new IllegalArgumentException( "Cannot create " + crs.getDimension() + "D point with " + coordinates.length + " coordinates" );
+        }
+        return Values.pointValue( crs, coordinates );
+    }
+
+    private static enum PointValueField
+    {
+        X
+                {
+                    @Override
+                    ValueGroup valueType() { return NUMBER; }
+                },
+        Y
+                {
+                    @Override
+                    ValueGroup valueType() { return NUMBER; }
+                },
+        Z
+                {
+                    @Override
+                    ValueGroup valueType() { return NUMBER; }
+                },
+        LATITUDE
+                {
+                    @Override
+                    ValueGroup valueType()
+                    {
+                        return NUMBER;
+                    }
+                },
+        LONGITUDE
+                {
+                    @Override
+                    ValueGroup valueType()
+                    {
+                        return NUMBER;
+                    }
+                },
+        HEIGHT
+                {
+                    @Override
+                    ValueGroup valueType() { return NUMBER; }
+                },
+        CRS
+                {
+                    @Override
+                    ValueGroup valueType() { return TEXT; }
+                },
+        __MAX_VALUE__;
+
+        ValueGroup valueType() { return ValueGroup.NO_VALUE; }
     }
 }

--- a/community/values/src/test/java/org/neo4j/values/storable/PointTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/PointTest.java
@@ -77,6 +77,9 @@ public class PointTest
         assertTrue( pointValue( WGS84, 1, 2 ).valueGroup() != null );
     }
 
+    //-------------------------------------------------------------
+    // Parser tests
+
     @Test
     public void shouldBeAbleToParsePoints()
     {
@@ -127,10 +130,9 @@ public class PointTest
     @Test
     public void shouldNotBeAbleToParsePointsWithConflictingDuplicateFields()
     {
-        // TODO: Make this fail
-        assertEqual( pointValue( WGS84, 1.0, 3.0 ), PointValue.parse( "{latitude: 2.0, longitude: 1.0, latitude: 3.0}" ) );
-        assertEqual( pointValue( Cartesian, 1.0, 3.0 ), PointValue.parse( "{crs: 'cartesian', x: 2.0, x: 1.0, y: 3}" ) );
-        assertEqual( pointValue( Cartesian, 1.0, 3.0 ), PointValue.parse( "{crs: 'invalid crs', x: 1.0, y: 3, crs: 'cartesian'}" ) );
+        assertTrue( assertCannotParse( "{latitude: 2.0, longitude: 1.0, latitude: 3.0}" ).getMessage().contains( "Duplicate field" ) );
+        assertTrue( assertCannotParse( "{crs: 'cartesian', x: 2.0, x: 1.0, y: 3}" ).getMessage().contains( "Duplicate field" ) );
+        assertTrue( assertCannotParse( "{crs: 'invalid crs', x: 1.0, y: 3, crs: 'cartesian'}" ).getMessage().contains( "Duplicate field" ) );
     }
 
     @Test

--- a/community/values/src/test/java/org/neo4j/values/storable/PointTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/PointTest.java
@@ -23,7 +23,9 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
 import static org.neo4j.values.storable.CoordinateReferenceSystem.Cartesian;
+import static org.neo4j.values.storable.CoordinateReferenceSystem.Cartesian_3D;
 import static org.neo4j.values.storable.CoordinateReferenceSystem.WGS84;
+import static org.neo4j.values.storable.CoordinateReferenceSystem.WGS84_3D;
 import static org.neo4j.values.storable.Values.pointValue;
 import static org.neo4j.values.utils.AnyValueTestUtil.assertEqual;
 import static org.neo4j.values.utils.AnyValueTestUtil.assertNotEqual;
@@ -73,5 +75,90 @@ public class PointTest
     {
         assertTrue( pointValue( Cartesian, 1, 2 ).valueGroup() != null );
         assertTrue( pointValue( WGS84, 1, 2 ).valueGroup() != null );
+    }
+
+    @Test
+    public void shouldBeAbleToParsePoints()
+    {
+        assertEqual( pointValue( WGS84, 13.2, 56.7 ),
+                PointValue.parse( "{latitude: 56.7, longitude: 13.2}" ) );
+        assertEqual( pointValue( WGS84, -74.0060, 40.7128 ),
+                PointValue.parse( "{latitude: 40.7128, longitude: -74.0060, crs: 'wgs-84'}" ) ); // - explicitly WGS84
+        assertEqual( pointValue( Cartesian, -21, -45.3 ),
+                PointValue.parse( "{x: -21, y: -45.3}" ) ); // - default to cartesian 2D
+        assertEqual( pointValue( Cartesian, 17, -52.8 ),
+                PointValue.parse( "{x: 17, y: -52.8, crs: 'cartesian'}" ) ); // - explicit cartesian 2D
+        assertEqual( pointValue( WGS84_3D, 13.2, 56.7, 123.4 ),
+                PointValue.parse( "{latitude: 56.7, longitude: 13.2, height: 123.4}" ) ); // - defaults to WGS84-3D
+        assertEqual( pointValue( WGS84_3D, 13.2, 56.7, 123.4 ),
+                PointValue.parse( "{latitude: 56.7, longitude: 13.2, z: 123.4}" ) ); // - defaults to WGS84-3D
+        assertEqual( pointValue( WGS84_3D, -74.0060, 40.7128, 567.8 ),
+                PointValue.parse( "{latitude: 40.7128, longitude: -74.0060, height: 567.8, crs: 'wgs-84-3D'}" ) ); // - explicitly WGS84-3D
+        assertEqual( pointValue( Cartesian_3D, -21, -45.3, 7.2 ),
+                PointValue.parse( "{x: -21, y: -45.3, z: 7.2}" ) ); // - default to cartesian 3D
+        assertEqual( pointValue( Cartesian_3D, 17, -52.8, -83.1 ),
+                PointValue.parse( "{x: 17, y: -52.8, z: -83.1, crs: 'cartesian-3D'}" ) ); // - explicit cartesian 3D
+    }
+
+    @Test
+    public void shouldBeAbleToParsePointWithUnquotedCrs()
+    {
+        assertEqual( pointValue( WGS84_3D, -74.0060, 40.7128, 567.8 ),
+                PointValue.parse( "{latitude: 40.7128, longitude: -74.0060, height: 567.8, crs:wgs-84-3D}" ) ); // - explicitly WGS84-3D, without quotes
+    }
+
+    @Test
+    public void shouldBeAbleToParseWeirdlyFormattedPoints()
+    {
+        assertEqual( pointValue( WGS84, 1.0, 2.0 ), PointValue.parse( " \t\n { latitude : 2.0  ,longitude :1.0  } \t" ) );
+        // TODO: Should some/all of these fail?
+        assertEqual( pointValue( WGS84, 1.0, 2.0 ), PointValue.parse( " \t\n { latitude : 2.0  ,longitude :1.0 , } \t" ) );
+        assertEqual( pointValue( Cartesian, 2.0E-8, -1.0E7 ), PointValue.parse( " \t\n { x :+.2e-7,y: -1.0E07 , } \t" ) );
+        assertEqual( pointValue( Cartesian, 2.0E-8, -1.0E7 ), PointValue.parse( " \t\n { x :+.2e-7,y: -1.0E07 , garbage} \t" ) );
+        assertEqual( pointValue( Cartesian, 2.0E-8, -1.0E7 ), PointValue.parse( " \t\n { gar ba ge,x :+.2e-7,y: -1.0E07} \t" ) );
+    }
+
+    @Test
+    public void shouldBeAbleToParsePointAndIgnoreUnknownFields()
+    {
+        assertEqual( pointValue( WGS84, 1.0, 2.0 ), PointValue.parse( "{latitude:2.0,longitude:1.0,unknown_field:\"hello\"}" ) );
+    }
+
+    @Test
+    public void shouldNotBeAbleToParsePointsWithConflictingDuplicateFields()
+    {
+        // TODO: Make this fail
+        assertEqual( pointValue( WGS84, 1.0, 3.0 ), PointValue.parse( "{latitude: 2.0, longitude: 1.0, latitude: 3.0}" ) );
+        assertEqual( pointValue( Cartesian, 1.0, 3.0 ), PointValue.parse( "{crs: 'cartesian', x: 2.0, x: 1.0, y: 3}" ) );
+        assertEqual( pointValue( Cartesian, 1.0, 3.0 ), PointValue.parse( "{crs: 'invalid crs', x: 1.0, y: 3, crs: 'cartesian'}" ) );
+    }
+
+    @Test
+    public void shouldNotBeAbleToParseIncompletePoints()
+    {
+        assertCannotParse( "{latitude: 56.7, longitude:}" );
+        assertCannotParse( "{latitude: 56.7}" );
+        assertCannotParse( "{}" );
+        assertCannotParse( "{only_a_key}" );
+        assertCannotParse( "{crs:'WGS-84'}" );
+        assertCannotParse( "{a:a}" );
+        assertCannotParse( "{ : 2.0, x : 1.0 }" );
+        assertCannotParse( "x:1,y:2" );
+        assertCannotParse( "{x:1,y:'2'}" );
+        assertCannotParse( "{crs:WGS-84 , lat:1, y:2}" );
+    }
+
+    private IllegalArgumentException assertCannotParse( String text )
+    {
+        PointValue value;
+        try
+        {
+            value = PointValue.parse( text );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            return e;
+        }
+        throw new AssertionError( String.format( "'%s' parsed to %s", text, value ) );
     }
 }

--- a/community/values/src/test/java/org/neo4j/values/utils/AnyValueTestUtil.java
+++ b/community/values/src/test/java/org/neo4j/values/utils/AnyValueTestUtil.java
@@ -31,20 +31,22 @@ public class AnyValueTestUtil
 {
     public static void assertEqual( AnyValue a, AnyValue b )
     {
-        assertTrue(
-                String.format( "%s should be equivalent to %s", a.getClass().getSimpleName(), b.getClass().getSimpleName() ),
+        assertTrue( formatMessage( "should be equivalent to", a, b ),
                 a.equals( b ) );
         assertTrue(
-                String.format( "%s should be equivalent to %s", a.getClass().getSimpleName(), b.getClass().getSimpleName() ),
+                formatMessage( "should be equivalent to", b, a ),
                 b.equals( a ) );
-        assertTrue(
-                String.format( "%s should be equal %s", a.getClass().getSimpleName(), b.getClass().getSimpleName() ),
+        assertTrue( formatMessage( "should be equal to", a, b ),
                 a.ternaryEquals( b ) );
-        assertTrue(
-                String.format( "%s should be equal %s", a.getClass().getSimpleName(), b.getClass().getSimpleName() ),
+        assertTrue( formatMessage( "should be equal to", b, a ),
                 b.ternaryEquals( a ) );
-        assertTrue( String.format( "%s should have same hashcode as %s", a.getClass().getSimpleName(),
-                b.getClass().getSimpleName() ), a.hashCode() == b.hashCode() );
+        assertTrue( formatMessage( "should have same hashcode as", a, b ),
+                a.hashCode() == b.hashCode() );
+    }
+
+    private static String formatMessage( String should, AnyValue a, AnyValue b )
+    {
+        return String.format( "%s(%s) %s %s(%s)", a.getClass().getSimpleName(), a.toString(), should, b.getClass().getSimpleName(), b.toString() );
     }
 
     public static void assertEqualValues( AnyValue a, AnyValue b )

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
@@ -104,17 +104,23 @@ class SpatialFunctionsAcceptanceTest extends ExecutionEngineFunSuite with Cypher
   }
 
   test("should fail properly if missing cartesian coordinates") {
-    failWithError(pointConfig, "RETURN point({params}) as point", List("A point must contain either 'x' and 'y' or 'latitude' and 'longitude'"),
+    failWithError(pointConfig, "RETURN point({params}) as point",
+      List("A cartesian point must contain 'x' and 'y'",
+           "A point must contain either 'x' and 'y' or 'latitude' and 'longitude'" /* in version < 3.4 */),
       params = "params" -> Map("y" -> 1.0, "crs" -> "cartesian"))
   }
 
   test("should fail properly if missing geographic longitude") {
-    failWithError(pointConfig, "RETURN point({params}) as point", List("A point must contain either 'x' and 'y' or 'latitude' and 'longitude'"),
+    failWithError(pointConfig, "RETURN point({params}) as point",
+      List("A WGS-84 point must contain 'latitude' and 'longitude'",
+           "A point must contain either 'x' and 'y' or 'latitude' and 'longitude'" /* in version < 3.4 */),
       params = "params" -> Map("latitude" -> 1.0, "crs" -> "WGS-84"))
   }
 
   test("should fail properly if missing geographic latitude") {
-    failWithError(pointConfig, "RETURN point({params}) as point", List("A point must contain either 'x' and 'y' or 'latitude' and 'longitude'"),
+    failWithError(pointConfig, "RETURN point({params}) as point",
+      List("A WGS-84 point must contain 'latitude' and 'longitude'",
+           "A point must contain either 'x' and 'y' or 'latitude' and 'longitude'" /* in version < 3.4 */),
       params = "params" -> Map("longitude" -> 1.0, "crs" -> "WGS-84"))
   }
 


### PR DESCRIPTION
- Add simple map-parser for PointValue.
- Move the logic for creating a PointValue with different default
coordinate reference systems depending on the given fields, so that
it can be shared with the batch importer without having to instantiate
an actual Map object. Instead it can build an array with the given
fields directly from the parser.
- Let the csv module depend on the values module so it can produce
values directly.