### PR TITLE
3.4 Multiclustering server-side

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -3,7 +3,7 @@
 Please note that GitHub issues are only meant for bug reports/feature requests.  If you have questions on how to use Neo4j, please ask on [StackOverflow](http://stackoverflow.com/questions/tagged/neo4j) instead of creating an issue here.
 
 If you want to make a feature request then there is no guideline, so feel free to stop reading and open an issue. If you have a bug report however, please continue reading.
-
+osjf
 To help us understand your issue, please specify important details, primarily:
 
 - Neo4j version: X.Y.Z

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -3,7 +3,6 @@
 Please note that GitHub issues are only meant for bug reports/feature requests.  If you have questions on how to use Neo4j, please ask on [StackOverflow](http://stackoverflow.com/questions/tagged/neo4j) instead of creating an issue here.
 
 If you want to make a feature request then there is no guideline, so feel free to stop reading and open an issue. If you have a bug report however, please continue reading.
-osjf
 To help us understand your issue, please specify important details, primarily:
 
 - Neo4j version: X.Y.Z

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/ClusterSeedingIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/ClusterSeedingIT.java
@@ -38,7 +38,11 @@ import org.neo4j.causalclustering.backup_stores.NoStore;
 import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.CoreClusterMember;
 import org.neo4j.causalclustering.discovery.IpFamily;
-import org.neo4j.causalclustering.discovery.SharedDiscoveryService;
+import org.neo4j.causalclustering.discovery.SharedDiscoveryServiceFactory;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.enterprise.configuration.OnlineBackupSettings;
 import org.neo4j.kernel.impl.store.format.standard.Standard;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.rule.SuppressOutput;
@@ -82,12 +86,13 @@ public class ClusterSeedingIT
     public void setup() throws Exception
     {
         this.fileCopyDetector = new FileCopyDetector();
+        backupCluster = new Cluster( testDir.directory( "cluster-for-backup" ), 3, 0,
+                new SharedDiscoveryServiceFactory(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), Standard
+                .LATEST_NAME, IpFamily.IPV4, false );
 
-        backupCluster = new Cluster( testDir.directory( "cluster-for-backup" ), 3, 0, new SharedDiscoveryService(), emptyMap(), emptyMap(), emptyMap(),
-                emptyMap(), Standard.LATEST_NAME, IpFamily.IPV4, false );
-
-        cluster = new Cluster( testDir.directory( "cluster-b" ), 3, 0, new SharedDiscoveryService(), emptyMap(), emptyMap(), emptyMap(), emptyMap(),
-                Standard.LATEST_NAME, IpFamily.IPV4, false );
+        cluster = new Cluster( testDir.directory( "cluster-b" ), 3, 0,
+                new SharedDiscoveryServiceFactory(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), Standard.LATEST_NAME,
+                IpFamily.IPV4, false );
 
         baseBackupDir = testDir.directory( "backups" );
     }

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/NewMemberSeedingIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/NewMemberSeedingIT.java
@@ -42,7 +42,7 @@ import org.neo4j.causalclustering.cluster_load.SmallBurst;
 import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.CoreClusterMember;
 import org.neo4j.causalclustering.discovery.IpFamily;
-import org.neo4j.causalclustering.discovery.SharedDiscoveryService;
+import org.neo4j.causalclustering.discovery.SharedDiscoveryServiceFactory;
 import org.neo4j.kernel.impl.store.format.standard.Standard;
 import org.neo4j.test.rule.SuppressOutput;
 import org.neo4j.test.rule.TestDirectory;
@@ -106,7 +106,7 @@ public class NewMemberSeedingIT
     public void setup() throws Exception
     {
         this.fileCopyDetector = new FileCopyDetector();
-        cluster = new Cluster( testDir.directory( "cluster-b" ), 3, 0, new SharedDiscoveryService(), emptyMap(), emptyMap(), emptyMap(), emptyMap(),
+        cluster = new Cluster( testDir.directory( "cluster-b" ), 3, 0, new SharedDiscoveryServiceFactory(), emptyMap(), emptyMap(), emptyMap(), emptyMap(),
                 Standard.LATEST_NAME, IpFamily.IPV4, false );
         baseBackupDir = testDir.directory( "backups" );
     }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/ReplicationModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/ReplicationModule.java
@@ -85,9 +85,7 @@ public class ReplicationModule
                 leaderRetryStrategy,
                 platformModule.availabilityGuard,
                 logProvider,
-                replicationLimit,
-                platformModule.clock
-        ) );
+                replicationLimit ) );
     }
 
     public RaftReplicator getReplicator()

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
@@ -80,6 +80,10 @@ public class CausalClusteringSettings implements LoadableConfig
     public static final Setting<Boolean> refuse_to_be_leader =
             setting( "causal_clustering.refuse_to_be_leader", BOOLEAN, FALSE );
 
+    @Description( "The name of the database hosted by this server instance" )
+    public static final Setting<String> database =
+            setting( "causal_clustering.database", STRING, "default" );
+
     @Description( "Enable pre-voting extension to the Raft protocol (this is breaking and must match between the core cluster members)" )
     public static final Setting<Boolean> enable_pre_voting =
             setting( "causal_clustering.enable_pre_voting", BOOLEAN, FALSE );
@@ -108,6 +112,7 @@ public class CausalClusteringSettings implements LoadableConfig
     public static final Setting<Integer> expected_core_cluster_size =
             setting( "causal_clustering.expected_core_cluster_size", INTEGER, "3" );
 
+    //TODO: Document that when using multi-clustering this size refers to the size of the sub-cluster which shares this instances database name
     @Description( "Minimum number of Core machines in the cluster at formation. The expected_core_cluster size setting is used when bootstrapping the " +
             "cluster on first formation. A cluster will not form without the configured amount of cores and this should in general be configured to the" +
             " full and fixed amount." )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
@@ -112,10 +112,10 @@ public class CausalClusteringSettings implements LoadableConfig
     public static final Setting<Integer> expected_core_cluster_size =
             setting( "causal_clustering.expected_core_cluster_size", INTEGER, "3" );
 
-    //TODO: Document that when using multi-clustering this size refers to the size of the sub-cluster which shares this instances database name
     @Description( "Minimum number of Core machines in the cluster at formation. The expected_core_cluster size setting is used when bootstrapping the " +
             "cluster on first formation. A cluster will not form without the configured amount of cores and this should in general be configured to the" +
-            " full and fixed amount." )
+            " full and fixed amount. When using multi-clustering (configuring multiple distinct database names across core hosts), this setting is used " +
+            "to define the minimum size of *each* sub-cluster at formation." )
     public static final Setting<Integer> minimum_core_cluster_size_at_formation =
             buildSetting( "causal_clustering.minimum_core_cluster_size_at_formation", INTEGER, expected_core_cluster_size.getDefaultValue() )
                     .constraint( min( 2 ) ).build();

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
@@ -171,7 +171,7 @@ public class EnterpriseCoreEditionModule extends EditionModule
                     config, logProvider ) );
         }
 
-        procedures.register( new ClusterOverviewProcedure( topologyService, consensusModule.raftMachine(), logProvider ) );
+        procedures.register( new ClusterOverviewProcedure( topologyService, logProvider ) );
         procedures.register( new CoreRoleProcedure( consensusModule.raftMachine() ) );
         procedures.register( new InstalledProtocolsProcedure( clientInstalledProtocols, serverInstalledProtocols ) );
         procedures.registerComponent( Replicator.class, x -> replicationModule.getReplicator(), true );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/ConsensusModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/ConsensusModule.java
@@ -143,7 +143,9 @@ public class ConsensusModule
                 config.get( refuse_to_be_leader ),
                 supportsPreVoting, platformModule.monitors );
 
-        life.add( new RaftCoreTopologyConnector( coreTopologyService, raftMachine ) );
+        String dbName = config.get( CausalClusteringSettings.database );
+
+        life.add( new RaftCoreTopologyConnector( coreTopologyService, raftMachine, dbName ) );
 
         life.add( logShipping );
     }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderInfo.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderInfo.java
@@ -19,13 +19,37 @@
  */
 package org.neo4j.causalclustering.core.consensus;
 
+import java.io.Serializable;
+
 import org.neo4j.causalclustering.identity.MemberId;
 
-public interface LeaderLocator
+// TODO: basics for Serializable
+public class LeaderInfo implements Serializable
 {
-    MemberId getLeader() throws NoLeaderFoundException;
+    public static final LeaderInfo INITIAL = new LeaderInfo( null, -1 );
 
-    void registerListener( LeaderListener listener );
+    private final MemberId memberId;
+    private final long term;
 
-    void unregisterListener( LeaderListener listener );
+    public LeaderInfo( MemberId memberId, long term )
+    {
+        this.memberId = memberId;
+        this.term = term;
+    }
+
+    public MemberId memberId()
+    {
+        return memberId;
+    }
+
+    public long term()
+    {
+        return term;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "LeaderInfo{" + "memberId=" + memberId + ", term=" + term + '}';
+    }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderInfo.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderInfo.java
@@ -23,9 +23,11 @@ import java.io.Serializable;
 
 import org.neo4j.causalclustering.identity.MemberId;
 
-// TODO: basics for Serializable
 public class LeaderInfo implements Serializable
 {
+
+    private static final long serialVersionUID = 7983780359510842910L;
+
     public static final LeaderInfo INITIAL = new LeaderInfo( null, -1 );
 
     private final MemberId memberId;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderListener.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderListener.java
@@ -17,36 +17,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.causalclustering.discovery;
+package org.neo4j.causalclustering.core.consensus;
 
-import java.io.Serializable;
-import java.util.UUID;
-
-import org.neo4j.causalclustering.identity.MemberId;
-
-/**
- * Simple struct representing a raft leader - move to the raft module and make sure its used properly there.
- */
-public class RaftLeader implements Serializable
+public interface LeaderListener
 {
-
-    private final long term;
-    private final UUID memberUUID;
-
-    public RaftLeader( MemberId memberId, long term )
-    {
-        this.memberUUID = memberId.getUuid();
-        this.term = term;
-    }
-
-    public long term()
-    {
-        return term;
-    }
-
-    public MemberId memberId()
-    {
-        return new MemberId( memberUUID );
-    }
+    void onLeaderSwitch( LeaderInfo leaderInfo );
 }
-

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMachine.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMachine.java
@@ -215,6 +215,7 @@ public class RaftMachine implements LeaderLocator, CoreMetaData
     {
         for ( Listener<MemberId> listener : leaderListeners )
         {
+            //TODO: Update to pass leader and term, probably creating a leader-term pair/immutable struct
             listener.receive( outcome.getLeader() );
         }
     }
@@ -247,6 +248,8 @@ public class RaftMachine implements LeaderLocator, CoreMetaData
         {
             return true;
         }
+
+        //TODO: Add logic for handling leader step-down with no replacement
 
         return false;
     }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/state/RaftState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/state/RaftState.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.neo4j.causalclustering.core.consensus.LeaderInfo;
 import org.neo4j.causalclustering.core.consensus.log.cache.InFlightCache;
 import org.neo4j.causalclustering.core.consensus.log.RaftLog;
 import org.neo4j.causalclustering.core.consensus.log.ReadableRaftLog;
@@ -52,6 +53,7 @@ public class RaftState implements ReadableRaftState
     private VoteState voteState;
 
     private MemberId leader;
+    private LeaderInfo leaderInfo = LeaderInfo.INITIAL;
     private Set<MemberId> votesForMe = new HashSet<>();
     private Set<MemberId> preVotesForMe = new HashSet<>();
     private Set<MemberId> heartbeatResponses = new HashSet<>();
@@ -122,6 +124,12 @@ public class RaftState implements ReadableRaftState
     public MemberId leader()
     {
         return leader;
+    }
+
+    @Override
+    public LeaderInfo leaderInfo()
+    {
+        return leaderInfo;
     }
 
     @Override
@@ -218,6 +226,7 @@ public class RaftState implements ReadableRaftState
 
         logIfLeaderChanged( outcome.getLeader() );
         leader = outcome.getLeader();
+        leaderInfo = new LeaderInfo( outcome.getLeader(), outcome.getTerm() );
 
         leaderCommit = outcome.getLeaderCommit();
         votesForMe = outcome.getVotesForMe();

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/state/ReadableRaftState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/state/ReadableRaftState.java
@@ -21,6 +21,7 @@ package org.neo4j.causalclustering.core.consensus.state;
 
 import java.util.Set;
 
+import org.neo4j.causalclustering.core.consensus.LeaderInfo;
 import org.neo4j.causalclustering.core.consensus.log.ReadableRaftLog;
 import org.neo4j.causalclustering.core.consensus.roles.follower.FollowerStates;
 import org.neo4j.causalclustering.identity.MemberId;
@@ -36,6 +37,8 @@ public interface ReadableRaftState
     long term();
 
     MemberId leader();
+
+    LeaderInfo leaderInfo();
 
     long leaderCommit();
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/RaftReplicator.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/RaftReplicator.java
@@ -19,10 +19,11 @@
  */
 package org.neo4j.causalclustering.core.replication;
 
-import java.time.Clock;
 import java.util.concurrent.Future;
 import java.util.function.BiConsumer;
 
+import org.neo4j.causalclustering.core.consensus.LeaderInfo;
+import org.neo4j.causalclustering.core.consensus.LeaderListener;
 import org.neo4j.causalclustering.core.consensus.LeaderLocator;
 import org.neo4j.causalclustering.core.consensus.NoLeaderFoundException;
 import org.neo4j.causalclustering.core.consensus.RaftMessages;
@@ -33,7 +34,6 @@ import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.messaging.Outbound;
 import org.neo4j.graphdb.DatabaseShutdownException;
 import org.neo4j.kernel.AvailabilityGuard;
-import org.neo4j.kernel.impl.util.Listener;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
@@ -41,7 +41,7 @@ import org.neo4j.logging.LogProvider;
 /**
  * A replicator implementation suitable in a RAFT context. Will handle resending due to timeouts and leader switches.
  */
-public class RaftReplicator extends LifecycleAdapter implements Replicator, Listener<MemberId>
+public class RaftReplicator extends LifecycleAdapter implements Replicator, LeaderListener
 {
     private final MemberId me;
     private final Outbound<MemberId,RaftMessages.RaftMessage> outbound;
@@ -53,11 +53,10 @@ public class RaftReplicator extends LifecycleAdapter implements Replicator, List
     private final TimeoutStrategy leaderTimeoutStrategy;
     private final Log log;
     private final Throttler throttler;
-    private final Clock clock;
 
     public RaftReplicator( LeaderLocator leaderLocator, MemberId me, Outbound<MemberId,RaftMessages.RaftMessage> outbound, LocalSessionPool sessionPool,
             ProgressTracker progressTracker, TimeoutStrategy progressTimeoutStrategy, TimeoutStrategy leaderTimeoutStrategy,
-            AvailabilityGuard availabilityGuard, LogProvider logProvider, long replicationLimit, Clock clock )
+            AvailabilityGuard availabilityGuard, LogProvider logProvider, long replicationLimit )
     {
         this.me = me;
         this.outbound = outbound;
@@ -68,7 +67,6 @@ public class RaftReplicator extends LifecycleAdapter implements Replicator, List
         this.availabilityGuard = availabilityGuard;
         this.throttler = new Throttler( replicationLimit );
         this.leaderLocator = leaderLocator;
-        this.clock = clock;
         leaderLocator.registerListener( this );
         log = logProvider.getLog( getClass() );
     }
@@ -137,7 +135,7 @@ public class RaftReplicator extends LifecycleAdapter implements Replicator, List
     }
 
     @Override
-    public void receive( MemberId leader )
+    public void onLeaderSwitch( LeaderInfo leaderInfo )
     {
         progressTracker.triggerReplicationEvent();
     }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/ClusteringModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/ClusteringModule.java
@@ -77,8 +77,11 @@ public class ClusteringModule
         CoreBootstrapper coreBootstrapper =
                 new CoreBootstrapper( platformModule.storeDir, platformModule.pageCache, fileSystem, config, logProvider );
 
+        int minimumCoreHosts = config.get( CausalClusteringSettings.minimum_core_cluster_size_at_formation );
+        String dbName = config.get( CausalClusteringSettings.database );
+
         clusterBinder = new ClusterBinder( clusterIdStorage, topologyService, logProvider, Clocks.systemClock(),
-                () -> sleep( 100 ), 300_000, coreBootstrapper );
+                () -> sleep( 100 ), 300_000, coreBootstrapper, dbName, minimumCoreHosts );
     }
 
     private static TopologyServiceRetryStrategy resolveStrategy( Config config, LogProvider logProvider )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/AbstractTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/AbstractTopologyService.java
@@ -17,11 +17,22 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.causalclustering.discovery.procedures;
+package org.neo4j.causalclustering.discovery;
 
-public enum Role
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+public abstract class AbstractTopologyService extends LifecycleAdapter implements TopologyService
 {
-    LEADER,
-    FOLLOWER,
-    READ_REPLICA
+
+    @Override
+    public CoreTopology localCoreServers()
+    {
+        return allCoreServers().filterTopologyByDb( localDBName() );
+    }
+
+    @Override
+    public ReadReplicaTopology localReadReplicas()
+    {
+        return allReadReplicas().filterTopologyByDb( localDBName() );
+    }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreServerInfo.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreServerInfo.java
@@ -31,20 +31,28 @@ public class CoreServerInfo implements DiscoveryServerInfo
     private final AdvertisedSocketAddress catchupServer;
     private final ClientConnectorAddresses clientConnectorAddresses;
     private final Set<String> groups;
+    private final String dbName;
 
     public CoreServerInfo( AdvertisedSocketAddress raftServer, AdvertisedSocketAddress catchupServer,
-            ClientConnectorAddresses clientConnectors )
+            ClientConnectorAddresses clientConnectors, String dbName )
     {
-        this( raftServer, catchupServer, clientConnectors, emptySet() );
+        this( raftServer, catchupServer, clientConnectors, emptySet(), dbName );
     }
 
     public CoreServerInfo( AdvertisedSocketAddress raftServer, AdvertisedSocketAddress catchupServer,
-            ClientConnectorAddresses clientConnectorAddresses, Set<String> groups )
+            ClientConnectorAddresses clientConnectorAddresses, Set<String> groups, String dbName )
     {
         this.raftServer = raftServer;
         this.catchupServer = catchupServer;
         this.clientConnectorAddresses = clientConnectorAddresses;
         this.groups = groups;
+        this.dbName = dbName;
+    }
+
+    @Override
+    public String getDatabaseName()
+    {
+        return dbName;
     }
 
     public AdvertisedSocketAddress getRaftServer()

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopology.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopology.java
@@ -21,6 +21,7 @@ package org.neo4j.causalclustering.discovery;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.neo4j.causalclustering.identity.ClusterId;
@@ -71,4 +72,32 @@ public class CoreTopology implements Topology<CoreServerInfo>
             return coreMembers.keySet().stream().findAny();
     }
 
