### PR TITLE
Reworked index drop during ongoing population.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractDelegatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractDelegatingIndexProxy.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.impl.api.index;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.concurrent.Future;
 
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.internal.kernel.api.IndexCapability;
@@ -57,9 +56,9 @@ public abstract class AbstractDelegatingIndexProxy implements IndexProxy
     }
 
     @Override
-    public Future<Void> drop() throws IOException
+    public void drop() throws IOException
     {
-        return getDelegate().drop();
+        getDelegate().drop();
     }
 
     @Override
@@ -105,9 +104,9 @@ public abstract class AbstractDelegatingIndexProxy implements IndexProxy
     }
 
     @Override
-    public Future<Void> close() throws IOException
+    public void close() throws IOException
     {
-        return getDelegate().close();
+        getDelegate().close();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractSwallowingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractSwallowingIndexProxy.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.api.index;
 
-import java.util.concurrent.Future;
-
 import org.neo4j.internal.kernel.api.IndexCapability;
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.io.pagecache.IOLimiter;
@@ -30,8 +28,6 @@ import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.index.updater.SwallowingIndexUpdater;
 import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.storageengine.api.schema.PopulationProgress;
-
-import static org.neo4j.helpers.FutureAdapter.VOID;
 
 public abstract class AbstractSwallowingIndexProxy implements IndexProxy
 {
@@ -104,9 +100,8 @@ public abstract class AbstractSwallowingIndexProxy implements IndexProxy
     }
 
     @Override
-    public Future<Void> close()
+    public void close()
     {
-        return VOID;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/ContractCheckingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/ContractCheckingIndexProxy.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.impl.api.index;
 
 import java.io.IOException;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -134,11 +133,12 @@ public class ContractCheckingIndexProxy extends DelegatingIndexProxy
     }
 
     @Override
-    public Future<Void> drop() throws IOException
+    public void drop() throws IOException
     {
         if ( state.compareAndSet( State.INIT, State.CLOSED ) )
         {
-            return super.drop();
+            super.drop();
+            return;
         }
 
         if ( State.STARTING == state.get() )
@@ -149,18 +149,20 @@ public class ContractCheckingIndexProxy extends DelegatingIndexProxy
         if ( state.compareAndSet( State.STARTED, State.CLOSED ) )
         {
             waitOpenCallsToClose();
-            return super.drop();
+            super.drop();
+            return;
         }
 
         throw new IllegalStateException( "IndexProxy already closed" );
     }
 
     @Override
-    public Future<Void> close() throws IOException
+    public void close() throws IOException
     {
         if ( state.compareAndSet( State.INIT, State.CLOSED ) )
         {
-            return super.close();
+            super.close();
+            return;
         }
 
         if ( state.compareAndSet( State.STARTING, State.CLOSED ) )
@@ -171,7 +173,8 @@ public class ContractCheckingIndexProxy extends DelegatingIndexProxy
         if ( state.compareAndSet( State.STARTED, State.CLOSED ) )
         {
             waitOpenCallsToClose();
-            return super.close();
+            super.close();
+            return;
         }
 
         throw new IllegalStateException( "IndexProxy already closed" );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FailedIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FailedIndexProxy.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.impl.api.index;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.concurrent.Future;
 
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.internal.kernel.api.InternalIndexState;
@@ -30,7 +29,6 @@ import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 
-import static org.neo4j.helpers.FutureAdapter.VOID;
 import static org.neo4j.helpers.collection.Iterators.emptyResourceIterator;
 
 public class FailedIndexProxy extends AbstractSwallowingIndexProxy
@@ -55,14 +53,13 @@ public class FailedIndexProxy extends AbstractSwallowingIndexProxy
     }
 
     @Override
-    public Future<Void> drop() throws IOException
+    public void drop() throws IOException
     {
         indexCountsRemover.remove();
         String message = "FailedIndexProxy#drop index on " + indexUserDescription + " dropped due to:\n" +
                      getPopulationFailure().asString();
         log.info( message );
         populator.drop();
-        return VOID;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxy.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.api.index;
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.Callable;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -103,13 +102,13 @@ public class FlippableIndexProxy implements IndexProxy
     }
 
     @Override
-    public Future<Void> drop() throws IOException
+    public void drop() throws IOException
     {
         lock.readLock().lock();
         try
         {
             closed = true;
-            return delegate.drop();
+            delegate.drop();
         }
         finally
         {
@@ -285,13 +284,13 @@ public class FlippableIndexProxy implements IndexProxy
     }
 
     @Override
-    public Future<Void> close() throws IOException
+    public void close() throws IOException
     {
         lock.readLock().lock();
         try
         {
             closed = true;
-            return delegate.close();
+            delegate.close();
         }
         finally
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationJob.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationJob.java
@@ -85,14 +85,19 @@ public class IndexPopulationJob implements Runnable
     @Override
     public void run()
     {
-        assert multiPopulator.hasPopulators() : "No index populators was added so there'd be no point in running this job";
-        assert storeScan == null : "Population have already started";
-
         String oldThreadName = currentThread().getName();
-        currentThread().setName( "Index populator" );
-
         try
         {
+            if ( !multiPopulator.hasPopulators() )
+            {
+                return;
+            }
+            if ( storeScan != null )
+            {
+                throw new IllegalStateException( "Population already started." );
+            }
+
+            currentThread().setName( "Index populator" );
             try
             {
                 multiPopulator.create();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxy.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.impl.api.index;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.concurrent.Future;
 
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.internal.kernel.api.IndexCapability;
@@ -68,17 +67,15 @@ public interface IndexProxy extends LabelSchemaSupplier
     IndexUpdater newUpdater( IndexUpdateMode mode );
 
     /**
-     * Initiates dropping this index context. The returned {@link Future} can be used to await
-     * its completion.
+     * Drop index.
      * Must close the context as well.
      */
-    Future<Void> drop() throws IOException;
+    void drop() throws IOException;
 
     /**
-     * Initiates a closing of this index context. The returned {@link Future} can be used to await
-     * its completion.
+     * Close this index context.
      */
-    Future<Void> close() throws IOException;
+    void close() throws IOException;
 
     IndexDescriptor getDescriptor();
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxyCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxyCreator.java
@@ -65,7 +65,6 @@ class IndexProxyCreator
     {
         final FlippableIndexProxy flipper = new FlippableIndexProxy();
 
-        // TODO: This is here because there is a circular dependency from PopulatingIndexProxy to FlippableIndexProxy
         final String indexUserDescription = indexUserDescription( descriptor, providerDescriptor );
         IndexPopulator populator = populatorFromProvider( providerDescriptor, ruleId, descriptor, samplingConfig );
         IndexMeta indexMeta = indexMetaFromProvider( providerDescriptor, descriptor );
@@ -77,9 +76,9 @@ class IndexProxyCreator
                 new IndexCountsRemover( storeView, ruleId ),
                 logProvider );
 
-        PopulatingIndexProxy populatingIndex = new PopulatingIndexProxy( indexMeta, populationJob );
-
-        populationJob.addPopulator( populator, ruleId, indexMeta, indexUserDescription, flipper, failureDelegateFactory );
+        MultipleIndexPopulator.IndexPopulation indexPopulation = populationJob
+                .addPopulator( populator, ruleId, indexMeta, indexUserDescription, flipper, failureDelegateFactory );
+        PopulatingIndexProxy populatingIndex = new PopulatingIndexProxy( indexMeta, populationJob, indexPopulation );
 
         flipper.flipTo( populatingIndex );
 
@@ -116,7 +115,6 @@ class IndexProxyCreator
             IndexDescriptor descriptor,
             SchemaIndexProvider.Descriptor providerDescriptor )
     {
-        // TODO Hook in version verification/migration calls to the SchemaIndexProvider here
         try
         {
             IndexAccessor onlineAccessor =

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/OnlineIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/OnlineIndexProxy.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.impl.api.index;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.concurrent.Future;
 
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.internal.kernel.api.IndexCapability;
@@ -37,8 +36,6 @@ import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.index.updater.UpdateCountingIndexUpdater;
 import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.storageengine.api.schema.PopulationProgress;
-
-import static org.neo4j.helpers.FutureAdapter.VOID;
 
 public class OnlineIndexProxy implements IndexProxy
 {
@@ -124,11 +121,10 @@ public class OnlineIndexProxy implements IndexProxy
     }
 
     @Override
-    public Future<Void> drop() throws IOException
+    public void drop() throws IOException
     {
         indexCountsRemover.remove();
         accessor.drop();
-        return VOID;
     }
 
     @Override
@@ -174,10 +170,9 @@ public class OnlineIndexProxy implements IndexProxy
     }
 
     @Override
-    public Future<Void> close() throws IOException
+    public void close() throws IOException
     {
         accessor.close();
-        return VOID;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.impl.api.index;
 
 import java.io.File;
-import java.util.concurrent.Future;
 
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.internal.kernel.api.IndexCapability;
@@ -41,11 +40,13 @@ public class PopulatingIndexProxy implements IndexProxy
 {
     private final IndexMeta indexMeta;
     private final IndexPopulationJob job;
+    private final MultipleIndexPopulator.IndexPopulation indexPopulation;
 
-    PopulatingIndexProxy( IndexMeta indexMeta, IndexPopulationJob job )
+    PopulatingIndexProxy( IndexMeta indexMeta, IndexPopulationJob job, MultipleIndexPopulator.IndexPopulation indexPopulation )
     {
         this.indexMeta = indexMeta;
         this.job = job;
+        this.indexPopulation = indexPopulation;
     }
 
     @Override
@@ -81,9 +82,9 @@ public class PopulatingIndexProxy implements IndexProxy
     }
 
     @Override
-    public Future<Void> drop()
+    public void drop()
     {
-        return job.cancel();
+        job.cancelPopulation( indexPopulation );
     }
 
     @Override
@@ -129,9 +130,9 @@ public class PopulatingIndexProxy implements IndexProxy
     }
 
     @Override
-    public Future<Void> close()
+    public void close()
     {
-        return job.cancel();
+        job.cancelPopulation( indexPopulation );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/RecoveringIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/RecoveringIndexProxy.java
@@ -20,14 +20,10 @@
 package org.neo4j.kernel.impl.api.index;
 
 import java.io.File;
-import java.util.concurrent.Future;
 
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.internal.kernel.api.InternalIndexState;
-import org.neo4j.kernel.api.exceptions.index.IndexPopulationFailedKernelException;
 import org.neo4j.storageengine.api.schema.PopulationProgress;
-
-import static org.neo4j.helpers.FutureAdapter.VOID;
 
 public class RecoveringIndexProxy extends AbstractSwallowingIndexProxy
 {
@@ -67,9 +63,8 @@ public class RecoveringIndexProxy extends AbstractSwallowingIndexProxy
     }
 
     @Override
-    public Future<Void> drop()
+    public void drop()
     {
-        return VOID;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
@@ -237,31 +237,31 @@ class TemporalIndexAccessor extends TemporalIndexCache<TemporalIndexAccessor.Par
         }
 
         @Override
-        public PartAccessor<?> newDateTime() throws IOException
+        public PartAccessor<?> newDateTime()
         {
             throw new UnsupportedOperationException( "no comprende" );
         }
 
         @Override
-        public PartAccessor<?> newDateTimeZoned() throws IOException
+        public PartAccessor<?> newDateTimeZoned()
         {
             throw new UnsupportedOperationException( "no comprende" );
         }
 
         @Override
-        public PartAccessor<?> newTime() throws IOException
+        public PartAccessor<?> newTime()
         {
             throw new UnsupportedOperationException( "no comprende" );
         }
 
         @Override
-        public PartAccessor<?> newTimeZoned() throws IOException
+        public PartAccessor<?> newTimeZoned()
         {
             throw new UnsupportedOperationException( "no comprende" );
         }
 
         @Override
-        public PartAccessor<?> newDuration() throws IOException
+        public PartAccessor<?> newDuration()
         {
             throw new UnsupportedOperationException( "no comprende" );
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexProxyAdapter.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexProxyAdapter.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.impl.api.index;
 
 import java.io.File;
-import java.util.concurrent.Future;
 
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.internal.kernel.api.IndexCapability;
@@ -34,7 +33,6 @@ import org.neo4j.kernel.impl.api.index.updater.SwallowingIndexUpdater;
 import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.storageengine.api.schema.PopulationProgress;
 
-import static org.neo4j.helpers.FutureAdapter.VOID;
 import static org.neo4j.helpers.collection.Iterators.emptyResourceIterator;
 
 public class IndexProxyAdapter implements IndexProxy
@@ -51,9 +49,8 @@ public class IndexProxyAdapter implements IndexProxy
     }
 
     @Override
-    public Future<Void> drop()
+    public void drop()
     {
-        return VOID;
     }
 
     @Override
@@ -78,9 +75,8 @@ public class IndexProxyAdapter implements IndexProxy
     }
 
     @Override
-    public Future<Void> close()
+    public void close()
     {
-        return VOID;
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsIT.java
@@ -51,10 +51,8 @@ import org.neo4j.register.Register.DoubleLongRegister;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
-import static org.junit.Assert.assertEquals;
-
 import static java.util.Arrays.asList;
-
+import static org.junit.Assert.assertEquals;
 import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.index_background_sampling_enabled;
 import static org.neo4j.logging.AssertableLogProvider.inLog;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxyTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.index;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.verify;
+
+@RunWith( MockitoJUnitRunner.class )
+public class PopulatingIndexProxyTest
+{
+    @Mock
+    private IndexMeta indexMeta;
+    @Mock
+    private IndexPopulationJob indexPopulationJob;
+    @Mock
+    private MultipleIndexPopulator.IndexPopulation indexPopulation;
+    private PopulatingIndexProxy populatingIndexProxy;
+
+    @Before
+    public void setUp()
+    {
+        populatingIndexProxy = new PopulatingIndexProxy( indexMeta, indexPopulationJob, indexPopulation );
+    }
+
+    @Test
+    public void cancelPopulationJobOnClose()
+    {
+        populatingIndexProxy.close();
+
+        verify( indexPopulationJob ).cancelPopulation( indexPopulation );
+    }
+
+    @Test
+    public void cancelPopulationJobOnDrop()
+    {
+        populatingIndexProxy.drop();
+
+        verify( indexPopulationJob ).cancelPopulation( indexPopulation );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/SchemaIndexTestHelper.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/SchemaIndexTestHelper.java
@@ -25,7 +25,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 
-import org.neo4j.helpers.FutureAdapter;
 import org.neo4j.internal.kernel.api.InternalIndexState;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
@@ -38,7 +37,6 @@ import org.neo4j.kernel.lifecycle.Lifecycle;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class SchemaIndexTestHelper
 {
@@ -78,10 +76,7 @@ public class SchemaIndexTestHelper
 
     public static IndexProxy mockIndexProxy() throws IOException
     {
-        IndexProxy result = mock( IndexProxy.class );
-        when( result.drop() ).thenReturn( FutureAdapter.VOID );
-        when( result.close() ).thenReturn( FutureAdapter.VOID );
-        return result;
+        return mock( IndexProxy.class );
     }
 
     public static <T> T awaitFuture( Future<T> future )

--- a/community/neo4j/src/test/java/schema/MultiIndexPopulationConcurrentUpdatesIT.java
+++ b/community/neo4j/src/test/java/schema/MultiIndexPopulationConcurrentUpdatesIT.java
@@ -92,6 +92,8 @@ import org.neo4j.values.storable.Values;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 
 //[NodePropertyUpdate[0, prop:0 add:Sweden, labelsBefore:[], labelsAfter:[0]]]
 //[NodePropertyUpdate[1, prop:0 add:USA, labelsBefore:[], labelsAfter:[0]]]
@@ -110,6 +112,7 @@ public class MultiIndexPopulationConcurrentUpdatesIT
 
     @Rule
     public EmbeddedDatabaseRule embeddedDatabase = new EmbeddedDatabaseRule();
+    private IndexRule[] rules;
 
     @Parameterized.Parameters( name = "{0}" )
     public static Collection<SchemaIndexProvider.Descriptor> parameters()
@@ -164,7 +167,7 @@ public class MultiIndexPopulationConcurrentUpdatesIT
         updates.add( NodeUpdates.forNode( color2.getId(), id( COLOR_LABEL ) )
                 .removed( propertyId, Values.of( "green" ) ).build() );
 
-        launchCustomIndexPopulation( labelsNameIdMap, propertyId, updates );
+        launchCustomIndexPopulation( labelsNameIdMap, propertyId, new UpdateGenerator( updates ) );
         waitAndActivateIndexes( labelsNameIdMap, propertyId );
 
         try ( Transaction ignored = embeddedDatabase.beginTx() )
@@ -194,7 +197,7 @@ public class MultiIndexPopulationConcurrentUpdatesIT
         updates.add( NodeUpdates.forNode( otherNodes[1].getId(), id( CAR_LABEL ) )
                 .added( propertyId, Values.of( "BMW" ) ).build() );
 
-        launchCustomIndexPopulation( labelsNameIdMap, propertyId, updates );
+        launchCustomIndexPopulation( labelsNameIdMap, propertyId, new UpdateGenerator( updates ) );
         waitAndActivateIndexes( labelsNameIdMap, propertyId );
 
         try ( Transaction ignored = embeddedDatabase.beginTx() )
@@ -224,7 +227,7 @@ public class MultiIndexPopulationConcurrentUpdatesIT
         updates.add( NodeUpdates.forNode( car2.getId(), id( CAR_LABEL ) )
                 .changed( propertyId, Values.of( "Ford" ), Values.of( "SAAB" ) ).build() );
 
-        launchCustomIndexPopulation( labelsNameIdMap, propertyId, updates );
+        launchCustomIndexPopulation( labelsNameIdMap, propertyId, new UpdateGenerator( updates ) );
         waitAndActivateIndexes( labelsNameIdMap, propertyId );
 
         try ( Transaction ignored = embeddedDatabase.beginTx() )
@@ -250,6 +253,43 @@ public class MultiIndexPopulationConcurrentUpdatesIT
         }
     }
 
+    @Test
+    public void dropOneOfTheIndexesWhilePopulationIsOngoingDoesInfluenceOtherPopulators() throws Exception
+    {
+        launchCustomIndexPopulation( labelsNameIdMap, propertyId,
+                new IndexDropAction( labelsNameIdMap.get( COLOR_LABEL ) ) );
+        labelsNameIdMap.remove( COLOR_LABEL );
+        waitAndActivateIndexes( labelsNameIdMap, propertyId );
+
+        checkIndexIsOnline( labelsNameIdMap.get( CAR_LABEL ) );
+        checkIndexIsOnline( labelsNameIdMap.get( COUNTRY_LABEL ));
+    }
+
+    @Test
+    public void indexDroppedDuringPopulationDoesNotExist() throws Exception
+    {
+        Integer labelToDropId = labelsNameIdMap.get( COLOR_LABEL );
+        launchCustomIndexPopulation( labelsNameIdMap, propertyId,
+                new IndexDropAction( labelToDropId ) );
+        labelsNameIdMap.remove( COLOR_LABEL );
+        waitAndActivateIndexes( labelsNameIdMap, propertyId );
+        try
+        {
+            indexService.getIndexProxy( SchemaDescriptorFactory.forLabel( labelToDropId, propertyId ) );
+            fail( "Index does not exist, we should fail to find it." );
+        }
+        catch ( IndexNotFoundKernelException infe )
+        {
+            // expected
+        }
+    }
+
+    private void checkIndexIsOnline( int labelId ) throws IndexNotFoundKernelException
+    {
+        IndexProxy indexProxy = indexService.getIndexProxy( SchemaDescriptorFactory.forLabel( labelId, propertyId ) );
+        assertSame( indexProxy.getState(), InternalIndexState.ONLINE );
+    }
+
     private long[] id( String label )
     {
         return new long[]{labelsNameIdMap.get( label )};
@@ -262,7 +302,7 @@ public class MultiIndexPopulationConcurrentUpdatesIT
     }
 
     private void launchCustomIndexPopulation( Map<String,Integer> labelNameIdMap, int propertyId,
-            List<NodeUpdates> updates ) throws Exception
+            Runnable customAction ) throws Exception
     {
         NeoStores neoStores = getNeoStores();
         LabelScanStore labelScanStore = getLabelScanStore();
@@ -271,7 +311,7 @@ public class MultiIndexPopulationConcurrentUpdatesIT
         try ( Transaction transaction = embeddedDatabase.beginTx();
               KernelTransaction ktx = transactionStatementContextBridge.getKernelTransactionBoundToThisThread( true ) )
         {
-            DynamicIndexStoreView storeView = dynamicIndexStoreViewWrapper( updates, neoStores, labelScanStore );
+            DynamicIndexStoreView storeView = dynamicIndexStoreViewWrapper( customAction, neoStores, labelScanStore );
 
             SchemaIndexProviderMap providerMap = getSchemaIndexProvider();
             JobScheduler scheduler = getJobScheduler();
@@ -282,19 +322,19 @@ public class MultiIndexPopulationConcurrentUpdatesIT
                     NullLogProvider.getInstance(), IndexingService.NO_MONITOR, getSchemaState() );
             indexService.start();
 
-            IndexRule[] rules = createIndexRules( labelNameIdMap, propertyId );
+            rules = createIndexRules( labelNameIdMap, propertyId );
 
             indexService.createIndexes( rules );
             transaction.success();
         }
     }
 
-    private DynamicIndexStoreView dynamicIndexStoreViewWrapper( List<NodeUpdates> updates, NeoStores neoStores,
+    private DynamicIndexStoreView dynamicIndexStoreViewWrapper( Runnable customAction, NeoStores neoStores,
             LabelScanStore labelScanStore )
     {
         LockService locks = LockService.NO_LOCK_SERVICE;
         NeoStoreIndexStoreView neoStoreIndexStoreView = new NeoStoreIndexStoreView( locks, neoStores );
-        return new DynamicIndexStoreViewWrapper( neoStoreIndexStoreView, labelScanStore, locks, neoStores, updates );
+        return new DynamicIndexStoreViewWrapper( neoStoreIndexStoreView, labelScanStore, locks, neoStores, customAction );
     }
 
     private void waitAndActivateIndexes( Map<String,Integer> labelsIds, int propertyId )
@@ -442,13 +482,13 @@ public class MultiIndexPopulationConcurrentUpdatesIT
 
     private class DynamicIndexStoreViewWrapper extends DynamicIndexStoreView
     {
-        private final List<NodeUpdates> updates;
+        private final Runnable customAction;
 
         DynamicIndexStoreViewWrapper( NeoStoreIndexStoreView neoStoreIndexStoreView, LabelScanStore labelScanStore, LockService locks,
-                NeoStores neoStores, List<NodeUpdates> updates )
+                NeoStores neoStores, Runnable customAction )
         {
             super( neoStoreIndexStoreView, labelScanStore, locks, neoStores, NullLogProvider.getInstance() );
-            this.updates = updates;
+            this.customAction = customAction;
         }
 
         @Override
@@ -462,26 +502,26 @@ public class MultiIndexPopulationConcurrentUpdatesIT
                     labelUpdateVisitor, forceStoreScan );
             return new LabelScanViewNodeStoreWrapper<>( nodeStore, locks, propertyStore, getLabelScanStore(),
                     element -> false, propertyUpdatesVisitor, labelIds, propertyKeyIdFilter,
-                    (LabelScanViewNodeStoreScan<FAILURE>) storeScan, updates );
+                    (LabelScanViewNodeStoreScan<FAILURE>) storeScan, customAction );
         }
     }
 
     private class LabelScanViewNodeStoreWrapper<FAILURE extends Exception> extends LabelScanViewNodeStoreScan<FAILURE>
     {
         private final LabelScanViewNodeStoreScan<FAILURE> delegate;
-        private final List<NodeUpdates> updates;
+        private final Runnable customAction;
 
         LabelScanViewNodeStoreWrapper( NodeStore nodeStore, LockService locks,
                 PropertyStore propertyStore,
                 LabelScanStore labelScanStore, Visitor<NodeLabelUpdate,FAILURE> labelUpdateVisitor,
                 Visitor<NodeUpdates,FAILURE> propertyUpdatesVisitor, int[] labelIds, IntPredicate propertyKeyIdFilter,
                 LabelScanViewNodeStoreScan<FAILURE> delegate,
-                List<NodeUpdates> updates )
+                Runnable customAction )
         {
             super( nodeStore, locks, propertyStore, labelScanStore, labelUpdateVisitor,
                     propertyUpdatesVisitor, labelIds, propertyKeyIdFilter );
             this.delegate = delegate;
-            this.updates = updates;
+            this.customAction = customAction;
         }
 
         @Override
@@ -495,21 +535,21 @@ public class MultiIndexPopulationConcurrentUpdatesIT
         public PrimitiveLongResourceIterator getNodeIdIterator()
         {
             PrimitiveLongResourceIterator originalIterator = delegate.getNodeIdIterator();
-            return new DelegatingPrimitiveLongResourceIterator( originalIterator, updates );
+            return new DelegatingPrimitiveLongResourceIterator( originalIterator, customAction );
         }
     }
 
     private class DelegatingPrimitiveLongResourceIterator implements PrimitiveLongResourceIterator
     {
-        private final List<NodeUpdates> updates;
+        private final Runnable customAction;
         private final PrimitiveLongResourceIterator delegate;
 
         DelegatingPrimitiveLongResourceIterator(
                 PrimitiveLongResourceIterator delegate,
-                List<NodeUpdates> updates )
+                Runnable customAction )
         {
             this.delegate = delegate;
-            this.updates = updates;
+            this.customAction = customAction;
         }
 
         @Override
@@ -524,7 +564,32 @@ public class MultiIndexPopulationConcurrentUpdatesIT
             long value = delegate.next();
             if ( !hasNext() )
             {
-                for ( NodeUpdates update : updates )
+                customAction.run();
+            }
+            return value;
+        }
+
+        @Override
+        public void close()
+        {
+            delegate.close();
+        }
+    }
+
+    private class UpdateGenerator implements Runnable
+    {
+
+        private Iterable<NodeUpdates> updates;
+
+        UpdateGenerator( Iterable<NodeUpdates> updates )
+        {
+            this.updates = updates;
+        }
+
+        @Override
+        public void run()
+        {
+            for ( NodeUpdates update : updates )
                 {
                     try ( Transaction transaction = embeddedDatabase.beginTx() )
                     {
@@ -570,14 +635,38 @@ public class MultiIndexPopulationConcurrentUpdatesIT
                 {
                     throw new RuntimeException( e );
                 }
-            }
-            return value;
+        }
+    }
+
+    private class IndexDropAction implements Runnable
+    {
+
+        private int labelIdToDropIndexFor;
+
+        private IndexDropAction( int labelIdToDropIndexFor )
+        {
+            this.labelIdToDropIndexFor = labelIdToDropIndexFor;
         }
 
         @Override
-        public void close()
+        public void run()
         {
-            delegate.close();
+            org.neo4j.kernel.api.schema.LabelSchemaDescriptor descriptor =
+                    SchemaDescriptorFactory.forLabel( labelIdToDropIndexFor, propertyId );
+            IndexRule rule = findRuleForLabel( descriptor );
+            indexService.dropIndex( rule );
+        }
+
+        private IndexRule findRuleForLabel( LabelSchemaDescriptor schemaDescriptor )
+        {
+            for ( IndexRule rule : rules )
+            {
+                if ( rule.schema().equals( schemaDescriptor ) )
+                {
+                    return rule;
+                }
+            }
+            return null;
         }
     }
 }


### PR DESCRIPTION
Allow index to be dropped during population without waiting ongoing
population job to fully completed.
In the cases when population job have more than 1 index to populate allow those
populations to continue, before all of those would be canceled for
no reason if one of the indexes where dropped.
Do not use futures-timeouts for ongoing index drop/close operations.