### PR TITLE
Make sure that the page cache warmer does not artificially extend the life of file mappings.

### DIFF
--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
@@ -62,6 +62,7 @@ import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.io.pagecache.impl.FileIsNotMappedException;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.test.Barrier;
 import org.neo4j.test.rule.PageCacheRule;
@@ -890,7 +891,7 @@ public class GBPTreeTest
         write.get();
         close.get();
         assertTrue( "Writer should not be able to acquired after close",
-                writerError.get() instanceof IllegalStateException );
+                writerError.get() instanceof FileIsNotMappedException );
     }
 
     private PageCache pageCacheWithBarrierInClose( final AtomicBoolean enabled, final Barrier.Control barrier )

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
@@ -87,10 +87,12 @@ public interface PageCache extends AutoCloseable
     /**
      * List a snapshot of the current file mappings.
      * <p>
-     * The mappings can change as soon as this method returns. However, the returned {@link PagedFile}s will remain
-     * valid even if they are closed elsewhere.
+     * The mappings can change as soon as this method returns.
      * <p>
-     * <strong>NOTE:</strong> The calling code is responsible for closing <em>all</em> the returned paged files.
+     * <strong>NOTE:</strong> The calling code should <em>not</em> close the returned paged files, unless it does so
+     * in collaboration with the code that originally mapped the file. Any reference count in the mapping will
+     * <em>not</em> be incremented by this method, so calling code must be prepared for that the returned
+     * {@link PagedFile}s can be asynchronously closed elsewhere.
      *
      * @throws IOException if page cache has been closed or page eviction problems occur.
      */

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/FileIsNotMappedException.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/FileIsNotMappedException.java
@@ -30,6 +30,6 @@ public class FileIsNotMappedException extends IOException
 {
     public FileIsNotMappedException( File file )
     {
-        super( "File is not mapped: " + file );
+        super( "File has been unmapped: " + file );
     }
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/FileIsNotMappedException.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/FileIsNotMappedException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.pagecache.impl;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Thrown when accessing a {@link org.neo4j.io.pagecache.PageCursor} of a {@link org.neo4j.io.pagecache.PagedFile} that
+ * has been closed.
+ */
+public class FileIsNotMappedException extends IOException
+{
+    public FileIsNotMappedException( File file )
+    {
+        super( "File is not mapped: " + file );
+    }
+}

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -460,8 +460,9 @@ public class MuninnPageCache implements PageCache
 
         while ( current != null )
         {
+            // Note that we are NOT incrementing the reference count here.
+            // Calling code is expected to be able to deal with asynchronously closed PagedFiles.
             MuninnPagedFile pagedFile = current.pagedFile;
-            pagedFile.incrementRefCount();
             list.add( pagedFile );
             current = current.next;
         }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
@@ -28,6 +28,7 @@ import org.neo4j.io.pagecache.CursorException;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PageSwapper;
 import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.io.pagecache.impl.FileIsNotMappedException;
 import org.neo4j.io.pagecache.tracing.PageFaultEvent;
 import org.neo4j.io.pagecache.tracing.PinEvent;
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer;
@@ -426,7 +427,7 @@ abstract class MuninnPageCursor extends PageCursor
         pinEvent.done();
     }
 
-    long assertPagedFileStillMappedAndGetIdOfLastPage()
+    long assertPagedFileStillMappedAndGetIdOfLastPage() throws FileIsNotMappedException
     {
         return pagedFile.getLastPageId();
     }
@@ -435,7 +436,8 @@ abstract class MuninnPageCursor extends PageCursor
 
     protected abstract void convertPageFaultLock( long pageRef );
 
-    protected abstract void pinCursorToPage( long pageRef, long filePageId, PageSwapper swapper );
+    protected abstract void pinCursorToPage( long pageRef, long filePageId, PageSwapper swapper )
+            throws FileIsNotMappedException;
 
     protected abstract boolean tryLockPage( long pageRef );
 

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
@@ -32,6 +32,7 @@ import org.neo4j.io.pagecache.PageEvictionCallback;
 import org.neo4j.io.pagecache.PageSwapper;
 import org.neo4j.io.pagecache.PageSwapperFactory;
 import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.io.pagecache.impl.FileIsNotMappedException;
 import org.neo4j.io.pagecache.impl.PagedReadableByteChannel;
 import org.neo4j.io.pagecache.impl.PagedWritableByteChannel;
 import org.neo4j.io.pagecache.tracing.FlushEvent;
