### PR TITLE
Fix bug that concatenation of covariant lists would specify wrong type

### DIFF
--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/symbols/IntegerType.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/symbols/IntegerType.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.frontend.v3_2.symbols
 object IntegerType {
   val instance = new IntegerType() {
     val parentType = CTNumber
-    override lazy val coercibleTo: Set[CypherType] = Set(CTFloat)
+    override lazy val coercibleTo: Set[CypherType] = Set(CTFloat) ++ parentType.coercibleTo
     override val toString = "Integer"
     override val toNeoTypeString = "INTEGER?"
 

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/symbols/ListType.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/symbols/ListType.scala
@@ -28,7 +28,7 @@ object ListType {
     val parentType = CTAny
     override val legacyIteratedType = innerType
 
-    override lazy val coercibleTo: Set[CypherType] = Set(CTBoolean)
+    override lazy val coercibleTo: Set[CypherType] = Set(CTBoolean) ++ parentType.coercibleTo
 
     override def parents = innerType.parents.map(copy) ++ super.parents
 

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/symbols/TypeSpec.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/symbols/TypeSpec.scala
@@ -128,10 +128,7 @@ class TypeSpec private (private val ranges: Seq[TypeRange]) extends Equals {
   def unwrapLists: TypeSpec = TypeSpec(ranges.map(_.reparent { case c: ListType => c.innerType }))
 
   def coercions: TypeSpec = {
-    val simpleCoercions = TypeSpec.simpleTypes.filter(this contains).flatMap(_.coercibleTo)
-    if (this containsAny CTList(CTAny).covariant)
-      TypeSpec.exact(simpleCoercions ++ CTList(CTAny).coercibleTo)
-    else
+    val simpleCoercions = ranges.flatMap(_.lower.coercibleTo)
       TypeSpec.exact(simpleCoercions)
   }
 

--- a/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/AddTest.scala
+++ b/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/AddTest.scala
@@ -57,6 +57,25 @@ class AddTest extends InfixExpressionTestBase(Add(_, _)(DummyPosition(0))) {
 
     testValidTypes(CTNode, CTList(CTNode))(CTList(CTNode))
     testValidTypes(CTFloat, CTList(CTFloat))(CTList(CTFloat))
+
+    testValidTypes(CTList(CTAny), CTList(CTAny))(CTList(CTAny))
+  }
+
+  test("should handle covariant types") {
+    testValidTypes(CTString.covariant, CTString.covariant)(CTString)
+    testValidTypes(CTString.covariant, CTInteger)(CTString)
+    testValidTypes(CTString, CTInteger.covariant)(CTString)
+    testValidTypes(CTInteger.covariant, CTInteger.covariant)(CTInteger)
+    testValidTypes(CTInteger.covariant, CTFloat)(CTFloat)
+    testValidTypes(CTInteger, CTFloat.covariant)(CTFloat)
+    testValidTypes(CTFloat.covariant, CTFloat.covariant)(CTFloat.covariant)
+
+    testValidTypes(CTList(CTFloat).covariant, CTList(CTFloat).covariant)(CTList(CTFloat))
+
+    testValidTypes(CTList(CTNode).covariant, CTNode)(CTList(CTNode))
+    testValidTypes(CTList(CTNode), CTNode.covariant)(CTList(CTNode))
+
+    testValidTypes(CTList(CTAny).covariant, CTList(CTAny).covariant)(CTList(CTAny).covariant)
   }
 
   test("shouldHandleCombinedSpecializations") {

--- a/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/AddTest.scala
+++ b/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/AddTest.scala
@@ -68,7 +68,7 @@ class AddTest extends InfixExpressionTestBase(Add(_, _)(DummyPosition(0))) {
     testValidTypes(CTInteger.covariant, CTInteger.covariant)(CTInteger)
     testValidTypes(CTInteger.covariant, CTFloat)(CTFloat)
     testValidTypes(CTInteger, CTFloat.covariant)(CTFloat)
-    testValidTypes(CTFloat.covariant, CTFloat.covariant)(CTFloat.covariant)
+    testValidTypes(CTFloat.covariant, CTFloat.covariant)(CTFloat)
 
     testValidTypes(CTList(CTFloat).covariant, CTList(CTFloat).covariant)(CTList(CTFloat))
 

--- a/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/symbols/TypeSpecTest.scala
+++ b/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/symbols/TypeSpecTest.scala
@@ -249,8 +249,9 @@ class TypeSpecTest extends CypherFunSuite {
     (CTFloat | CTInteger).coercions should equal(CTFloat.invariant)
     CTList(CTAny).covariant.coercions should equal(CTBoolean.invariant)
     TypeSpec.exact(CTList(CTPath)).coercions should equal(CTBoolean.invariant)
-    TypeSpec.all.coercions should equal(CTBoolean | CTFloat)
     CTList(CTAny).covariant.coercions should equal(CTBoolean.invariant)
+    TypeSpec.all.coercions should equal(TypeSpec.none)
+    CTInteger.contravariant.coercions should equal(TypeSpec.none)
   }
 
   test("should intersect with coercions") {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -800,4 +800,9 @@ return p""")
 
     result.toList should equal(List(Map("req.eid" -> null, "y.eid" -> null)))
   }
+
+  test("Reduce and concat gh #10978") {
+    val result = executeWithAllPlannersAndCompatibilityMode("RETURN REDUCE(s = 0, p in [5,8,2,9] + [1,2] | s + p) as num")
+    result.toList should be(List(Map("num" -> 27)))
+  }
 }


### PR DESCRIPTION
The SemanticChecker would compute coercions of covariant types wrong.
This led to problems when specifying the type of add(List<?>, List<?>).

Fixes #10978