+    @Override
+    public CoreTopology filterTopologyByDb( String dbName )
+    {
+        Map<MemberId, CoreServerInfo> filteredMembers = filterHostsByDb( members(), dbName );
+
+        return new CoreTopology( clusterId(), canBeBootstrapped(), filteredMembers );
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        CoreTopology that = (CoreTopology) o;
+        return Objects.equals( coreMembers, that.coreMembers );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( coreMembers );
+    }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyListenerService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyListenerService.java
@@ -21,21 +21,35 @@ package org.neo4j.causalclustering.discovery;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 class CoreTopologyListenerService
 {
-    private final List<CoreTopologyService.Listener> listeners = new ArrayList<>();
+    private final Set<CoreTopologyService.Listener> listeners;
+
+    CoreTopologyListenerService()
+    {
+        this.listeners = ConcurrentHashMap.newKeySet();
+    }
 
     void addCoreTopologyListener( CoreTopologyService.Listener listener )
     {
         listeners.add( listener );
     }
 
+    void removeCoreTopologyListener( CoreTopologyService.Listener listener )
+    {
+        listeners.remove( listener );
+    }
+
     void notifyListeners( CoreTopology coreTopology )
     {
         for ( CoreTopologyService.Listener listener : listeners )
         {
-            listener.onCoreTopologyChange( coreTopology );
+            String dbName = listener.dbName();
+
+            listener.onCoreTopologyChange( coreTopology.filterTopologyByDb( dbName ) );
         }
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyService.java
@@ -19,7 +19,9 @@
  */
 package org.neo4j.causalclustering.discovery;
 
+import org.neo4j.causalclustering.discovery.procedures.ClusterOverviewProcedure;
 import org.neo4j.causalclustering.identity.ClusterId;
+import org.neo4j.causalclustering.identity.MemberId;
 
 /**
  * Extends upon the topology service with a few extra services, connected to
@@ -29,6 +31,8 @@ public interface CoreTopologyService extends TopologyService
 {
     void addCoreTopologyListener( Listener listener );
 
+    void removeCoreTopologyListener( Listener listener );
+
     /**
      * Publishes the cluster ID so that other members might discover it.
      * Should only succeed to publish if one missing or already the same (CAS logic).
@@ -37,11 +41,23 @@ public interface CoreTopologyService extends TopologyService
      *
      * @return True if the cluster ID was successfully CAS:ed, otherwise false.
      */
-    boolean setClusterId( ClusterId clusterId ) throws InterruptedException;
+    boolean setClusterId( ClusterId clusterId, String dbName ) throws InterruptedException;
 
-    @FunctionalInterface
+    /**
+     * Sets or updates the leader memberId for the given database (i.e. Raft consensus group).
+     * This is intended for informational purposes **only**, e.g. in {@link ClusterOverviewProcedure}.
+     * The leadership information should otherwise be communicated via raft as before.
+     *
+     * @param memberId The member ID to declare as the new leader
+     * @param dbName The database name for which memberId is the new leader
+     * @param term The raft term for which memberId is the leader of dbName
+     *
+     */
+    void setLeader( MemberId memberId, String dbName, long term );
+
     interface Listener
     {
         void onCoreTopologyChange( CoreTopology coreTopology );
+        String dbName();
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyService.java
@@ -19,9 +19,9 @@
  */
 package org.neo4j.causalclustering.discovery;
 
+import org.neo4j.causalclustering.core.consensus.LeaderInfo;
 import org.neo4j.causalclustering.discovery.procedures.ClusterOverviewProcedure;
 import org.neo4j.causalclustering.identity.ClusterId;
-import org.neo4j.causalclustering.identity.MemberId;
 
 /**
  * Extends upon the topology service with a few extra services, connected to
@@ -47,13 +47,10 @@ public interface CoreTopologyService extends TopologyService
      * Sets or updates the leader memberId for the given database (i.e. Raft consensus group).
      * This is intended for informational purposes **only**, e.g. in {@link ClusterOverviewProcedure}.
      * The leadership information should otherwise be communicated via raft as before.
-     *
-     * @param memberId The member ID to declare as the new leader
+     * @param leaderInfo Information about the new leader
      * @param dbName The database name for which memberId is the new leader
-     * @param term The raft term for which memberId is the leader of dbName
-     *
      */
-    void setLeader( MemberId memberId, String dbName, long term );
+    void setLeader( LeaderInfo leaderInfo, String dbName );
 
     interface Listener
     {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyService.java
@@ -29,9 +29,9 @@ import org.neo4j.causalclustering.identity.ClusterId;
  */
 public interface CoreTopologyService extends TopologyService
 {
-    void addCoreTopologyListener( Listener listener );
+    void addLocalCoreTopologyListener( Listener listener );
 
-    void removeCoreTopologyListener( Listener listener );
+    void removeLocalCoreTopologyListener( Listener listener );
 
     /**
      * Publishes the cluster ID so that other members might discover it.

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/DiscoveryServerInfo.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/DiscoveryServerInfo.java
@@ -21,4 +21,5 @@ package org.neo4j.causalclustering.discovery;
 
 public interface DiscoveryServerInfo extends CatchupServerAddress, ClientConnector, GroupedServer
 {
+    String getDatabaseName();
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClusterTopology.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClusterTopology.java
@@ -31,9 +31,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.identity.ClusterId;
@@ -42,6 +46,7 @@ import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.Log;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.neo4j.causalclustering.core.CausalClusteringSettings.refuse_to_be_leader;
 import static java.util.stream.Stream.concat;
@@ -57,15 +62,18 @@ public class HazelcastClusterTopology
     static final String TRANSACTION_SERVER = "transaction_server";
     static final String RAFT_SERVER = "raft_server";
     static final String CLIENT_CONNECTOR_ADDRESSES = "client_connector_addresses";
+    static final String MEMBER_DB_NAME = "member_database_name";
 
     private static final String REFUSE_TO_BE_LEADER_KEY = "refuseToBeLeader";
 
     // cluster-wide attributes
-    private static final String CLUSTER_UUID = "cluster_uuid";
-    static final String SERVER_GROUPS_MULTIMAP_NAME = "groups";
-    static final String READ_REPLICA_TRANSACTION_SERVER_ADDRESS_MAP_NAME = "read-replica-transaction-servers";
-    static final String READ_REPLICA_BOLT_ADDRESS_MAP_NAME = "read_replicas"; // hz client uuid string -> boltAddress string
-    static final String READ_REPLICA_MEMBER_ID_MAP_NAME = "read-replica-member-ids";
+    static final String CLUSTER_UUID_DB_NAME_MAP = "cluster_uuid";
+    static final String SERVER_GROUPS_MULTIMAP = "groups";
+    static final String READ_REPLICA_TRANSACTION_SERVER_ADDRESS_MAP = "read-replica-transaction-servers";
+    static final String READ_REPLICA_BOLT_ADDRESS_MAP = "read_replicas"; // hz client uuid string -> boltAddress string
+    static final String READ_REPLICA_MEMBER_ID_MAP = "read-replica-member-ids";
+    static final String READ_REPLICAS_DB_NAME_MAP = "read_replicas_database_names";
+    static final String DB_NAME_LEADER_TERM_PREFIX = "leader_term_for_database_name_";
 
     private HazelcastClusterTopology()
     {
@@ -92,6 +100,7 @@ public class HazelcastClusterTopology
         Map<MemberId,CoreServerInfo> coreMembers = emptyMap();
         boolean canBeBootstrapped = false;
         ClusterId clusterId = null;
+        String dbName = config.get( CausalClusteringSettings.database );
 
         if ( hazelcastInstance != null )
         {
@@ -100,7 +109,7 @@ public class HazelcastClusterTopology
 
             coreMembers = toCoreMemberMap( hzMembers, log, hazelcastInstance );
 
-            clusterId = getClusterId( hazelcastInstance );
+            clusterId = getClusterId( hazelcastInstance, dbName );
         }
         else
         {
@@ -129,17 +138,39 @@ public class HazelcastClusterTopology
         return catchupAddressMap;
     }
 
-    private static ClusterId getClusterId( HazelcastInstance hazelcastInstance )
+    private static ClusterId getClusterId( HazelcastInstance hazelcastInstance, String dbName )
     {
-        IAtomicReference<UUID> uuidReference = hazelcastInstance.getAtomicReference( CLUSTER_UUID );
-        UUID uuid = uuidReference.get();
+        IMap<String, UUID> uuidPerDbCluster = hazelcastInstance.getMap( CLUSTER_UUID_DB_NAME_MAP );
+        UUID uuid = uuidPerDbCluster.get( dbName );
         return uuid != null ? new ClusterId( uuid ) : null;
     }
 
-    static boolean casClusterId( HazelcastInstance hazelcastInstance, ClusterId clusterId )
+    public static Set<String> getDBNames( HazelcastInstance hazelcastInstance )
     {
-        IAtomicReference<UUID> uuidReference = hazelcastInstance.getAtomicReference( CLUSTER_UUID );
-        return uuidReference.compareAndSet( null, clusterId.uuid() ) || uuidReference.get().equals( clusterId.uuid() );
+        IMap<String, UUID> uuidPerDbCluster = hazelcastInstance.getMap( CLUSTER_UUID_DB_NAME_MAP );
+        return uuidPerDbCluster.keySet();
+    }
+
+    public static Map<MemberId,RoleInfo> getCoreRoles( HazelcastInstance hazelcastInstance, Set<MemberId> coreMembers )
+    {
+
+        Set<String> dbNames = getDBNames( hazelcastInstance );
+        Set<MemberId> allLeaders = dbNames.stream()
+                .map( n -> getLeaderForDBName( hazelcastInstance, n ) )
+                .filter( Optional::isPresent )
+                .map( l -> l.get().memberId() )
+                .collect( Collectors.toSet() );
+
+        Function<MemberId,RoleInfo> roleMapper = m -> allLeaders.contains( m ) ? RoleInfo.LEADER : RoleInfo.FOLLOWER;
+
+        return coreMembers.stream().collect( Collectors.toMap( Function.identity(), roleMapper ) );
+    }
+
+    static boolean casClusterId( HazelcastInstance hazelcastInstance, ClusterId clusterId, String dbName )
+    {
+        IMap<String, UUID> uuidPerDbCluster = hazelcastInstance.getMap( CLUSTER_UUID_DB_NAME_MAP );
+        UUID uuid = uuidPerDbCluster.putIfAbsent( dbName, clusterId.uuid() );
+        return uuid == null || clusterId.uuid().equals( uuid );
     }
 
     private static Map<MemberId,ReadReplicaInfo> readReplicas( HazelcastInstance hazelcastInstance )
@@ -147,10 +178,11 @@ public class HazelcastClusterTopology
         Map<MemberId,ReadReplicaInfo> result = new HashMap<>();
 
         IMap<String/*uuid*/,String/*boltAddress*/> clientAddressMap =
-                hazelcastInstance.getMap( READ_REPLICA_BOLT_ADDRESS_MAP_NAME );
-        IMap<String,String> txServerMap = hazelcastInstance.getMap( READ_REPLICA_TRANSACTION_SERVER_ADDRESS_MAP_NAME );
-        IMap<String,String> memberIdMap = hazelcastInstance.getMap( READ_REPLICA_MEMBER_ID_MAP_NAME );
-        MultiMap<String,String> serverGroups = hazelcastInstance.getMultiMap( SERVER_GROUPS_MULTIMAP_NAME );
+                hazelcastInstance.getMap( READ_REPLICA_BOLT_ADDRESS_MAP );
+        IMap<String,String> txServerMap = hazelcastInstance.getMap( READ_REPLICA_TRANSACTION_SERVER_ADDRESS_MAP );
+        IMap<String,String> memberIdMap = hazelcastInstance.getMap( READ_REPLICA_MEMBER_ID_MAP );
+        MultiMap<String,String> serverGroups = hazelcastInstance.getMultiMap( SERVER_GROUPS_MULTIMAP );
+        IMap<String, String> memberDbMap = hazelcastInstance.getMap( READ_REPLICAS_DB_NAME_MAP );
 
         if ( of( clientAddressMap, txServerMap, memberIdMap, serverGroups ).anyMatch( Objects::isNull ) )
         {
@@ -162,6 +194,7 @@ public class HazelcastClusterTopology
             String sAddresses = clientAddressMap.get( hzUUID );
             String sCatchupAddress = txServerMap.get( hzUUID );
             String sMemberId = memberIdMap.get( hzUUID );
+            String dbName = memberDbMap.get( hzUUID );
             Collection<String> sServerGroups = serverGroups.get( hzUUID );
 
             if ( concat( of( sServerGroups ), of( sAddresses, sCatchupAddress, sMemberId ) ).anyMatch( Objects::isNull ) )
@@ -172,50 +205,70 @@ public class HazelcastClusterTopology
             ClientConnectorAddresses clientConnectorAddresses = ClientConnectorAddresses.fromString( sAddresses );
             AdvertisedSocketAddress catchupAddress = socketAddress( sCatchupAddress, AdvertisedSocketAddress::new );
 
-            ReadReplicaInfo readReplicaInfo = new ReadReplicaInfo( clientConnectorAddresses, catchupAddress, asSet( sServerGroups ) );
+            ReadReplicaInfo readReplicaInfo = new ReadReplicaInfo( clientConnectorAddresses, catchupAddress, asSet( sServerGroups ), dbName );
             result.put( new MemberId( UUID.fromString( sMemberId ) ), readReplicaInfo );
         }
         return result;
     }
 
+    static boolean casLeaders( HazelcastInstance hazelcastInstance, MemberId leader, long term, String dbName )
+    {
+        IAtomicReference<RaftLeader> leaderRef = hazelcastInstance.getAtomicReference( DB_NAME_LEADER_TERM_PREFIX + dbName );
+
+        RaftLeader expected = leaderRef.get();
+
+        boolean noUpdate = Optional.ofNullable( expected ).map( RaftLeader::memberId ).equals( Optional.ofNullable( leader ) );
+
+        boolean greaterOrEqualTermExists = Optional.ofNullable( expected ).map(l -> l.term() >= term ).orElse( false );
+
+        if ( greaterOrEqualTermExists || noUpdate )
+        {
+            return false;
+        }
+
+        return leaderRef.compareAndSet( expected, new RaftLeader( leader, term ) );
+    }
+
+    static Optional<RaftLeader> getLeaderForDBName( HazelcastInstance hazelcastInstance, String dbName )
+    {
+        IAtomicReference<RaftLeader> leader = hazelcastInstance.getAtomicReference( DB_NAME_LEADER_TERM_PREFIX + dbName );
+        return Optional.ofNullable( leader.get() );
+    }
+
     private static boolean canBeBootstrapped( HazelcastInstance hazelcastInstance, Config config )
     {
         Set<Member> members = hazelcastInstance.getCluster().getMembers();
+        String dbName = config.get( CausalClusteringSettings.database );
 
-        if ( config.get( refuse_to_be_leader ) )
-        {
-            return false;
-        }
-        else
-        {
-            for ( Member member : members )
-            {
-                if ( !member.getBooleanAttribute( REFUSE_TO_BE_LEADER_KEY ) )
-                {
-                    return member.localMember();
-                }
-            }
-            return false;
-        }
+        Predicate<Member> acceptsToBeLeader = m -> !m.getBooleanAttribute( REFUSE_TO_BE_LEADER_KEY );
+        Predicate<Member> hostsMyDb = m -> dbName.equals( m.getStringAttribute( MEMBER_DB_NAME ) );
+
+        Stream<Member> membersWhoCanLeadForMyDb = members.stream().filter( acceptsToBeLeader ).filter( hostsMyDb );
+
+        Optional<Member> firstAppropriateMember = membersWhoCanLeadForMyDb.findFirst();
+
+        return firstAppropriateMember.map( Member::localMember ).orElse( false );
     }
 
     static Map<MemberId,CoreServerInfo> toCoreMemberMap( Set<Member> members, Log log,
             HazelcastInstance hazelcastInstance )
     {
         Map<MemberId,CoreServerInfo> coreMembers = new HashMap<>();
-        MultiMap<String,String> serverGroupsMMap = hazelcastInstance.getMultiMap( SERVER_GROUPS_MULTIMAP_NAME );
+        MultiMap<String,String> serverGroupsMMap = hazelcastInstance.getMultiMap( SERVER_GROUPS_MULTIMAP );
 
         for ( Member member : members )
         {
             try
             {
                 MemberId memberId = new MemberId( UUID.fromString( member.getStringAttribute( MEMBER_UUID ) ) );
+                String dbName = member.getStringAttribute( MEMBER_DB_NAME );
 
                 CoreServerInfo coreServerInfo = new CoreServerInfo(
                         socketAddress( member.getStringAttribute( RAFT_SERVER ), AdvertisedSocketAddress::new ),
                         socketAddress( member.getStringAttribute( TRANSACTION_SERVER ), AdvertisedSocketAddress::new ),
                         ClientConnectorAddresses.fromString( member.getStringAttribute( CLIENT_CONNECTOR_ADDRESSES ) ),
-                        asSet( serverGroupsMMap.get( memberId.getUuid().toString() ) ) );
+                        asSet( serverGroupsMMap.get( memberId.getUuid().toString() ) ),
+                        dbName );
 
                 coreMembers.put( memberId, coreServerInfo );
             }
@@ -230,7 +283,7 @@ public class HazelcastClusterTopology
 
     static void refreshGroups( HazelcastInstance hazelcastInstance, String memberId, List<String> groups )
     {
-        MultiMap<String,String> groupsMap = hazelcastInstance.getMultiMap( SERVER_GROUPS_MULTIMAP_NAME );
+        MultiMap<String,String> groupsMap = hazelcastInstance.getMultiMap( SERVER_GROUPS_MULTIMAP );
         Collection<String> existing = groupsMap.get( memberId );
 
         Set<String> superfluous = existing.stream().filter( t -> !groups.contains( t ) ).collect( Collectors.toSet() );
@@ -242,6 +295,7 @@ public class HazelcastClusterTopology
 
     static MemberAttributeConfig buildMemberAttributesForCore( MemberId myself, Config config )
     {
+
         MemberAttributeConfig memberAttributeConfig = new MemberAttributeConfig();
         memberAttributeConfig.setStringAttribute( MEMBER_UUID, myself.getUuid().toString() );
 
@@ -260,6 +314,8 @@ public class HazelcastClusterTopology
 
         memberAttributeConfig.setBooleanAttribute( REFUSE_TO_BE_LEADER_KEY,
                 config.get( refuse_to_be_leader )  );
+
+        memberAttributeConfig.setStringAttribute( MEMBER_DB_NAME, config.get( CausalClusteringSettings.database ) );
 
         return memberAttributeConfig;
     }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClusterTopology.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClusterTopology.java
@@ -54,7 +54,7 @@ import static java.util.stream.Stream.of;
 import static org.neo4j.helpers.SocketAddressParser.socketAddress;
 import static org.neo4j.helpers.collection.Iterables.asSet;
 
-public class HazelcastClusterTopology
+public final class HazelcastClusterTopology
 {
     // per server attributes
     private static final String DISCOVERY_SERVER = "discovery_server"; // not currently used

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
@@ -44,7 +44,6 @@ import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.helpers.ListenSocketAddress;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.scheduler.JobScheduler;
@@ -64,9 +63,11 @@ import static org.neo4j.causalclustering.discovery.HazelcastClusterTopology.getC
 import static org.neo4j.causalclustering.discovery.HazelcastClusterTopology.getReadReplicaTopology;
 import static org.neo4j.causalclustering.discovery.HazelcastClusterTopology.refreshGroups;
 
-public class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopologyService
+public class HazelcastCoreTopologyService extends AbstractTopologyService implements CoreTopologyService
 {
     private static final long HAZELCAST_IS_HEALTHY_TIMEOUT_MS = TimeUnit.MINUTES.toMillis( 10 );
+    private static final int HAZELCAST_MIN_CLUSTER = 2;
+
     private final Config config;
     private final MemberId myself;
     private final Log log;
@@ -74,13 +75,15 @@ public class HazelcastCoreTopologyService extends LifecycleAdapter implements Co
     private final CoreTopologyListenerService listenerService;
     private final RobustJobSchedulerWrapper scheduler;
     private final long refreshPeriod;
-    private final LogProvider logProvider;
     private final HostnameResolver hostnameResolver;
     private final TopologyServiceRetryStrategy topologyServiceRetryStrategy;
+    private final String localDBName;
 
     private String membershipRegistrationId;
     private JobScheduler.JobHandle refreshJob;
 
+    private volatile MemberId localLeader;
+    private volatile long term;
     private volatile HazelcastInstance hazelcastInstance;
     private volatile ReadReplicaTopology readReplicaTopology = ReadReplicaTopology.EMPTY;
     private volatile CoreTopology coreTopology = CoreTopology.EMPTY;
@@ -89,7 +92,7 @@ public class HazelcastCoreTopologyService extends LifecycleAdapter implements Co
     private Thread startingThread;
     private volatile boolean stopped;
 
-    public HazelcastCoreTopologyService( Config config, MemberId myself, JobScheduler jobScheduler,
+    protected HazelcastCoreTopologyService( Config config, MemberId myself, JobScheduler jobScheduler,
             LogProvider logProvider, LogProvider userLogProvider, HostnameResolver hostnameResolver,
             TopologyServiceRetryStrategy topologyServiceRetryStrategy )
     {
@@ -97,26 +100,57 @@ public class HazelcastCoreTopologyService extends LifecycleAdapter implements Co
         this.myself = myself;
         this.listenerService = new CoreTopologyListenerService();
         this.log = logProvider.getLog( getClass() );
-        this.logProvider = logProvider;
         this.scheduler = new RobustJobSchedulerWrapper( jobScheduler, log );
         this.userLog = userLogProvider.getLog( getClass() );
         this.refreshPeriod = config.get( CausalClusteringSettings.cluster_topology_refresh ).toMillis();
         this.hostnameResolver = hostnameResolver;
         this.topologyServiceRetryStrategy = topologyServiceRetryStrategy;
+        this.term = -1L;
+        this.localDBName = config.get( CausalClusteringSettings.database );
     }
 
     @Override
     public void addCoreTopologyListener( Listener listener )
     {
         listenerService.addCoreTopologyListener( listener );
-        listener.onCoreTopologyChange( coreTopology );
+        listener.onCoreTopologyChange( localCoreServers() );
     }
 
     @Override
-    public boolean setClusterId( ClusterId clusterId ) throws InterruptedException
+    public void removeCoreTopologyListener( Listener listener )
+    {
+        listenerService.removeCoreTopologyListener( listener );
+    }
+
+    @Override
+    public boolean setClusterId( ClusterId clusterId, String dbName ) throws InterruptedException
     {
         waitOnHazelcastInstanceCreation();
-        return HazelcastClusterTopology.casClusterId( hazelcastInstance, clusterId );
+        return HazelcastClusterTopology.casClusterId( hazelcastInstance, clusterId, dbName );
+    }
+
+    @Override
+    public void setLeader( MemberId memberId, String dbName, long term )
+    {
+        if ( this.term < term )
+        {
+            localLeader = memberId;
+            this.term = term;
+        }
+    }
+
+    @Override
+    public Map<MemberId,RoleInfo> allCoreRoles() throws InterruptedException
+    {
+        waitOnHazelcastInstanceCreation();
+
+        return HazelcastClusterTopology.getCoreRoles( hazelcastInstance, allCoreServers().members().keySet() );
+    }
+
+    @Override
+    public String localDBName()
+    {
+        return localDBName;
     }
 
     @Override
@@ -211,8 +245,6 @@ public class HazelcastCoreTopologyService extends LifecycleAdapter implements Co
             networkConfig.setInterfaces( interfaces );
         }
 
-        additionalConfig( networkConfig, logProvider );
-
         networkConfig.setPort( hazelcastAddress.getPort() );
         networkConfig.setJoin( joinConfig );
         networkConfig.setPortAutoIncrement( false );
@@ -232,8 +264,7 @@ public class HazelcastCoreTopologyService extends LifecycleAdapter implements Co
         c.setProperty( OPERATION_CALL_TIMEOUT_MILLIS.getName(), String.valueOf( baseHazelcastTimeoutMillis ) );
         c.setProperty( MERGE_NEXT_RUN_DELAY_SECONDS.getName(), String.valueOf( baseHazelcastTimeoutSeconds ) );
         c.setProperty( MERGE_FIRST_RUN_DELAY_SECONDS.getName(), String.valueOf( baseHazelcastTimeoutSeconds ) );
-        c.setProperty( INITIAL_MIN_CLUSTER_SIZE.getName(),
-                String.valueOf( minimumClusterSizeThatCanTolerateOneFaultForExpectedClusterSize() ) );
+        c.setProperty( INITIAL_MIN_CLUSTER_SIZE.getName(), String.valueOf( HAZELCAST_MIN_CLUSTER ) );
 
         if ( config.get( disable_middleware_logging ) )
         {
@@ -278,11 +309,6 @@ public class HazelcastCoreTopologyService extends LifecycleAdapter implements Co
         return hazelcastInstance;
     }
 
-    protected void additionalConfig( NetworkConfig networkConfig, LogProvider logProvider )
-    {
-
-    }
-
     private void logConnectionInfo( List<AdvertisedSocketAddress> initialMembers )
     {
         userLog.info( "My connection info: " + "[\n\tDiscovery:   listen=%s, advertised=%s," +
@@ -298,19 +324,17 @@ public class HazelcastCoreTopologyService extends LifecycleAdapter implements Co
         userLog.info( "Attempting to connect to the other cluster members before continuing..." );
     }
 
-    private Integer minimumClusterSizeThatCanTolerateOneFaultForExpectedClusterSize()
-    {
-        return config.get( CausalClusteringSettings.minimum_core_cluster_size_at_formation ) / 2 + 1;
-    }
-
     @Override
-    public CoreTopology coreServers()
+    public CoreTopology allCoreServers()
     {
+        // It is perhaps confusing (Or even error inducing) that this core Topology will always contain the cluster id
+        // for the database local to the host upon which this method is called.
+        // TODO: evaluate returning clusterId = null for global Topologies returned by allCoreServers()
         return coreTopology;
     }
 
     @Override
-    public ReadReplicaTopology readReplicas()
+    public ReadReplicaTopology allReadReplicas()
     {
         return readReplicaTopology;
     }
@@ -326,11 +350,21 @@ public class HazelcastCoreTopologyService extends LifecycleAdapter implements Co
         return Optional.ofNullable( catchupAddressMap.get( memberId ) );
     }
 
+    private void refreshRoles() throws InterruptedException
+    {
+        if ( localLeader != null && localLeader.equals( myself ) )
+        {
+            waitOnHazelcastInstanceCreation();
+            HazelcastClusterTopology.casLeaders( hazelcastInstance, localLeader, term, localDBName );
+        }
+    }
+
     private synchronized void refreshTopology() throws InterruptedException
     {
         refreshCoreTopology();
         refreshReadReplicaTopology();
-        catchupAddressMap = extractCatchupAddressesMap( coreTopology, readReplicaTopology );
+        refreshRoles();
+        catchupAddressMap = extractCatchupAddressesMap( localCoreServers(), localReadReplicas() );
     }
 
     private void refreshCoreTopology() throws InterruptedException

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RaftCoreTopologyConnector.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RaftCoreTopologyConnector.java
@@ -28,7 +28,7 @@ import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
 /**
- * Makes the Raft aware of changes to the core topology and visa versa
+ * Makes the Raft aware of changes to the core topology and vice versa
  */
 public class RaftCoreTopologyConnector extends LifecycleAdapter implements CoreTopologyService.Listener, LeaderListener
 {
@@ -46,7 +46,7 @@ public class RaftCoreTopologyConnector extends LifecycleAdapter implements CoreT
     @Override
     public void start()
     {
-        coreTopologyService.addCoreTopologyListener( this );
+        coreTopologyService.addLocalCoreTopologyListener( this );
         raftMachine.registerListener( this );
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RaftCoreTopologyConnector.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RaftCoreTopologyConnector.java
@@ -21,15 +21,16 @@ package org.neo4j.causalclustering.discovery;
 
 import java.util.Set;
 
+import org.neo4j.causalclustering.core.consensus.LeaderInfo;
+import org.neo4j.causalclustering.core.consensus.LeaderListener;
 import org.neo4j.causalclustering.core.consensus.RaftMachine;
 import org.neo4j.causalclustering.identity.MemberId;
-import org.neo4j.kernel.impl.util.Listener;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
 /**
  * Makes the Raft aware of changes to the core topology and visa versa
  */
-public class RaftCoreTopologyConnector extends LifecycleAdapter implements CoreTopologyService.Listener, Listener<MemberId>
+public class RaftCoreTopologyConnector extends LifecycleAdapter implements CoreTopologyService.Listener, LeaderListener
 {
     private final CoreTopologyService coreTopologyService;
     private final RaftMachine raftMachine;
@@ -57,11 +58,9 @@ public class RaftCoreTopologyConnector extends LifecycleAdapter implements CoreT
     }
 
     @Override
-    public void receive( MemberId notification )
+    public void onLeaderSwitch( LeaderInfo leaderInfo )
     {
-        //TODO: Create LeaderListener interface implementing Listener<MemberId>
-        //Don't like this pattern as its not clear form the api that receive() is called from raftMachine.
-        coreTopologyService.setLeader( notification, dbName, raftMachine.term() );
+        coreTopologyService.setLeader( leaderInfo, dbName );
     }
 
     @Override

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RaftLeader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RaftLeader.java
@@ -17,20 +17,36 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.causalclustering.discovery.procedures;
+package org.neo4j.causalclustering.discovery;
 
-import org.neo4j.causalclustering.discovery.RoleInfo;
+import java.io.Serializable;
+import java.util.UUID;
 
-public class ReadReplicaRoleProcedure extends RoleProcedure
+import org.neo4j.causalclustering.identity.MemberId;
+
+/**
+ * Simple struct representing a raft leader - move to the raft module and make sure its used properly there.
+ */
+public class RaftLeader implements Serializable
 {
-    public ReadReplicaRoleProcedure()
+
+    private final long term;
+    private final UUID memberUUID;
+
+    public RaftLeader( MemberId memberId, long term )
     {
-        super();
+        this.memberUUID = memberId.getUuid();
+        this.term = term;
     }
 
-    @Override
-    RoleInfo role()
+    public long term()
     {
-        return RoleInfo.READ_REPLICA;
+        return term;
+    }
+
+    public MemberId memberId()
+    {
+        return new MemberId( memberUUID );
     }
 }
+

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ReadReplicaInfo.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ReadReplicaInfo.java
@@ -30,18 +30,26 @@ public class ReadReplicaInfo implements DiscoveryServerInfo
     private final AdvertisedSocketAddress catchupServerAddress;
     private final ClientConnectorAddresses clientConnectorAddresses;
     private final Set<String> groups;
+    private final String dbName;
 
-    public ReadReplicaInfo( ClientConnectorAddresses clientConnectorAddresses, AdvertisedSocketAddress catchupServerAddress )
+    public ReadReplicaInfo( ClientConnectorAddresses clientConnectorAddresses, AdvertisedSocketAddress catchupServerAddress, String dbName )
     {
-        this( clientConnectorAddresses, catchupServerAddress, emptySet() );
+        this( clientConnectorAddresses, catchupServerAddress, emptySet(), dbName );
     }
 
     public ReadReplicaInfo( ClientConnectorAddresses clientConnectorAddresses,
-            AdvertisedSocketAddress catchupServerAddress, Set<String> groups )
+            AdvertisedSocketAddress catchupServerAddress, Set<String> groups, String dbName )
     {
         this.clientConnectorAddresses = clientConnectorAddresses;
         this.catchupServerAddress = catchupServerAddress;
         this.groups = groups;
+        this.dbName = dbName;
+    }
+
+    @Override
+    public String getDatabaseName()
+    {
+        return dbName;
     }
 
     @Override

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ReadReplicaTopology.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ReadReplicaTopology.java
@@ -59,4 +59,12 @@ public class ReadReplicaTopology implements Topology<ReadReplicaInfo>
     {
         return readReplicaMembers.keySet().stream().findAny();
     }
+
+    @Override
+    public ReadReplicaTopology filterTopologyByDb( String dbName )
+    {
+        Map<MemberId, ReadReplicaInfo> filteredMembers = filterHostsByDb( members(), dbName );
+
+        return new ReadReplicaTopology( filteredMembers );
+    }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RoleInfo.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RoleInfo.java
@@ -17,20 +17,29 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.causalclustering.discovery.procedures;
+package org.neo4j.causalclustering.discovery;
 
-import org.neo4j.causalclustering.discovery.RoleInfo;
-
-public class ReadReplicaRoleProcedure extends RoleProcedure
+public enum RoleInfo
 {
-    public ReadReplicaRoleProcedure()
-    {
-        super();
-    }
+    //TODO: Factor out for the Role which already exists in cc.consensus.roles
+    LEADER,
+    FOLLOWER,
+    READ_REPLICA,
+    UNKNOWN;
 
     @Override
-    RoleInfo role()
+    public String toString()
     {
-        return RoleInfo.READ_REPLICA;
+        switch ( this )
+        {
+            case LEADER:
+                return "LEADER";
+            case FOLLOWER:
+                return "FOLLOWER";
+            case READ_REPLICA:
+                return "READ REPLICA";
+            default:
+                return "UNKNOWN";
+        }
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/Topology.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/Topology.java
@@ -22,6 +22,7 @@ package org.neo4j.causalclustering.discovery;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.neo4j.causalclustering.identity.MemberId;
 
@@ -49,4 +50,12 @@ public interface Topology<T extends DiscoveryServerInfo>
     {
         return Optional.ofNullable( members().get( memberId ) );
     }
+
+    default Map<MemberId, T> filterHostsByDb( Map<MemberId, T> s, String dbName )
+    {
+        return s.entrySet().stream().filter(e -> e.getValue().getDatabaseName().equals( dbName ) )
+                .collect( Collectors.toMap( Map.Entry::getKey, Map.Entry::getValue ) );
+    }
+
+    Topology<T> filterTopologyByDb( String dbName );
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyService.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.causalclustering.discovery;
 
+import java.util.Map;
 import java.util.Optional;
 
 import org.neo4j.causalclustering.identity.MemberId;
@@ -30,9 +31,17 @@ import org.neo4j.kernel.lifecycle.Lifecycle;
  */
 public interface TopologyService extends Lifecycle
 {
-    CoreTopology coreServers();
+    String localDBName();
 
-    ReadReplicaTopology readReplicas();
+    CoreTopology allCoreServers();
+
+    CoreTopology localCoreServers();
+
+    ReadReplicaTopology allReadReplicas();
+
+    ReadReplicaTopology localReadReplicas();
 
     Optional<AdvertisedSocketAddress> findCatchupAddress( MemberId upstream );
+
+    Map<MemberId,RoleInfo> allCoreRoles() throws InterruptedException;
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyService.java
@@ -43,5 +43,5 @@ public interface TopologyService extends Lifecycle
 
     Optional<AdvertisedSocketAddress> findCatchupAddress( MemberId upstream );
 
-    Map<MemberId,RoleInfo> allCoreRoles() throws InterruptedException;
+    Map<MemberId,RoleInfo> allCoreRoles();
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedure.java
@@ -42,8 +42,6 @@ import org.neo4j.internal.kernel.api.procs.QualifiedName;
 import org.neo4j.kernel.api.ResourceTracker;
 import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.Context;
-import org.neo4j.kernel.api.proc.Neo4jTypes;
-import org.neo4j.kernel.api.proc.QualifiedName;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 
@@ -84,14 +82,7 @@ public class ClusterOverviewProcedure extends CallableProcedure.BasicProcedure
     {
         Map<MemberId,RoleInfo> roleMap = emptyMap();
         List<ReadWriteEndPoint> endpoints = new ArrayList<>();
-        try
-        {
-            roleMap = topologyService.allCoreRoles();
-        }
-        catch ( InterruptedException e )
-        {
-            log.warn( "Hazelcast instance not yet available.", e );
-        }
+        roleMap = topologyService.allCoreRoles();
 
         CoreTopology coreTopology = topologyService.allCoreServers();
         Set<MemberId> coreMembers = coreTopology.members().keySet();

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedure.java
@@ -28,12 +28,11 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import org.neo4j.causalclustering.core.consensus.LeaderLocator;
-import org.neo4j.causalclustering.core.consensus.NoLeaderFoundException;
 import org.neo4j.causalclustering.discovery.ClientConnectorAddresses;
 import org.neo4j.causalclustering.discovery.CoreServerInfo;
 import org.neo4j.causalclustering.discovery.CoreTopology;
 import org.neo4j.causalclustering.discovery.ReadReplicaInfo;
+import org.neo4j.causalclustering.discovery.RoleInfo;
 import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.collection.RawIterator;
@@ -43,9 +42,12 @@ import org.neo4j.internal.kernel.api.procs.QualifiedName;
 import org.neo4j.kernel.api.ResourceTracker;
 import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.Context;
+import org.neo4j.kernel.api.proc.Neo4jTypes;
+import org.neo4j.kernel.api.proc.QualifiedName;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Comparator.comparing;
 import static org.neo4j.helpers.collection.Iterables.asList;
 import static org.neo4j.helpers.collection.Iterators.asRawIterator;
@@ -60,21 +62,19 @@ public class ClusterOverviewProcedure extends CallableProcedure.BasicProcedure
     private static final String[] PROCEDURE_NAMESPACE = {"dbms", "cluster"};
     public static final String PROCEDURE_NAME = "overview";
     private final TopologyService topologyService;
-    private final LeaderLocator leaderLocator;
     private final Log log;
 
-    public ClusterOverviewProcedure( TopologyService topologyService,
-            LeaderLocator leaderLocator, LogProvider logProvider )
+    public ClusterOverviewProcedure( TopologyService topologyService, LogProvider logProvider )
     {
         super( procedureSignature( new QualifiedName( PROCEDURE_NAMESPACE, PROCEDURE_NAME ) )
                 .out( "id", Neo4jTypes.NTString )
                 .out( "addresses", Neo4jTypes.NTList( Neo4jTypes.NTString ) )
                 .out( "role", Neo4jTypes.NTString )
                 .out( "groups", Neo4jTypes.NTList( Neo4jTypes.NTString ) )
+                .out( "database", Neo4jTypes.NTString )
                 .description( "Overview of all currently accessible cluster members and their roles." )
                 .build() );
         this.topologyService = topologyService;
-        this.leaderLocator = leaderLocator;
         this.log = logProvider.getLog( getClass() );
     }
 
@@ -82,28 +82,29 @@ public class ClusterOverviewProcedure extends CallableProcedure.BasicProcedure
     public RawIterator<Object[],ProcedureException> apply(
             Context ctx, Object[] input, ResourceTracker resourceTracker )
     {
+        Map<MemberId,RoleInfo> roleMap = emptyMap();
         List<ReadWriteEndPoint> endpoints = new ArrayList<>();
-        CoreTopology coreTopology = topologyService.coreServers();
-        Set<MemberId> coreMembers = coreTopology.members().keySet();
-        MemberId leader = null;
-
         try
         {
-            leader = leaderLocator.getLeader();
+            roleMap = topologyService.allCoreRoles();
         }
-        catch ( NoLeaderFoundException e )
+        catch ( InterruptedException e )
         {
-            log.debug( "No write server found. This can happen during a leader switch." );
+            log.warn( "Hazelcast instance not yet available.", e );
         }
+
+        CoreTopology coreTopology = topologyService.allCoreServers();
+        Set<MemberId> coreMembers = coreTopology.members().keySet();
 
         for ( MemberId memberId : coreMembers )
         {
             Optional<CoreServerInfo> coreServerInfo = coreTopology.find( memberId );
             if ( coreServerInfo.isPresent() )
             {
-                Role role = memberId.equals( leader ) ? Role.LEADER : Role.FOLLOWER;
-                endpoints.add( new ReadWriteEndPoint( coreServerInfo.get().connectors(), role, memberId.getUuid(),
-                        asList( coreServerInfo.get().groups() ) ) );
+                CoreServerInfo info = coreServerInfo.get();
+                RoleInfo role = roleMap.getOrDefault( memberId, RoleInfo.UNKNOWN );
+                endpoints.add( new ReadWriteEndPoint( info.connectors(), role, memberId.getUuid(),
+                        asList( info.groups() ), info.getDatabaseName() ) );
             }
             else
             {
@@ -111,11 +112,11 @@ public class ClusterOverviewProcedure extends CallableProcedure.BasicProcedure
             }
         }
 
-        for ( Map.Entry<MemberId,ReadReplicaInfo> readReplica : topologyService.readReplicas().members().entrySet() )
+        for ( Map.Entry<MemberId,ReadReplicaInfo> readReplica : topologyService.allReadReplicas().members().entrySet() )
         {
             ReadReplicaInfo readReplicaInfo = readReplica.getValue();
-            endpoints.add( new ReadWriteEndPoint( readReplicaInfo.connectors(), Role.READ_REPLICA,
-                    readReplica.getKey().getUuid(), asList( readReplicaInfo.groups() ) ) );
+            endpoints.add( new ReadWriteEndPoint( readReplicaInfo.connectors(), RoleInfo.READ_REPLICA,
+                    readReplica.getKey().getUuid(), asList( readReplicaInfo.groups() ), readReplicaInfo.getDatabaseName() ) );
         }
 
         endpoints.sort( comparing( o -> o.addresses().toString() ) );
@@ -125,7 +126,8 @@ public class ClusterOverviewProcedure extends CallableProcedure.BasicProcedure
                                 endpoint.memberId().toString(),
                                 endpoint.addresses().uriList().stream().map( URI::toString ).collect( Collectors.toList() ),
                                 endpoint.role().name(),
-                                endpoint.groups()
+                                endpoint.groups(),
+                                endpoint.dbName()
                         },
                 asRawIterator( endpoints.iterator() ) );
     }
@@ -133,16 +135,17 @@ public class ClusterOverviewProcedure extends CallableProcedure.BasicProcedure
     static class ReadWriteEndPoint
     {
         private final ClientConnectorAddresses clientConnectorAddresses;
-        private final Role role;
+        private final RoleInfo role;
         private final UUID memberId;
         private final List<String> groups;
+        private final String dbName;
 
         public ClientConnectorAddresses addresses()
         {
             return clientConnectorAddresses;
         }
 
-        public Role role()
+        public RoleInfo role()
         {
             return role;
         }
@@ -157,12 +160,18 @@ public class ClusterOverviewProcedure extends CallableProcedure.BasicProcedure
             return groups;
         }
 
-        ReadWriteEndPoint( ClientConnectorAddresses clientConnectorAddresses, Role role, UUID memberId, List<String> groups )
+        String dbName()
+        {
+            return dbName;
+        }
+
+        ReadWriteEndPoint( ClientConnectorAddresses clientConnectorAddresses, RoleInfo role, UUID memberId, List<String> groups, String dbName )
         {
             this.clientConnectorAddresses = clientConnectorAddresses;
             this.role = role;
             this.memberId = memberId;
             this.groups = groups;
+            this.dbName = dbName;
         }
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/CoreRoleProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/CoreRoleProcedure.java
@@ -20,6 +20,7 @@
 package org.neo4j.causalclustering.discovery.procedures;
 
 import org.neo4j.causalclustering.core.consensus.RaftMachine;
+import org.neo4j.causalclustering.discovery.RoleInfo;
 
 public class CoreRoleProcedure extends RoleProcedure
 {
@@ -32,8 +33,8 @@ public class CoreRoleProcedure extends RoleProcedure
     }
 
     @Override
-    Role role()
+    RoleInfo role()
     {
-        return raft.isLeader() ? Role.LEADER : Role.FOLLOWER;
+        return raft.isLeader() ? RoleInfo.LEADER : RoleInfo.FOLLOWER;
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/RoleProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/RoleProcedure.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.causalclustering.discovery.procedures;
 
+import org.neo4j.causalclustering.discovery.RoleInfo;
 import org.neo4j.collection.RawIterator;
 import org.neo4j.internal.kernel.api.exceptions.ProcedureException;
 import org.neo4j.internal.kernel.api.procs.Neo4jTypes;
@@ -50,5 +51,5 @@ abstract class RoleProcedure extends CallableProcedure.BasicProcedure
         return RawIterator.<Object[],ProcedureException>of( new Object[]{role().name()} );
     }
 
-    abstract Role role();
+    abstract RoleInfo role();
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/ClusterBinder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/ClusterBinder.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.time.Clock;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
@@ -32,8 +33,11 @@ import org.neo4j.causalclustering.core.state.storage.SimpleStorage;
 import org.neo4j.causalclustering.discovery.CoreTopology;
 import org.neo4j.causalclustering.discovery.CoreTopologyService;
 import org.neo4j.function.ThrowingAction;
+import org.neo4j.kernel.impl.util.CappedLogger;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
+
+import static java.lang.String.format;
 
 public class ClusterBinder implements Supplier<Optional<ClusterId>>
 {
@@ -41,23 +45,58 @@ public class ClusterBinder implements Supplier<Optional<ClusterId>>
     private final CoreTopologyService topologyService;
     private final CoreBootstrapper coreBootstrapper;
     private final Log log;
+    private final CappedLogger cappedLog;
     private final Clock clock;
     private final ThrowingAction<InterruptedException> retryWaiter;
     private final long timeoutMillis;
+    private final String dbName;
+    private final int minCoreHosts;
 
     private ClusterId clusterId;
 
     public ClusterBinder( SimpleStorage<ClusterId> clusterIdStorage, CoreTopologyService topologyService,
                             LogProvider logProvider, Clock clock, ThrowingAction<InterruptedException> retryWaiter,
-                            long timeoutMillis, CoreBootstrapper coreBootstrapper )
+                            long timeoutMillis, CoreBootstrapper coreBootstrapper, String dbName, int minCoreHosts )
     {
         this.clusterIdStorage = clusterIdStorage;
         this.topologyService = topologyService;
         this.coreBootstrapper = coreBootstrapper;
         this.log = logProvider.getLog( getClass() );
+        this.cappedLog = new CappedLogger( log ).setTimeLimit( 5, TimeUnit.SECONDS, clock );
         this.clock = clock;
         this.retryWaiter = retryWaiter;
         this.timeoutMillis = timeoutMillis;
+        this.dbName = dbName;
+        this.minCoreHosts = minCoreHosts;
+    }
+
+    /**
+     * This method verifies if the local topology being returned by the discovery service is a viable cluster.
+     * If true, then a) the topology is sufficiently large to form a cluster; & b) this host can bootstrap for
+     * its configured database.
+     *
+     * @param coreTopology the present state of the local topology, as reported by the discovery service.
+     * @return Whether or not coreTopology, in its current state, can form a viable cluster
+     */
+    private boolean isViableCluster( CoreTopology coreTopology )
+    {
+        int memberCount = coreTopology.members().size();
+        if ( memberCount < minCoreHosts )
+        {
+            String message = "Waiting for %d members. Currently discovered %d members: %s. ";
+            cappedLog.info( format( message, minCoreHosts, memberCount, coreTopology.members() ) );
+            return false;
+        }
+        else if ( !coreTopology.canBeBootstrapped() )
+        {
+            String message = "Discovered sufficient members (%d) but waiting for bootstrap by other instance.";
+            cappedLog.info( format( message, memberCount ) );
+            return false;
+        }
+        else
+        {
+            return true;
+        }
     }
 
     /**
@@ -84,18 +123,18 @@ public class ClusterBinder implements Supplier<Optional<ClusterId>>
 
         do
         {
-            topology = topologyService.coreServers();
+            topology = topologyService.localCoreServers();
 
             if ( topology.clusterId() != null )
             {
                 clusterId = topology.clusterId();
                 log.info( "Bound to cluster: " + clusterId );
             }
-            else if ( topology.canBeBootstrapped() )
+            else if ( isViableCluster( topology ) )
             {
                 clusterId = new ClusterId( UUID.randomUUID() );
                 snapshot = coreBootstrapper.bootstrap( topology.members().keySet() );
-                log.info( String.format( "Bootstrapped with snapshot: %s and clusterId: %s", snapshot, clusterId ) );
+                log.info( format( "Bootstrapped with snapshot: %s and clusterId: %s", snapshot, clusterId ) );
 
                 publishClusterId( clusterId );
             }
@@ -107,7 +146,7 @@ public class ClusterBinder implements Supplier<Optional<ClusterId>>
 
         if ( clusterId == null )
         {
-            throw new TimeoutException( String.format(
+            throw new TimeoutException( format(
                     "Failed to join a cluster with members %s. Another member should have published " +
                     "a clusterId but none was detected. Please restart the cluster.", topology ) );
         }
@@ -124,7 +163,7 @@ public class ClusterBinder implements Supplier<Optional<ClusterId>>
 
     private void publishClusterId( ClusterId localClusterId ) throws BindingException, InterruptedException
     {
-        boolean success = topologyService.setClusterId( localClusterId );
+        boolean success = topologyService.setClusterId( localClusterId, dbName );
         if ( !success )
         {
             throw new BindingException( "Failed to publish: " + localClusterId );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/ClusterBinder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/ClusterBinder.java
@@ -71,14 +71,16 @@ public class ClusterBinder implements Supplier<Optional<ClusterId>>
     }
 
     /**
-     * This method verifies if the local topology being returned by the discovery service is a viable cluster.
+     * This method verifies if the local topology being returned by the discovery service is a viable cluster
+     * and should be bootstrapped by this host.
+     *
      * If true, then a) the topology is sufficiently large to form a cluster; & b) this host can bootstrap for
      * its configured database.
      *
      * @param coreTopology the present state of the local topology, as reported by the discovery service.
      * @return Whether or not coreTopology, in its current state, can form a viable cluster
      */
-    private boolean isViableCluster( CoreTopology coreTopology )
+    private boolean hostShouldBootstrapCluster( CoreTopology coreTopology )
     {
         int memberCount = coreTopology.members().size();
         if ( memberCount < minCoreHosts )
@@ -130,7 +132,7 @@ public class ClusterBinder implements Supplier<Optional<ClusterId>>
                 clusterId = topology.clusterId();
                 log.info( "Bound to cluster: " + clusterId );
             }
-            else if ( isViableCluster( topology ) )
+            else if ( hostShouldBootstrapCluster( topology ) )
             {
                 clusterId = new ClusterId( UUID.randomUUID() );
                 snapshot = coreBootstrapper.bootstrap( topology.members().keySet() );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/MemberId.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/MemberId.java
@@ -20,6 +20,7 @@
 package org.neo4j.causalclustering.identity;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -29,7 +30,8 @@ import org.neo4j.storageengine.api.WritableChannel;
 
 import static java.lang.String.format;
 
-public class MemberId
+// TODO: basics for Serializable
+public class MemberId implements Serializable
 {
     private final UUID uuid;
     private final String shortName;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/plugins/server_policies/ServerPoliciesPlugin.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/plugins/server_policies/ServerPoliciesPlugin.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.causalclustering.load_balancing.plugins.server_policies;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -100,8 +101,8 @@ public class ServerPoliciesPlugin implements LoadBalancingPlugin
     {
         Policy policy = policies.selectFor( context );
 
-        CoreTopology coreTopology = topologyService.coreServers();
-        ReadReplicaTopology rrTopology = topologyService.readReplicas();
+        CoreTopology coreTopology = topologyService.localCoreServers();
+        ReadReplicaTopology rrTopology = topologyService.localReadReplicas();
 
         return new LoadBalancingResult( routeEndpoints( coreTopology ), writeEndpoints( coreTopology ),
                 readEndpoints( coreTopology, rrTopology, policy ), timeToLive );
@@ -115,6 +116,7 @@ public class ServerPoliciesPlugin implements LoadBalancingPlugin
 
     private List<Endpoint> writeEndpoints( CoreTopology cores )
     {
+
         MemberId leader;
         try
         {
@@ -134,6 +136,7 @@ public class ServerPoliciesPlugin implements LoadBalancingPlugin
 
     private List<Endpoint> readEndpoints( CoreTopology coreTopology, ReadReplicaTopology rrTopology, Policy policy )
     {
+
         Set<ServerInfo> possibleReaders = rrTopology.members().entrySet().stream()
                 .map( entry -> new ServerInfo( entry.getValue().connectors().boltAddress(), entry.getKey(),
                         entry.getValue().groups() ) )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/procedure/GetServersProcedureForSingleDC.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/procedure/GetServersProcedureForSingleDC.java
@@ -78,6 +78,7 @@ public class GetServersProcedureForSingleDC implements CallableProcedure
     private final LeaderLocator leaderLocator;
     private final Config config;
     private final Log log;
+    private final String dbName;
 
     public GetServersProcedureForSingleDC( TopologyService topologyService, LeaderLocator leaderLocator,
             Config config, LogProvider logProvider )
@@ -86,6 +87,7 @@ public class GetServersProcedureForSingleDC implements CallableProcedure
         this.leaderLocator = leaderLocator;
         this.config = config;
         this.log = logProvider.getLog( getClass() );
+        this.dbName = config.get( CausalClusteringSettings.database );
     }
 
     @Override
@@ -120,12 +122,12 @@ public class GetServersProcedureForSingleDC implements CallableProcedure
             return Optional.empty();
         }
 
-        return topologyService.coreServers().find( leader ).map( extractBoltAddress() );
+        return topologyService.localCoreServers().find( leader ).map( extractBoltAddress() );
     }
 
     private List<Endpoint> routeEndpoints()
     {
-        Stream<AdvertisedSocketAddress> routers = topologyService.coreServers()
+        Stream<AdvertisedSocketAddress> routers = topologyService.localCoreServers()
                 .members().values().stream().map( extractBoltAddress() );
         List<Endpoint> routeEndpoints = routers.map( Endpoint::route ).collect( toList() );
         Collections.shuffle( routeEndpoints );
@@ -139,7 +141,7 @@ public class GetServersProcedureForSingleDC implements CallableProcedure
 
     private List<Endpoint> readEndpoints()
     {
-        List<AdvertisedSocketAddress> readReplicas = topologyService.readReplicas().allMemberInfo().stream()
+        List<AdvertisedSocketAddress> readReplicas = topologyService.localReadReplicas().allMemberInfo().stream()
                 .map( extractBoltAddress() ).collect( toList() );
         boolean addFollowers = readReplicas.isEmpty() || config.get( cluster_allow_reads_on_followers );
         Stream<AdvertisedSocketAddress> readCore = addFollowers ? coreReadEndPoints() : Stream.empty();
@@ -152,8 +154,8 @@ public class GetServersProcedureForSingleDC implements CallableProcedure
     private Stream<AdvertisedSocketAddress> coreReadEndPoints()
     {
         Optional<AdvertisedSocketAddress> leader = leaderBoltAddress();
-        Collection<CoreServerInfo> coreServerInfo = topologyService.coreServers().members().values();
-        Stream<AdvertisedSocketAddress> boltAddresses = topologyService.coreServers()
+        Collection<CoreServerInfo> coreServerInfo = topologyService.localCoreServers().members().values();
+        Stream<AdvertisedSocketAddress> boltAddresses = topologyService.localCoreServers()
                 .members().values().stream().map( extractBoltAddress() );
 
         // if the leader is present and it is not alone filter it out from the read end points

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/procedure/LegacyGetServersProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/procedure/LegacyGetServersProcedure.java
@@ -73,6 +73,7 @@ public class LegacyGetServersProcedure implements CallableProcedure
     private final LeaderLocator leaderLocator;
     private final Config config;
     private final Log log;
+    private final String dbName;
 
     public LegacyGetServersProcedure( TopologyService topologyService, LeaderLocator leaderLocator,
             Config config, LogProvider logProvider )
@@ -81,6 +82,7 @@ public class LegacyGetServersProcedure implements CallableProcedure
         this.leaderLocator = leaderLocator;
         this.config = config;
         this.log = logProvider.getLog( getClass() );
+        this.dbName = config.get( CausalClusteringSettings.database );
     }
 
     @Override
@@ -115,12 +117,12 @@ public class LegacyGetServersProcedure implements CallableProcedure
             return Optional.empty();
         }
 
-        return topologyService.coreServers().find( leader ).map( extractBoltAddress() );
+        return topologyService.localCoreServers().find( leader ).map( extractBoltAddress() );
     }
 
     private List<Endpoint> routeEndpoints()
     {
-        Stream<AdvertisedSocketAddress> routers = topologyService.coreServers()
+        Stream<AdvertisedSocketAddress> routers = topologyService.localCoreServers()
                 .members().values().stream().map( extractBoltAddress() );
         List<Endpoint> routeEndpoints = routers.map( Endpoint::route ).collect( toList() );
         Collections.shuffle( routeEndpoints );
@@ -134,7 +136,7 @@ public class LegacyGetServersProcedure implements CallableProcedure
 
     private List<Endpoint> readEndpoints()
     {
-        List<AdvertisedSocketAddress> readReplicas = topologyService.readReplicas().allMemberInfo().stream()
+        List<AdvertisedSocketAddress> readReplicas = topologyService.localReadReplicas().allMemberInfo().stream()
                 .map( extractBoltAddress() ).collect( toList() );
         boolean addFollowers = readReplicas.isEmpty() || config.get( cluster_allow_reads_on_followers );
         Stream<AdvertisedSocketAddress> readCore = addFollowers ? coreReadEndPoints() : Stream.empty();
@@ -147,8 +149,8 @@ public class LegacyGetServersProcedure implements CallableProcedure
     private Stream<AdvertisedSocketAddress> coreReadEndPoints()
     {
         Optional<AdvertisedSocketAddress> leader = leaderBoltAddress();
-        Collection<CoreServerInfo> coreServerInfo = topologyService.coreServers().members().values();
-        Stream<AdvertisedSocketAddress> boltAddresses = topologyService.coreServers()
+        Collection<CoreServerInfo> coreServerInfo = topologyService.localCoreServers().members().values();
+        Stream<AdvertisedSocketAddress> boltAddresses = topologyService.localCoreServers()
                 .members().values().stream().map( extractBoltAddress() );
 
         // if the leader is present and it is not alone filter it out from the read end points

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/RaftOutbound.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/RaftOutbound.java
@@ -62,7 +62,7 @@ public class RaftOutbound implements Outbound<MemberId, RaftMessage>
             return;
         }
 
-        Optional<CoreServerInfo> coreServerInfo = coreTopologyService.coreServers().find( to );
+        Optional<CoreServerInfo> coreServerInfo = coreTopologyService.localCoreServers().find( to );
         if ( coreServerInfo.isPresent() )
         {
             outbound.send( coreServerInfo.get().getRaftServer(), RaftMessages.ClusterIdAwareMessage.of( clusterId.get(), message ), block );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/ConnectRandomlyToServerGroupImpl.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/ConnectRandomlyToServerGroupImpl.java
@@ -35,18 +35,20 @@ class ConnectRandomlyToServerGroupImpl
     private final List<String> groups;
     private final TopologyService topologyService;
     private final MemberId myself;
+    private final String dbName;
     private final Random random = new Random();
 
-    ConnectRandomlyToServerGroupImpl( List<String> groups, TopologyService topologyService, MemberId myself )
+    ConnectRandomlyToServerGroupImpl( List<String> groups, TopologyService topologyService, MemberId myself, String dbName )
     {
         this.groups = groups;
         this.topologyService = topologyService;
         this.myself = myself;
+        this.dbName = dbName;
     }
 
     public Optional<MemberId> upstreamDatabase()
     {
-        Map<MemberId, ReadReplicaInfo> replicas = topologyService.readReplicas().members();
+        Map<MemberId, ReadReplicaInfo> replicas = topologyService.localReadReplicas().members();
 
         List<MemberId> choices = groups.stream()
                 .flatMap( group -> replicas.entrySet().stream().filter( isMyGroupAndNotMe( group ) ) )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/ConnectRandomlyToServerGroupStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/ConnectRandomlyToServerGroupStrategy.java
@@ -43,7 +43,7 @@ public class ConnectRandomlyToServerGroupStrategy extends UpstreamDatabaseSelect
     {
         List<String> groups = config.get( CausalClusteringSettings.connect_randomly_to_server_group_strategy );
         strategyImpl = new ConnectRandomlyToServerGroupImpl( groups, topologyService,
-                myself );
+                myself, dbName );
 
         if ( groups.isEmpty() )
         {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/ConnectRandomlyWithinServerGroupStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/ConnectRandomlyWithinServerGroupStrategy.java
@@ -40,7 +40,7 @@ public class ConnectRandomlyWithinServerGroupStrategy extends UpstreamDatabaseSe
     void init()
     {
         List<String> groups = config.get( CausalClusteringSettings.server_groups );
-        strategyImpl = new ConnectRandomlyToServerGroupImpl( groups, topologyService, myself );
+        strategyImpl = new ConnectRandomlyToServerGroupImpl( groups, topologyService, myself, dbName );
         log.warn( "Upstream selection strategy " + readableName + " is deprecated. Consider using " + ConnectRandomlyToServerGroupStrategy.NAME + " instead." );
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/ConnectToRandomCoreServerStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/ConnectToRandomCoreServerStrategy.java
@@ -22,6 +22,7 @@ package org.neo4j.causalclustering.readreplica;
 import java.util.Optional;
 import java.util.Random;
 
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.discovery.CoreTopology;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.helpers.Service;
@@ -39,7 +40,7 @@ public class ConnectToRandomCoreServerStrategy extends UpstreamDatabaseSelection
     @Override
     public Optional<MemberId> upstreamDatabase() throws UpstreamDatabaseSelectionException
     {
-        final CoreTopology coreTopology = topologyService.coreServers();
+        final CoreTopology coreTopology = topologyService.localCoreServers();
 
         if ( coreTopology.members().size() == 0 )
         {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/TypicallyConnectToRandomReadReplicaStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/TypicallyConnectToRandomReadReplicaStrategy.java
@@ -21,6 +21,7 @@ package org.neo4j.causalclustering.readreplica;
 
 import java.util.Optional;
 
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.helpers.Service;
 
@@ -39,11 +40,11 @@ public class TypicallyConnectToRandomReadReplicaStrategy extends UpstreamDatabas
     {
         if ( counter.shouldReturnCoreMemberId() )
         {
-            return topologyService.coreServers().anyCoreMemberId();
+            return topologyService.localCoreServers().anyCoreMemberId();
         }
         else
         {
-            return topologyService.readReplicas().anyReadReplicaMemberId();
+            return topologyService.localReadReplicas().anyReadReplicaMemberId();
         }
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/UpstreamDatabaseSelectionStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/UpstreamDatabaseSelectionStrategy.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.helpers.Service;
@@ -37,6 +38,7 @@ public abstract class UpstreamDatabaseSelectionStrategy extends Service
     protected Log log;
     protected MemberId myself;
     protected String readableName;
+    protected String dbName;
 
     public UpstreamDatabaseSelectionStrategy( String key, String... altKeys )
     {
@@ -50,6 +52,7 @@ public abstract class UpstreamDatabaseSelectionStrategy extends Service
         this.config = config;
         this.log = logProvider.getLog( this.getClass() );
         this.myself = myself;
+        this.dbName = config.get( CausalClusteringSettings.database );
 
         readableName = StreamSupport.stream( getKeys().spliterator(), false ).collect( Collectors.joining( ", " ) );
         log.info( "Using upstream selection strategy " + readableName );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/UserDefinedConfigurationStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/UserDefinedConfigurationStrategy.java
@@ -85,7 +85,7 @@ public class UserDefinedConfigurationStrategy extends UpstreamDatabaseSelectionS
     private Set<ServerInfo> possibleServers()
     {
         Stream<Map.Entry<MemberId, ? extends DiscoveryServerInfo>> infoMap =
-                Stream.of( topologyService.readReplicas(), topologyService.coreServers() )
+                Stream.of( topologyService.localReadReplicas(), topologyService.localCoreServers() )
                         .map( Topology::members )
                         .map( Map::entrySet )
                         .flatMap( Set::stream );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/TestStoreId.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/TestStoreId.java
@@ -21,6 +21,7 @@ package org.neo4j.causalclustering;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileSystem;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -46,6 +47,12 @@ public class TestStoreId
     public static void assertAllStoresHaveTheSameStoreId( List<File> coreStoreDirs, FileSystemAbstraction fs )
             throws IOException
     {
+        Set<StoreId> storeIds = getStoreIds( coreStoreDirs, fs );
+        assertEquals( "Store Ids " + storeIds, 1, storeIds.size() );
+    }
+
+    public static Set<StoreId> getStoreIds( List<File> coreStoreDirs, FileSystemAbstraction fs ) throws IOException
+    {
         Set<StoreId> storeIds = new HashSet<>();
         try ( PageCache pageCache = StandalonePageCacheFactory.createPageCache( fs ) )
         {
@@ -54,7 +61,8 @@ public class TestStoreId
                 storeIds.add( doReadStoreId( coreStoreDir, pageCache ) );
             }
         }
-        assertEquals( "Store Ids " + storeIds, 1, storeIds.size() );
+
+        return storeIds;
     }
 
     private static StoreId doReadStoreId( File coreStoreDir, PageCache pageCache ) throws IOException

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/ComparableRaftState.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/ComparableRaftState.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import org.neo4j.causalclustering.core.consensus.LeaderInfo;
 import org.neo4j.causalclustering.core.consensus.log.cache.ConsecutiveInFlightCache;
 import org.neo4j.causalclustering.core.consensus.log.cache.InFlightCache;
 import org.neo4j.causalclustering.core.consensus.log.RaftLog;
@@ -47,6 +48,7 @@ public class ComparableRaftState implements ReadableRaftState
     private final Log log;
     protected long term;
     protected MemberId leader;
+    private LeaderInfo leaderInfo = LeaderInfo.INITIAL;
     private long leaderCommit = -1;
     private MemberId votedFor;
     private Set<MemberId> votesForMe = new HashSet<>();
@@ -106,6 +108,12 @@ public class ComparableRaftState implements ReadableRaftState
     public MemberId leader()
     {
         return leader;
+    }
+
+    @Override
+    public LeaderInfo leaderInfo()
+    {
+        return leaderInfo;
     }
 
     @Override

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/replication/RaftReplicatorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/replication/RaftReplicatorTest.java
@@ -24,7 +24,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.time.Clock;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -84,8 +83,7 @@ public class RaftReplicatorTest
 
         RaftReplicator replicator =
                 new RaftReplicator( leaderLocator, myself, outbound, sessionPool,
-                        capturedProgress, noWaitTimeoutStrategy, noWaitTimeoutStrategy, availabilityGuard, NullLogProvider.getInstance(), replicationLimit,
-                        Clock.systemUTC() );
+                        capturedProgress, noWaitTimeoutStrategy, noWaitTimeoutStrategy, availabilityGuard, NullLogProvider.getInstance(), replicationLimit );
 
         ReplicatedInteger content = ReplicatedInteger.valueOf( 5 );
         Thread replicatingThread = replicatingThread( replicator, content, false );
@@ -112,8 +110,7 @@ public class RaftReplicatorTest
         CapturingOutbound<RaftMessages.RaftMessage> outbound = new CapturingOutbound<>();
 
         RaftReplicator replicator = new RaftReplicator( leaderLocator, myself, outbound,
-                sessionPool, capturedProgress, noWaitTimeoutStrategy, noWaitTimeoutStrategy, availabilityGuard, NullLogProvider.getInstance(), replicationLimit,
-                Clock.systemUTC() );
+                sessionPool, capturedProgress, noWaitTimeoutStrategy, noWaitTimeoutStrategy, availabilityGuard, NullLogProvider.getInstance(), replicationLimit );
 
         ReplicatedInteger content = ReplicatedInteger.valueOf( 5 );
         Thread replicatingThread = replicatingThread( replicator, content, false );
@@ -143,7 +140,7 @@ public class RaftReplicatorTest
         RaftReplicator replicator =
                 new RaftReplicator( leaderLocator, myself, outbound, sessionPool,
                         capturedProgress, noWaitTimeoutStrategy, new SpyRetryStrategy( leaderRetries ),
-                        availabilityGuard, NullLogProvider.getInstance(), replicationLimit, Clock.systemUTC() );
+                        availabilityGuard, NullLogProvider.getInstance(), replicationLimit );
 
         ReplicatedInteger content = ReplicatedInteger.valueOf( 5 );
         Thread replicatingThread = replicatingThread( replicator, content, false );
@@ -168,8 +165,7 @@ public class RaftReplicatorTest
         CapturingOutbound<RaftMessages.RaftMessage> outbound = new CapturingOutbound<>();
 
         RaftReplicator replicator = new RaftReplicator( leaderLocator, myself, outbound,
-                sessionPool, capturedProgress, noWaitTimeoutStrategy, noWaitTimeoutStrategy, availabilityGuard, NullLogProvider.getInstance(), replicationLimit,
-                Clock.systemUTC() );
+                sessionPool, capturedProgress, noWaitTimeoutStrategy, noWaitTimeoutStrategy, availabilityGuard, NullLogProvider.getInstance(), replicationLimit );
 
         ReplicatedInteger content = ReplicatedInteger.valueOf( 5 );
         Thread replicatingThread = replicatingThread( replicator, content, true );
@@ -200,7 +196,7 @@ public class RaftReplicatorTest
 
         RaftReplicator replicator =
                 new RaftReplicator( leaderLocator, myself, outbound, sessionPool, capturedProgress, noWaitTimeoutStrategy, noWaitTimeoutStrategy,
-                        availabilityGuard, NullLogProvider.getInstance(), replicationLimit, Clock.systemUTC() );
+                        availabilityGuard, NullLogProvider.getInstance(), replicationLimit );
 
         ReplicatedInteger content = ReplicatedInteger.valueOf( 5 );
         ReplicatingThread replicatingThread = replicatingThread( replicator, content, true );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/replication/RaftReplicatorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/replication/RaftReplicatorTest.java
@@ -83,7 +83,8 @@ public class RaftReplicatorTest
 
         RaftReplicator replicator =
                 new RaftReplicator( leaderLocator, myself, outbound, sessionPool,
-                        capturedProgress, noWaitTimeoutStrategy, noWaitTimeoutStrategy, availabilityGuard, NullLogProvider.getInstance(), replicationLimit );
+                        capturedProgress, noWaitTimeoutStrategy, noWaitTimeoutStrategy,
+                        availabilityGuard, NullLogProvider.getInstance(), replicationLimit );
 
         ReplicatedInteger content = ReplicatedInteger.valueOf( 5 );
         Thread replicatingThread = replicatingThread( replicator, content, false );
@@ -110,7 +111,8 @@ public class RaftReplicatorTest
         CapturingOutbound<RaftMessages.RaftMessage> outbound = new CapturingOutbound<>();
 
         RaftReplicator replicator = new RaftReplicator( leaderLocator, myself, outbound,
-                sessionPool, capturedProgress, noWaitTimeoutStrategy, noWaitTimeoutStrategy, availabilityGuard, NullLogProvider.getInstance(), replicationLimit );
+                sessionPool, capturedProgress, noWaitTimeoutStrategy, noWaitTimeoutStrategy,
+                availabilityGuard, NullLogProvider.getInstance(), replicationLimit );
 
         ReplicatedInteger content = ReplicatedInteger.valueOf( 5 );
         Thread replicatingThread = replicatingThread( replicator, content, false );
@@ -165,7 +167,8 @@ public class RaftReplicatorTest
         CapturingOutbound<RaftMessages.RaftMessage> outbound = new CapturingOutbound<>();
 
         RaftReplicator replicator = new RaftReplicator( leaderLocator, myself, outbound,
-                sessionPool, capturedProgress, noWaitTimeoutStrategy, noWaitTimeoutStrategy, availabilityGuard, NullLogProvider.getInstance(), replicationLimit );
+                sessionPool, capturedProgress, noWaitTimeoutStrategy, noWaitTimeoutStrategy,
+                availabilityGuard, NullLogProvider.getInstance(), replicationLimit );
 
         ReplicatedInteger content = ReplicatedInteger.valueOf( 5 );
         Thread replicatingThread = replicatingThread( replicator, content, true );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/IdReusabilityConditionTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/IdReusabilityConditionTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import java.util.UUID;
 
+import org.neo4j.causalclustering.core.consensus.LeaderInfo;
 import org.neo4j.causalclustering.core.consensus.RaftMachine;
 import org.neo4j.causalclustering.core.consensus.state.ExposedRaftState;
 import org.neo4j.causalclustering.identity.MemberId;
@@ -62,7 +63,7 @@ public class IdReusabilityConditionTest
     {
         MemberId someoneElse = new MemberId( UUID.randomUUID() );
 
-        idReusabilityCondition.receive( someoneElse );
+        idReusabilityCondition.onLeaderSwitch( new LeaderInfo( someoneElse, 1 ));
         assertFalse( idReusabilityCondition.getAsBoolean() );
     }
 
@@ -74,7 +75,7 @@ public class IdReusabilityConditionTest
         when( commandIndexTracker.getAppliedCommandIndex() ).thenReturn( 2L ); // gap-free
         when( state.lastLogIndexBeforeWeBecameLeader() ).thenReturn( 5L );
 
-        idReusabilityCondition.receive( myself );
+        idReusabilityCondition.onLeaderSwitch( new LeaderInfo( myself, 1 ) );
 
         assertFalse( idReusabilityCondition.getAsBoolean() );
         assertFalse( idReusabilityCondition.getAsBoolean() );
@@ -92,7 +93,7 @@ public class IdReusabilityConditionTest
         when( commandIndexTracker.getAppliedCommandIndex() ).thenReturn( 2L, 5L, 6L ); // gap-free
         when( state.lastLogIndexBeforeWeBecameLeader() ).thenReturn( 5L );
 
-        idReusabilityCondition.receive( myself );
+        idReusabilityCondition.onLeaderSwitch( new LeaderInfo( myself, 1 ) );
 
         assertFalse( idReusabilityCondition.getAsBoolean() );
         assertFalse( idReusabilityCondition.getAsBoolean() );
@@ -110,14 +111,14 @@ public class IdReusabilityConditionTest
         when( commandIndexTracker.getAppliedCommandIndex() ).thenReturn( 2L, 5L, 6L ); // gap-free
         when( state.lastLogIndexBeforeWeBecameLeader() ).thenReturn( 5L );
 
-        idReusabilityCondition.receive( myself );
+        idReusabilityCondition.onLeaderSwitch( new LeaderInfo( myself, 1 ) );
 
         assertFalse( idReusabilityCondition.getAsBoolean() );
         assertFalse( idReusabilityCondition.getAsBoolean() );
         assertTrue( idReusabilityCondition.getAsBoolean() );
 
         MemberId someoneElse = new MemberId( UUID.randomUUID() );
-        idReusabilityCondition.receive( someoneElse );
+        idReusabilityCondition.onLeaderSwitch( new LeaderInfo( someoneElse, 1 ) );
 
         assertFalse( idReusabilityCondition.getAsBoolean() );
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdGeneratorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdGeneratorTest.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
+import org.neo4j.causalclustering.core.consensus.LeaderInfo;
 import org.neo4j.causalclustering.core.consensus.RaftMachine;
 import org.neo4j.causalclustering.core.consensus.state.ExposedRaftState;
 import org.neo4j.causalclustering.identity.MemberId;
@@ -165,7 +166,7 @@ public class ReplicatedIdGeneratorTest extends IdGeneratorContractTest
 
         when( commandIndexTracker.getAppliedCommandIndex() ).thenReturn( 6L ); // gap-free
         when( state.lastLogIndexBeforeWeBecameLeader() ).thenReturn( 5L );
-        idReusabilityCondition.receive( myself );
+        idReusabilityCondition.onLeaderSwitch( new LeaderInfo( myself, 1 ) );
 
         idGenerator.freeId( 10 );
         assertEquals( 1, idGenerator.getDefragCount() );
@@ -210,7 +211,7 @@ public class ReplicatedIdGeneratorTest extends IdGeneratorContractTest
 
         when( commandIndexTracker.getAppliedCommandIndex() ).thenReturn( 4L, 6L ); // gap-free
         when( state.lastLogIndexBeforeWeBecameLeader() ).thenReturn( 5L );
-        idReusabilityCondition.receive( myself );
+        idReusabilityCondition.onLeaderSwitch( new LeaderInfo( myself, 1 ) );
 
         assertEquals( 24, idGenerator.nextId() );
         idGenerator.freeId( 11 );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderServiceTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderServiceTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.neo4j.causalclustering.catchup.CatchupAddressProvider;
+import org.neo4j.causalclustering.core.consensus.LeaderListener;
 import org.neo4j.causalclustering.core.consensus.LeaderLocator;
 import org.neo4j.causalclustering.core.consensus.NoLeaderFoundException;
 import org.neo4j.causalclustering.core.state.CommandApplicationProcess;
@@ -37,7 +38,6 @@ import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.function.Predicates;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.kernel.impl.util.CountingJobScheduler;
-import org.neo4j.kernel.impl.util.Listener;
 import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
@@ -149,13 +149,13 @@ public class CoreStateDownloaderServiceTest
         }
 
         @Override
-        public void registerListener( Listener<MemberId> listener )
+        public void registerListener( LeaderListener listener )
         {
             // do nothing
         }
 
         @Override
-        public void unregisterListener( Listener<MemberId> listener )
+        public void unregisterListener( LeaderListener listener )
         {
             // do nothing
         }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
@@ -23,8 +23,10 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -38,6 +40,7 @@ import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.core.CoreGraphDatabase;
 import org.neo4j.causalclustering.core.LeaderCanWrite;
 import org.neo4j.causalclustering.core.consensus.NoLeaderFoundException;
@@ -47,6 +50,7 @@ import org.neo4j.causalclustering.core.state.machines.locks.LeaderOnlyLockManage
 import org.neo4j.causalclustering.readreplica.ReadReplicaGraphDatabase;
 import org.neo4j.function.ThrowingSupplier;
 import org.neo4j.graphdb.DatabaseShutdownException;
+import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.graphdb.security.WriteOperationsNotAllowedException;
@@ -81,6 +85,7 @@ public class Cluster
     protected final DiscoveryServiceFactory discoveryServiceFactory;
     protected final String listenAddress;
     protected final String advertisedAddress;
+    private final Set<String> dbNames;
 
     private Map<Integer,CoreClusterMember> coreMembers = new ConcurrentHashMap<>();
     private Map<Integer,ReadReplica> readReplicas = new ConcurrentHashMap<>();
@@ -90,6 +95,17 @@ public class Cluster
             Map<String,String> coreParams, Map<String,IntFunction<String>> instanceCoreParams,
             Map<String,String> readReplicaParams, Map<String,IntFunction<String>> instanceReadReplicaParams,
             String recordFormat, IpFamily ipFamily, boolean useWildcard )
+    {
+        this( parentDir, noOfCoreMembers, noOfReadReplicas, discoveryServiceFactory, coreParams,
+                instanceCoreParams, readReplicaParams, instanceReadReplicaParams, recordFormat, ipFamily,
+                useWildcard, Collections.singleton( CausalClusteringSettings.database.getDefaultValue() ) );
+    }
+
+    public Cluster( File parentDir, int noOfCoreMembers, int noOfReadReplicas,
+            DiscoveryServiceFactory discoveryServiceFactory,
+            Map<String,String> coreParams, Map<String,IntFunction<String>> instanceCoreParams,
+            Map<String,String> readReplicaParams, Map<String,IntFunction<String>> instanceReadReplicaParams,
+            String recordFormat, IpFamily ipFamily, boolean useWildcard, Set<String> dbNames )
     {
         this.discoveryServiceFactory = discoveryServiceFactory;
         this.parentDir = parentDir;
@@ -103,6 +119,7 @@ public class Cluster
         List<AdvertisedSocketAddress> initialHosts = initialHosts( noOfCoreMembers );
         createCoreMembers( noOfCoreMembers, initialHosts, coreParams, instanceCoreParams, recordFormat );
         createReadReplicas( noOfReadReplicas, initialHosts, readReplicaParams, instanceReadReplicaParams, recordFormat );
+        this.dbNames = dbNames;
     }
 
     private List<AdvertisedSocketAddress> initialHosts( int noOfCoreMembers )
@@ -122,8 +139,7 @@ public class Cluster
     public Set<CoreClusterMember> healthyCoreMembers()
     {
         return coreMembers.values().stream()
-                .filter( db -> db.database().getDependencyResolver().resolveDependency( DatabaseHealth.class )
-                        .isHealthy() )
+                .filter( db -> db.database().getDependencyResolver().resolveDependency( DatabaseHealth.class ).isHealthy() )
                 .collect( Collectors.toSet() );
     }
 
@@ -247,9 +263,9 @@ public class Cluster
         return list;
     }
 
-    public void removeCoreMemberWithMemberId( int memberId )
+    public void removeCoreMemberWithServerId( int serverId )
     {
-        CoreClusterMember memberToRemove = getCoreMemberById( memberId );
+        CoreClusterMember memberToRemove = getCoreMemberById( serverId );
 
         if ( memberToRemove != null )
         {
@@ -258,7 +274,7 @@ public class Cluster
         }
         else
         {
-            throw new RuntimeException( "Could not remove core member with id " + memberId );
+            throw new RuntimeException( "Could not remove core member with id " + serverId );
         }
     }
 
@@ -303,27 +319,54 @@ public class Cluster
         return firstOrNull( readReplicas.values() );
     }
 
+    private void ensureDBName( String dbName ) throws IllegalArgumentException
+    {
+        if ( !dbNames.contains( dbName ) )
+        {
+            throw new IllegalArgumentException( "Database name " + dbName + " does not exist in this cluster." );
+        }
+    }
+
     public CoreClusterMember getDbWithRole( Role role )
     {
         return getDbWithAnyRole( role );
     }
 
+    public CoreClusterMember getDbWithRole( String dbName, Role role )
+    {
+        return getDbWithAnyRole( dbName, role );
+    }
+
     public CoreClusterMember getDbWithAnyRole( Role... roles )
     {
+        String dbName = CausalClusteringSettings.database.getDefaultValue();
+        return getDbWithAnyRole( dbName, roles );
+    }
+
+    public CoreClusterMember getDbWithAnyRole( String dbName, Role... roles )
+    {
+        ensureDBName( dbName );
         Set<Role> roleSet = Arrays.stream( roles ).collect( toSet() );
-        for ( CoreClusterMember coreClusterMember : coreMembers.values() )
-        {
-            if ( coreClusterMember.database() != null && roleSet.contains( coreClusterMember.database().getRole() ) )
-            {
-                return coreClusterMember;
-            }
-        }
-        return null;
+
+        Optional<CoreClusterMember> firstAppropriate = coreMembers.values().stream().filter( m ->
+            m.database() != null && m.dbName().equals( dbName ) &&  roleSet.contains( m.database().getRole() ) ).findFirst();
+
+        return firstAppropriate.orElse( null );
     }
 
     public CoreClusterMember awaitLeader() throws TimeoutException
     {
         return awaitCoreMemberWithRole( Role.LEADER, DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS );
+    }
+
+    public CoreClusterMember awaitLeader( String dbName ) throws TimeoutException
+    {
+        return awaitCoreMemberWithRole( dbName, Role.LEADER, DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS );
+    }
+
+    public CoreClusterMember awaitLeader( String dbName, long timeout, TimeUnit timeUnit ) throws TimeoutException
+    {
+        return awaitCoreMemberWithRole( dbName, Role.LEADER, timeout, timeUnit );
     }
 
     public CoreClusterMember awaitLeader( long timeout, TimeUnit timeUnit ) throws TimeoutException
@@ -336,13 +379,19 @@ public class Cluster
         return await( () -> getDbWithRole( role ), notNull(), timeout, timeUnit );
     }
 
+    public CoreClusterMember awaitCoreMemberWithRole( String dbName, Role role, long timeout, TimeUnit timeUnit ) throws TimeoutException
+    {
+        return await( () -> getDbWithRole( dbName, role ), notNull(), timeout, timeUnit );
+    }
+
     public int numberOfCoreMembersReportedByTopology()
     {
+
         CoreClusterMember aCoreGraphDb = coreMembers.values().stream()
                 .filter( member -> member.database() != null ).findAny().orElseThrow( IllegalArgumentException::new );
         CoreTopologyService coreTopologyService = aCoreGraphDb.database().getDependencyResolver()
                 .resolveDependency( CoreTopologyService.class );
-        return coreTopologyService.coreServers().members().size();
+        return coreTopologyService.localCoreServers().members().size();
     }
 
     /**
@@ -350,19 +399,28 @@ public class Cluster
      */
     public CoreClusterMember coreTx( BiConsumer<CoreGraphDatabase,Transaction> op ) throws Exception
     {
-        // this currently wraps the leader-only strategy, since it is the recommended and only approach
-        return leaderTx( op, DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS );
+        String dbName = CausalClusteringSettings.database.getDefaultValue();
+        return coreTx( dbName, op );
+    }
+
+    /**
+     * Perform a transaction against the core cluster, selecting the target and retrying as necessary.
+     */
+    public CoreClusterMember coreTx( String dbName, BiConsumer<CoreGraphDatabase,Transaction> op ) throws Exception
+    {
+        ensureDBName( dbName );
+        return leaderTx( dbName, op, DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS );
     }
 
     /**
      * Perform a transaction against the leader of the core cluster, retrying as necessary.
      */
-    private CoreClusterMember leaderTx( BiConsumer<CoreGraphDatabase,Transaction> op, int timeout, TimeUnit timeUnit )
+    private CoreClusterMember leaderTx( String dbName, BiConsumer<CoreGraphDatabase,Transaction> op, int timeout, TimeUnit timeUnit )
             throws Exception
     {
         ThrowingSupplier<CoreClusterMember,Exception> supplier = () ->
         {
-            CoreClusterMember member = awaitLeader( timeout, timeUnit );
+            CoreClusterMember member = awaitLeader( dbName, timeout, timeUnit );
             CoreGraphDatabase db = member.database();
             if ( db == null )
             {

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreClusterMember.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreClusterMember.java
@@ -48,6 +48,7 @@ import org.neo4j.kernel.impl.enterprise.configuration.OnlineBackupSettings;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.Level;
+import org.neo4j.management.CausalClustering;
 
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
@@ -72,6 +73,7 @@ public class CoreClusterMember implements ClusterMember<GraphDatabaseFacade>
     private final Config memberConfig;
     private final ThreadGroup threadGroup;
     private final Monitors monitors = new Monitors();
+    private final String dbName;
 
     public CoreClusterMember( int serverId,
                               int discoveryPort,
@@ -140,6 +142,8 @@ public class CoreClusterMember implements ClusterMember<GraphDatabaseFacade>
         raftLogDir = new File( clusterStateDir, RAFT_LOG_DIRECTORY_NAME );
         storeDir = new File( new File( dataDir, "databases" ), "graph.db" );
         memberConfig = Config.defaults( config );
+
+        this.dbName = memberConfig.get( CausalClusteringSettings.database );
 
         //noinspection ResultOfMethodCallIgnored
         storeDir.mkdirs();
@@ -237,6 +241,11 @@ public class CoreClusterMember implements ClusterMember<GraphDatabaseFacade>
     public int serverId()
     {
         return serverId;
+    }
+
+    public String dbName()
+    {
+        return dbName;
     }
 
     @Override

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/HazelcastClientTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/HazelcastClientTest.java
@@ -68,6 +68,7 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.kernel.configuration.BoltConnector;
 import org.neo4j.kernel.configuration.Config;
@@ -78,6 +79,7 @@ import org.neo4j.test.OnDemandJobScheduler;
 
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
@@ -86,6 +88,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.causalclustering.discovery.HazelcastClusterTopology.CLIENT_CONNECTOR_ADDRESSES;
+import static org.neo4j.causalclustering.discovery.HazelcastClusterTopology.MEMBER_DB_NAME;
 import static org.neo4j.causalclustering.discovery.HazelcastClusterTopology.MEMBER_UUID;
 import static org.neo4j.causalclustering.discovery.HazelcastClusterTopology.RAFT_SERVER;
 import static org.neo4j.causalclustering.discovery.HazelcastClusterTopology.TRANSACTION_SERVER;
@@ -95,10 +98,9 @@ public class HazelcastClientTest
 {
     private MemberId myself = new MemberId( UUID.randomUUID() );
     private TopologyServiceRetryStrategy topologyServiceRetryStrategy = new TopologyServiceNoRetriesStrategy();
-
-    private Config config()
-    {
+    private static final java.util.function.Supplier<HashMap<String, String>> DEFAULT_SETTINGS = () -> {
         HashMap<String, String> settings = new HashMap<>();
+
         settings.put( new BoltConnector( "bolt" ).type.name(), "BOLT" );
         settings.put( new BoltConnector( "bolt" ).enabled.name(), "true" );
         settings.put( new BoltConnector( "bolt" ).advertised_address.name(), "bolt:3001" );
@@ -106,41 +108,112 @@ public class HazelcastClientTest
         settings.put( new BoltConnector( "http" ).type.name(), "HTTP" );
         settings.put( new BoltConnector( "http" ).enabled.name(), "true" );
         settings.put( new BoltConnector( "http" ).advertised_address.name(), "http:3001" );
+        return settings;
+    };
 
-        return Config.defaults( settings );
+    private Config config( HashMap<String, String> settings )
+    {
+        HashMap<String, String> defaults = DEFAULT_SETTINGS.get();
+        defaults.putAll( settings );
+        return Config.defaults( defaults );
+    }
+
+    private Config config( String key, String value )
+    {
+        HashMap<String, String> defaults = DEFAULT_SETTINGS.get();
+        defaults.put(key, value);
+        return Config.defaults( defaults );
+    }
+
+    private Config config()
+    {
+
+        return Config.defaults( DEFAULT_SETTINGS.get() );
+    }
+
+    private HazelcastClient hzClient( OnDemandJobScheduler jobScheduler, com.hazelcast.core.Cluster cluster, Config config )
+    {
+        HazelcastConnector connector = mock( HazelcastConnector.class );
+
+        HazelcastClient client = new HazelcastClient( connector, jobScheduler, NullLogProvider.getInstance(), config, myself,
+                topologyServiceRetryStrategy );
+
+        HazelcastInstance hazelcastInstance = mock( HazelcastInstance.class );
+        when( connector.connectToHazelcast() ).thenReturn( hazelcastInstance );
+
+        when( hazelcastInstance.getSet( anyString() ) ).thenReturn( new HazelcastSet() );
+        when( hazelcastInstance.getMultiMap( anyString() ) ).thenReturn( new HazelcastMultiMap() );
+        when( hazelcastInstance.getMap( anyString() ) ).thenReturn( new HazelcastMap() );
+
+        when( hazelcastInstance.getCluster() ).thenReturn( cluster );
+        when( hazelcastInstance.getExecutorService( anyString() ) ).thenReturn( new StubExecutorService() );
+
+        return client;
+    }
+
+    private HazelcastClient startedClientWithMembers( Set<Member> members, Config config )
+    {
+        OnDemandJobScheduler jobScheduler = new OnDemandJobScheduler();
+        com.hazelcast.core.Cluster cluster = mock( Cluster.class );
+
+        when( cluster.getMembers() ).thenReturn( members );
+
+        HazelcastClient client = hzClient( jobScheduler, cluster, config );
+        client.start();
+        jobScheduler.runJob();
+
+        return client;
     }
 
     @Test
     public void shouldReturnTopologyUsingHazelcastMembers()
     {
         // given
-        HazelcastConnector connector = mock( HazelcastConnector.class );
-        OnDemandJobScheduler jobScheduler = new OnDemandJobScheduler();
-
-        HazelcastClient client = new HazelcastClient( connector, jobScheduler, NullLogProvider.getInstance(), config(), myself,
-                topologyServiceRetryStrategy );
-
-        HazelcastInstance hazelcastInstance = mock( HazelcastInstance.class );
-        when( connector.connectToHazelcast() ).thenReturn( hazelcastInstance );
-
-        when( hazelcastInstance.getAtomicReference( anyString() ) ).thenReturn( mock( IAtomicReference.class ) );
-        when( hazelcastInstance.getSet( anyString() ) ).thenReturn( new HazelcastSet() );
-        when( hazelcastInstance.getMultiMap( anyString() ) ).thenReturn( new HazelcastMultiMap() );
-
-        com.hazelcast.core.Cluster cluster = mock( Cluster.class );
-        when( hazelcastInstance.getCluster() ).thenReturn( cluster );
-        when( hazelcastInstance.getExecutorService( anyString() ) ).thenReturn( new StubExecutorService() );
-
         Set<Member> members = asSet( makeMember( 1 ), makeMember( 2 ) );
-        when( cluster.getMembers() ).thenReturn( members );
+        HazelcastClient client = startedClientWithMembers( members, config() );
 
         // when
-        client.start();
-        jobScheduler.runJob();
-        CoreTopology topology = client.coreServers();
+        CoreTopology topology = client.localCoreServers();
 
         // then
         assertEquals( members.size(), topology.members().size() );
+    }
+
+    @Test
+    public void localAndAllTopologiesShouldMatchForSingleDBName()
+    {
+        // given
+        Set<Member> members = asSet( makeMember( 1 ), makeMember( 2 ) );
+        HazelcastClient client = startedClientWithMembers( members, config() );
+
+        // then
+        String message = "Different local and global topologies reported despite single, default database name.";
+        assertEquals(message, client.allCoreServers(), client.localCoreServers() );
+    }
+
+    @Test
+    public void localAndAllTopologiesShouldDifferForMultipleDBNames()
+    {
+        // given
+        Set<Member> members = asSet( makeMember( 1, "foo" ), makeMember( 2, "bar" ) );
+        HazelcastClient client = startedClientWithMembers( members, config( CausalClusteringSettings.database.name(), "foo" ) );
+
+        // then
+        String message = "Identical local and global topologies reported despite multiple, distinct database names.";
+        assertNotEquals(message, client.allCoreServers(), client.localCoreServers() );
+        assertEquals( 1, client.localCoreServers().members().size() );
+    }
+
+    @Test
+    public void allTopologyShouldContainAllMembers()
+    {
+        // given
+        Set<Member> members = asSet( makeMember( 1, "foo" ), makeMember( 2, "bar" ) );
+        HazelcastClient client = startedClientWithMembers( members, config( CausalClusteringSettings.database.name(), "foo" ) );
+
+        // then
+        String message = "Global topology should contain all Hazelcast Members despite different db names.";
+        assertEquals(message, members.size(), client.allCoreServers().members().size() );
     }
 
     @Test
@@ -156,10 +229,10 @@ public class HazelcastClientTest
         HazelcastInstance hazelcastInstance = mock( HazelcastInstance.class );
         when( connector.connectToHazelcast() ).thenReturn( hazelcastInstance );
 
-        when( hazelcastInstance.getAtomicReference( anyString() ) ).thenReturn( mock( IAtomicReference.class ) );
         when( hazelcastInstance.getSet( anyString() ) ).thenReturn( new HazelcastSet() );
         when( hazelcastInstance.getMultiMap( anyString() ) ).thenReturn( new HazelcastMultiMap() );
         when( hazelcastInstance.getExecutorService( anyString() ) ).thenReturn( new StubExecutorService() );
+        when( hazelcastInstance.getMap( anyString() ) ).thenReturn( new HazelcastMap() );
 
         com.hazelcast.core.Cluster cluster = mock( Cluster.class );
         when( hazelcastInstance.getCluster() ).thenReturn( cluster );
@@ -174,7 +247,7 @@ public class HazelcastClientTest
         CoreTopology topology;
         for ( int i = 0; i < 5; i++ )
         {
-            topology = client.coreServers();
+            topology = client.allCoreServers();
             assertEquals( members.size(), topology.members().size() );
         }
 
@@ -210,7 +283,7 @@ public class HazelcastClientTest
         // when
         client.start();
         jobScheduler.runJob();
-        CoreTopology topology = client.coreServers();
+        CoreTopology topology = client.allCoreServers();
 
         assertEquals( 0, topology.members().size() );
     }
@@ -340,12 +413,18 @@ public class HazelcastClientTest
 
     private Member makeMember( int id )
     {
+        return makeMember( id, CausalClusteringSettings.database.getDefaultValue() );
+    }
+
+    private Member makeMember( int id, String databaseName )
+    {
         Member member = mock( Member.class );
         when( member.getStringAttribute( MEMBER_UUID ) ).thenReturn( UUID.randomUUID().toString() );
         when( member.getStringAttribute( TRANSACTION_SERVER ) ).thenReturn( format( "host%d:%d", id, 7000 + id ) );
         when( member.getStringAttribute( RAFT_SERVER ) ).thenReturn( format( "host%d:%d", id, 6000 + id ) );
         when( member.getStringAttribute( CLIENT_CONNECTOR_ADDRESSES ) )
                 .thenReturn( format( "bolt://host%d:%d,http://host%d:%d", id, 5000 + id, id, 5000 + id ) );
+        when( member.getStringAttribute( MEMBER_DB_NAME ) ).thenReturn( databaseName );
         return member;
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/HazelcastClusterTopologyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/HazelcastClusterTopologyTest.java
@@ -20,7 +20,6 @@
 package org.neo4j.causalclustering.discovery;
 
 import com.hazelcast.client.impl.MemberImpl;
-import com.hazelcast.concurrent.atomicreference.AtomicReferenceProxy;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicReference;
 import com.hazelcast.core.IMap;
@@ -32,7 +31,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -46,6 +44,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
+import org.neo4j.causalclustering.core.consensus.LeaderInfo;
 import org.neo4j.causalclustering.helpers.CausalClusteringTestHelpers;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
@@ -245,14 +244,14 @@ public class HazelcastClusterTopologyTest
                 .mapToObj( ignored -> new MemberId( UUID.randomUUID() ) ).collect( Collectors.toList() );
 
         @SuppressWarnings( "unchecked" )
-        IAtomicReference<RaftLeader> leaderRef = mock( IAtomicReference.class );
+        IAtomicReference<LeaderInfo> leaderRef = mock( IAtomicReference.class );
         MemberId chosenLeaderId = members.get( 0 );
-        when( leaderRef.get() ).thenReturn( new RaftLeader( chosenLeaderId, 0L ) );
+        when( leaderRef.get() ).thenReturn( new LeaderInfo( chosenLeaderId, 0L ) );
 
         @SuppressWarnings( "unchecked" )
         IMap<String, UUID> uuidDBMap = mock( IMap.class );
         when( uuidDBMap.keySet() ).thenReturn( Collections.singleton( DEFAULT_DB_NAME ) );
-        when( hzInstance.<RaftLeader>getAtomicReference( startsWith( DB_NAME_LEADER_TERM_PREFIX ) ) ).thenReturn( leaderRef );
+        when( hzInstance.<LeaderInfo>getAtomicReference( startsWith( DB_NAME_LEADER_TERM_PREFIX ) ) ).thenReturn( leaderRef );
         when( hzInstance.<String, UUID>getMap( eq( CLUSTER_UUID_DB_NAME_MAP ) ) ).thenReturn( uuidDBMap );
 
         // when

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/HazelcastClusterTopologyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/HazelcastClusterTopologyTest.java
@@ -20,26 +20,46 @@
 package org.neo4j.causalclustering.discovery;
 
 import com.hazelcast.client.impl.MemberImpl;
+import com.hazelcast.concurrent.atomicreference.AtomicReferenceProxy;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IAtomicReference;
+import com.hazelcast.core.IMap;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MultiMap;
 import com.hazelcast.nio.Address;
+import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.IntFunction;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
+import org.neo4j.causalclustering.helpers.CausalClusteringTestHelpers;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.kernel.configuration.BoltConnector;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.logging.AssertableLogProvider;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.neo4j.causalclustering.discovery.HazelcastClusterTopology.CLUSTER_UUID_DB_NAME_MAP;
+import static org.neo4j.causalclustering.discovery.HazelcastClusterTopology.DB_NAME_LEADER_TERM_PREFIX;
+import static org.neo4j.logging.AssertableLogProvider.inLog;
+import org.neo4j.logging.Log;
 import org.neo4j.logging.NullLog;
 
 import static org.hamcrest.CoreMatchers.hasItems;
@@ -58,6 +78,23 @@ public class HazelcastClusterTopologyTest
 {
     private static final Set<String> GROUPS = asSet( "group1", "group2", "group3" );
 
+    private static final Set<String> DB_NAMES = Stream.of( "foo", "bar", "baz" ).collect( Collectors.toSet() );
+    private static final String DEFAULT_DB_NAME = "default";
+
+    private static final IntFunction<HashMap<String, String>> DEFAULT_SETTINGS_GENERATOR = i -> {
+        HashMap<String, String> settings = new HashMap<>();
+        settings.put( CausalClusteringSettings.transaction_advertised_address.name(), "tx:" + (i + 1) );
+        settings.put( CausalClusteringSettings.raft_advertised_address.name(), "raft:" + (i + 1) );
+        settings.put( new BoltConnector( "bolt" ).type.name(), "BOLT" );
+        settings.put( new BoltConnector( "bolt" ).enabled.name(), "true" );
+        settings.put( new BoltConnector( "bolt" ).advertised_address.name(), "bolt:" + (i + 1) );
+        settings.put( new BoltConnector( "http" ).type.name(), "HTTP" );
+        settings.put( new BoltConnector( "http" ).enabled.name(), "true" );
+        settings.put( new BoltConnector( "http" ).advertised_address.name(), "http:" + (i + 1) );
+
+        return settings;
+    };
+
     private final HazelcastInstance hzInstance = mock( HazelcastInstance.class );
 
     @Before
@@ -69,79 +106,160 @@ public class HazelcastClusterTopologyTest
         when( hzInstance.getMultiMap( anyString() ) ).thenReturn( (MultiMap) serverGroupsMMap );
     }
 
+    private static List<Config> generateConfigs( int numConfigs )
+    {
+        return generateConfigs( numConfigs, DEFAULT_SETTINGS_GENERATOR );
+    }
+
+    private static List<Config> generateConfigs( int numConfigs, IntFunction<HashMap<String, String>> generator )
+    {
+        return IntStream.range(0, numConfigs).mapToObj( generator ).map( Config::defaults ).collect( Collectors.toList() );
+    }
+
     @Test
     public void shouldCollectMembersAsAMap() throws Exception
     {
         // given
+        int numMembers = 5;
         Set<Member> hazelcastMembers = new HashSet<>();
         List<MemberId> coreMembers = new ArrayList<>();
-        for ( int i = 0; i < 5; i++ )
+
+        List<Config> configs = generateConfigs( numMembers );
+
+        for ( int i = 0; i < configs.size(); i++ )
         {
-            MemberId memberId = new MemberId( UUID.randomUUID() );
-            coreMembers.add( memberId );
-            Config config = Config.defaults();
-            HashMap<String, String> settings = new HashMap<>();
-            settings.put( CausalClusteringSettings.transaction_advertised_address.name(), "tx:" + (i + 1) );
-            settings.put( CausalClusteringSettings.raft_advertised_address.name(), "raft:" + (i + 1) );
-            settings.put( new BoltConnector( "bolt" ).type.name(), "BOLT" );
-            settings.put( new BoltConnector( "bolt" ).enabled.name(), "true" );
-            settings.put( new BoltConnector( "bolt" ).advertised_address.name(), "bolt:" + (i + 1) );
-            settings.put( new BoltConnector( "http" ).type.name(), "HTTP" );
-            settings.put( new BoltConnector( "http" ).enabled.name(), "true" );
-            settings.put( new BoltConnector( "http" ).advertised_address.name(), "http:" + (i + 1) );
+            MemberId mId = new MemberId( UUID.randomUUID() );
+            coreMembers.add( mId );
 
-            config.augment( settings );
-            Map<String, Object> attributes = buildMemberAttributesForCore( memberId, config ).getAttributes();
+            Config c = configs.get( i );
+            Map<String, Object> attributes = buildMemberAttributesForCore( mId, c ).getAttributes();
             hazelcastMembers.add( new MemberImpl( new Address( "localhost", i ), null, attributes, false ) );
-
         }
 
         // when
         Map<MemberId,CoreServerInfo> coreMemberMap = toCoreMemberMap( hazelcastMembers, NullLog.getInstance(), hzInstance );
 
         // then
-        for ( int i = 0; i < 5; i++ )
+        for ( int i = 0; i < numMembers; i++ )
         {
             CoreServerInfo coreServerInfo = coreMemberMap.get( coreMembers.get( i ) );
             assertEquals( new AdvertisedSocketAddress( "tx", i + 1 ), coreServerInfo.getCatchupServer() );
             assertEquals( new AdvertisedSocketAddress( "raft", i + 1 ), coreServerInfo.getRaftServer() );
             assertEquals( new AdvertisedSocketAddress( "bolt", i + 1 ), coreServerInfo.connectors().boltAddress() );
+            assertEquals( coreServerInfo.getDatabaseName(), DEFAULT_DB_NAME );
             assertEquals( coreServerInfo.groups(), GROUPS );
         }
+    }
+
+    @Test
+    public void shouldBuildMemberAttributedWithSpecifiedDBNames() throws Exception
+    {
+        //given
+        int numMembers = 10;
+        Set<Member> hazelcastMembers = new HashSet<>();
+        List<MemberId> coreMembers = new ArrayList<>();
+
+        Map<Integer, String> dbNames = CausalClusteringTestHelpers.distributeDatabaseNamesToHostNums( numMembers, DB_NAMES );
+        IntFunction<HashMap<String, String>> generator = i -> {
+            HashMap<String, String> settings =  DEFAULT_SETTINGS_GENERATOR.apply( i );
+            settings.put( CausalClusteringSettings.database.name(), dbNames.get( i ) );
+            return settings;
+        };
+
+        List<Config> configs = generateConfigs( numMembers, generator );
+
+        for ( int i = 0; i < configs.size(); i++ )
+        {
+            MemberId mId = new MemberId( UUID.randomUUID() );
+            coreMembers.add( mId );
+
+            Config c = configs.get( i );
+            Map<String, Object> attributes = buildMemberAttributesForCore( mId, c ).getAttributes();
+            hazelcastMembers.add( new MemberImpl( new Address( "localhost", i ), null, attributes, false ) );
+        }
+
+        // when
+        Map<MemberId,CoreServerInfo> coreMemberMap = toCoreMemberMap( hazelcastMembers, NullLog.getInstance(), hzInstance );
+
+        // then
+        for ( int i = 0; i < numMembers; i++ )
+        {
+            CoreServerInfo coreServerInfo = coreMemberMap.get( coreMembers.get( i ) );
+            String expectedDBName = dbNames.get( i );
+            assertEquals( expectedDBName, coreServerInfo.getDatabaseName() );
+        }
+
     }
 
     @Test
     public void shouldLogAndExcludeMembersWithMissingAttributes() throws Exception
     {
         // given
+        int numMembers = 4;
         Set<Member> hazelcastMembers = new HashSet<>();
         List<MemberId> coreMembers = new ArrayList<>();
-        for ( int i = 0; i < 4; i++ )
+
+        IntFunction<HashMap<String, String>> generator = i -> {
+            HashMap<String, String> settings =  DEFAULT_SETTINGS_GENERATOR.apply( i );
+            settings.remove( CausalClusteringSettings.transaction_advertised_address.name() );
+            settings.remove( CausalClusteringSettings.raft_advertised_address.name() );
+            return settings;
+        };
+
+        List<Config> configs = generateConfigs( numMembers, generator );
+
+        for ( int i = 0; i < configs.size(); i++ )
         {
             MemberId memberId = new MemberId( UUID.randomUUID() );
             coreMembers.add( memberId );
-            Config config = Config.defaults();
-            HashMap<String, String> settings = new HashMap<>();
-            settings.put( new BoltConnector( "bolt" ).type.name(), "BOLT" );
-            settings.put( new BoltConnector( "bolt" ).enabled.name(), "true" );
-            settings.put( new BoltConnector( "bolt" ).advertised_address.name(), "bolt:" + (i + 1) );
-            settings.put( new BoltConnector( "http" ).type.name(), "HTTP" );
-            settings.put( new BoltConnector( "http" ).enabled.name(), "true" );
-            settings.put( new BoltConnector( "http" ).advertised_address.name(), "http:" + (i + 1) );
-
-            config.augment( settings );
-            Map<String, Object> attributes = buildMemberAttributesForCore( memberId, config ).getAttributes();
+            Config c = configs.get( i );
+            Map<String, Object> attributes = buildMemberAttributesForCore( memberId, c ).getAttributes();
             if ( i == 2 )
             {
                 attributes.remove( HazelcastClusterTopology.RAFT_SERVER );
             }
             hazelcastMembers.add( new MemberImpl( new Address( "localhost", i ), null, attributes, false ) );
         }
+
         // when
-        Map<MemberId,CoreServerInfo> map = toCoreMemberMap( hazelcastMembers, NullLog.getInstance(), hzInstance );
+        AssertableLogProvider logProvider = new AssertableLogProvider();
+        Log log = logProvider.getLog( this.getClass() );
+        Map<MemberId,CoreServerInfo> map = toCoreMemberMap( hazelcastMembers, log, hzInstance );
 
         // then
         assertThat( map.keySet(), hasItems( coreMembers.get( 0 ), coreMembers.get( 1 ), coreMembers.get( 3 ) ) );
         assertThat( map.keySet(), not( hasItems( coreMembers.get( 2 ) ) ) );
+        logProvider.assertExactly( inLog( this.getClass() )
+                .warn( equalTo("Incomplete member attributes supplied from Hazelcast"),
+                        CoreMatchers.instanceOf( IllegalArgumentException.class )) );
+
     }
+
+    @Test
+    public void shouldCorrectlyReturnCoreMemberRoles()
+    {
+        //given
+        int numMembers = 3;
+
+        List<MemberId> members = IntStream.range(0, numMembers)
+                .mapToObj( ignored -> new MemberId( UUID.randomUUID() ) ).collect( Collectors.toList() );
+
+        @SuppressWarnings( "unchecked" )
+        IAtomicReference<RaftLeader> leaderRef = mock( IAtomicReference.class );
+        MemberId chosenLeaderId = members.get( 0 );
+        when( leaderRef.get() ).thenReturn( new RaftLeader( chosenLeaderId, 0L ) );
+
+        @SuppressWarnings( "unchecked" )
+        IMap<String, UUID> uuidDBMap = mock( IMap.class );
+        when( uuidDBMap.keySet() ).thenReturn( Collections.singleton( DEFAULT_DB_NAME ) );
+        when( hzInstance.<RaftLeader>getAtomicReference( startsWith( DB_NAME_LEADER_TERM_PREFIX ) ) ).thenReturn( leaderRef );
+        when( hzInstance.<String, UUID>getMap( eq( CLUSTER_UUID_DB_NAME_MAP ) ) ).thenReturn( uuidDBMap );
+
+        // when
+        Map<MemberId, RoleInfo> roleMap = HazelcastClusterTopology.getCoreRoles( hzInstance, new HashSet<>( members ) );
+
+        // then
+        assertEquals( "First member was expected to be leader.", RoleInfo.LEADER, roleMap.get( chosenLeaderId ) );
+    }
+
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryCoreClient.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryCoreClient.java
@@ -19,58 +19,97 @@
  */
 package org.neo4j.causalclustering.discovery;
 
-import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.identity.ClusterId;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 
-class SharedDiscoveryCoreClient extends LifecycleAdapter implements CoreTopologyService
+class SharedDiscoveryCoreClient extends AbstractTopologyService implements CoreTopologyService, Comparable<SharedDiscoveryCoreClient>
 {
     private final SharedDiscoveryService sharedDiscoveryService;
-    private final MemberId member;
+    private final MemberId myself;
     private final CoreServerInfo coreServerInfo;
-    private final Set<Listener> listeners = new LinkedHashSet<>();
+    private final CoreTopologyListenerService listenerService;
     private final Log log;
     private final boolean refusesToBeLeader;
+    private final String localDBName;
 
-    private CoreTopology coreTopology;
-    private ReadReplicaTopology readReplicaTopology;
+    private MemberId localLeader;
+    private long term;
 
-    SharedDiscoveryCoreClient( SharedDiscoveryService sharedDiscoveryService, MemberId member, LogProvider logProvider, Config config )
+    private volatile CoreTopology coreTopology;
+    private volatile ReadReplicaTopology readReplicaTopology;
+
+    SharedDiscoveryCoreClient( SharedDiscoveryService sharedDiscoveryService,
+            MemberId member, LogProvider logProvider, Config config )
     {
         this.sharedDiscoveryService = sharedDiscoveryService;
-        this.member = member;
+        this.listenerService = new CoreTopologyListenerService();
+        this.myself = member;
         this.coreServerInfo = extractCoreServerInfo( config );
         this.log = logProvider.getLog( getClass() );
         this.refusesToBeLeader = config.get( CausalClusteringSettings.refuse_to_be_leader );
+        this.term = -1L;
+        this.localDBName = config.get( CausalClusteringSettings.database );
+    }
+
+    @Override
+    public int compareTo( SharedDiscoveryCoreClient o )
+    {
+        return Optional.ofNullable( o ).map( c -> c.myself.getUuid().compareTo( this.myself.getUuid() ) ).orElse( -1 );
     }
 
     @Override
     public synchronized void addCoreTopologyListener( Listener listener )
     {
-        listeners.add( listener );
-        listener.onCoreTopologyChange( coreTopology );
+        listenerService.addCoreTopologyListener( listener );
+        listener.onCoreTopologyChange( localCoreServers() );
     }
 
     @Override
-    public boolean setClusterId( ClusterId clusterId )
+    public void removeCoreTopologyListener( Listener listener )
     {
-        return sharedDiscoveryService.casClusterId( clusterId );
+        listenerService.removeCoreTopologyListener( listener );
+    }
+
+    @Override
+    public boolean setClusterId( ClusterId clusterId, String dbName )
+    {
+        return sharedDiscoveryService.casClusterId( clusterId, dbName );
+    }
+
+    @Override
+    public Map<MemberId,RoleInfo> allCoreRoles()
+    {
+        return sharedDiscoveryService.getCoreRoles();
+    }
+
+    @Override
+    public void setLeader( MemberId memberId, String dbName, long term )
+    {
+        if ( this.term < term && memberId != null )
+        {
+            localLeader = memberId;
+            this.term = term;
+            sharedDiscoveryService.casLeaders( localLeader, term, localDBName );
+        }
     }
 
     @Override
     public void start() throws InterruptedException
     {
-        sharedDiscoveryService.registerCoreMember( member, coreServerInfo, this );
-        log.info( "Registered core server %s", member );
+        coreTopology = sharedDiscoveryService.getCoreTopology( this );
+        readReplicaTopology = sharedDiscoveryService.getReadReplicaTopology();
+
+        sharedDiscoveryService.registerCoreMember( this );
+        log.info( "Registered core server %s", myself );
+
         sharedDiscoveryService.waitForClusterFormation();
         log.info( "Cluster formed" );
     }
@@ -78,12 +117,12 @@ class SharedDiscoveryCoreClient extends LifecycleAdapter implements CoreTopology
     @Override
     public void stop()
     {
-        sharedDiscoveryService.unRegisterCoreMember( member, this );
-        log.info( "Unregistered core server %s", member );
+        sharedDiscoveryService.unRegisterCoreMember( this );
+        log.info( "Unregistered core server %s", myself );
     }
 
     @Override
-    public ReadReplicaTopology readReplicas()
+    public ReadReplicaTopology allReadReplicas()
     {
         return readReplicaTopology;
     }
@@ -91,26 +130,42 @@ class SharedDiscoveryCoreClient extends LifecycleAdapter implements CoreTopology
     @Override
     public Optional<AdvertisedSocketAddress> findCatchupAddress( MemberId upstream )
     {
-        return coreTopology.find( upstream )
+        return localCoreServers().find( upstream )
                 .map( info -> Optional.of( info.getCatchupServer() ) )
                 .orElseGet( () -> readReplicaTopology.find( upstream )
                         .map( ReadReplicaInfo::getCatchupServer ) );
     }
 
     @Override
-    public CoreTopology coreServers()
+    public CoreTopology allCoreServers()
     {
-        return coreTopology;
+        // It is perhaps confusing (Or even error inducing) that this core Topology will always contain the cluster id
+        // for the database local to the host upon which this method is called.
+        // TODO: evaluate returning clusterId = null for global Topologies returned by allCoreServers()
+        return this.coreTopology;
+    }
+
+    @Override
+    public String localDBName()
+    {
+        return localDBName;
+    }
+
+    public MemberId getMemberId()
+    {
+        return myself;
+    }
+
+    public CoreServerInfo getCoreServerInfo()
+    {
+        return coreServerInfo;
     }
 
     synchronized void onCoreTopologyChange( CoreTopology coreTopology )
     {
         log.info( "Notified of core topology change " + coreTopology );
         this.coreTopology = coreTopology;
-        for ( Listener listener : listeners )
-        {
-            listener.onCoreTopologyChange( coreTopology );
-        }
+        listenerService.notifyListeners( coreTopology );
     }
 
     synchronized void onReadReplicaTopologyChange( ReadReplicaTopology readReplicaTopology )
@@ -124,12 +179,20 @@ class SharedDiscoveryCoreClient extends LifecycleAdapter implements CoreTopology
         AdvertisedSocketAddress raftAddress = config.get( CausalClusteringSettings.raft_advertised_address );
         AdvertisedSocketAddress transactionSource = config.get( CausalClusteringSettings.transaction_advertised_address );
         ClientConnectorAddresses clientConnectorAddresses = ClientConnectorAddresses.extractFromConfig( config );
+        String dbName = config.get( CausalClusteringSettings.database );
 
-        return new CoreServerInfo( raftAddress, transactionSource, clientConnectorAddresses );
+        return new CoreServerInfo( raftAddress, transactionSource, clientConnectorAddresses, dbName );
     }
 
     public boolean refusesToBeLeader()
     {
         return refusesToBeLeader;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "SharedDiscoveryCoreClient{" + "myself=" + myself + ", coreServerInfo=" + coreServerInfo + ", refusesToBeLeader=" + refusesToBeLeader +
+                ", localDBName='" + localDBName + '\'' + ", localLeader=" + localLeader + ", term=" + term + ", coreTopology=" + coreTopology + '}';
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryCoreClient.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryCoreClient.java
@@ -64,14 +64,14 @@ class SharedDiscoveryCoreClient extends AbstractTopologyService implements CoreT
     }
 
     @Override
-    public synchronized void addCoreTopologyListener( Listener listener )
+    public synchronized void addLocalCoreTopologyListener( Listener listener )
     {
         listenerService.addCoreTopologyListener( listener );
         listener.onCoreTopologyChange( localCoreServers() );
     }
 
     @Override
-    public void removeCoreTopologyListener( Listener listener )
+    public void removeLocalCoreTopologyListener( Listener listener )
     {
         listenerService.removeCoreTopologyListener( listener );
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryReadReplicaClient.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryReadReplicaClient.java
@@ -19,32 +19,34 @@
  */
 package org.neo4j.causalclustering.discovery;
 
+import java.util.Map;
 import java.util.Optional;
 
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 
 import static org.neo4j.helpers.SocketAddressParser.socketAddress;
 
-class SharedDiscoveryReadReplicaClient extends LifecycleAdapter implements TopologyService
+class SharedDiscoveryReadReplicaClient extends AbstractTopologyService
 {
     private final SharedDiscoveryService sharedDiscoveryService;
     private final ReadReplicaInfo addresses;
     private final MemberId memberId;
     private final Log log;
+    private final String dbName;
 
     SharedDiscoveryReadReplicaClient( SharedDiscoveryService sharedDiscoveryService, Config config, MemberId memberId,
             LogProvider logProvider )
     {
         this.sharedDiscoveryService = sharedDiscoveryService;
+        this.dbName = config.get( CausalClusteringSettings.database );
         this.addresses = new ReadReplicaInfo( ClientConnectorAddresses.extractFromConfig( config ),
                 socketAddress( config.get( CausalClusteringSettings.transaction_advertised_address ).toString(),
-                        AdvertisedSocketAddress::new ) );
+                        AdvertisedSocketAddress::new ), dbName );
         this.memberId = memberId;
         this.log = logProvider.getLog( getClass() );
     }
@@ -52,40 +54,58 @@ class SharedDiscoveryReadReplicaClient extends LifecycleAdapter implements Topol
     @Override
     public void start()
     {
-        sharedDiscoveryService.registerReadReplica( memberId, addresses );
+        sharedDiscoveryService.registerReadReplica( this );
         log.info( "Registered read replica member id: %s at %s", memberId, addresses );
     }
 
     @Override
     public void stop()
     {
-        sharedDiscoveryService.unRegisterReadReplica( memberId);
+        sharedDiscoveryService.unRegisterReadReplica( this );
     }
 
     @Override
-    public CoreTopology coreServers()
+    public CoreTopology allCoreServers()
     {
-        CoreTopology topology = sharedDiscoveryService.coreTopology( null );
-        log.info( "Core topology is %s", topology );
-        return topology;
+        return sharedDiscoveryService.getCoreTopology( dbName, false );
     }
 
     @Override
-    public ReadReplicaTopology readReplicas()
+    public ReadReplicaTopology allReadReplicas()
     {
-        ReadReplicaTopology topology = sharedDiscoveryService.readReplicaTopology();
-        log.info( "Read replica topology is %s", topology );
-        return topology;
+        return sharedDiscoveryService.getReadReplicaTopology();
     }
 
     @Override
     public Optional<AdvertisedSocketAddress> findCatchupAddress( MemberId upstream )
     {
-        return sharedDiscoveryService.coreTopology( null )
+        return sharedDiscoveryService.getCoreTopology( dbName, false )
                 .find( upstream )
                 .map( info -> Optional.of( info.getCatchupServer() ) )
-                .orElseGet( () -> sharedDiscoveryService.readReplicaTopology()
+                .orElseGet( () -> sharedDiscoveryService.getReadReplicaTopology()
                         .find( upstream )
                         .map( ReadReplicaInfo::getCatchupServer ) );
+    }
+
+    @Override
+    public String localDBName()
+    {
+        return dbName;
+    }
+
+    @Override
+    public Map<MemberId,RoleInfo> allCoreRoles()
+    {
+        return sharedDiscoveryService.getCoreRoles();
+    }
+
+    public MemberId getMemberId()
+    {
+        return memberId;
+    }
+
+    public ReadReplicaInfo getReadReplicainfo()
+    {
+        return addresses;
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryService.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryService.java
@@ -35,7 +35,7 @@ import org.neo4j.causalclustering.core.consensus.LeaderInfo;
 import org.neo4j.causalclustering.identity.ClusterId;
 import org.neo4j.causalclustering.identity.MemberId;
 
-public class SharedDiscoveryService
+public final class SharedDiscoveryService
 {
     private static final int MIN_DISCOVERY_MEMBERS = 2;
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryServiceFactory.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryServiceFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.discovery;
+
+import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.scheduler.JobScheduler;
+
+public class SharedDiscoveryServiceFactory implements DiscoveryServiceFactory
+{
+
+    private final SharedDiscoveryService discoveryService = new SharedDiscoveryService();
+
+    @Override
+    public CoreTopologyService coreTopologyService( Config config, MemberId myself, JobScheduler jobScheduler, LogProvider logProvider,
+            LogProvider userLogProvider, HostnameResolver hostnameResolver, TopologyServiceRetryStrategy topologyServiceRetryStrategy )
+    {
+        return new SharedDiscoveryCoreClient( discoveryService, myself, logProvider, config );
+    }
+
+    @Override
+    public TopologyService topologyService( Config config, LogProvider logProvider, JobScheduler jobScheduler, MemberId myself,
+            HostnameResolver hostnameResolver, TopologyServiceRetryStrategy topologyServiceRetryStrategy )
+    {
+        return new SharedDiscoveryReadReplicaClient( discoveryService, config, myself, logProvider );
+    }
+
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryServiceIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryServiceIT.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -73,7 +72,7 @@ public class SharedDiscoveryServiceIT
                 members.add( new MemberId( UUID.randomUUID() ) );
             }
 
-            SharedDiscoveryService sharedService = new SharedDiscoveryService();
+            DiscoveryServiceFactory sharedService = new SharedDiscoveryServiceFactory();
 
             List<Callable<Void>> discoveryJobs = new ArrayList<>();
             for ( MemberId member : members )
@@ -118,8 +117,10 @@ public class SharedDiscoveryServiceIT
             try
             {
                 RaftMachine raftMock = mock( RaftMachine.class );
+                RaftCoreTopologyConnector tc = new RaftCoreTopologyConnector( topologyService,
+                        raftMock, CausalClusteringSettings.database.getDefaultValue() );
                 topologyService.start();
-                topologyService.addCoreTopologyListener( new RaftCoreTopologyConnector( topologyService, raftMock ) );
+                tc.start();
 
                 assertEventually( "should discover complete target set", () ->
                 {

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/TestTopology.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/TestTopology.java
@@ -49,7 +49,7 @@ public class TestTopology
         AdvertisedSocketAddress catchupServerAddress = new AdvertisedSocketAddress( "localhost", 4000 + id );
         AdvertisedSocketAddress boltServerAddress = new AdvertisedSocketAddress( "localhost", 5000 + id );
         return new CoreServerInfo( raftServerAddress, catchupServerAddress, wrapAsClientConnectorAddresses( boltServerAddress ),
-                asSet( "core", "core" + id ) );
+                asSet( "core", "core" + id ), "default" );
     }
 
     public static ReadReplicaInfo addressesForReadReplica( int id )
@@ -59,7 +59,7 @@ public class TestTopology
                 singletonList( new ClientConnectorAddresses.ConnectorUri( bolt, advertisedSocketAddress ) ) );
 
         return new ReadReplicaInfo( clientConnectorAddresses, advertisedSocketAddress,
-                asSet( "replica", "replica" + id ) );
+                asSet( "replica", "replica" + id ), "default" );
     }
 
     public static Map<MemberId,ReadReplicaInfo> readReplicaInfoMap( int... ids )
@@ -74,6 +74,6 @@ public class TestTopology
         return new ReadReplicaInfo(
                 new ClientConnectorAddresses( singletonList( new ClientConnectorAddresses.ConnectorUri( bolt, advertisedSocketAddress ) ) ),
                 new AdvertisedSocketAddress( "localhost", 4000 + id ),
-                asSet( "replica", "replica" + id ) );
+                asSet( "replica", "replica" + id ), "default" );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/TopologyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/TopologyTest.java
@@ -126,6 +126,15 @@ public class TopologyTest
         {
             return members;
         }
+
+        @Override
+        public Topology<ReadReplicaInfo> filterTopologyByDb( String dbName )
+        {
+            Map<MemberId, ReadReplicaInfo> newMembers = this.members.entrySet().stream()
+                    .filter( e -> e.getValue().getDatabaseName().equals( dbName ) )
+                    .collect( Collectors.toMap( Map.Entry::getKey, Map.Entry::getValue ) );
+            return new TestTopology( newMembers );
+        }
     }
 
     private Map<MemberId,ReadReplicaInfo> randomMembers( int quantity )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/procedures/RoleProcedureTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/procedures/RoleProcedureTest.java
@@ -21,6 +21,7 @@ package org.neo4j.causalclustering.discovery.procedures;
 
 import org.junit.Test;
 
+import org.neo4j.causalclustering.discovery.RoleInfo;
 import org.neo4j.causalclustering.core.consensus.RaftMachine;
 import org.neo4j.collection.RawIterator;
 import org.neo4j.helpers.collection.Iterators;
@@ -45,7 +46,7 @@ public class RoleProcedureTest
         RawIterator<Object[], ProcedureException> result = proc.apply( null, null, null );
 
         // then
-        assertEquals( Role.LEADER.name(), single( result )[0]);
+        assertEquals( RoleInfo.LEADER.name(), single( result )[0]);
     }
 
     @Test
@@ -60,7 +61,7 @@ public class RoleProcedureTest
         RawIterator<Object[], ProcedureException> result = proc.apply( null, null, null );
 
         // then
-        assertEquals( Role.FOLLOWER.name(), single( result )[0]);
+        assertEquals( RoleInfo.FOLLOWER.name(), single( result )[0]);
     }
 
     @Test
@@ -73,7 +74,7 @@ public class RoleProcedureTest
         RawIterator<Object[], ProcedureException> result = proc.apply( null, null, null );
 
         // then
-        assertEquals( Role.READ_REPLICA.name(), single( result )[0]);
+        assertEquals( RoleInfo.READ_REPLICA.name(), single( result )[0]);
     }
 
     private Object[] single( RawIterator<Object[], ProcedureException> result ) throws ProcedureException

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helpers/CausalClusteringTestHelpers.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helpers/CausalClusteringTestHelpers.java
@@ -19,6 +19,13 @@
  */
 package org.neo4j.causalclustering.helpers;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.kernel.configuration.Config;
@@ -33,5 +40,24 @@ public class CausalClusteringTestHelpers
                 .resolveDependency( Config.class )
                 .get( CausalClusteringSettings.transaction_advertised_address );
         return String.format( "%s:%s", hostnamePort.getHostname(), hostnamePort.getPort() );
+    }
+
+    public static Map<Integer, String> distributeDatabaseNamesToHostNums( int nHosts, Set<String> databaseNames )
+    {
+        //Max number of hosts per database is (nHosts / nDatabases) or (nHosts / nDatabases) + 1
+        int nDatabases = databaseNames.size();
+        int maxCapacity = (nHosts % nDatabases == 0) ? (nHosts / nDatabases) : (nHosts / nDatabases) + 1;
+
+        List<String> repeated = databaseNames.stream()
+                .flatMap( db -> IntStream.range( 0, maxCapacity ).mapToObj( ignored -> db ) )
+                .collect( Collectors.toList() );
+
+        Map<Integer,String> mapping = new HashMap<>( nHosts );
+
+        for ( int hostId = 0; hostId < nHosts; hostId++ )
+        {
+            mapping.put( hostId, repeated.get( hostId ) );
+        }
+        return mapping;
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/identity/ClusterBinderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/identity/ClusterBinderTest.java
@@ -21,17 +21,23 @@ package org.neo4j.causalclustering.identity;
 
 import org.junit.Test;
 
-import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.IntStream;
 
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.core.state.CoreBootstrapper;
 import org.neo4j.causalclustering.core.state.snapshot.CoreSnapshot;
 import org.neo4j.causalclustering.core.state.storage.SimpleStorage;
+import org.neo4j.causalclustering.discovery.CoreServerInfo;
 import org.neo4j.causalclustering.discovery.CoreTopology;
 import org.neo4j.causalclustering.discovery.CoreTopologyService;
+import org.neo4j.causalclustering.discovery.TestTopology;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.time.Clocks;
 import org.neo4j.time.FakeClock;
@@ -41,6 +47,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -51,17 +58,29 @@ public class ClusterBinderTest
     private final CoreBootstrapper coreBootstrapper = mock( CoreBootstrapper.class );
     private final FakeClock clock = Clocks.fakeClock();
 
+    private final Config config = Config.defaults();
+    private final int minCoreHosts = config.get( CausalClusteringSettings.minimum_core_cluster_size_at_formation );
+    private final String dbName = config.get( CausalClusteringSettings.database );
+
+    private ClusterBinder clusterBinder( SimpleStorage<ClusterId> clusterIdStorage, CoreTopologyService topologyService )
+    {
+        return new ClusterBinder( clusterIdStorage, topologyService, NullLogProvider.getInstance(), clock,
+                () -> clock.forward( 1, TimeUnit.SECONDS ), 3_000, coreBootstrapper, dbName, minCoreHosts );
+    }
+
     @Test
     public void shouldTimeoutWhenNotBootrappableAndNobodyElsePublishesClusterId() throws Throwable
     {
         // given
         CoreTopology unboundTopology = new CoreTopology( null, false, emptyMap() );
         CoreTopologyService topologyService = mock( CoreTopologyService.class );
-        when( topologyService.coreServers() ).thenReturn( unboundTopology );
+        when( topologyService.localCoreServers() ).thenReturn( unboundTopology );
 
-        ClusterBinder binder = new ClusterBinder( new StubClusterIdStorage(), topologyService,
-                NullLogProvider.getInstance(), clock, () -> clock.forward( 1, TimeUnit.SECONDS ), 3_000,
-                coreBootstrapper );
+        Config config = Config.defaults();
+        int minCoreHosts = config.get( CausalClusteringSettings.minimum_core_cluster_size_at_formation );
+        String dbName = config.get( CausalClusteringSettings.database );
+
+        ClusterBinder binder = clusterBinder( new StubClusterIdStorage(), topologyService );
 
         try
         {
@@ -75,7 +94,7 @@ public class ClusterBinderTest
         }
 
         // then
-        verify( topologyService, atLeast( 2 ) ).coreServers();
+        verify( topologyService, atLeast( 2 ) ).localCoreServers();
     }
 
     @Test
@@ -87,11 +106,9 @@ public class ClusterBinderTest
         CoreTopology boundTopology = new CoreTopology( publishedClusterId, false, emptyMap() );
 
         CoreTopologyService topologyService = mock( CoreTopologyService.class );
-        when( topologyService.coreServers() ).thenReturn( unboundTopology ).thenReturn( boundTopology );
+        when( topologyService.localCoreServers() ).thenReturn( unboundTopology ).thenReturn( boundTopology );
 
-        ClusterBinder binder = new ClusterBinder( new StubClusterIdStorage(), topologyService,
-                NullLogProvider.getInstance(), clock, () -> clock.forward( 1, TimeUnit.SECONDS ), 3_000,
-                coreBootstrapper );
+        ClusterBinder binder = clusterBinder( new StubClusterIdStorage(), topologyService );
 
         // when
         binder.bindToCluster();
@@ -100,7 +117,7 @@ public class ClusterBinderTest
         Optional<ClusterId> clusterId = binder.get();
         assertTrue( clusterId.isPresent() );
         assertEquals( publishedClusterId, clusterId.get() );
-        verify( topologyService, atLeast( 2 ) ).coreServers();
+        verify( topologyService, atLeast( 2 ) ).localCoreServers();
     }
 
     @Test
@@ -110,20 +127,18 @@ public class ClusterBinderTest
         ClusterId previouslyBoundClusterId = new ClusterId( UUID.randomUUID() );
 
         CoreTopologyService topologyService = mock( CoreTopologyService.class );
-        when( topologyService.setClusterId( previouslyBoundClusterId ) ).thenReturn( true );
+        when( topologyService.setClusterId( previouslyBoundClusterId, "default" ) ).thenReturn( true );
 
         StubClusterIdStorage clusterIdStorage = new StubClusterIdStorage();
         clusterIdStorage.writeState( previouslyBoundClusterId );
 
-        ClusterBinder binder = new ClusterBinder( clusterIdStorage, topologyService,
-                NullLogProvider.getInstance(), clock, () -> clock.forward( 1, TimeUnit.SECONDS ), 3_000,
-                coreBootstrapper );
+        ClusterBinder binder = clusterBinder( clusterIdStorage, topologyService );
 
         // when
         binder.bindToCluster();
 
         // then
-        verify( topologyService ).setClusterId( previouslyBoundClusterId );
+        verify( topologyService ).setClusterId( previouslyBoundClusterId, "default" );
         Optional<ClusterId> clusterId = binder.get();
         assertTrue( clusterId.isPresent() );
         assertEquals( previouslyBoundClusterId, clusterId.get() );
@@ -136,14 +151,12 @@ public class ClusterBinderTest
         ClusterId previouslyBoundClusterId = new ClusterId( UUID.randomUUID() );
 
         CoreTopologyService topologyService = mock( CoreTopologyService.class );
-        when( topologyService.setClusterId( previouslyBoundClusterId ) ).thenReturn( false );
+        when( topologyService.setClusterId( previouslyBoundClusterId, "default" ) ).thenReturn( false );
 
         StubClusterIdStorage clusterIdStorage = new StubClusterIdStorage();
         clusterIdStorage.writeState( previouslyBoundClusterId );
 
-        ClusterBinder binder = new ClusterBinder( clusterIdStorage, topologyService,
-                NullLogProvider.getInstance(), clock, () -> clock.forward( 1, TimeUnit.SECONDS ), 3_000,
-                coreBootstrapper );
+        ClusterBinder binder = clusterBinder( clusterIdStorage, topologyService );
 
         // when
         try
@@ -161,17 +174,20 @@ public class ClusterBinderTest
     public void shouldBootstrapWhenBootstrappable() throws Throwable
     {
         // given
-        CoreTopology bootstrappableTopology = new CoreTopology( null, true, emptyMap() );
+        Map<MemberId,CoreServerInfo> members = new HashMap<>();
+
+        IntStream.range(0, minCoreHosts).forEach( i ->
+                members.put( new MemberId( UUID.randomUUID() ), TestTopology.addressesForCore( i ) ) );
+
+        CoreTopology bootstrappableTopology = new CoreTopology( null, true, members );
 
         CoreTopologyService topologyService = mock( CoreTopologyService.class );
-        when( topologyService.coreServers() ).thenReturn( bootstrappableTopology );
-        when( topologyService.setClusterId( any() ) ).thenReturn( true );
+        when( topologyService.localCoreServers() ).thenReturn( bootstrappableTopology );
+        when( topologyService.setClusterId( any(), eq("default" ) ) ).thenReturn( true );
         CoreSnapshot snapshot = mock( CoreSnapshot.class );
         when( coreBootstrapper.bootstrap( any() ) ).thenReturn( snapshot );
 
-        ClusterBinder binder = new ClusterBinder( new StubClusterIdStorage(), topologyService,
-                NullLogProvider.getInstance(), clock, () -> clock.forward( 1, TimeUnit.SECONDS ),
-                3_000, coreBootstrapper );
+        ClusterBinder binder = clusterBinder( new StubClusterIdStorage(), topologyService );
 
         // when
         BoundState boundState = binder.bindToCluster();
@@ -180,7 +196,7 @@ public class ClusterBinderTest
         verify( coreBootstrapper ).bootstrap( any() );
         Optional<ClusterId> clusterId = binder.get();
         assertTrue( clusterId.isPresent() );
-        verify( topologyService ).setClusterId( clusterId.get() );
+        verify( topologyService ).setClusterId( clusterId.get(), "default" );
         assertTrue( boundState.snapshot().isPresent() );
         assertEquals( boundState.snapshot().get(), snapshot );
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/procedure/GetServersProcedureV1RoutingTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/procedure/GetServersProcedureV1RoutingTest.java
@@ -81,8 +81,8 @@ public class GetServersProcedureV1RoutingTest
         coreMembers.put( member( 2 ), addressesForCore( 2 ) );
 
         final CoreTopology clusterTopology = new CoreTopology( clusterId, false, coreMembers );
-        when( coreTopologyService.coreServers() ).thenReturn( clusterTopology );
-        when( coreTopologyService.readReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
+        when( coreTopologyService.localCoreServers() ).thenReturn( clusterTopology );
+        when( coreTopologyService.localReadReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
 
         final LegacyGetServersProcedure proc =
                 new LegacyGetServersProcedure( coreTopologyService, leaderLocator, config, getInstance() );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/procedure/GetServersProcedureV1Test.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/procedure/GetServersProcedureV1Test.java
@@ -102,8 +102,8 @@ public class GetServersProcedureV1Test
         LeaderLocator leaderLocator = mock( LeaderLocator.class );
 
         final CoreTopology clusterTopology = new CoreTopology( clusterId, false, new HashMap<>() );
-        when( coreTopologyService.coreServers() ).thenReturn( clusterTopology );
-        when( coreTopologyService.readReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
+        when( coreTopologyService.localCoreServers() ).thenReturn( clusterTopology );
+        when( coreTopologyService.localReadReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
 
         // set the TTL in minutes
         config.augment( cluster_routing_ttl, "10m" );
@@ -147,8 +147,8 @@ public class GetServersProcedureV1Test
         coreMembers.put( member( 0 ), addressesForCore( 0 ) );
 
         final CoreTopology clusterTopology = new CoreTopology( clusterId, false, coreMembers );
-        when( coreTopologyService.coreServers() ).thenReturn( clusterTopology );
-        when( coreTopologyService.readReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
+        when( coreTopologyService.localCoreServers() ).thenReturn( clusterTopology );
+        when( coreTopologyService.localReadReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
 
         final LegacyGetServersProcedure proc =
                 new LegacyGetServersProcedure( coreTopologyService, leaderLocator, config, getInstance() );
@@ -179,8 +179,8 @@ public class GetServersProcedureV1Test
         coreMembers.put( member( 2 ), addressesForCore( 2 ) );
 
         final CoreTopology clusterTopology = new CoreTopology( clusterId, false, coreMembers );
-        when( coreTopologyService.coreServers() ).thenReturn( clusterTopology );
-        when( coreTopologyService.readReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
+        when( coreTopologyService.localCoreServers() ).thenReturn( clusterTopology );
+        when( coreTopologyService.localReadReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
 
         final LegacyGetServersProcedure proc =
                 new LegacyGetServersProcedure( coreTopologyService, leaderLocator, config, getInstance() );
@@ -213,8 +213,8 @@ public class GetServersProcedureV1Test
         coreMembers.put( member( 0 ), addressesForCore( 0 ) );
 
         final CoreTopology clusterTopology = new CoreTopology( clusterId, false, coreMembers );
-        when( coreTopologyService.coreServers() ).thenReturn( clusterTopology );
-        when( coreTopologyService.readReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
+        when( coreTopologyService.localCoreServers() ).thenReturn( clusterTopology );
+        when( coreTopologyService.localReadReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
 
         final LegacyGetServersProcedure proc =
                 new LegacyGetServersProcedure( coreTopologyService, leaderLocator, config, getInstance() );
@@ -241,8 +241,8 @@ public class GetServersProcedureV1Test
         MemberId theLeader = member( 0 );
         coreMembers.put( theLeader, addressesForCore( 0 ) );
 
-        when( topologyService.coreServers() ).thenReturn( new CoreTopology( clusterId, false, coreMembers ) );
-        when( topologyService.readReplicas() ).thenReturn( new ReadReplicaTopology( readReplicaInfoMap( 1 ) ) );
+        when( topologyService.localCoreServers() ).thenReturn( new CoreTopology( clusterId, false, coreMembers ) );
+        when( topologyService.localReadReplicas() ).thenReturn( new ReadReplicaTopology( readReplicaInfoMap( 1 ) ) );
 
         LeaderLocator leaderLocator = mock( LeaderLocator.class );
         when( leaderLocator.getLeader() ).thenReturn( theLeader );
@@ -276,8 +276,8 @@ public class GetServersProcedureV1Test
         MemberId theLeader = member( 0 );
         coreMembers.put( theLeader, addressesForCore( 0 ) );
 
-        when( topologyService.coreServers() ).thenReturn( new CoreTopology( clusterId, false, coreMembers ) );
-        when( topologyService.readReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
+        when( topologyService.localCoreServers() ).thenReturn( new CoreTopology( clusterId, false, coreMembers ) );
+        when( topologyService.localReadReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
 
         LeaderLocator leaderLocator = mock( LeaderLocator.class );
         when( leaderLocator.getLeader() ).thenReturn( theLeader );
@@ -306,8 +306,8 @@ public class GetServersProcedureV1Test
         Map<MemberId,CoreServerInfo> coreMembers = new HashMap<>();
         coreMembers.put( member( 0 ), addressesForCore( 0 ) );
 
-        when( topologyService.coreServers() ).thenReturn( new CoreTopology( clusterId, false, coreMembers ) );
-        when( topologyService.readReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
+        when( topologyService.localCoreServers() ).thenReturn( new CoreTopology( clusterId, false, coreMembers ) );
+        when( topologyService.localReadReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
 
         LeaderLocator leaderLocator = mock( LeaderLocator.class );
         when( leaderLocator.getLeader() ).thenThrow( new NoLeaderFoundException() );
@@ -335,8 +335,8 @@ public class GetServersProcedureV1Test
         Map<MemberId,CoreServerInfo> coreMembers = new HashMap<>();
         coreMembers.put( member( 0 ), addressesForCore( 0 ) );
 
-        when( topologyService.coreServers() ).thenReturn( new CoreTopology( clusterId, false, coreMembers ) );
-        when( topologyService.readReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
+        when( topologyService.localCoreServers() ).thenReturn( new CoreTopology( clusterId, false, coreMembers ) );
+        when( topologyService.localReadReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
 
         LeaderLocator leaderLocator = mock( LeaderLocator.class );
         when( leaderLocator.getLeader() ).thenReturn( member( 1 ) );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/ConnectRandomlyToServerGroupStrategyImplTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/ConnectRandomlyToServerGroupStrategyImplTest.java
@@ -57,7 +57,7 @@ public class ConnectRandomlyToServerGroupStrategyImplTest
         MemberId[] myGroupMemberIds = memberIDs( 10 );
         TopologyService topologyService = getTopologyService( myServerGroup, myGroupMemberIds, Collections.singletonList( "your_server_group" ) );
 
-        ConnectRandomlyToServerGroupImpl strategy = new ConnectRandomlyToServerGroupImpl( myServerGroup, topologyService, myGroupMemberIds[0] );
+        ConnectRandomlyToServerGroupImpl strategy = new ConnectRandomlyToServerGroupImpl( myServerGroup, topologyService, myGroupMemberIds[0], "default" );
 
         // when
         Optional<MemberId> memberId = strategy.upstreamDatabase();
@@ -75,7 +75,7 @@ public class ConnectRandomlyToServerGroupStrategyImplTest
         MemberId[] myGroupMemberIds = memberIDs( 10 );
         TopologyService topologyService = getTopologyService( myServerGroups, myGroupMemberIds, Arrays.asList( "x", "y", "z" ) );
 
-        ConnectRandomlyToServerGroupImpl strategy = new ConnectRandomlyToServerGroupImpl( myServerGroups, topologyService, myGroupMemberIds[0] );
+        ConnectRandomlyToServerGroupImpl strategy = new ConnectRandomlyToServerGroupImpl( myServerGroups, topologyService, myGroupMemberIds[0], "default" );
 
         // when
         Optional<MemberId> memberId = strategy.upstreamDatabase();
@@ -91,7 +91,7 @@ public class ConnectRandomlyToServerGroupStrategyImplTest
         MemberId[] myGroupMemberIds = memberIDs( 10 );
         TopologyService topologyService =
                 getTopologyService( Collections.singletonList( "my_server_group" ), myGroupMemberIds, Arrays.asList( "x", "y", "z" ) );
-        ConnectRandomlyToServerGroupImpl strategy = new ConnectRandomlyToServerGroupImpl( Collections.emptyList(), topologyService, null );
+        ConnectRandomlyToServerGroupImpl strategy = new ConnectRandomlyToServerGroupImpl( Collections.emptyList(), topologyService, null, "default" );
 
         // when
         Optional<MemberId> memberId = strategy.upstreamDatabase();
@@ -109,7 +109,7 @@ public class ConnectRandomlyToServerGroupStrategyImplTest
         MemberId[] myGroupMemberIds = memberIDs( 1 );
         TopologyService topologyService = getTopologyService( myServerGroup, myGroupMemberIds, Arrays.asList( "x", "y", "z" ) );
 
-        ConnectRandomlyToServerGroupImpl strategy = new ConnectRandomlyToServerGroupImpl( myServerGroup, topologyService, myGroupMemberIds[0] );
+        ConnectRandomlyToServerGroupImpl strategy = new ConnectRandomlyToServerGroupImpl( myServerGroup, topologyService, myGroupMemberIds[0], "default" );
 
         // when
         Optional<MemberId> memberId = strategy.upstreamDatabase();
@@ -135,7 +135,7 @@ public class ConnectRandomlyToServerGroupStrategyImplTest
             readReplicas.put( memberId, new ReadReplicaInfo( new ClientConnectorAddresses( singletonList(
                     new ClientConnectorAddresses.ConnectorUri( ClientConnectorAddresses.Scheme.bolt,
                             new AdvertisedSocketAddress( "localhost", 11000 + offset ) ) ) ), new AdvertisedSocketAddress( "localhost", 10000 + offset ),
-                    new HashSet<>( wanted ) ) );
+                    new HashSet<>( wanted ), "default" ) );
 
             offset++;
         }
@@ -145,7 +145,7 @@ public class ConnectRandomlyToServerGroupStrategyImplTest
             readReplicas.put( new MemberId( UUID.randomUUID() ), new ReadReplicaInfo( new ClientConnectorAddresses( singletonList(
                     new ClientConnectorAddresses.ConnectorUri( ClientConnectorAddresses.Scheme.bolt,
                             new AdvertisedSocketAddress( "localhost", 11000 + offset ) ) ) ), new AdvertisedSocketAddress( "localhost", 10000 + offset ),
-                    new HashSet<>( unwanted ) ) );
+                    new HashSet<>( unwanted ), "default" ) );
 
             offset++;
         }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/ConnectToRandomCoreServerStrategyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/ConnectToRandomCoreServerStrategyTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.discovery.ClientConnectorAddresses;
 import org.neo4j.causalclustering.discovery.CoreServerInfo;
 import org.neo4j.causalclustering.discovery.CoreTopology;
@@ -33,6 +34,7 @@ import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.ClusterId;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.NullLogProvider;
 
 import static java.util.Collections.singletonList;
@@ -40,6 +42,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.AnyOf.anyOf;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.collection.Iterators.asSet;
@@ -55,11 +58,11 @@ public class ConnectToRandomCoreServerStrategyTest
         MemberId memberId3 = new MemberId( UUID.randomUUID() );
 
         TopologyService topologyService = mock( TopologyService.class );
-        when( topologyService.coreServers() )
+        when( topologyService.localCoreServers() )
                 .thenReturn( fakeCoreTopology( memberId1, memberId2, memberId3 ) );
 
         ConnectToRandomCoreServerStrategy connectionStrategy = new ConnectToRandomCoreServerStrategy();
-        connectionStrategy.inject( topologyService, null, NullLogProvider.getInstance(), null );
+        connectionStrategy.inject( topologyService, Config.defaults(), NullLogProvider.getInstance(), null );
 
         // when
         Optional<MemberId> memberId = connectionStrategy.upstreamDatabase();
@@ -83,7 +86,7 @@ public class ConnectToRandomCoreServerStrategyTest
             coreMembers.put( memberId, new CoreServerInfo( new AdvertisedSocketAddress( "localhost", 5000 + offset ),
                     new AdvertisedSocketAddress( "localhost", 6000 + offset ), new ClientConnectorAddresses(
                     singletonList( new ClientConnectorAddresses.ConnectorUri( ClientConnectorAddresses.Scheme.bolt,
-                            new AdvertisedSocketAddress( "localhost", 7000 + offset ) ) ) ), asSet( "core" ) ) );
+                            new AdvertisedSocketAddress( "localhost", 7000 + offset ) ) ) ), asSet( "core" ), "default" ) );
 
             offset++;
         }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/ReadReplicaStartupProcessTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/ReadReplicaStartupProcessTest.java
@@ -33,7 +33,7 @@ import java.util.stream.Stream;
 import org.neo4j.causalclustering.catchup.storecopy.LocalDatabase;
 import org.neo4j.causalclustering.catchup.storecopy.RemoteStore;
 import org.neo4j.causalclustering.catchup.storecopy.StoreCopyProcess;
-import org.neo4j.causalclustering.catchup.storecopy.StoreIdDownloadFailedException;
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.discovery.CoreServerInfo;
 import org.neo4j.causalclustering.discovery.CoreTopology;
 import org.neo4j.causalclustering.discovery.TopologyService;
@@ -44,6 +44,7 @@ import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.helpers.Service;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.logging.NullLogProvider;
 
@@ -85,7 +86,7 @@ public class ReadReplicaStartupProcessTest
         when( pageCache.getCachedFileSystem() ).thenReturn( fileSystemAbstraction );
         when( localDatabase.storeDir() ).thenReturn( storeDir );
         when( localDatabase.storeId() ).thenReturn( localStoreId );
-        when( topologyService.coreServers() ).thenReturn( clusterTopology );
+        when( topologyService.allCoreServers() ).thenReturn( clusterTopology );
         when( clusterTopology.members() ).thenReturn( members );
         when( topologyService.findCatchupAddress( memberId ) ).thenReturn( Optional.of( fromAddress ) );
     }
@@ -114,7 +115,9 @@ public class ReadReplicaStartupProcessTest
     private UpstreamDatabaseStrategySelector chooseFirstMember()
     {
         AlwaysChooseFirstMember firstMember = new AlwaysChooseFirstMember();
-        firstMember.inject( topologyService, null, NullLogProvider.getInstance(), null);
+        Config config = mock( Config.class );
+        when( config.get( CausalClusteringSettings.database ) ).thenReturn( "default" );
+        firstMember.inject( topologyService, config, NullLogProvider.getInstance(), null);
 
         return new UpstreamDatabaseStrategySelector( firstMember );
     }
@@ -198,7 +201,7 @@ public class ReadReplicaStartupProcessTest
         @Override
         public Optional<MemberId> upstreamDatabase()
         {
-            CoreTopology coreTopology = topologyService.coreServers();
+            CoreTopology coreTopology = topologyService.allCoreServers();
             return Optional.ofNullable( coreTopology.members().keySet().iterator().next() );
         }
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/TypicallyConnectToRandomReadReplicaStrategyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/TypicallyConnectToRandomReadReplicaStrategyTest.java
@@ -25,12 +25,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
+import org.neo4j.causalclustering.discovery.CoreTopology;
 import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.NullLogProvider;
+import org.neo4j.management.CausalClustering;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.neo4j.causalclustering.readreplica.ConnectToRandomCoreServerStrategyTest.fakeCoreTopology;
 import static org.neo4j.causalclustering.readreplica.UserDefinedConfigurationStrategyTest.fakeReadReplicaTopology;
 import static org.neo4j.causalclustering.readreplica.UserDefinedConfigurationStrategyTest.fakeTopologyService;
@@ -46,9 +52,12 @@ public class TypicallyConnectToRandomReadReplicaStrategyTest
         TopologyService topologyService =
                 fakeTopologyService( fakeCoreTopology( theCoreMemberId ), fakeReadReplicaTopology( memberIDs( 100 ) ) );
 
+        Config config = mock( Config.class );
+        when( config.get( CausalClusteringSettings.database ) ).thenReturn( "default" );
+
         TypicallyConnectToRandomReadReplicaStrategy connectionStrategy =
                 new TypicallyConnectToRandomReadReplicaStrategy();
-        connectionStrategy.inject( topologyService, null, NullLogProvider.getInstance(), null );
+        connectionStrategy.inject( topologyService, config, NullLogProvider.getInstance(), null );
 
         List<MemberId> responses = new ArrayList<>();
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/UpstreamDatabaseStrategySelectorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/UpstreamDatabaseStrategySelectorTest.java
@@ -26,12 +26,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.discovery.CoreServerInfo;
 import org.neo4j.causalclustering.discovery.CoreTopology;
 import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.ClusterId;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.helpers.Service;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.NullLogProvider;
 
 import static org.junit.Assert.assertEquals;
@@ -75,11 +77,11 @@ public class UpstreamDatabaseStrategySelectorTest
         // given
         TopologyService topologyService = mock( TopologyService.class );
         MemberId memberId = new MemberId( UUID.randomUUID() );
-        when( topologyService.coreServers() ).thenReturn( new CoreTopology( new ClusterId( UUID.randomUUID() ), false,
+        when( topologyService.localCoreServers() ).thenReturn( new CoreTopology( new ClusterId( UUID.randomUUID() ), false,
                 mapOf( memberId, mock( CoreServerInfo.class ) ) ) );
 
         ConnectToRandomCoreServerStrategy defaultStrategy = new ConnectToRandomCoreServerStrategy();
-        defaultStrategy.inject( topologyService, null, NullLogProvider.getInstance(), null );
+        defaultStrategy.inject( topologyService, Config.defaults(), NullLogProvider.getInstance(), null );
 
         UpstreamDatabaseStrategySelector selector = new UpstreamDatabaseStrategySelector( defaultStrategy );
 
@@ -96,7 +98,7 @@ public class UpstreamDatabaseStrategySelectorTest
         // given
         TopologyService topologyService = mock( TopologyService.class );
         MemberId memberId = new MemberId( UUID.randomUUID() );
-        when( topologyService.coreServers() ).thenReturn( new CoreTopology( new ClusterId( UUID.randomUUID() ), false,
+        when( topologyService.localCoreServers() ).thenReturn( new CoreTopology( new ClusterId( UUID.randomUUID() ), false,
                 mapOf( memberId, mock( CoreServerInfo.class ) ) ) );
 
         ConnectToRandomCoreServerStrategy shouldNotUse = new ConnectToRandomCoreServerStrategy();

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/UserDefinedConfigurationStrategyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/UserDefinedConfigurationStrategyTest.java
@@ -34,10 +34,12 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
+import org.neo4j.causalclustering.discovery.AbstractTopologyService;
 import org.neo4j.causalclustering.discovery.ClientConnectorAddresses;
 import org.neo4j.causalclustering.discovery.CoreTopology;
 import org.neo4j.causalclustering.discovery.ReadReplicaInfo;
 import org.neo4j.causalclustering.discovery.ReadReplicaTopology;
+import org.neo4j.causalclustering.discovery.RoleInfo;
 import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
@@ -46,6 +48,7 @@ import org.neo4j.logging.NullLogProvider;
 
 import static co.unruly.matchers.OptionalMatchers.contains;
 import static co.unruly.matchers.OptionalMatchers.empty;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.isIn;
@@ -193,23 +196,23 @@ public class UserDefinedConfigurationStrategyTest
         return new ReadReplicaInfo( new ClientConnectorAddresses( singletonList(
                 new ClientConnectorAddresses.ConnectorUri( ClientConnectorAddresses.Scheme.bolt,
                         new AdvertisedSocketAddress( "localhost", offset.getAndIncrement() ) ) ) ),
-                new AdvertisedSocketAddress( "localhost", offset.getAndIncrement() ), groupGenerator.apply( memberId ) );
+                new AdvertisedSocketAddress( "localhost", offset.getAndIncrement() ), groupGenerator.apply( memberId ), "default" );
     }
 
     static TopologyService fakeTopologyService( CoreTopology coreTopology, ReadReplicaTopology readReplicaTopology )
     {
-        return new TopologyService()
+        return new AbstractTopologyService()
         {
             private Map<MemberId,AdvertisedSocketAddress> catchupAddresses = extractCatchupAddressesMap( coreTopology, readReplicaTopology );
 
             @Override
-            public CoreTopology coreServers()
+            public CoreTopology allCoreServers()
             {
                 return coreTopology;
             }
 
             @Override
-            public ReadReplicaTopology readReplicas()
+            public ReadReplicaTopology allReadReplicas()
             {
                 return readReplicaTopology;
             }
@@ -218,6 +221,18 @@ public class UserDefinedConfigurationStrategyTest
             public Optional<AdvertisedSocketAddress> findCatchupAddress( MemberId upstream )
             {
                 return Optional.ofNullable( catchupAddresses.get( upstream ) );
+            }
+
+            @Override
+            public Map<MemberId,RoleInfo> allCoreRoles()
+            {
+                return emptyMap();
+            }
+
+            @Override
+            public String localDBName()
+            {
+                return "default";
             }
 
             @Override

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterBindingIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterBindingIT.java
@@ -147,7 +147,7 @@ public class ClusterBindingIT
 
         File storeDir = cluster.getCoreMemberById( 0 ).storeDir();
 
-        cluster.removeCoreMemberWithMemberId( 0 );
+        cluster.removeCoreMemberWithServerId( 0 );
         changeStoreId( storeDir );
 
         // WHEN
@@ -173,7 +173,8 @@ public class ClusterBindingIT
             tx.success();
         } );
 
-        cluster.removeCoreMemberWithMemberId( 0 );
+        //TODO: Work out if/why this won't potentially remove a leader?
+        cluster.removeCoreMemberWithServerId( 0 );
 
         SampleData.createSomeData( 100, cluster );
 
@@ -207,7 +208,7 @@ public class ClusterBindingIT
         } );
 
         CoreClusterMember coreMember = cluster.getCoreMemberById( 0 );
-        cluster.removeCoreMemberWithMemberId( 0 );
+        cluster.removeCoreMemberWithServerId( 0 );
         changeClusterId( coreMember );
 
         SampleData.createSomeData( 100, cluster );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterCommunityToEnterpriseIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterCommunityToEnterpriseIT.java
@@ -28,7 +28,7 @@ import java.io.File;
 
 import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.IpFamily;
-import org.neo4j.causalclustering.discovery.SharedDiscoveryService;
+import org.neo4j.causalclustering.discovery.SharedDiscoveryServiceFactory;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
@@ -60,7 +60,7 @@ public class ClusterCommunityToEnterpriseIT
         fsa = fileSystemRule.get();
 
         cluster = new Cluster( testDir.directory( "cluster" ), 3, 0,
-                new SharedDiscoveryService(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), HighLimit.NAME,
+                new SharedDiscoveryServiceFactory(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), HighLimit.NAME,
                 IpFamily.IPV4, false );
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterFormationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterFormationIT.java
@@ -101,7 +101,7 @@ public class ClusterFormationIT
         assertEquals( 3, cluster.numberOfCoreMembersReportedByTopology() );
 
         // when
-        cluster.removeCoreMemberWithMemberId( 1 );
+        cluster.removeCoreMemberWithServerId( 1 );
 
         // then
         assertEquals( 2, cluster.numberOfCoreMembersReportedByTopology() );
@@ -136,7 +136,7 @@ public class ClusterFormationIT
         assertEquals( 3, cluster.numberOfCoreMembersReportedByTopology() );
 
         // when
-        cluster.removeCoreMemberWithMemberId( 0 );
+        cluster.removeCoreMemberWithServerId( 0 );
 
         // then
         assertEquals( 2, cluster.numberOfCoreMembersReportedByTopology() );
@@ -164,7 +164,7 @@ public class ClusterFormationIT
         assertEquals( 3, cluster.numberOfCoreMembersReportedByTopology() );
 
         // when
-        cluster.removeCoreMemberWithMemberId( 1 );
+        cluster.removeCoreMemberWithServerId( 1 );
 
         cluster.addCoreMemberWithId( 3 ).start();
         cluster.shutdown();

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterIdReuseIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterIdReuseIT.java
@@ -23,8 +23,6 @@ import org.apache.commons.lang3.mutable.MutableLong;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.util.concurrent.TimeoutException;
-
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.CoreClusterMember;
@@ -115,7 +113,7 @@ public class ClusterIdReuseIT
         assertEquals( 2, creationLeaderIdGenerator.getDefragCount() );
 
         // Force leader switch
-        cluster.removeCoreMemberWithMemberId( creationLeader.serverId() );
+        cluster.removeCoreMemberWithServerId( creationLeader.serverId() );
 
         // waiting for new leader
         CoreClusterMember newLeader = cluster.awaitLeader();
@@ -154,13 +152,13 @@ public class ClusterIdReuseIT
         assertEquals( 2, creationLeaderIdGenerator.getDefragCount() );
 
         // Restart and re-elect first leader
-        cluster.removeCoreMemberWithMemberId( creationLeader.serverId() );
+        cluster.removeCoreMemberWithServerId( creationLeader.serverId() );
         cluster.addCoreMemberWithId( creationLeader.serverId() ).start();
 
         CoreClusterMember leader = cluster.awaitLeader();
         while ( leader.serverId() != creationLeader.serverId() )
         {
-            cluster.removeCoreMemberWithMemberId( leader.serverId() );
+            cluster.removeCoreMemberWithServerId( leader.serverId() );
             cluster.addCoreMemberWithId( leader.serverId() ).start();
             leader = cluster.awaitLeader();
         }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterIpFamilyIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterIpFamilyIT.java
@@ -63,8 +63,7 @@ public class ClusterIpFamilyIT
 
     public ClusterIpFamilyIT( DiscoveryServiceType discoveryServiceType, IpFamily ipFamily, boolean useWildcard )
     {
-        clusterRule.withDiscoveryServiceFactory( discoveryServiceType.create() );
-
+        clusterRule.withDiscoveryServiceType( discoveryServiceType );
         clusterRule.withIpFamily( ipFamily ).useWildcard( useWildcard );
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterOverviewIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterOverviewIT.java
@@ -43,8 +43,8 @@ import java.util.stream.Stream;
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.ClusterMember;
+import org.neo4j.causalclustering.discovery.RoleInfo;
 import org.neo4j.causalclustering.discovery.procedures.ClusterOverviewProcedure;
-import org.neo4j.causalclustering.discovery.procedures.Role;
 import org.neo4j.collection.RawIterator;
 import org.neo4j.internal.kernel.api.Transaction.Type;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
@@ -62,9 +62,9 @@ import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
-import static org.neo4j.causalclustering.discovery.procedures.Role.FOLLOWER;
-import static org.neo4j.causalclustering.discovery.procedures.Role.LEADER;
-import static org.neo4j.causalclustering.discovery.procedures.Role.READ_REPLICA;
+import static org.neo4j.causalclustering.discovery.RoleInfo.FOLLOWER;
+import static org.neo4j.causalclustering.discovery.RoleInfo.LEADER;
+import static org.neo4j.causalclustering.discovery.RoleInfo.READ_REPLICA;
 import static org.neo4j.helpers.collection.Iterators.asSet;
 import static org.neo4j.internal.kernel.api.procs.ProcedureSignature.procedureName;
 import static org.neo4j.test.assertion.Assert.assertEventually;
@@ -84,7 +84,7 @@ public class ClusterOverviewIT
 
     public ClusterOverviewIT( DiscoveryServiceType discoveryServiceType )
     {
-        clusterRule.withDiscoveryServiceFactory( discoveryServiceType.create() );
+        clusterRule.withDiscoveryServiceType( discoveryServiceType );
     }
 
     @Test
@@ -255,8 +255,8 @@ public class ClusterOverviewIT
         }
 
         // when
-        cluster.removeCoreMemberWithMemberId( 0 );
-        cluster.removeCoreMemberWithMemberId( 1 );
+        cluster.removeCoreMemberWithServerId( 0 );
+        cluster.removeCoreMemberWithServerId( 1 );
 
         for ( int coreServerId = 2; coreServerId < coreMembers; coreServerId++ )
         {
@@ -311,7 +311,7 @@ public class ClusterOverviewIT
         ).collect( toList() ) );
     }
 
-    private Matcher<List<MemberInfo>> containsRole( Role expectedRole, long expectedCount )
+    private Matcher<List<MemberInfo>> containsRole( RoleInfo expectedRole, long expectedCount )
     {
         return new FeatureMatcher<List<MemberInfo>,Long>( equalTo( expectedCount ), expectedRole.name(), "count" )
         {
@@ -323,7 +323,7 @@ public class ClusterOverviewIT
         };
     }
 
-    private Matcher<List<MemberInfo>> doesNotContainRole( Role unexpectedRole )
+    private Matcher<List<MemberInfo>> doesNotContainRole( RoleInfo unexpectedRole )
     {
        return containsRole( unexpectedRole, 0 );
     }
@@ -345,7 +345,7 @@ public class ClusterOverviewIT
                 Object[] row = itr.next();
                 List<String> addresses = (List<String>) row[1];
                 infos.add( new MemberInfo( addresses.toArray( new String[addresses.size()] ),
-                        Role.valueOf( (String) row[2] ) ) );
+                        RoleInfo.valueOf( (String) row[2] ) ) );
             }
         }
 
@@ -355,9 +355,9 @@ public class ClusterOverviewIT
     private static class MemberInfo
     {
         private final String[] addresses;
-        private final Role role;
+        private final RoleInfo role;
 
-        MemberInfo( String[] addresses, Role role )
+        MemberInfo( String[] addresses, RoleInfo role )
         {
             this.addresses = addresses;
             this.role = role;

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreReplicationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreReplicationIT.java
@@ -296,7 +296,7 @@ public class CoreReplicationIT
             tx.success();
         } );
 
-        cluster.removeCoreMemberWithMemberId( 0 );
+        cluster.removeCoreMemberWithServerId( 0 );
         CoreClusterMember replacement = cluster.addCoreMemberWithId( 0 );
         replacement.start();
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/DiscoveryServiceType.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/DiscoveryServiceType.java
@@ -24,10 +24,11 @@ import java.util.function.Supplier;
 import org.neo4j.causalclustering.discovery.DiscoveryServiceFactory;
 import org.neo4j.causalclustering.discovery.HazelcastDiscoveryServiceFactory;
 import org.neo4j.causalclustering.discovery.SharedDiscoveryService;
+import org.neo4j.causalclustering.discovery.SharedDiscoveryServiceFactory;
 
 public enum DiscoveryServiceType
 {
-    SHARED( SharedDiscoveryService::new ),
+    SHARED( SharedDiscoveryServiceFactory::new ),
     HAZELCAST( HazelcastDiscoveryServiceFactory::new );
 
     private final Supplier<DiscoveryServiceFactory> factory;

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/MultiClusteringIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/MultiClusteringIT.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.scenarios;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.neo4j.causalclustering.core.consensus.roles.Role;
+import org.neo4j.causalclustering.discovery.Cluster;
+import org.neo4j.causalclustering.discovery.CoreClusterMember;
+import org.neo4j.causalclustering.helpers.DataCreator;
+import org.neo4j.causalclustering.identity.StoreId;
+import org.neo4j.graphdb.Node;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.test.causalclustering.ClusterRule;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.causalclustering.TestStoreId.getStoreIds;
+import static org.neo4j.causalclustering.discovery.Cluster.dataMatchesEventually;
+import static org.neo4j.causalclustering.scenarios.DiscoveryServiceType.HAZELCAST;
+import static org.neo4j.causalclustering.scenarios.DiscoveryServiceType.SHARED;
+import static org.neo4j.graphdb.Label.label;
+
+@RunWith( Parameterized.class )
+public class MultiClusteringIT
+{
+    private static Set<String> DB_NAMES_1 = Stream.of( "foo", "bar" ).collect( Collectors.toSet() );
+    private static Set<String> DB_NAMES_2 = Collections.singleton( "default" );
+    private static Set<String> DB_NAMES_3 = Stream.of( "foo", "bar", "baz" ).collect( Collectors.toSet() );
+
+    @Parameterized.Parameters( name = "{0}" )
+    public static Collection<Object[]> data()
+    {
+        return Arrays.asList( new Object[][]
+                {
+                        { "[shared discovery, 6 core hosts, 2 databases]", 6, 0, DB_NAMES_1, SHARED },
+                        { "[hazelcast discovery, 6 core hosts, 2 databases]", 6, 0, DB_NAMES_1, HAZELCAST },
+                        { "[shared discovery, 5 core hosts, 1 database]", 5, 0, DB_NAMES_2, SHARED },
+                        { "[hazelcast discovery, 5 core hosts, 2 databases]", 5, 0, DB_NAMES_1, HAZELCAST },
+                        { "[hazelcast discovery, 9 core hosts, 3 read replicas, 3 databases]", 9, 3, DB_NAMES_3, HAZELCAST },
+                        { "[shared discovery, 8 core hosts, 2 read replicas, 3 databases]", 8, 2, DB_NAMES_3, SHARED }
+                }
+        );
+    }
+
+    private final Set<String> dbNames;
+    private final ClusterRule clusterRule;
+    private final DefaultFileSystemRule fileSystemRule;
+    private final DiscoveryServiceType discoveryType;
+
+    @Rule
+    public final RuleChain ruleChain;
+    private Cluster cluster;
+    private FileSystemAbstraction fs;
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(300);
+
+    public MultiClusteringIT( String ignoredName, int numCores, int numReplicas, Set<String> dbNames, DiscoveryServiceType discoveryType )
+    {
+        this.dbNames = dbNames;
+        this.discoveryType = discoveryType;
+
+        this.clusterRule = new ClusterRule()
+            .withNumberOfCoreMembers( numCores )
+            .withNumberOfReadReplicas( numReplicas )
+            .withDatabaseNames( dbNames );
+
+        this.fileSystemRule = new DefaultFileSystemRule();
+
+        this.ruleChain = RuleChain.outerRule( fileSystemRule ).around( clusterRule );
+    }
+
+    @Before
+    public void setup() throws Exception
+    {
+        clusterRule.withDiscoveryServiceType( discoveryType );
+        fs = fileSystemRule.get();
+        cluster = clusterRule.startCluster();
+    }
+
+    @Test
+    public void shouldRunDistinctTransactionsAndDiverge() throws Exception
+    {
+        int numNodes = 1;
+        Map<CoreClusterMember, List<CoreClusterMember>> leaderMap = new HashMap<>();
+        for ( String dbName : dbNames )
+        {
+            int i = 0;
+            CoreClusterMember leader;
+
+            do
+            {
+                leader = cluster.coreTx( dbName, ( db, tx ) ->
+                {
+                    Node node = db.createNode( label("database") );
+                    node.setProperty( "name" , dbName );
+                    tx.success();
+                } );
+                i++;
+            }
+            while ( i < numNodes );
+
+            int leaderId = leader.serverId();
+            List<CoreClusterMember> notLeaders = cluster.coreMembers().stream()
+                    .filter( m -> m.dbName().equals( dbName ) && m.serverId() != leaderId )
+                    .collect( Collectors.toList() );
+
+            leaderMap.put( leader, notLeaders );
+            numNodes++;
+        }
+
+        Set<Long> nodesPerDb = leaderMap.keySet().stream()
+                .map( DataCreator::countNodes ).collect( Collectors.toSet() );
+        assertEquals("Each logical database in the multicluster should have a unique number of nodes.", nodesPerDb.size(), dbNames.size() );
+        for ( Map.Entry<CoreClusterMember, List<CoreClusterMember>> subCluster : leaderMap.entrySet() )
+        {
+            dataMatchesEventually( subCluster.getKey(), subCluster.getValue() );
+        }
+
+    }
+
+    @Test
+    public void distinctDatabasesShouldHaveDistinctStoreIds() throws Exception
+    {
+        for ( String dbName : dbNames )
+        {
+            cluster.coreTx( dbName, ( db, tx ) ->
+            {
+                Node node = db.createNode( label("database") );
+                node.setProperty( "name" , dbName );
+                tx.success();
+            } );
+        }
+
+        List<File> storeDirs = cluster.coreMembers().stream()
+                .map( CoreClusterMember::storeDir )
+                .collect( Collectors.toList() );
+
+        cluster.shutdown();
+
+        Set<StoreId> storeIds = getStoreIds( storeDirs, fs );
+        int expectedNumStoreIds = dbNames.size();
+        assertEquals( "Expected distinct store ids for distinct sub clusters.", expectedNumStoreIds, storeIds.size());
+    }
+
+    @Test
+    public void rejoiningFollowerShouldDownloadSnapshotFromCorrectDatabase() throws Exception
+    {
+        String dbName = dbNames.stream()
+                .findFirst()
+                .orElseThrow( () -> new IllegalArgumentException( "The dbNames parameter must not be empty." ) );
+
+        int followerId = cluster.getDbWithAnyRole( dbName, Role.FOLLOWER ).serverId();
+
+        cluster.removeCoreMemberWithServerId( followerId );
+
+        for ( int  i = 0; i < 100; i++ )
+        {
+            cluster.coreTx( dbName, ( db, tx ) ->
+            {
+                Node node = db.createNode( label( dbName + "Node" ) );
+                node.setProperty( "name", dbName );
+                tx.success();
+            } );
+        }
+
+        for ( CoreClusterMember m : cluster.coreMembers() )
+        {
+            m.raftLogPruner().prune();
+        }
+
+        cluster.addCoreMemberWithId( followerId ).start();
+
+        CoreClusterMember dbLeader = cluster.awaitLeader( dbName );
+
+        boolean followerIsHealthy = cluster.healthyCoreMembers().stream()
+                .anyMatch( m -> m.serverId() == followerId );
+
+        assertTrue( "Rejoining / lagging follower is expected to be healthy.", followerIsHealthy );
+
+        CoreClusterMember follower = cluster.getCoreMemberById( followerId );
+
+        dataMatchesEventually( dbLeader, Collections.singleton(follower) );
+
+        List<File> storeDirs = cluster.coreMembers().stream()
+                .filter( m -> dbName.equals( m.dbName() ) )
+                .map( CoreClusterMember::storeDir )
+                .collect( Collectors.toList() );
+
+        cluster.shutdown();
+
+        Set<StoreId> storeIds = getStoreIds( storeDirs, fs );
+        String message = "All members of a sub-cluster should have the same store Id after downloading a snapshot.";
+        assertEquals( message, 1, storeIds.size() );
+    }
+
+    //TODO: Test that rejoining followers wait for majority of hosts *for each database* to be available before joining
+
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaHierarchicalCatchupIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaHierarchicalCatchupIT.java
@@ -63,7 +63,7 @@ public class ReadReplicaHierarchicalCatchupIT
                     .withSharedCoreParam( CausalClusteringSettings.cluster_topology_refresh, "5s" )
                     .withSharedCoreParam( CausalClusteringSettings.multi_dc_license, "true" )
                     .withSharedReadReplicaParam( CausalClusteringSettings.multi_dc_license, "true" )
-                    .withDiscoveryServiceFactory( new HazelcastDiscoveryServiceFactory() );
+                    .withDiscoveryServiceType( DiscoveryServiceType.HAZELCAST );
 
     @Test
     public void shouldCatchupThroughHierarchy() throws Throwable

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaReplicationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaReplicationIT.java
@@ -119,7 +119,7 @@ public class ReadReplicaReplicationIT
     public final ClusterRule clusterRule = new ClusterRule().withNumberOfCoreMembers( NR_CORE_MEMBERS )
             .withNumberOfReadReplicas( NR_READ_REPLICAS )
             .withSharedCoreParam( CausalClusteringSettings.cluster_topology_refresh, "5s" )
-            .withDiscoveryServiceFactory( new HazelcastDiscoveryServiceFactory() );
+            .withDiscoveryServiceType( DiscoveryServiceType.HAZELCAST );
 
     @Test
     public void shouldNotBeAbleToWriteToReadReplica() throws Exception

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaReplicationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaReplicationIT.java
@@ -448,7 +448,7 @@ public class ReadReplicaReplicationIT
         // when the poller is paused, transaction doesn't make it to the read replica
         try
         {
-            transactionIdTracker( readReplicaGraphDatabase ).awaitUpToDate( transactionVisibleOnLeader, ofSeconds( 3 ) );
+            transactionIdTracker( readReplicaGraphDatabase ).awaitUpToDate( transactionVisibleOnLeader, ofSeconds( 15 ) );
             fail( "should have thrown exception" );
         }
         catch ( TransactionFailureException e )
@@ -458,7 +458,7 @@ public class ReadReplicaReplicationIT
 
         // when the poller is resumed, it does make it to the read replica
         pollingClient.start();
-        transactionIdTracker( readReplicaGraphDatabase ).awaitUpToDate( transactionVisibleOnLeader, ofSeconds( 3 ) );
+        transactionIdTracker( readReplicaGraphDatabase ).awaitUpToDate( transactionVisibleOnLeader, ofSeconds( 15 ) );
     }
 
     private TransactionIdTracker transactionIdTracker( GraphDatabaseAPI database )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaToReadReplicaCatchupIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaToReadReplicaCatchupIT.java
@@ -31,7 +31,6 @@ import org.neo4j.causalclustering.discovery.CoreClusterMember;
 import org.neo4j.causalclustering.discovery.HazelcastDiscoveryServiceFactory;
 import org.neo4j.causalclustering.discovery.ReadReplica;
 import org.neo4j.causalclustering.identity.MemberId;
-import org.neo4j.causalclustering.readreplica.UpstreamDatabaseSelectionException;
 import org.neo4j.causalclustering.readreplica.UpstreamDatabaseSelectionStrategy;
 import org.neo4j.function.ThrowingSupplier;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -60,7 +59,7 @@ public class ReadReplicaToReadReplicaCatchupIT
                     .withSharedCoreParam( CausalClusteringSettings.cluster_topology_refresh, "5s" )
                     .withSharedCoreParam( CausalClusteringSettings.multi_dc_license, "true" )
                     .withSharedReadReplicaParam( CausalClusteringSettings.multi_dc_license, "true" )
-                    .withDiscoveryServiceFactory( new HazelcastDiscoveryServiceFactory() );
+                    .withDiscoveryServiceType( DiscoveryServiceType.HAZELCAST );
 
     @Test
     public void shouldEventuallyPullTransactionAcrossReadReplicas() throws Throwable

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/RecoveryIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/RecoveryIT.java
@@ -84,7 +84,7 @@ public class RecoveryIT
         // when
         for ( int i = 0; i < clusterSize; i++ )
         {
-            cluster.removeCoreMemberWithMemberId( i );
+            cluster.removeCoreMemberWithServerId( i );
             fireSomeLoadAtTheCluster( cluster );
             cluster.addCoreMemberWithId( i ).start();
         }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/RestartIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/RestartIT.java
@@ -61,7 +61,7 @@ public class RestartIT
         Cluster cluster = clusterRule.startCluster();
 
         // when
-        cluster.removeCoreMemberWithMemberId( 0 );
+        cluster.removeCoreMemberWithServerId( 0 );
         cluster.addCoreMemberWithId( 0 ).start();
 
         // then
@@ -75,7 +75,7 @@ public class RestartIT
         Cluster cluster = clusterRule.startCluster();
 
         // when
-        cluster.removeCoreMemberWithMemberId( 1 );
+        cluster.removeCoreMemberWithServerId( 1 );
         cluster.addCoreMemberWithId( 1 ).start();
 
         // then
@@ -112,7 +112,7 @@ public class RestartIT
         } );
         Thread.sleep( 500 );
 
-        cluster.removeCoreMemberWithMemberId( 1 );
+        cluster.removeCoreMemberWithServerId( 1 );
         cluster.addCoreMemberWithId( 1 ).start();
         Thread.sleep( 500 );
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/WillNotBecomeLeaderIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/WillNotBecomeLeaderIT.java
@@ -41,7 +41,7 @@ public class WillNotBecomeLeaderIT
     @Rule
     public final ClusterRule clusterRule =
             new ClusterRule().withNumberOfCoreMembers( 3 ).withNumberOfReadReplicas( 0 )
-                    .withDiscoveryServiceFactory( new HazelcastDiscoveryServiceFactory() )
+                    .withDiscoveryServiceType( DiscoveryServiceType.HAZELCAST )
                     .withSharedCoreParam( CausalClusteringSettings.multi_dc_license, "true" );
 
     @Rule
@@ -77,7 +77,7 @@ public class WillNotBecomeLeaderIT
         } );
 
         // When
-        cluster.removeCoreMemberWithMemberId( leaderId );
+        cluster.removeCoreMemberWithServerId( leaderId );
 
         // Then
         try

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/test/causalclustering/ClusterRule.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/test/causalclustering/ClusterRule.java
@@ -24,21 +24,27 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.Set;
 import java.util.function.IntFunction;
+import java.util.stream.Collectors;
 
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.discovery.Cluster;
-import org.neo4j.causalclustering.discovery.DiscoveryServiceFactory;
 import org.neo4j.causalclustering.discovery.IpFamily;
-import org.neo4j.causalclustering.discovery.SharedDiscoveryService;
+import org.neo4j.causalclustering.helpers.CausalClusteringTestHelpers;
+import org.neo4j.causalclustering.scenarios.DiscoveryServiceType;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.kernel.impl.store.format.standard.Standard;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.VerboseTimeout;
 
 import static org.neo4j.causalclustering.discovery.IpFamily.IPV4;
+import static org.neo4j.causalclustering.scenarios.DiscoveryServiceType.SHARED;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 /**
@@ -53,7 +59,7 @@ public class ClusterRule extends ExternalResource
 
     private int noCoreMembers = 3;
     private int noReadReplicas = 3;
-    private DiscoveryServiceFactory discoveryServiceFactory = new SharedDiscoveryService();
+    private DiscoveryServiceType discoveryServiceType = SHARED;
     private Map<String,String> coreParams = stringMap();
     private Map<String,IntFunction<String>> instanceCoreParams = new HashMap<>();
     private Map<String,String> readReplicaParams = stringMap();
@@ -62,6 +68,7 @@ public class ClusterRule extends ExternalResource
     private IpFamily ipFamily = IPV4;
     private boolean useWildcard;
     private VerboseTimeout.VerboseTimeoutBuilder timeoutBuilder = new VerboseTimeout.VerboseTimeoutBuilder().withTimeout( 15, TimeUnit.MINUTES );
+    private Set<String> dbNames = Collections.singleton( CausalClusteringSettings.database.getDefaultValue() );
 
     public ClusterRule()
     {
@@ -117,7 +124,10 @@ public class ClusterRule extends ExternalResource
     {
         createCluster();
         cluster.start();
-        cluster.awaitLeader();
+        for ( String dbName : dbNames )
+        {
+            cluster.awaitLeader( dbName );
+        }
         return cluster;
     }
 
@@ -125,8 +135,8 @@ public class ClusterRule extends ExternalResource
     {
         if ( cluster == null )
         {
-            cluster = new Cluster( clusterDirectory, noCoreMembers, noReadReplicas, discoveryServiceFactory, coreParams,
-                    instanceCoreParams, readReplicaParams, instanceReadReplicaParams, recordFormat, ipFamily, useWildcard );
+            cluster = new Cluster( clusterDirectory, noCoreMembers, noReadReplicas, discoveryServiceType.create(), coreParams,
+                    instanceCoreParams, readReplicaParams, instanceReadReplicaParams, recordFormat, ipFamily, useWildcard, dbNames );
         }
 
         return cluster;
@@ -142,6 +152,29 @@ public class ClusterRule extends ExternalResource
         return clusterDirectory;
     }
 
+    public ClusterRule withDatabaseNames( Set<String> dbNames )
+    {
+        this.dbNames = dbNames;
+        Map<Integer, String> coreDBMap = CausalClusteringTestHelpers.distributeDatabaseNamesToHostNums( noCoreMembers, dbNames );
+        Map<Integer, String> rrDBMap = CausalClusteringTestHelpers.distributeDatabaseNamesToHostNums( noReadReplicas, dbNames );
+
+        Map<String,Long> minCoresPerDb = coreDBMap.entrySet().stream()
+                .collect( Collectors.groupingBy( Map.Entry::getValue, Collectors.counting() ) );
+
+        Map<Integer,String> minCoresSettingsMap = new HashMap<>();
+
+        for ( Map.Entry<Integer,String> entry: coreDBMap.entrySet() )
+        {
+            Optional<Long> minNumCores = Optional.ofNullable( minCoresPerDb.get( entry.getValue() ) );
+            minNumCores.ifPresent( n -> minCoresSettingsMap.put( entry.getKey(), n.toString() ) );
+        }
+
+        withInstanceCoreParam( CausalClusteringSettings.database, coreDBMap::get );
+        withInstanceCoreParam( CausalClusteringSettings.minimum_core_cluster_size_at_formation, minCoresSettingsMap::get );
+        withInstanceReadReplicaParam( CausalClusteringSettings.database, rrDBMap::get );
+        return this;
+    }
+
     public ClusterRule withNumberOfCoreMembers( int noCoreMembers )
     {
         this.noCoreMembers = noCoreMembers;
@@ -154,9 +187,9 @@ public class ClusterRule extends ExternalResource
         return this;
     }
 
-    public ClusterRule withDiscoveryServiceFactory( DiscoveryServiceFactory factory )
+    public ClusterRule withDiscoveryServiceType( DiscoveryServiceType discoveryType )
     {
-        this.discoveryServiceFactory = factory;
+        this.discoveryServiceType = discoveryType;
         return this;
     }
 

--- a/enterprise/neo4j-harness-enterprise/src/main/java/org/neo4j/harness/CausalClusterInProcessBuilder.java
+++ b/enterprise/neo4j-harness-enterprise/src/main/java/org/neo4j/harness/CausalClusterInProcessBuilder.java
@@ -1,0 +1,428 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.harness;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.harness.internal.EnterpriseInProcessServerBuilder;
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.configuration.BoltConnector;
+import org.neo4j.kernel.configuration.HttpConnector;
+import org.neo4j.kernel.configuration.Settings;
+import org.neo4j.kernel.impl.enterprise.configuration.EnterpriseEditionSettings;
+import org.neo4j.kernel.impl.enterprise.configuration.OnlineBackupSettings;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.server.configuration.ServerSettings;
+
+import static java.util.Collections.synchronizedList;
+
+public class CausalClusterInProcessBuilder
+{
+
+    public static WithCores init()
+    {
+        return new Builder();
+    }
+
+    /**
+     * Step Builder to ensure that Cluster has all the required pieces
+     * TODO: Add mapping methods to allow for core hosts and replicas to be unevenly distributed  between databases
+     */
+    public static class Builder implements WithCores, WithReplicas, WithLogger, WithPath, WithOptionalDatabasesAndPorts
+    {
+
+        private int numCoreHosts;
+        private int numReadReplicas;
+        private Log log;
+        private Path path;
+        private PortPickingFactory portFactory = PortPickingFactory.DEFAULT;
+        private List<String> databases = new ArrayList<>( Collections.singletonList( "default" ) );
+
+        public WithReplicas withCores( int n )
+        {
+            numCoreHosts = n;
+            return this;
+        }
+
+        public WithLogger withReplicas( int n )
+        {
+            numReadReplicas = n;
+            return this;
+        }
+
+        public WithPath withLogger( LogProvider l )
+        {
+            log = l.getLog( "org.neo4j.harness.CausalCluster" );
+            return this;
+        }
+
+        public Builder atPath( Path p )
+        {
+            path = p;
+            return this;
+        }
+
+        @Override
+        public Builder withOptionalPortsStrategy( PortPickingStrategy s )
+        {
+            portFactory = new PortPickingFactory( s );
+            return this;
+        }
+
+        @Override
+        public Builder withOptionalDatabases( List<String> databaseNames )
+        {
+            if ( !databaseNames.isEmpty() )
+            {
+                databases = databaseNames;
+            }
+            return this;
+        }
+
+        public CausalCluster build()
+        {
+            int nDatabases = databases.size();
+            if ( nDatabases > numCoreHosts )
+            {
+                throw new IllegalArgumentException(
+                        "You cannot have more databases than core hosts. Each database in the cluster must have at least 1 core " + "host. You have provided " +
+                                nDatabases + " databases and " + numCoreHosts + " core hosts." );
+            }
+            return new CausalCluster( this );
+        }
+    }
+
+    /**
+     * Builder step interfaces
+     */
+    interface WithCores
+    {
+        WithReplicas withCores( int n );
+    }
+
+    interface WithReplicas
+    {
+        WithLogger withReplicas( int n );
+    }
+
+    interface WithLogger
+    {
+        WithPath withLogger( LogProvider l );
+    }
+
+    interface WithPath
+    {
+        Builder atPath( Path p );
+    }
+
+    interface WithOptionalDatabasesAndPorts
+    {
+        Builder withOptionalPortsStrategy( PortPickingStrategy s );
+
+        Builder withOptionalDatabases( List<String> databaseNames );
+    }
+
+    /**
+     * Port picker functional interface
+     */
+    public interface PortPickingStrategy
+    {
+        int port( int offset, int id );
+    }
+
+    /**
+     * Port picker factory
+     */
+    public static final class PortPickingFactory
+    {
+        public static final PortPickingFactory DEFAULT = new PortPickingFactory( ( offset, id ) -> offset + id );
+
+        private final PortPickingStrategy st;
+
+        public PortPickingFactory( PortPickingStrategy st )
+        {
+            this.st = st;
+        }
+
+        int hazelcastPort( int coreId )
+        {
+            return st.port( 55000, coreId );
+        }
+
+        int txCorePort( int coreId )
+        {
+            return st.port( 56000, coreId );
+        }
+
+        int raftCorePort( int coreId )
+        {
+            return st.port( 57000, coreId );
+        }
+
+        int boltCorePort( int coreId )
+        {
+            return st.port( 58000, coreId );
+        }
+
+        int httpCorePort( int coreId )
+        {
+            return st.port( 59000, coreId );
+        }
+
+        int httpsCorePort( int coreId )
+        {
+            return st.port( 60000, coreId );
+        }
+
+        int txReadReplicaPort( int replicaId )
+        {
+            return st.port( 56500, replicaId );
+        }
+
+        int boltReadReplicaPort( int replicaId )
+        {
+            return st.port( 58500, replicaId );
+        }
+
+        int httpReadReplicaPort( int replicaId )
+        {
+            return st.port( 59500, replicaId );
+        }
+
+        int httpsReadReplicaPort( int replicaId )
+        {
+            return st.port( 60500, replicaId );
+        }
+    }
+
+    /**
+     * Implementation of in process Cluster
+     */
+    static class CausalCluster
+    {
+        private final int nCores;
+        private final int nReplicas;
+        private final int nDatabases;
+        private final List<String> databaseNames;
+        private final Path clusterPath;
+        private final Log log;
+        private final PortPickingFactory portFactory;
+
+        private List<ServerControls> coreControls = synchronizedList( new ArrayList<>() );
+        private List<ServerControls> replicaControls = synchronizedList( new ArrayList<>() );
+
+        private CausalCluster( CausalClusterInProcessBuilder.Builder bldr )
+        {
+            this.nCores = bldr.numCoreHosts;
+            this.nReplicas = bldr.numReadReplicas;
+            this.clusterPath = bldr.path;
+            this.log = bldr.log;
+            this.portFactory = bldr.portFactory;
+            this.nDatabases = bldr.databases.size();
+            this.databaseNames = bldr.databases;
+        }
+
+        private Map<Integer,String> distributeHostsBetweenDatabases( int nHosts, List<String> databases )
+        {
+            //Max number of hosts per database is (nHosts / nDatabases) or (nHosts / nDatabases) + 1
+            int nDatabases = databases.size();
+            int maxCapacity = ( nHosts % nDatabases == 0 ) ? (nHosts / nDatabases) : (nHosts / nDatabases) + 1;
+
+            List<String> repeated =
+                    databases.stream().flatMap( db -> IntStream.range( 0, maxCapacity ).mapToObj( ignored -> db ) ).collect( Collectors.toList() );
+
+            Map<Integer,String> mapping = new HashMap<>( nHosts );
+
+            for ( int hostId = 0; hostId < nHosts; hostId++ )
+            {
+                mapping.put( hostId, repeated.get( hostId ) );
+            }
+            return mapping;
+        }
+
+        void boot() throws InterruptedException
+        {
+            List<String> initialMembers = new ArrayList<>( nCores );
+
+            Map<Integer,String> initialMembersToDatabase = distributeHostsBetweenDatabases( nCores, databaseNames );
+
+            for ( int coreId = 0; coreId < nCores; coreId++ )
+            {
+                int hazelcastPort = portFactory.hazelcastPort( coreId );
+                initialMembers.add( "localhost:" + hazelcastPort );
+            }
+
+            List<Thread> coreThreads = new ArrayList<>();
+            List<Thread> replicaThreads = new ArrayList<>();
+
+            for ( int coreId = 0; coreId < nCores; coreId++ )
+            {
+                int hazelcastPort = portFactory.hazelcastPort( coreId );
+                int txPort = portFactory.txCorePort( coreId );
+                int raftPort = portFactory.raftCorePort( coreId );
+                int boltPort = portFactory.boltCorePort( coreId );
+                int httpPort = portFactory.httpCorePort( coreId );
+                int httpsPort = portFactory.httpsCorePort( coreId );
+
+                String homeDir = "core-" + coreId;
+                TestServerBuilder builder = new EnterpriseInProcessServerBuilder( clusterPath.toFile(), homeDir );
+
+                String homePath = Paths.get( clusterPath.toString(), homeDir ).toAbsolutePath().toString();
+                builder.withConfig( GraphDatabaseSettings.neo4j_home.name(), homePath );
+                builder.withConfig( GraphDatabaseSettings.pagecache_memory.name(), "8m" );
+
+                builder.withConfig( EnterpriseEditionSettings.mode.name(), EnterpriseEditionSettings.Mode.CORE.name() );
+                builder.withConfig( CausalClusteringSettings.multi_dc_license.name(), "true" );
+                builder.withConfig( CausalClusteringSettings.initial_discovery_members.name(), String.join( ",", initialMembers ) );
+
+                builder.withConfig( CausalClusteringSettings.discovery_listen_address.name(), specifyPortOnly( hazelcastPort ) );
+                builder.withConfig( CausalClusteringSettings.transaction_listen_address.name(), specifyPortOnly( txPort ) );
+                builder.withConfig( CausalClusteringSettings.raft_listen_address.name(), specifyPortOnly( raftPort ) );
+
+                builder.withConfig( CausalClusteringSettings.database.name(), initialMembersToDatabase.get( coreId ) );
+
+                builder.withConfig( CausalClusteringSettings.minimum_core_cluster_size_at_formation.name(), String.valueOf( nCores ) );
+                builder.withConfig( CausalClusteringSettings.minimum_core_cluster_size_at_runtime.name(), String.valueOf( nCores ) );
+                builder.withConfig( CausalClusteringSettings.server_groups.name(), "core," + "core" + coreId );
+                configureConnectors( boltPort, httpPort, httpsPort, builder );
+
+                builder.withConfig( ServerSettings.jmx_module_enabled.name(), Settings.FALSE );
+
+                builder.withConfig( OnlineBackupSettings.online_backup_enabled, Settings.FALSE );
+
+                int finalCoreId = coreId;
+                Thread coreThread = new Thread( () ->
+                {
+                    coreControls.add( builder.newServer() );
+                    log.info( "Core " + finalCoreId + " started." );
+                } );
+                coreThreads.add( coreThread );
+                coreThread.start();
+            }
+
+            for ( Thread coreThread : coreThreads )
+            {
+                coreThread.join();
+            }
+
+            Map<Integer,String> replicasToDatabase = distributeHostsBetweenDatabases( nReplicas, databaseNames );
+
+            for ( int replicaId = 0; replicaId < nReplicas; replicaId++ )
+            {
+                int txPort = portFactory.txReadReplicaPort( replicaId );
+                int boltPort = portFactory.boltReadReplicaPort( replicaId );
+                int httpPort = portFactory.httpReadReplicaPort( replicaId );
+                int httpsPort = portFactory.httpsReadReplicaPort( replicaId );
+
+                String homeDir = "replica-" + replicaId;
+                TestServerBuilder builder = new EnterpriseInProcessServerBuilder( clusterPath.toFile(), homeDir );
+
+                String homePath = Paths.get( clusterPath.toString(), homeDir ).toAbsolutePath().toString();
+                builder.withConfig( GraphDatabaseSettings.neo4j_home.name(), homePath );
+                builder.withConfig( GraphDatabaseSettings.pagecache_memory.name(), "8m" );
+
+                builder.withConfig( EnterpriseEditionSettings.mode.name(), EnterpriseEditionSettings.Mode.READ_REPLICA.name() );
+                builder.withConfig( CausalClusteringSettings.initial_discovery_members.name(), String.join( ",", initialMembers ) );
+                builder.withConfig( CausalClusteringSettings.transaction_listen_address.name(), specifyPortOnly( txPort ) );
+
+                builder.withConfig( CausalClusteringSettings.database.name(), replicasToDatabase.get( replicaId ) );
+
+                builder.withConfig( CausalClusteringSettings.server_groups.name(), "replica," + "replica" + replicaId );
+                configureConnectors( boltPort, httpPort, httpsPort, builder );
+
+                builder.withConfig( ServerSettings.jmx_module_enabled.name(), Settings.FALSE );
+
+                builder.withConfig( OnlineBackupSettings.online_backup_enabled, Settings.FALSE );
+                int finalReplicaId = replicaId;
+                Thread replicaThread = new Thread( () ->
+                {
+                    replicaControls.add( builder.newServer() );
+                    log.info( "Read replica " + finalReplicaId + " started." );
+                } );
+                replicaThreads.add( replicaThread );
+                replicaThread.start();
+            }
+
+            for ( Thread replicaThread : replicaThreads )
+            {
+                replicaThread.join();
+            }
+        }
+
+        private static String specifyPortOnly( int port )
+        {
+            return ":" + port;
+        }
+
+        private static void configureConnectors( int boltPort, int httpPort, int httpsPort, TestServerBuilder builder )
+        {
+            builder.withConfig( new BoltConnector( "bolt" ).type.name(), "BOLT" );
+            builder.withConfig( new BoltConnector( "bolt" ).enabled.name(), "true" );
+            builder.withConfig( new BoltConnector( "bolt" ).listen_address.name(), specifyPortOnly( boltPort ) );
+            builder.withConfig( new BoltConnector( "bolt" ).advertised_address.name(), specifyPortOnly( boltPort ) );
+
+            builder.withConfig( new HttpConnector( "http", HttpConnector.Encryption.NONE ).type.name(), "HTTP" );
+            builder.withConfig( new HttpConnector( "http", HttpConnector.Encryption.NONE ).enabled.name(), "true" );
+            builder.withConfig( new HttpConnector( "http", HttpConnector.Encryption.NONE ).listen_address.name(), specifyPortOnly( httpPort ) );
+            builder.withConfig( new HttpConnector( "http", HttpConnector.Encryption.NONE ).advertised_address.name(), specifyPortOnly( httpPort ) );
+
+            builder.withConfig( new HttpConnector( "https", HttpConnector.Encryption.TLS ).type.name(), "HTTP" );
+            builder.withConfig( new HttpConnector( "https", HttpConnector.Encryption.TLS ).enabled.name(), "true" );
+            builder.withConfig( new HttpConnector( "https", HttpConnector.Encryption.TLS ).listen_address.name(), specifyPortOnly( httpsPort ) );
+            builder.withConfig( new HttpConnector( "https", HttpConnector.Encryption.TLS ).advertised_address.name(), specifyPortOnly( httpsPort ) );
+        }
+
+        void shutdown() throws InterruptedException
+        {
+            shutdownControls( replicaControls );
+            shutdownControls( coreControls );
+        }
+
+        private void shutdownControls( Iterable<? extends ServerControls> controls ) throws InterruptedException
+        {
+            Collection<Thread> threads = new ArrayList<>();
+            for ( ServerControls control : controls )
+            {
+                Thread thread = new Thread( control::close );
+                threads.add( thread );
+                thread.start();
+            }
+
+            for ( Thread thread : threads )
+            {
+                thread.join();
+            }
+        }
+    }
+}

--- a/enterprise/neo4j-harness-enterprise/src/main/java/org/neo4j/harness/ClusterOfClustersInProcessRunner.java
+++ b/enterprise/neo4j-harness-enterprise/src/main/java/org/neo4j/harness/ClusterOfClustersInProcessRunner.java
@@ -21,30 +21,11 @@ package org.neo4j.harness;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.Arrays;
 
-import org.neo4j.causalclustering.core.CausalClusteringSettings;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.harness.internal.EnterpriseInProcessServerBuilder;
-import org.neo4j.kernel.configuration.BoltConnector;
-import org.neo4j.kernel.configuration.HttpConnector;
-import org.neo4j.kernel.configuration.Settings;
-import org.neo4j.kernel.impl.enterprise.configuration.EnterpriseEditionSettings;
-import org.neo4j.kernel.impl.enterprise.configuration.OnlineBackupSettings;
-import org.neo4j.logging.Log;
-import org.neo4j.logging.LogProvider;
-import org.neo4j.server.configuration.ServerSettings;
-
-import static java.util.Collections.synchronizedList;
 import static org.neo4j.logging.FormattedLogProvider.toOutputStream;
 
-/**
- * Simple main class for manual testing of the complete causal cluster stack, including server etc.
- */
-public class CausalClusterInProcessRunner
+public class ClusterOfClustersInProcessRunner
 {
 
     public static void main( String[] args )
@@ -56,16 +37,17 @@ public class CausalClusterInProcessRunner
 
             CausalClusterInProcessBuilder.CausalCluster cluster =
                     CausalClusterInProcessBuilder.init()
-                            .withCores( 3 )
-                            .withReplicas( 3 )
+                            .withCores( 6 )
+                            .withReplicas( 4 )
                             .withLogger( toOutputStream( System.out ) )
                             .atPath( clusterPath )
+                            .withOptionalDatabases( Arrays.asList("foo", "bar") )
                             .build();
 
             System.out.println( "Waiting for cluster to boot up..." );
             cluster.boot();
 
-            System.out.println( "Press ENTER to exit..." );
+            System.out.println( "Press ENTER to exit ..." );
             //noinspection ResultOfMethodCallIgnored
             System.in.read();
 

--- a/enterprise/neo4j-harness-enterprise/src/test/java/org/neo4j/harness/CausalClusterInProcessRunnerIT.java
+++ b/enterprise/neo4j-harness-enterprise/src/test/java/org/neo4j/harness/CausalClusterInProcessRunnerIT.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import org.neo4j.harness.CausalClusterInProcessRunner.CausalCluster;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.ports.allocation.PortAuthority;
 import org.neo4j.test.rule.TestDirectory;
@@ -40,12 +39,12 @@ public class CausalClusterInProcessRunnerIT
     public void shouldBootAndShutdownCluster() throws Exception
     {
         Path clusterPath = testDirectory.absolutePath().toPath();
-        CausalClusterInProcessRunner.PortPickingStrategy portPickingStrategy = new CausalClusterInProcessRunner.PortPickingStrategy()
+        CausalClusterInProcessBuilder.PortPickingStrategy portPickingStrategy = new CausalClusterInProcessBuilder.PortPickingStrategy()
         {
             Map<Integer, Integer> cache = new HashMap<>();
 
             @Override
-            int port( int offset, int id )
+            public int port( int offset, int id )
             {
                 int key = offset + id;
                 if ( ! cache.containsKey( key ) )
@@ -56,7 +55,15 @@ public class CausalClusterInProcessRunnerIT
                 return cache.get( key );
             }
         };
-        CausalCluster cluster = new CausalCluster( 3, 3, clusterPath, NullLogProvider.getInstance(), portPickingStrategy );
+
+        CausalClusterInProcessBuilder.CausalCluster cluster =
+                CausalClusterInProcessBuilder.init()
+                        .withCores( 3 )
+                        .withReplicas( 3 )
+                        .withLogger( NullLogProvider.getInstance() )
+                        .atPath( clusterPath )
+                        .withOptionalPortsStrategy( portPickingStrategy )
+                        .build();
 
         cluster.boot();
         cluster.shutdown();

--- a/integrationtests/src/test/java/org/neo4j/auth/FlatFilePredictableStressIT.java
+++ b/integrationtests/src/test/java/org/neo4j/auth/FlatFilePredictableStressIT.java
@@ -352,7 +352,7 @@ public class FlatFilePredictableStressIT extends FlatFileStressBase
 
         private boolean validRoleDoesNotExist( InvalidArgumentsException e )
         {
-            return !exists && e.getMessage().contains( "RoleInfo '" + roleName + "' does not exist" );
+            return !exists && e.getMessage().contains( "Role '" + roleName + "' does not exist" );
         }
 
         private boolean userDoesNotExist( InvalidArgumentsException e )

--- a/integrationtests/src/test/java/org/neo4j/auth/FlatFilePredictableStressIT.java
+++ b/integrationtests/src/test/java/org/neo4j/auth/FlatFilePredictableStressIT.java
@@ -352,7 +352,7 @@ public class FlatFilePredictableStressIT extends FlatFileStressBase
 
         private boolean validRoleDoesNotExist( InvalidArgumentsException e )
         {
-            return !exists && e.getMessage().contains( "Role '" + roleName + "' does not exist" );
+            return !exists && e.getMessage().contains( "RoleInfo '" + roleName + "' does not exist" );
         }
 
         private boolean userDoesNotExist( InvalidArgumentsException e )


### PR DESCRIPTION
Introduces a mechanism for running multiple logical clusters as part of a single physical neo4j causal-cluster. 

Essentially, the changes in this PR logically partition the discovery service by a string `database` config value. This causes distinct Raft membership sets to form for each `database`, allowing the databases of each set to diverge. 

This feature could potentially serve for basic multi tenancy, or federated database use cases.

At the moment these distinct databases may only be used by knowing the addresses of, and connecting directly to, hosts from each logical partition. However, support for automatic routing of requests to the write hosts at the driver level is upcoming.