@@ -204,7 +205,7 @@ final class MuninnPagedFile extends PageList implements PagedFile, Flushable
     }
 
     @Override
-    public long fileSize()
+    public long fileSize() throws FileIsNotMappedException
     {
         final long lastPageId = getLastPageId();
         if ( lastPageId < 0 )
@@ -519,13 +520,12 @@ final class MuninnPagedFile extends PageList implements PagedFile, Flushable
     }
 
     @Override
-    public long getLastPageId()
+    public long getLastPageId() throws FileIsNotMappedException
     {
         long state = getHeaderState();
         if ( refCountOf( state ) == 0 )
         {
-            String msg = "File has been unmapped: " + file().getPath();
-            IllegalStateException exception = new IllegalStateException( msg );
+            FileIsNotMappedException exception = new FileIsNotMappedException( file() );
             Exception closedBy = closeStackTrace;
             if ( closedBy != null )
             {

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnWritePageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnWritePageCursor.java
@@ -22,6 +22,7 @@ package org.neo4j.io.pagecache.impl.muninn;
 import java.io.IOException;
 
 import org.neo4j.io.pagecache.PageSwapper;
+import org.neo4j.io.pagecache.impl.FileIsNotMappedException;
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer;
 import org.neo4j.io.pagecache.tracing.cursor.context.VersionContextSupplier;
 
@@ -113,7 +114,7 @@ final class MuninnWritePageCursor extends MuninnPageCursor
     }
 
     @Override
-    protected void pinCursorToPage( long pageRef, long filePageId, PageSwapper swapper )
+    protected void pinCursorToPage( long pageRef, long filePageId, PageSwapper swapper ) throws FileIsNotMappedException
     {
         reset( pageRef );
         // Check if we've been racing with unmapping. We want to do this before

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheSlowTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheSlowTest.java
@@ -39,6 +39,7 @@ import org.neo4j.adversaries.RandomAdversary;
 import org.neo4j.adversaries.fs.AdversarialFileSystemAbstraction;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.impl.FileIsNotMappedException;
 import org.neo4j.io.pagecache.tracing.PageCacheTracer;
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier;
 import org.neo4j.io.pagecache.tracing.linear.LinearHistoryTracerFactory;
@@ -469,7 +470,7 @@ public abstract class PageCacheSlowTest<T extends PageCache> extends PageCacheTe
             catch ( ExecutionException e )
             {
                 Throwable cause = e.getCause();
-                assertThat( cause, instanceOf( IllegalStateException.class ) );
+                assertThat( cause, instanceOf( FileIsNotMappedException.class ) );
                 assertThat( cause.getMessage(), startsWith( "File has been unmapped" ) );
             }
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/AbstractKeyValueStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/AbstractKeyValueStoreTest.java
@@ -37,6 +37,7 @@ import org.neo4j.function.ThrowingConsumer;
 import org.neo4j.helpers.collection.Pair;
 import org.neo4j.io.fs.OpenMode;
 import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.io.pagecache.impl.FileIsNotMappedException;
 import org.neo4j.io.pagecache.tracing.cursor.context.EmptyVersionContextSupplier;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.lifecycle.Lifespan;
@@ -106,7 +107,7 @@ public class AbstractKeyValueStoreTest
 
     @Test
     @Resources.Life( STARTED )
-    public void accessClosedStateCauseIllegalStateException() throws Exception
+    public void accessClosedStateShouldThrow() throws Exception
     {
         Store store = resourceManager.managed( new Store() );
         store.put( "test", "value" );
@@ -114,7 +115,7 @@ public class AbstractKeyValueStoreTest
         ProgressiveState<String> lookupState = store.state;
         store.prepareRotation( 0 ).rotate();
 
-        expectedException.expect( IllegalStateException.class );
+        expectedException.expect( FileIsNotMappedException.class );
         expectedException.expectMessage( "File has been unmapped" );
 
         lookupState.lookup( "test", new ValueSink()

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
@@ -332,8 +332,7 @@ public class EnterpriseCoreEditionModule extends EditionModule
                 fileName -> fileName.startsWith( TransactionLogFiles.DEFAULT_NAME ),
                 fileName -> fileName.startsWith( IndexConfigStore.INDEX_DB_FILE_NAME ),
                 filename -> filename.startsWith( StoreUtil.TEMP_COPY_DIRECTORY_NAME ),
-                filename -> filename.endsWith( PageCacheWarmer.SUFFIX_CACHEPROF ),
-                filename -> filename.endsWith( PageCacheWarmer.SUFFIX_CACHEPROF_TMP )
+                filename -> filename.endsWith( PageCacheWarmer.SUFFIX_CACHEPROF )
         );
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
@@ -306,8 +306,7 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
                 fileName -> fileName.startsWith( IndexConfigStore.INDEX_DB_FILE_NAME ),
                 filename -> filename.startsWith( StoreUtil.BRANCH_SUBDIRECTORY ),
                 filename -> filename.startsWith( StoreUtil.TEMP_COPY_DIRECTORY_NAME ),
-                filename -> filename.endsWith( PageCacheWarmer.SUFFIX_CACHEPROF ),
-                filename -> filename.endsWith( PageCacheWarmer.SUFFIX_CACHEPROF_TMP ) );
+                filename -> filename.endsWith( PageCacheWarmer.SUFFIX_CACHEPROF ) );
     }
 
     @Override

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModuleIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModuleIT.java
@@ -74,6 +74,5 @@ public class EnterpriseCoreEditionModuleIT
         assertTrue( filter.test( IndexConfigStore.INDEX_DB_FILE_NAME + ".any" ) );
         assertTrue( filter.test( StoreUtil.TEMP_COPY_DIRECTORY_NAME ) );
         assertTrue( filter.test( MetaDataStore.DEFAULT_NAME + PageCacheWarmer.SUFFIX_CACHEPROF ) );
-        assertTrue( filter.test( MetaDataStore.DEFAULT_NAME + PageCacheWarmer.SUFFIX_CACHEPROF_TMP ) );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModuleTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModuleTest.java
@@ -47,6 +47,5 @@ public class EnterpriseReadReplicaEditionModuleTest
         assertTrue( filter.test( StoreUtil.BRANCH_SUBDIRECTORY ) );
         assertTrue( filter.test( StoreUtil.TEMP_COPY_DIRECTORY_NAME ) );
         assertTrue( filter.test( MetaDataStore.DEFAULT_NAME + PageCacheWarmer.SUFFIX_CACHEPROF ) );
-        assertTrue( filter.test( MetaDataStore.DEFAULT_NAME + PageCacheWarmer.SUFFIX_CACHEPROF_TMP ) );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/io/pagecache/impl/muninn/VersionContextTrackingIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/io/pagecache/impl/muninn/VersionContextTrackingIT.java
@@ -36,6 +36,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageSwapper;
 import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.io.pagecache.impl.FileIsNotMappedException;
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer;
 import org.neo4j.io.pagecache.tracing.cursor.context.EmptyVersionContextSupplier;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
@@ -188,6 +189,7 @@ public class VersionContextTrackingIT
 
         @Override
         protected void pinCursorToPage( long pageRef, long filePageId, PageSwapper swapper )
+                throws FileIsNotMappedException
         {
             delegate.pinCursorToPage( pageRef, filePageId, swapper );
         }

--- a/enterprise/cluster/LICENSES.txt
+++ b/enterprise/cluster/LICENSES.txt
@@ -4,13 +4,11 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
-  Apache Commons Compress
   Apache Commons Lang
   Lucene Core
   Lucene Memory
   Netty
   Netty/All-in-One
-  Objenesis
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/enterprise/cluster/NOTICE.txt
+++ b/enterprise/cluster/NOTICE.txt
@@ -26,13 +26,11 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
-  Apache Commons Compress
   Apache Commons Lang
   Lucene Core
   Lucene Memory
   Netty
   Netty/All-in-One
-  Objenesis
 
 Bouncy Castle License
   Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs

--- a/enterprise/com/LICENSES.txt
+++ b/enterprise/com/LICENSES.txt
@@ -4,13 +4,11 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
-  Apache Commons Compress
   Apache Commons Lang
   Lucene Core
   Lucene Memory
   Netty
   Netty/All-in-One
-  Objenesis
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/enterprise/com/NOTICE.txt
+++ b/enterprise/com/NOTICE.txt
@@ -26,13 +26,11 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
-  Apache Commons Compress
   Apache Commons Lang
   Lucene Core
   Lucene Memory
   Netty
   Netty/All-in-One
-  Objenesis
 
 Bouncy Castle License
   Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs

--- a/enterprise/cypher/acceptance-spec-suite/LICENSES.txt
+++ b/enterprise/cypher/acceptance-spec-suite/LICENSES.txt
@@ -4,7 +4,6 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
-  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   ConcurrentLinkedHashMap
@@ -16,7 +15,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  Objenesis
   opencsv
   parboiled-core
   parboiled-scala

--- a/enterprise/cypher/acceptance-spec-suite/NOTICE.txt
+++ b/enterprise/cypher/acceptance-spec-suite/NOTICE.txt
@@ -26,7 +26,6 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
-  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   ConcurrentLinkedHashMap
@@ -38,7 +37,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  Objenesis
   opencsv
   parboiled-core
   parboiled-scala

--- a/enterprise/cypher/compatibility-spec-suite/LICENSES.txt
+++ b/enterprise/cypher/compatibility-spec-suite/LICENSES.txt
@@ -4,7 +4,6 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
-  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   ConcurrentLinkedHashMap
@@ -16,7 +15,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  Objenesis
   opencsv
   openCypher TCK Features and Graphs
   parboiled-core

--- a/enterprise/cypher/compatibility-spec-suite/NOTICE.txt
+++ b/enterprise/cypher/compatibility-spec-suite/NOTICE.txt
@@ -26,7 +26,6 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
-  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   ConcurrentLinkedHashMap
@@ -38,7 +37,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  Objenesis
   opencsv
   openCypher TCK Features and Graphs
   parboiled-core

--- a/enterprise/cypher/cypher/LICENSES.txt
+++ b/enterprise/cypher/cypher/LICENSES.txt
@@ -4,7 +4,6 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
-  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   ConcurrentLinkedHashMap
@@ -16,7 +15,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  Objenesis
   opencsv
   parboiled-core
   parboiled-scala

--- a/enterprise/cypher/cypher/NOTICE.txt
+++ b/enterprise/cypher/cypher/NOTICE.txt
@@ -26,7 +26,6 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
-  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   ConcurrentLinkedHashMap
@@ -38,7 +37,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  Objenesis
   opencsv
   parboiled-core
   parboiled-scala

--- a/enterprise/cypher/morsel-runtime/LICENSES.txt
+++ b/enterprise/cypher/morsel-runtime/LICENSES.txt
@@ -4,7 +4,6 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
-  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   ConcurrentLinkedHashMap
@@ -14,7 +13,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  Objenesis
   opencsv
   parboiled-core
   parboiled-scala

--- a/enterprise/cypher/morsel-runtime/NOTICE.txt
+++ b/enterprise/cypher/morsel-runtime/NOTICE.txt
@@ -26,7 +26,6 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
-  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   ConcurrentLinkedHashMap
@@ -36,7 +35,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  Objenesis
   opencsv
   parboiled-core
   parboiled-scala

--- a/enterprise/cypher/slotted-runtime/LICENSES.txt
+++ b/enterprise/cypher/slotted-runtime/LICENSES.txt
@@ -4,7 +4,6 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
-  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   ConcurrentLinkedHashMap
@@ -14,7 +13,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  Objenesis
   opencsv
   parboiled-core
   parboiled-scala

--- a/enterprise/cypher/slotted-runtime/NOTICE.txt
+++ b/enterprise/cypher/slotted-runtime/NOTICE.txt
@@ -26,7 +26,6 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
-  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   ConcurrentLinkedHashMap
@@ -36,7 +35,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  Objenesis
   opencsv
   parboiled-core
   parboiled-scala

--- a/enterprise/cypher/spec-suite-tools/LICENSES.txt
+++ b/enterprise/cypher/spec-suite-tools/LICENSES.txt
@@ -4,7 +4,6 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
-  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   casbah-commons
@@ -21,7 +20,6 @@ Apache Software License, Version 2.0
   MongoDB Java Driver
   Netty/All-in-One
   nscala-time
-  Objenesis
   openCypher TCK API
   openCypher TCK Features and Graphs
   org.apiguardian:apiguardian-api

--- a/enterprise/cypher/spec-suite-tools/NOTICE.txt
+++ b/enterprise/cypher/spec-suite-tools/NOTICE.txt
@@ -26,7 +26,6 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
-  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   casbah-commons
@@ -43,7 +42,6 @@ Apache Software License, Version 2.0
   MongoDB Java Driver
   Netty/All-in-One
   nscala-time
-  Objenesis
   openCypher TCK API
   openCypher TCK Features and Graphs
   org.apiguardian:apiguardian-api

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -578,8 +578,7 @@ public class HighlyAvailableEditionModule
                 fileName -> fileName.startsWith( IndexConfigStore.INDEX_DB_FILE_NAME ),
                 filename -> filename.startsWith( StoreUtil.BRANCH_SUBDIRECTORY ),
                 filename -> filename.startsWith( StoreUtil.TEMP_COPY_DIRECTORY_NAME ),
-                filename -> filename.endsWith( PageCacheWarmer.SUFFIX_CACHEPROF ),
-                filename -> filename.endsWith( PageCacheWarmer.SUFFIX_CACHEPROF_TMP )
+                filename -> filename.endsWith( PageCacheWarmer.SUFFIX_CACHEPROF )
         );
     }
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModuleIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModuleIT.java
@@ -73,6 +73,5 @@ public class HighlyAvailableEditionModuleIT
         assertTrue( filter.test( StoreUtil.BRANCH_SUBDIRECTORY ) );
         assertTrue( filter.test( StoreUtil.TEMP_COPY_DIRECTORY_NAME ) );
         assertTrue( filter.test( MetaDataStore.DEFAULT_NAME + PageCacheWarmer.SUFFIX_CACHEPROF ) );
-        assertTrue( filter.test( MetaDataStore.DEFAULT_NAME + PageCacheWarmer.SUFFIX_CACHEPROF_TMP ) );
     }
 }

--- a/enterprise/kernel/LICENSES.txt
+++ b/enterprise/kernel/LICENSES.txt
@@ -4,12 +4,10 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
-  Apache Commons Compress
   Apache Commons Lang
   Lucene Core
   Lucene Memory
   Netty/All-in-One
-  Objenesis
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/enterprise/kernel/NOTICE.txt
+++ b/enterprise/kernel/NOTICE.txt
@@ -26,12 +26,10 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
-  Apache Commons Compress
   Apache Commons Lang
   Lucene Core
   Lucene Memory
   Netty/All-in-One
-  Objenesis
 
 Bouncy Castle License
   Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs

--- a/enterprise/kernel/pom.xml
+++ b/enterprise/kernel/pom.xml
@@ -73,10 +73,6 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-compress</artifactId>
-    </dependency>
 
     <!-- Neo4j test dependencies -->
     <dependency>

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModule.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModule.java
@@ -78,8 +78,7 @@ public class EnterpriseEditionModule extends CommunityEditionModule
         return Predicates.any(
                 fileName -> fileName.startsWith( TransactionLogFiles.DEFAULT_NAME ),
                 fileName -> fileName.startsWith( IndexConfigStore.INDEX_DB_FILE_NAME ),
-                filename -> filename.endsWith( PageCacheWarmer.SUFFIX_CACHEPROF ),
-                filename -> filename.endsWith( PageCacheWarmer.SUFFIX_CACHEPROF_TMP )
+                filename -> filename.endsWith( PageCacheWarmer.SUFFIX_CACHEPROF )
         );
     }
 

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmer.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmer.java
@@ -19,14 +19,11 @@
  */
 package org.neo4j.kernel.impl.pagecache;
 
-import org.apache.commons.compress.compressors.CompressorException;
-import org.apache.commons.compress.compressors.CompressorStreamFactory;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.file.StandardCopyOption;
+import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.List;
 import java.util.OptionalLong;
@@ -37,10 +34,15 @@ import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+import java.util.zip.ZipException;
 
 import org.neo4j.graphdb.Resource;
 import org.neo4j.io.IOUtils;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.OpenMode;
+import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
@@ -65,15 +67,8 @@ import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_READ_LOCK;
 public class PageCacheWarmer implements NeoStoreFileListing.StoreFileProvider
 {
     public static final String SUFFIX_CACHEPROF = ".cacheprof";
-    public static final String SUFFIX_CACHEPROF_TMP = ".cacheprof.tmp";
 
-    // We use the deflate algorithm since it has been experimentally shown to be both the fastest,
-    // and the algorithm that produces the smallest output.
-    // For instance, a 5.7 GiB file where 7 out of 8 pages are in memory, produces a 57 KiB profile file,
-    // where the uncompressed profile is 87.5 KiB. A 35% reduction.
-    private static final String COMPRESSION_FORMAT = CompressorStreamFactory.getDeflate();
     private static final int IO_PARALLELISM = Runtime.getRuntime().availableProcessors();
-    private static final CompressorStreamFactory COMPRESSOR_FACTORY = new CompressorStreamFactory( true, 1024 );
 
     private final FileSystemAbstraction fs;
     private final PageCache pageCache;
@@ -109,7 +104,7 @@ public class PageCacheWarmer implements NeoStoreFileListing.StoreFileProvider
         List<PagedFile> files = pageCache.listExistingMappings();
         for ( PagedFile file : files )
         {
-            File profileFile = profileOutputFileFinal( file );
+            File profileFile = profileOutputFileName( file );
             if ( fs.fileExists( profileFile ) )
             {
                 coll.add( new StoreFileMetadata( profileFile, 1, false ) );
@@ -158,13 +153,31 @@ public class PageCacheWarmer implements NeoStoreFileListing.StoreFileProvider
     private long reheat( PagedFile file ) throws IOException
     {
         long pagesLoaded = 0;
-        File savedProfile = profileOutputFileFinal( file );
+        File savedProfile = profileOutputFileName( file );
 
         if ( !fs.fileExists( savedProfile ) )
         {
             return pagesLoaded;
         }
 
+        // First read through the profile to verify its checksum.
+        try ( InputStream inputStream = compressedInputStream( savedProfile ) )
+        {
+            int b;
+            do
+            {
+                b = inputStream.read();
+            }
+            while ( b != -1 );
+        }
+        catch ( ZipException ignore )
+        {
+            // ZipException is used to indicate checksum failures.
+            // Let's ignore this file since it's corrupt.
+            return pagesLoaded;
+        }
+
+        // The file contents checks out. Let's load it in.
         try ( InputStream inputStream = compressedInputStream( savedProfile );
               PageLoader loader = pageLoaderFactory.getLoader( file ) )
         {
@@ -224,9 +237,9 @@ public class PageCacheWarmer implements NeoStoreFileListing.StoreFileProvider
     private long profile( PagedFile file ) throws IOException
     {
         long pagesInMemory = 0;
-        File outputNext = profileOutputFileNext( file );
+        File outputFile = profileOutputFileName( file );
 
-        try ( OutputStream outputStream = compressedOutputStream( outputNext );
+        try ( OutputStream outputStream = compressedOutputStream( outputFile );
               PageCursor cursor = file.io( 0, PF_SHARED_READ_LOCK | PF_NO_FAULT ) )
         {
             int stepper = 0;
@@ -258,8 +271,6 @@ public class PageCacheWarmer implements NeoStoreFileListing.StoreFileProvider
             outputStream.flush();
         }
 
-        File outputFinal = profileOutputFileFinal( file );
-        fs.renameFile( outputNext, outputFinal, StandardCopyOption.REPLACE_EXISTING );
         return pagesInMemory;
     }
 
@@ -268,9 +279,9 @@ public class PageCacheWarmer implements NeoStoreFileListing.StoreFileProvider
         InputStream source = fs.openAsInputStream( input );
         try
         {
-            return COMPRESSOR_FACTORY.createCompressorInputStream( COMPRESSION_FORMAT, source );
+            return new GZIPInputStream( source );
         }
-        catch ( CompressorException e )
+        catch ( IOException e )
         {
             IOUtils.closeAllSilently( source );
             throw new IOException( "Exception when building decompressor.", e );
@@ -279,30 +290,43 @@ public class PageCacheWarmer implements NeoStoreFileListing.StoreFileProvider
 
     private OutputStream compressedOutputStream( File output ) throws IOException
     {
-        OutputStream sink = fs.openAsOutputStream( output, false );
+        StoreChannel channel = fs.open( output, OpenMode.READ_WRITE );
+        ByteBuffer buf = ByteBuffer.allocate( 1 );
+        OutputStream sink = new OutputStream()
+        {
+            @Override
+            public void write( int b ) throws IOException
+            {
+                buf.put( (byte) b );
+                buf.flip();
+                channel.write( buf );
+                buf.flip();
+            }
+
+            @Override
+            public void close() throws IOException
+            {
+                channel.truncate( channel.position() );
+                channel.close();
+            }
+        };
         try
         {
-            return COMPRESSOR_FACTORY.createCompressorOutputStream( COMPRESSION_FORMAT, sink );
+            return new GZIPOutputStream( sink );
         }
-        catch ( CompressorException e )
+        catch ( IOException e )
         {
-            IOUtils.closeAllSilently( sink );
+            // We close the channel instead of the sink here, because we don't want to truncate the file if we fail
+            // to open the gzip output stream.
+            IOUtils.closeAllSilently( channel );
             throw new IOException( "Exception when building compressor.", e );
         }
     }
 
-    private File profileOutputFileFinal( PagedFile file )
+    private File profileOutputFileName( PagedFile file )
     {
         File mappedFile = file.file();
         String profileOutputName = "." + mappedFile.getName() + SUFFIX_CACHEPROF;
-        File parent = mappedFile.getParentFile();
-        return new File( parent, profileOutputName );
-    }
-
-    private File profileOutputFileNext( PagedFile file )
-    {
-        File mappedFile = file.file();
-        String profileOutputName = "." + mappedFile.getName() + SUFFIX_CACHEPROF_TMP;
         File parent = mappedFile.getParentFile();
         return new File( parent, profileOutputName );
     }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModuleTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModuleTest.java
@@ -44,6 +44,5 @@ public class EnterpriseEditionModuleTest
         assertTrue( filter.test( TransactionLogFiles.DEFAULT_NAME + ".1" ) );
         assertTrue( filter.test( IndexConfigStore.INDEX_DB_FILE_NAME + ".any" ) );
         assertTrue( filter.test( MetaDataStore.DEFAULT_NAME + PageCacheWarmer.SUFFIX_CACHEPROF ) );
-        assertTrue( filter.test( MetaDataStore.DEFAULT_NAME + PageCacheWarmer.SUFFIX_CACHEPROF_TMP ) );
     }
 }

--- a/integrationtests/src/test/java/org/neo4j/kernel/PageCacheWarmupCcIT.java
+++ b/integrationtests/src/test/java/org/neo4j/kernel/PageCacheWarmupCcIT.java
@@ -30,7 +30,9 @@ import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.ClusterMember;
 import org.neo4j.causalclustering.discovery.CoreClusterMember;
 import org.neo4j.concurrent.BinaryLatch;
+import org.neo4j.ext.udc.UdcSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.pagecache.PageCacheWarmerMonitor;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.causalclustering.ClusterRule;
@@ -43,7 +45,9 @@ public class PageCacheWarmupCcIT extends PageCacheWarmupTestSupport
     @Rule
     public ClusterRule clusterRule = new ClusterRule()
             .withNumberOfReadReplicas( 0 )
+            .withSharedCoreParam( UdcSettings.udc_enabled, Settings.FALSE )
             .withSharedCoreParam( GraphDatabaseSettings.pagecache_warmup_profiling_interval, "100ms" )
+            .withSharedReadReplicaParam( UdcSettings.udc_enabled, Settings.FALSE )
             .withSharedReadReplicaParam( GraphDatabaseSettings.pagecache_warmup_profiling_interval, "100ms" );
 
     private Cluster cluster;


### PR DESCRIPTION
Much of the database expects to be able to close, unmap, and remap files as it pleases. Much of the database code assumes that it has complete control over their files.
The page cache warmer messed with this by grabbing references to the paged files, and thus increasing their reference count, and potentially extending their life beyond what other code intended for those mappings.
This has been fixed by making the `PageCache.listExistingMappings` method no longer incrimenting the paged file reference count, and the page cache warmer now instead anticipates and copes with asynchronously closed paged files.