### PR TITLE
Temporal indexing 3 - all the parts

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/v2/messaging/Neo4jPackV2Test.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v2/messaging/Neo4jPackV2Test.java
@@ -35,7 +35,7 @@ import java.util.stream.IntStream;
 import org.neo4j.bolt.v1.messaging.Neo4jPack;
 import org.neo4j.bolt.v1.packstream.PackedInputArray;
 import org.neo4j.bolt.v1.packstream.PackedOutputArray;
-import org.neo4j.kernel.impl.store.TimeZoneMapping;
+import org.neo4j.kernel.impl.store.TimeZones;
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.storable.CoordinateReferenceSystem;
 import org.neo4j.values.storable.DateTimeValue;
@@ -74,7 +74,9 @@ import static org.neo4j.values.virtual.VirtualValues.list;
 public class Neo4jPackV2Test
 {
     private static final String[] TIME_ZONE_NAMES =
-            TimeZoneMapping.supportedTimeZones().stream().filter( s -> ZoneId.getAvailableZoneIds().contains( s ) ).toArray( length -> new String[length] );
+            TimeZones.supportedTimeZones().stream()
+                    .filter( s -> ZoneId.getAvailableZoneIds().contains( s ) )
+                    .toArray( length -> new String[length] );
 
     private static final int RANDOM_VALUES_TO_TEST = 1_000;
     private static final int RANDOM_LISTS_TO_TEST = 1_000;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/BaseLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/BaseLayout.java
@@ -38,5 +38,4 @@ abstract class BaseLayout<KEY extends ComparableNativeSchemaKey<KEY>> extends Sc
     {
         return o1.compareValueTo( o2 );
     }
-
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/BaseLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/BaseLayout.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema;
+
+import org.neo4j.index.internal.gbptree.Layout;
+
+/**
+ * Simple GBPTree Layout with no values.
+ *
+ * @param <KEY> the key type
+ */
+abstract class BaseLayout<KEY extends ComparableNativeSchemaKey<KEY>> extends SchemaLayout<KEY>
+{
+    BaseLayout( String layoutName, int majorVersion, int minorVersion )
+    {
+        super( Layout.namedIdentifier( layoutName, NativeSchemaValue.SIZE ), majorVersion, minorVersion );
+    }
+
+    @Override
+    int compareValue( KEY o1, KEY o2 )
+    {
+        return o1.compareValueTo( o2 );
+    }
+
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ComparableNativeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ComparableNativeSchemaKey.java
@@ -22,7 +22,8 @@ package org.neo4j.kernel.impl.index.schema;
 import java.util.Comparator;
 
 /**
- * Adds comparability to NativeSchemaKey.
+ * Adds comparability to NativeSchemaKey. Note that comparability of keys is required for the GBPTree, so
+ * this has to be implemented even if the values in the key are not comparable.
  *
  * @param <SELF> the type of the concrete implementing subclass
  */
@@ -33,8 +34,8 @@ abstract class ComparableNativeSchemaKey<SELF extends ComparableNativeSchemaKey>
      * Compares the value of this key to that of another key.
      * This method is expected to be called in scenarios where inconsistent reads may happen (and later retried).
      *
-     * @param other the {@link LocalTimeSchemaKey} to compare to.
-     * @return comparison against the {@code other} {@link LocalTimeSchemaKey}.
+     * @param other the key to compare to.
+     * @return comparison against the {@code other} key.
      */
     abstract int compareValueTo( SELF other );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ComparableNativeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ComparableNativeSchemaKey.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema;
+
+import java.util.Comparator;
+
+/**
+ * Adds comparability to NativeSchemaKey.
+ *
+ * @param <SELF> the type of the concrete implementing subclass
+ */
+abstract class ComparableNativeSchemaKey<SELF extends ComparableNativeSchemaKey> extends NativeSchemaKey
+{
+
+    /**
+     * Compares the value of this key to that of another key.
+     * This method is expected to be called in scenarios where inconsistent reads may happen (and later retried).
+     *
+     * @param other the {@link LocalTimeSchemaKey} to compare to.
+     * @return comparison against the {@code other} {@link LocalTimeSchemaKey}.
+     */
+    abstract int compareValueTo( SELF other );
+
+    static <T extends ComparableNativeSchemaKey<T>> Comparator<T> UNIQUE()
+    {
+        return ( o1, o2 ) -> {
+            int comparison = o1.compareValueTo( o2 );
+            if ( comparison == 0 )
+            {
+                // This is a special case where we need also compare entityId to support inclusive/exclusive
+                if ( o1.getCompareId() || o2.getCompareId() )
+                {
+                    return Long.compare( o1.getEntityId(), o2.getEntityId() );
+                }
+            }
+            return comparison;
+        };
+    }
+
+    static <T extends ComparableNativeSchemaKey<T>> Comparator<T> NON_UNIQUE()
+    {
+        return ( o1, o2 ) -> {
+            int comparison = o1.compareValueTo( o2 );
+            return comparison != 0 ? comparison : Long.compare( o1.getEntityId(), o2.getEntityId() );
+        };
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DateLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DateLayout.java
@@ -26,22 +26,19 @@ import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 /**
  * {@link Layout} for dates.
  */
-class DateLayout extends SchemaLayout<DateSchemaKey>
+class DateLayout extends BaseLayout<DateSchemaKey>
 {
     public static Layout<DateSchemaKey,NativeSchemaValue> of( IndexDescriptor descriptor )
     {
         return descriptor.type() == IndexDescriptor.Type.UNIQUE ? DateLayout.UNIQUE : DateLayout.NON_UNIQUE;
     }
 
-    private static final long UNIQUE_LAYOUT_IDENTIFIER = Layout.namedIdentifier( "UTda", NativeSchemaValue.SIZE );
-    public static DateLayout UNIQUE = new DateLayout( UNIQUE_LAYOUT_IDENTIFIER, 0, 1 );
+    private static DateLayout UNIQUE = new DateLayout( "UTda", 0, 1 );
+    private static DateLayout NON_UNIQUE = new DateLayout( "NTda", 0, 1 );
 
-    private static final long NON_UNIQUE_LAYOUT_IDENTIFIER = Layout.namedIdentifier( "NTda", NativeSchemaValue.SIZE );
-    public static DateLayout NON_UNIQUE = new DateLayout( NON_UNIQUE_LAYOUT_IDENTIFIER, 0, 1 );
-
-    DateLayout( long identifier, int majorVersion, int minorVersion )
+    private DateLayout( String layoutName, int majorVersion, int minorVersion )
     {
-        super( identifier, majorVersion, minorVersion );
+        super( layoutName, majorVersion, minorVersion );
     }
 
     @Override
@@ -77,11 +74,5 @@ class DateLayout extends SchemaLayout<DateSchemaKey>
     {
         into.epochDay = cursor.getLong();
         into.setEntityId( cursor.getLong() );
-    }
-
-    @Override
-    int compareValue( DateSchemaKey o1, DateSchemaKey o2 )
-    {
-        return o1.compareValueTo( o2 );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DateLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DateLayout.java
@@ -23,6 +23,9 @@ import org.neo4j.index.internal.gbptree.Layout;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 
+/**
+ * {@link Layout} for dates.
+ */
 class DateLayout extends SchemaLayout<DateSchemaKey>
 {
     public static Layout<DateSchemaKey,NativeSchemaValue> of( IndexDescriptor descriptor )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DateSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DateSchemaKey.java
@@ -27,7 +27,7 @@ import static java.lang.String.format;
 /**
  * Includes value and entity id (to be able to handle non-unique values). A value can be any {@link DateValue}.
  */
-class DateSchemaKey extends NativeSchemaKey
+class DateSchemaKey extends ComparableNativeSchemaKey<DateSchemaKey>
 {
     static final int SIZE =
             Long.BYTES + /* epochDay */
@@ -53,14 +53,8 @@ class DateSchemaKey extends NativeSchemaKey
         epochDay = Long.MAX_VALUE;
     }
 
-    /**
-     * Compares the value of this key to that of another key.
-     * This method is expected to be called in scenarios where inconsistent reads may happen (and later retried).
-     *
-     * @param other the {@link DateSchemaKey} to compare to.
-     * @return comparison against the {@code other} {@link DateSchemaKey}.
-     */
-    int compareValueTo( DateSchemaKey other )
+    @Override
+    public int compareValueTo( DateSchemaKey other )
     {
         return Long.compare( epochDay, other.epochDay );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DateSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DateSchemaKey.java
@@ -36,30 +36,6 @@ class DateSchemaKey extends NativeSchemaKey
     long epochDay;
 
     @Override
-    void from( Value... values )
-    {
-        assertValidValue( values ).writeTo( this );
-    }
-
-    private DateValue assertValidValue( Value... values )
-    {
-        if ( values.length > 1 )
-        {
-            throw new IllegalArgumentException( "Tried to create composite key with non-composite schema key layout" );
-        }
-        if ( values.length < 1 )
-        {
-            throw new IllegalArgumentException( "Tried to create key without value" );
-        }
-        if ( !(values[0] instanceof DateValue) )
-        {
-            throw new IllegalArgumentException(
-                    "Key layout does only support DateValue, tried to create key from " + values[0] );
-        }
-        return (DateValue) values[0];
-    }
-
-    @Override
     public Value asValue()
     {
         return DateValue.epochDate( epochDay );
@@ -99,5 +75,15 @@ class DateSchemaKey extends NativeSchemaKey
     public void writeDate( long epochDay )
     {
         this.epochDay = epochDay;
+    }
+
+    @Override
+    protected void assertCorrectType( Value value )
+    {
+        if ( !(value instanceof DateValue) )
+        {
+            throw new IllegalArgumentException(
+                    "Key layout does only support DateValue, tried to create key from " + value );
+        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DateSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DateSchemaKey.java
@@ -72,12 +72,13 @@ class DateSchemaKey extends ComparableNativeSchemaKey<DateSchemaKey>
     }
 
     @Override
-    protected void assertCorrectType( Value value )
+    protected Value assertCorrectType( Value value )
     {
         if ( !(value instanceof DateValue) )
         {
             throw new IllegalArgumentException(
                     "Key layout does only support DateValue, tried to create key from " + value );
         }
+        return value;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DateSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DateSchemaKey.java
@@ -62,7 +62,7 @@ class DateSchemaKey extends ComparableNativeSchemaKey<DateSchemaKey>
     @Override
     public String toString()
     {
-        return format( "value=%s,entityId=%d,epochDay=%s", asValue(), getEntityId(), epochDay );
+        return format( "value=%s,entityId=%d,epochDay=%d", asValue(), getEntityId(), epochDay );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DurationLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DurationLayout.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema;
+
+import java.util.Comparator;
+
+import org.neo4j.index.internal.gbptree.Layout;
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.kernel.api.schema.index.IndexDescriptor;
+
+/**
+ * {@link Layout} for durations.
+ */
+class DurationLayout extends BaseLayout<DurationSchemaKey>
+{
+    public static Layout<DurationSchemaKey,NativeSchemaValue> of( IndexDescriptor descriptor )
+    {
+        return descriptor.type() == IndexDescriptor.Type.UNIQUE ? DurationLayout.UNIQUE : DurationLayout.NON_UNIQUE;
+    }
+
+    private static DurationLayout UNIQUE = new DurationLayout( "UTdu", 0, 1, ComparableNativeSchemaKey.UNIQUE() );
+    private static DurationLayout NON_UNIQUE = new DurationLayout( "NTdu", 0, 1, ComparableNativeSchemaKey.NON_UNIQUE() );
+
+    private DurationLayout(
+            String layoutName, int majorVersion, int minorVersion, Comparator<DurationSchemaKey> comparator )
+    {
+        super( layoutName, majorVersion, minorVersion, comparator );
+    }
+
+    @Override
+    public DurationSchemaKey newKey()
+    {
+        return new DurationSchemaKey();
+    }
+
+    @Override
+    public DurationSchemaKey copyKey( DurationSchemaKey key, DurationSchemaKey into )
+    {
+        into.totalAvgSeconds = key.totalAvgSeconds;
+        into.nanosOfSecond = key.nanosOfSecond;
+        into.months = key.months;
+        into.days = key.days;
+        into.setEntityId( key.getEntityId() );
+        into.setCompareId( key.getCompareId() );
+        return into;
+    }
+
+    @Override
+    public int keySize( DurationSchemaKey key )
+    {
+        return DurationSchemaKey.SIZE;
+    }
+
+    @Override
+    public void writeKey( PageCursor cursor, DurationSchemaKey key )
+    {
+        cursor.putLong( key.totalAvgSeconds );
+        cursor.putInt( key.nanosOfSecond );
+        cursor.putLong( key.months );
+        cursor.putLong( key.days );
+        cursor.putLong( key.getEntityId() );
+    }
+
+    @Override
+    public void readKey( PageCursor cursor, DurationSchemaKey into, int keySize )
+    {
+        into.totalAvgSeconds = cursor.getLong();
+        into.nanosOfSecond = cursor.getInt();
+        into.months = cursor.getLong();
+        into.days = cursor.getLong();
+        into.setEntityId( cursor.getLong() );
+    }
+
+    @Override
+    public boolean fixedSize()
+    {
+        return true;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DurationLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DurationLayout.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.index.schema;
 
-import java.util.Comparator;
-
 import org.neo4j.index.internal.gbptree.Layout;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
@@ -35,13 +33,12 @@ class DurationLayout extends BaseLayout<DurationSchemaKey>
         return descriptor.type() == IndexDescriptor.Type.UNIQUE ? DurationLayout.UNIQUE : DurationLayout.NON_UNIQUE;
     }
 
-    private static DurationLayout UNIQUE = new DurationLayout( "UTdu", 0, 1, ComparableNativeSchemaKey.UNIQUE() );
-    private static DurationLayout NON_UNIQUE = new DurationLayout( "NTdu", 0, 1, ComparableNativeSchemaKey.NON_UNIQUE() );
+    private static DurationLayout UNIQUE = new DurationLayout( "UTdu", 0, 1 );
+    private static DurationLayout NON_UNIQUE = new DurationLayout( "NTdu", 0, 1 );
 
-    private DurationLayout(
-            String layoutName, int majorVersion, int minorVersion, Comparator<DurationSchemaKey> comparator )
+    private DurationLayout( String layoutName, int majorVersion, int minorVersion )
     {
-        super( layoutName, majorVersion, minorVersion, comparator );
+        super( layoutName, majorVersion, minorVersion );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DurationLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DurationLayout.java
@@ -84,10 +84,4 @@ class DurationLayout extends BaseLayout<DurationSchemaKey>
         into.days = cursor.getLong();
         into.setEntityId( cursor.getLong() );
     }
-
-    @Override
-    public boolean fixedSize()
-    {
-        return true;
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DurationSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DurationSchemaKey.java
@@ -83,14 +83,14 @@ class DurationSchemaKey extends ComparableNativeSchemaKey<DurationSchemaKey>
         if ( comparison == 0 )
         {
             comparison = Integer.compare( nanosOfSecond, other.nanosOfSecond );
-        }
-        if ( comparison == 0 )
-        {
-            comparison = Long.compare( months, other.months );
-        }
-        if ( comparison == 0 )
-        {
-            comparison = Long.compare( days, other.days );
+            if ( comparison == 0 )
+            {
+                comparison = Long.compare( months, other.months );
+                if ( comparison == 0 )
+                {
+                    comparison = Long.compare( days, other.days );
+                }
+            }
         }
         return comparison;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DurationSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DurationSchemaKey.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema;
+
+import org.neo4j.values.storable.DurationValue;
+import org.neo4j.values.storable.Value;
+
+import static java.lang.String.format;
+
+/**
+ * Includes value and entity id (to be able to handle non-unique values). A value can be any {@link DurationValue}.
+ *
+ * Durations are tricky, because exactly how long a duration is depends on the start date. We therefore sort them by
+ * average total time in seconds, but keep the original months and days so we can reconstruct the value.
+ */
+class DurationSchemaKey extends TemporalSchemaKey implements ComparableNativeSchemaKey<DurationSchemaKey>
+{
+    /**
+     * An average month is 30 days, 10 hours and 30 minutes.
+     * In seconds this is (((30 * 24) + 10) * 60 + 30) * 60 = 2629800
+     */
+    private static final long AVG_MONTH_SECONDS = 2_629_800;
+    private static final long AVG_DAY_SECONDS = 86_400;
+
+    static final int SIZE =
+            Long.BYTES +    /* totalAvgSeconds */
+            Integer.BYTES + /* nanosOfSecond */
+            Long.BYTES +    /* months */
+            Long.BYTES +    /* days */
+            Long.BYTES;     /* entityId */
+
+    long totalAvgSeconds;
+    int nanosOfSecond;
+    long months;
+    long days;
+
+    @Override
+    public Value asValue()
+    {
+        long seconds = totalAvgSeconds - months * AVG_MONTH_SECONDS - days * AVG_DAY_SECONDS;
+        return DurationValue.duration( months, days, seconds, nanosOfSecond );
+    }
+
+    @Override
+    public void initAsLowest()
+    {
+        super.initAsLowest();
+        totalAvgSeconds = Long.MIN_VALUE;
+        nanosOfSecond = Integer.MIN_VALUE;
+        months = Long.MIN_VALUE;
+        days = Long.MIN_VALUE;
+    }
+
+    @Override
+    public void initAsHighest()
+    {
+        super.initAsHighest();
+        totalAvgSeconds = Long.MAX_VALUE;
+        nanosOfSecond = Integer.MAX_VALUE;
+        months = Long.MAX_VALUE;
+        days = Long.MAX_VALUE;
+    }
+
+    @Override
+    public int compareValueTo( DurationSchemaKey other )
+    {
+        int comparison = Long.compare( totalAvgSeconds, other.totalAvgSeconds );
+        if ( comparison == 0 )
+        {
+            comparison = Integer.compare( nanosOfSecond, other.nanosOfSecond );
+        }
+        if ( comparison == 0 )
+        {
+            comparison = Long.compare( months, other.months );
+        }
+        if ( comparison == 0 )
+        {
+            comparison = Long.compare( days, other.days );
+        }
+        return comparison;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "value=%s,entityId=%d,totalAvgSeconds=%d,nanosOfSecond=%d,months=%d,days=%d",
+                asValue(), entityId, totalAvgSeconds, nanosOfSecond, months, days );
+    }
+
+    @Override
+    public void writeDuration( long months, long days, long seconds, int nanos )
+    {   // no-op
+        this.totalAvgSeconds = months * AVG_MONTH_SECONDS + days * AVG_DAY_SECONDS + seconds;
+        this.nanosOfSecond = nanos;
+        this.months = months;
+        this.days = days;
+    }
+
+    @Override
+    protected Value assertCorrectType( Value value )
+    {
+        if ( !(value instanceof DurationValue) )
+        {
+            throw new IllegalArgumentException(
+                    "Key layout does only support DurationValue, tried to create key from " + value );
+        }
+        return value;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DurationSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DurationSchemaKey.java
@@ -30,7 +30,7 @@ import static java.lang.String.format;
  * Durations are tricky, because exactly how long a duration is depends on the start date. We therefore sort them by
  * average total time in seconds, but keep the original months and days so we can reconstruct the value.
  */
-class DurationSchemaKey extends TemporalSchemaKey implements ComparableNativeSchemaKey<DurationSchemaKey>
+class DurationSchemaKey extends ComparableNativeSchemaKey<DurationSchemaKey>
 {
     /**
      * An average month is 30 days, 10 hours and 30 minutes.
@@ -59,9 +59,8 @@ class DurationSchemaKey extends TemporalSchemaKey implements ComparableNativeSch
     }
 
     @Override
-    public void initAsLowest()
+    public void initValueAsLowest()
     {
-        super.initAsLowest();
         totalAvgSeconds = Long.MIN_VALUE;
         nanosOfSecond = Integer.MIN_VALUE;
         months = Long.MIN_VALUE;
@@ -69,9 +68,8 @@ class DurationSchemaKey extends TemporalSchemaKey implements ComparableNativeSch
     }
 
     @Override
-    public void initAsHighest()
+    public void initValueAsHighest()
     {
-        super.initAsHighest();
         totalAvgSeconds = Long.MAX_VALUE;
         nanosOfSecond = Integer.MAX_VALUE;
         months = Long.MAX_VALUE;
@@ -101,7 +99,7 @@ class DurationSchemaKey extends TemporalSchemaKey implements ComparableNativeSch
     public String toString()
     {
         return format( "value=%s,entityId=%d,totalAvgSeconds=%d,nanosOfSecond=%d,months=%d,days=%d",
-                asValue(), entityId, totalAvgSeconds, nanosOfSecond, months, days );
+                        asValue(), getEntityId(), totalAvgSeconds, nanosOfSecond, months, days );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeLayout.java
@@ -78,10 +78,4 @@ class LocalDateTimeLayout extends BaseLayout<LocalDateTimeSchemaKey>
         into.nanoOfSecond = cursor.getInt();
         into.setEntityId( cursor.getLong() );
     }
-
-    @Override
-    public boolean fixedSize()
-    {
-        return true;
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeLayout.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema;
+
+import org.neo4j.index.internal.gbptree.Layout;
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.kernel.api.schema.index.IndexDescriptor;
+
+/**
+ * {@link Layout} for local date times.
+ */
+abstract class LocalDateTimeLayout extends Layout.Adapter<LocalDateTimeSchemaKey,NativeSchemaValue>
+{
+    public static Layout<LocalDateTimeSchemaKey,NativeSchemaValue> of( IndexDescriptor descriptor )
+    {
+        return descriptor.type() == IndexDescriptor.Type.UNIQUE ? LocalDateTimeLayout.UNIQUE : LocalDateTimeLayout.NON_UNIQUE;
+    }
+
+    private static final long UNIQUE_LAYOUT_IDENTIFIER = Layout.namedIdentifier( "UTld", NativeSchemaValue.SIZE );
+    public static LocalDateTimeLayout UNIQUE = new LocalDateTimeLayout()
+    {
+        @Override
+        public long identifier()
+        {
+            return UNIQUE_LAYOUT_IDENTIFIER;
+        }
+
+        @Override
+        public int majorVersion()
+        {
+            return 0;
+        }
+
+        @Override
+        public int minorVersion()
+        {
+            return 1;
+        }
+
+        @Override
+        public int compare( LocalDateTimeSchemaKey o1, LocalDateTimeSchemaKey o2 )
+        {
+            int comparison = o1.compareValueTo( o2 );
+            if ( comparison == 0 )
+            {
+                // This is a special case where we need also compare entityId to support inclusive/exclusive
+                if ( o1.getCompareId() || o2.getCompareId() )
+                {
+                    return Long.compare( o1.getEntityId(), o2.getEntityId() );
+                }
+            }
+            return comparison;
+        }
+    };
+
+    private static final long NON_UNIQUE_LAYOUT_IDENTIFIER = Layout.namedIdentifier( "NTld", NativeSchemaValue.SIZE );
+    public static LocalDateTimeLayout NON_UNIQUE = new LocalDateTimeLayout()
+    {
+        @Override
+        public long identifier()
+        {
+            return NON_UNIQUE_LAYOUT_IDENTIFIER;
+        }
+
+        @Override
+        public int majorVersion()
+        {
+            return 0;
+        }
+
+        @Override
+        public int minorVersion()
+        {
+            return 1;
+        }
+
+        @Override
+        public int compare( LocalDateTimeSchemaKey o1, LocalDateTimeSchemaKey o2 )
+        {
+            int comparison = o1.compareValueTo( o2 );
+            return comparison != 0 ? comparison : Long.compare( o1.getEntityId(), o2.getEntityId() );
+        }
+    };
+
+    @Override
+    public LocalDateTimeSchemaKey newKey()
+    {
+        return new LocalDateTimeSchemaKey();
+    }
+
+    @Override
+    public LocalDateTimeSchemaKey copyKey( LocalDateTimeSchemaKey key, LocalDateTimeSchemaKey into )
+    {
+        into.epochSecond = key.epochSecond;
+        into.nanoOfSecond = key.nanoOfSecond;
+        into.setEntityId( key.getEntityId() );
+        into.setCompareId( key.getCompareId() );
+        return into;
+    }
+
+    @Override
+    public NativeSchemaValue newValue()
+    {
+        return NativeSchemaValue.INSTANCE;
+    }
+
+    @Override
+    public int keySize( LocalDateTimeSchemaKey key )
+    {
+        return LocalDateTimeSchemaKey.SIZE;
+    }
+
+    @Override
+    public int valueSize( NativeSchemaValue value )
+    {
+        return NativeSchemaValue.SIZE;
+    }
+
+    @Override
+    public void writeKey( PageCursor cursor, LocalDateTimeSchemaKey key )
+    {
+        cursor.putLong( key.epochSecond );
+        cursor.putInt( key.nanoOfSecond );
+        cursor.putLong( key.getEntityId() );
+    }
+
+    @Override
+    public void writeValue( PageCursor cursor, NativeSchemaValue value )
+    {
+    }
+
+    @Override
+    public void readKey( PageCursor cursor, LocalDateTimeSchemaKey into, int keySize )
+    {
+        into.epochSecond = cursor.getLong();
+        into.nanoOfSecond = cursor.getInt();
+        into.setEntityId( cursor.getLong() );
+    }
+
+    @Override
+    public void readValue( PageCursor cursor, NativeSchemaValue into, int valueSize )
+    {
+    }
+
+    @Override
+    public boolean fixedSize()
+    {
+        return true;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeLayout.java
@@ -26,78 +26,20 @@ import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 /**
  * {@link Layout} for local date times.
  */
-abstract class LocalDateTimeLayout extends Layout.Adapter<LocalDateTimeSchemaKey,NativeSchemaValue>
+class LocalDateTimeLayout extends BaseLayout<LocalDateTimeSchemaKey>
 {
     public static Layout<LocalDateTimeSchemaKey,NativeSchemaValue> of( IndexDescriptor descriptor )
     {
         return descriptor.type() == IndexDescriptor.Type.UNIQUE ? LocalDateTimeLayout.UNIQUE : LocalDateTimeLayout.NON_UNIQUE;
     }
 
-    private static final long UNIQUE_LAYOUT_IDENTIFIER = Layout.namedIdentifier( "UTld", NativeSchemaValue.SIZE );
-    public static LocalDateTimeLayout UNIQUE = new LocalDateTimeLayout()
+    private static LocalDateTimeLayout UNIQUE = new LocalDateTimeLayout( "UTld", 0, 1 );
+    private static LocalDateTimeLayout NON_UNIQUE = new LocalDateTimeLayout( "NTld", 0, 1 );
+
+    private LocalDateTimeLayout( String layoutName, int majorVersion, int minorVersion )
     {
-        @Override
-        public long identifier()
-        {
-            return UNIQUE_LAYOUT_IDENTIFIER;
-        }
-
-        @Override
-        public int majorVersion()
-        {
-            return 0;
-        }
-
-        @Override
-        public int minorVersion()
-        {
-            return 1;
-        }
-
-        @Override
-        public int compare( LocalDateTimeSchemaKey o1, LocalDateTimeSchemaKey o2 )
-        {
-            int comparison = o1.compareValueTo( o2 );
-            if ( comparison == 0 )
-            {
-                // This is a special case where we need also compare entityId to support inclusive/exclusive
-                if ( o1.getCompareId() || o2.getCompareId() )
-                {
-                    return Long.compare( o1.getEntityId(), o2.getEntityId() );
-                }
-            }
-            return comparison;
-        }
-    };
-
-    private static final long NON_UNIQUE_LAYOUT_IDENTIFIER = Layout.namedIdentifier( "NTld", NativeSchemaValue.SIZE );
-    public static LocalDateTimeLayout NON_UNIQUE = new LocalDateTimeLayout()
-    {
-        @Override
-        public long identifier()
-        {
-            return NON_UNIQUE_LAYOUT_IDENTIFIER;
-        }
-
-        @Override
-        public int majorVersion()
-        {
-            return 0;
-        }
-
-        @Override
-        public int minorVersion()
-        {
-            return 1;
-        }
-
-        @Override
-        public int compare( LocalDateTimeSchemaKey o1, LocalDateTimeSchemaKey o2 )
-        {
-            int comparison = o1.compareValueTo( o2 );
-            return comparison != 0 ? comparison : Long.compare( o1.getEntityId(), o2.getEntityId() );
-        }
-    };
+        super( layoutName, majorVersion, minorVersion );
+    }
 
     @Override
     public LocalDateTimeSchemaKey newKey()
@@ -116,21 +58,9 @@ abstract class LocalDateTimeLayout extends Layout.Adapter<LocalDateTimeSchemaKey
     }
 
     @Override
-    public NativeSchemaValue newValue()
-    {
-        return NativeSchemaValue.INSTANCE;
-    }
-
-    @Override
     public int keySize( LocalDateTimeSchemaKey key )
     {
         return LocalDateTimeSchemaKey.SIZE;
-    }
-
-    @Override
-    public int valueSize( NativeSchemaValue value )
-    {
-        return NativeSchemaValue.SIZE;
     }
 
     @Override
@@ -142,21 +72,11 @@ abstract class LocalDateTimeLayout extends Layout.Adapter<LocalDateTimeSchemaKey
     }
 
     @Override
-    public void writeValue( PageCursor cursor, NativeSchemaValue value )
-    {
-    }
-
-    @Override
     public void readKey( PageCursor cursor, LocalDateTimeSchemaKey into, int keySize )
     {
         into.epochSecond = cursor.getLong();
         into.nanoOfSecond = cursor.getInt();
         into.setEntityId( cursor.getLong() );
-    }
-
-    @Override
-    public void readValue( PageCursor cursor, NativeSchemaValue into, int valueSize )
-    {
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeSchemaKey.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema;
+
+import org.neo4j.values.storable.LocalDateTimeValue;
+import org.neo4j.values.storable.Value;
+import org.neo4j.values.storable.ValueWriter;
+
+import static java.lang.String.format;
+
+/**
+ * Includes value and entity id (to be able to handle non-unique values). A value can be any {@link LocalDateTimeValue}.
+ */
+class LocalDateTimeSchemaKey extends ValueWriter.Adapter<RuntimeException> implements NativeSchemaKey
+{
+    static final int SIZE =
+            Long.BYTES +    /* epochSecond */
+            Integer.BYTES + /* nanoOfSecond */
+            Long.BYTES;     /* entityId */
+
+    private long entityId;
+    private boolean compareId;
+
+    int nanoOfSecond;
+    long epochSecond;
+
+    public void setCompareId( boolean compareId )
+    {
+        this.compareId = compareId;
+    }
+
+    public boolean getCompareId()
+    {
+        return compareId;
+    }
+
+    @Override
+    public long getEntityId()
+    {
+        return entityId;
+    }
+
+    @Override
+    public void setEntityId( long entityId )
+    {
+        this.entityId = entityId;
+    }
+
+    @Override
+    public void from( long entityId, Value... values )
+    {
+        this.entityId = entityId;
+        compareId = false;
+        assertValidValue( values ).writeTo( this );
+    }
+
+    private LocalDateTimeValue assertValidValue( Value... values )
+    {
+        if ( values.length > 1 )
+        {
+            throw new IllegalArgumentException( "Tried to create composite key with non-composite schema key layout" );
+        }
+        if ( values.length < 1 )
+        {
+            throw new IllegalArgumentException( "Tried to create key without value" );
+        }
+        if ( !(values[0] instanceof LocalDateTimeValue) )
+        {
+            throw new IllegalArgumentException(
+                    "Key layout does only support LocalDateTimeValue, tried to create key from " + values[0] );
+        }
+        return (LocalDateTimeValue) values[0];
+    }
+
+    @Override
+    public String propertiesAsString()
+    {
+        return asValue().toString();
+    }
+
+    @Override
+    public Value asValue()
+    {
+        return LocalDateTimeValue.localDateTime( epochSecond, nanoOfSecond );
+    }
+
+    @Override
+    public void initAsLowest()
+    {
+        epochSecond = Long.MIN_VALUE;
+        nanoOfSecond = Integer.MIN_VALUE;
+        entityId = Long.MIN_VALUE;
+        compareId = true;
+    }
+
+    @Override
+    public void initAsHighest()
+    {
+        epochSecond = Long.MAX_VALUE;
+        nanoOfSecond = Integer.MAX_VALUE;
+        entityId = Long.MAX_VALUE;
+        compareId = true;
+    }
+
+    /**
+     * Compares the value of this key to that of another key.
+     * This method is expected to be called in scenarios where inconsistent reads may happen (and later retried).
+     *
+     * @param other the {@link LocalDateTimeSchemaKey} to compare to.
+     * @return comparison against the {@code other} {@link LocalDateTimeSchemaKey}.
+     */
+    int compareValueTo( LocalDateTimeSchemaKey other )
+    {
+        int compare = Long.compare( epochSecond, other.epochSecond );
+        if ( compare == 0 )
+        {
+            compare = Integer.compare( nanoOfSecond, other.nanoOfSecond );
+        }
+        return compare;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "value=%s,entityId=%d,nanoOfDay=%s", asValue(), entityId, nanoOfSecond );
+    }
+
+    @Override
+    public void writeLocalDateTime( long epochSecond, int nano )
+    {
+        this.nanoOfSecond = nano;
+        this.epochSecond = epochSecond;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeSchemaKey.java
@@ -38,30 +38,6 @@ class LocalDateTimeSchemaKey extends NativeSchemaKey
     long epochSecond;
 
     @Override
-    public void from( Value... values )
-    {
-        assertValidValue( values ).writeTo( this );
-    }
-
-    private LocalDateTimeValue assertValidValue( Value... values )
-    {
-        if ( values.length > 1 )
-        {
-            throw new IllegalArgumentException( "Tried to create composite key with non-composite schema key layout" );
-        }
-        if ( values.length < 1 )
-        {
-            throw new IllegalArgumentException( "Tried to create key without value" );
-        }
-        if ( !(values[0] instanceof LocalDateTimeValue) )
-        {
-            throw new IllegalArgumentException(
-                    "Key layout does only support LocalDateTimeValue, tried to create key from " + values[0] );
-        }
-        return (LocalDateTimeValue) values[0];
-    }
-
-    @Override
     public Value asValue()
     {
         return LocalDateTimeValue.localDateTime( epochSecond, nanoOfSecond );
@@ -101,7 +77,8 @@ class LocalDateTimeSchemaKey extends NativeSchemaKey
     @Override
     public String toString()
     {
-        return format( "value=%s,entityId=%d,nanoOfDay=%s", asValue(), getEntityId(), nanoOfSecond );
+        return format( "value=%s,entityId=%d,epochSecond=%d,nanoOfSecond=%d",
+                        asValue(), getEntityId(), epochSecond, nanoOfSecond );
     }
 
     @Override
@@ -109,5 +86,15 @@ class LocalDateTimeSchemaKey extends NativeSchemaKey
     {
         this.nanoOfSecond = nano;
         this.epochSecond = epochSecond;
+    }
+
+    @Override
+    protected void assertCorrectType( Value value )
+    {
+        if ( !(value instanceof LocalDateTimeValue) )
+        {
+            throw new IllegalArgumentException(
+                    "Key layout does only support LocalDateTimeValue, tried to create key from " + value );
+        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeSchemaKey.java
@@ -21,53 +21,25 @@ package org.neo4j.kernel.impl.index.schema;
 
 import org.neo4j.values.storable.LocalDateTimeValue;
 import org.neo4j.values.storable.Value;
-import org.neo4j.values.storable.ValueWriter;
 
 import static java.lang.String.format;
 
 /**
  * Includes value and entity id (to be able to handle non-unique values). A value can be any {@link LocalDateTimeValue}.
  */
-class LocalDateTimeSchemaKey extends ValueWriter.Adapter<RuntimeException> implements NativeSchemaKey
+class LocalDateTimeSchemaKey extends NativeSchemaKey
 {
     static final int SIZE =
             Long.BYTES +    /* epochSecond */
             Integer.BYTES + /* nanoOfSecond */
             Long.BYTES;     /* entityId */
 
-    private long entityId;
-    private boolean compareId;
-
     int nanoOfSecond;
     long epochSecond;
 
-    public void setCompareId( boolean compareId )
-    {
-        this.compareId = compareId;
-    }
-
-    public boolean getCompareId()
-    {
-        return compareId;
-    }
-
     @Override
-    public long getEntityId()
+    public void from( Value... values )
     {
-        return entityId;
-    }
-
-    @Override
-    public void setEntityId( long entityId )
-    {
-        this.entityId = entityId;
-    }
-
-    @Override
-    public void from( long entityId, Value... values )
-    {
-        this.entityId = entityId;
-        compareId = false;
         assertValidValue( values ).writeTo( this );
     }
 
@@ -90,33 +62,23 @@ class LocalDateTimeSchemaKey extends ValueWriter.Adapter<RuntimeException> imple
     }
 
     @Override
-    public String propertiesAsString()
-    {
-        return asValue().toString();
-    }
-
-    @Override
     public Value asValue()
     {
         return LocalDateTimeValue.localDateTime( epochSecond, nanoOfSecond );
     }
 
     @Override
-    public void initAsLowest()
+    public void initValueAsLowest()
     {
         epochSecond = Long.MIN_VALUE;
         nanoOfSecond = Integer.MIN_VALUE;
-        entityId = Long.MIN_VALUE;
-        compareId = true;
     }
 
     @Override
-    public void initAsHighest()
+    public void initValueAsHighest()
     {
         epochSecond = Long.MAX_VALUE;
         nanoOfSecond = Integer.MAX_VALUE;
-        entityId = Long.MAX_VALUE;
-        compareId = true;
     }
 
     /**
@@ -139,7 +101,7 @@ class LocalDateTimeSchemaKey extends ValueWriter.Adapter<RuntimeException> imple
     @Override
     public String toString()
     {
-        return format( "value=%s,entityId=%d,nanoOfDay=%s", asValue(), entityId, nanoOfSecond );
+        return format( "value=%s,entityId=%d,nanoOfDay=%s", asValue(), getEntityId(), nanoOfSecond );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeSchemaKey.java
@@ -83,12 +83,13 @@ class LocalDateTimeSchemaKey extends ComparableNativeSchemaKey<LocalDateTimeSche
     }
 
     @Override
-    protected void assertCorrectType( Value value )
+    protected Value assertCorrectType( Value value )
     {
         if ( !(value instanceof LocalDateTimeValue) )
         {
             throw new IllegalArgumentException(
                     "Key layout does only support LocalDateTimeValue, tried to create key from " + value );
         }
+        return value;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalDateTimeSchemaKey.java
@@ -27,7 +27,7 @@ import static java.lang.String.format;
 /**
  * Includes value and entity id (to be able to handle non-unique values). A value can be any {@link LocalDateTimeValue}.
  */
-class LocalDateTimeSchemaKey extends NativeSchemaKey
+class LocalDateTimeSchemaKey extends ComparableNativeSchemaKey<LocalDateTimeSchemaKey>
 {
     static final int SIZE =
             Long.BYTES +    /* epochSecond */
@@ -57,14 +57,8 @@ class LocalDateTimeSchemaKey extends NativeSchemaKey
         nanoOfSecond = Integer.MAX_VALUE;
     }
 
-    /**
-     * Compares the value of this key to that of another key.
-     * This method is expected to be called in scenarios where inconsistent reads may happen (and later retried).
-     *
-     * @param other the {@link LocalDateTimeSchemaKey} to compare to.
-     * @return comparison against the {@code other} {@link LocalDateTimeSchemaKey}.
-     */
-    int compareValueTo( LocalDateTimeSchemaKey other )
+    @Override
+    public int compareValueTo( LocalDateTimeSchemaKey other )
     {
         int compare = Long.compare( epochSecond, other.epochSecond );
         if ( compare == 0 )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalTimeLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalTimeLayout.java
@@ -75,10 +75,4 @@ class LocalTimeLayout extends BaseLayout<LocalTimeSchemaKey>
         into.nanoOfDay = cursor.getLong();
         into.setEntityId( cursor.getLong() );
     }
-
-    @Override
-    public boolean fixedSize()
-    {
-        return true;
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalTimeLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalTimeLayout.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema;
+
+import org.neo4j.index.internal.gbptree.Layout;
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.kernel.api.schema.index.IndexDescriptor;
+
+/**
+ * {@link Layout} for local times.
+ */
+abstract class LocalTimeLayout extends Layout.Adapter<LocalTimeSchemaKey,NativeSchemaValue>
+{
+    public static Layout<LocalTimeSchemaKey,NativeSchemaValue> of( IndexDescriptor descriptor )
+    {
+        return descriptor.type() == IndexDescriptor.Type.UNIQUE ? LocalTimeLayout.UNIQUE : LocalTimeLayout.NON_UNIQUE;
+    }
+
+    private static final long UNIQUE_LAYOUT_IDENTIFIER = Layout.namedIdentifier( "UTlt", NativeSchemaValue.SIZE );
+    public static LocalTimeLayout UNIQUE = new LocalTimeLayout()
+    {
+        @Override
+        public long identifier()
+        {
+            return UNIQUE_LAYOUT_IDENTIFIER;
+        }
+
+        @Override
+        public int majorVersion()
+        {
+            return 0;
+        }
+
+        @Override
+        public int minorVersion()
+        {
+            return 1;
+        }
+
+        @Override
+        public int compare( LocalTimeSchemaKey o1, LocalTimeSchemaKey o2 )
+        {
+            int comparison = o1.compareValueTo( o2 );
+            if ( comparison == 0 )
+            {
+                // This is a special case where we need also compare entityId to support inclusive/exclusive
+                if ( o1.getCompareId() || o2.getCompareId() )
+                {
+                    return Long.compare( o1.getEntityId(), o2.getEntityId() );
+                }
+            }
+            return comparison;
+        }
+    };
+
+    private static final long NON_UNIQUE_LAYOUT_IDENTIFIER = Layout.namedIdentifier( "NTlt", NativeSchemaValue.SIZE );
+    public static LocalTimeLayout NON_UNIQUE = new LocalTimeLayout()
+    {
+        @Override
+        public long identifier()
+        {
+            return NON_UNIQUE_LAYOUT_IDENTIFIER;
+        }
+
+        @Override
+        public int majorVersion()
+        {
+            return 0;
+        }
+
+        @Override
+        public int minorVersion()
+        {
+            return 1;
+        }
+
+        @Override
+        public int compare( LocalTimeSchemaKey o1, LocalTimeSchemaKey o2 )
+        {
+            int comparison = o1.compareValueTo( o2 );
+            return comparison != 0 ? comparison : Long.compare( o1.getEntityId(), o2.getEntityId() );
+        }
+    };
+
+    @Override
+    public LocalTimeSchemaKey newKey()
+    {
+        return new LocalTimeSchemaKey();
+    }
+
+    @Override
+    public LocalTimeSchemaKey copyKey( LocalTimeSchemaKey key, LocalTimeSchemaKey into )
+    {
+        into.nanoOfDay = key.nanoOfDay;
+        into.setEntityId( key.getEntityId() );
+        into.setCompareId( key.getCompareId() );
+        return into;
+    }
+
+    @Override
+    public NativeSchemaValue newValue()
+    {
+        return NativeSchemaValue.INSTANCE;
+    }
+
+    @Override
+    public int keySize( LocalTimeSchemaKey key )
+    {
+        return LocalTimeSchemaKey.SIZE;
+    }
+
+    @Override
+    public int valueSize( NativeSchemaValue value )
+    {
+        return NativeSchemaValue.SIZE;
+    }
+
+    @Override
+    public void writeKey( PageCursor cursor, LocalTimeSchemaKey key )
+    {
+        cursor.putLong( key.nanoOfDay );
+        cursor.putLong( key.getEntityId() );
+    }
+
+    @Override
+    public void writeValue( PageCursor cursor, NativeSchemaValue value )
+    {
+    }
+
+    @Override
+    public void readKey( PageCursor cursor, LocalTimeSchemaKey into, int keySize )
+    {
+        into.nanoOfDay = cursor.getLong();
+        into.setEntityId( cursor.getLong() );
+    }
+
+    @Override
+    public void readValue( PageCursor cursor, NativeSchemaValue into, int valueSize )
+    {
+    }
+
+    @Override
+    public boolean fixedSize()
+    {
+        return true;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalTimeLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalTimeLayout.java
@@ -26,78 +26,20 @@ import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 /**
  * {@link Layout} for local times.
  */
-abstract class LocalTimeLayout extends Layout.Adapter<LocalTimeSchemaKey,NativeSchemaValue>
+class LocalTimeLayout extends BaseLayout<LocalTimeSchemaKey>
 {
     public static Layout<LocalTimeSchemaKey,NativeSchemaValue> of( IndexDescriptor descriptor )
     {
         return descriptor.type() == IndexDescriptor.Type.UNIQUE ? LocalTimeLayout.UNIQUE : LocalTimeLayout.NON_UNIQUE;
     }
 
-    private static final long UNIQUE_LAYOUT_IDENTIFIER = Layout.namedIdentifier( "UTlt", NativeSchemaValue.SIZE );
-    public static LocalTimeLayout UNIQUE = new LocalTimeLayout()
+    private static LocalTimeLayout UNIQUE = new LocalTimeLayout( "UTlt", 0, 1 );
+    private static LocalTimeLayout NON_UNIQUE = new LocalTimeLayout( "NTlt", 0, 1 );
+
+    private LocalTimeLayout( String layoutName, int majorVersion, int minorVersion )
     {
-        @Override
-        public long identifier()
-        {
-            return UNIQUE_LAYOUT_IDENTIFIER;
-        }
-
-        @Override
-        public int majorVersion()
-        {
-            return 0;
-        }
-
-        @Override
-        public int minorVersion()
-        {
-            return 1;
-        }
-
-        @Override
-        public int compare( LocalTimeSchemaKey o1, LocalTimeSchemaKey o2 )
-        {
-            int comparison = o1.compareValueTo( o2 );
-            if ( comparison == 0 )
-            {
-                // This is a special case where we need also compare entityId to support inclusive/exclusive
-                if ( o1.getCompareId() || o2.getCompareId() )
-                {
-                    return Long.compare( o1.getEntityId(), o2.getEntityId() );
-                }
-            }
-            return comparison;
-        }
-    };
-
-    private static final long NON_UNIQUE_LAYOUT_IDENTIFIER = Layout.namedIdentifier( "NTlt", NativeSchemaValue.SIZE );
-    public static LocalTimeLayout NON_UNIQUE = new LocalTimeLayout()
-    {
-        @Override
-        public long identifier()
-        {
-            return NON_UNIQUE_LAYOUT_IDENTIFIER;
-        }
-
-        @Override
-        public int majorVersion()
-        {
-            return 0;
-        }
-
-        @Override
-        public int minorVersion()
-        {
-            return 1;
-        }
-
-        @Override
-        public int compare( LocalTimeSchemaKey o1, LocalTimeSchemaKey o2 )
-        {
-            int comparison = o1.compareValueTo( o2 );
-            return comparison != 0 ? comparison : Long.compare( o1.getEntityId(), o2.getEntityId() );
-        }
-    };
+        super( layoutName, majorVersion, minorVersion );
+    }
 
     @Override
     public LocalTimeSchemaKey newKey()
@@ -115,21 +57,9 @@ abstract class LocalTimeLayout extends Layout.Adapter<LocalTimeSchemaKey,NativeS
     }
 
     @Override
-    public NativeSchemaValue newValue()
-    {
-        return NativeSchemaValue.INSTANCE;
-    }
-
-    @Override
     public int keySize( LocalTimeSchemaKey key )
     {
         return LocalTimeSchemaKey.SIZE;
-    }
-
-    @Override
-    public int valueSize( NativeSchemaValue value )
-    {
-        return NativeSchemaValue.SIZE;
     }
 
     @Override
@@ -140,20 +70,10 @@ abstract class LocalTimeLayout extends Layout.Adapter<LocalTimeSchemaKey,NativeS
     }
 
     @Override
-    public void writeValue( PageCursor cursor, NativeSchemaValue value )
-    {
-    }
-
-    @Override
     public void readKey( PageCursor cursor, LocalTimeSchemaKey into, int keySize )
     {
         into.nanoOfDay = cursor.getLong();
         into.setEntityId( cursor.getLong() );
-    }
-
-    @Override
-    public void readValue( PageCursor cursor, NativeSchemaValue into, int valueSize )
-    {
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalTimeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalTimeSchemaKey.java
@@ -72,12 +72,13 @@ class LocalTimeSchemaKey extends ComparableNativeSchemaKey<LocalTimeSchemaKey>
     }
 
     @Override
-    protected void assertCorrectType( Value value )
+    protected Value assertCorrectType( Value value )
     {
         if ( !(value instanceof LocalTimeValue) )
         {
             throw new IllegalArgumentException(
                     "Key layout does only support LocalTimeValue, tried to create key from " + value );
         }
+        return value;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalTimeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalTimeSchemaKey.java
@@ -36,30 +36,6 @@ class LocalTimeSchemaKey extends NativeSchemaKey
     long nanoOfDay;
 
     @Override
-    public void from( Value... values )
-    {
-        assertValidValue( values ).writeTo( this );
-    }
-
-    private LocalTimeValue assertValidValue( Value... values )
-    {
-        if ( values.length > 1 )
-        {
-            throw new IllegalArgumentException( "Tried to create composite key with non-composite schema key layout" );
-        }
-        if ( values.length < 1 )
-        {
-            throw new IllegalArgumentException( "Tried to create key without value" );
-        }
-        if ( !(values[0] instanceof LocalTimeValue) )
-        {
-            throw new IllegalArgumentException(
-                    "Key layout does only support LocalTimeValue, tried to create key from " + values[0] );
-        }
-        return (LocalTimeValue) values[0];
-    }
-
-    @Override
     public Value asValue()
     {
         return LocalTimeValue.localTime( nanoOfDay );
@@ -99,5 +75,15 @@ class LocalTimeSchemaKey extends NativeSchemaKey
     public void writeLocalTime( long nanoOfDay )
     {
         this.nanoOfDay = nanoOfDay;
+    }
+
+    @Override
+    protected void assertCorrectType( Value value )
+    {
+        if ( !(value instanceof LocalTimeValue) )
+        {
+            throw new IllegalArgumentException(
+                    "Key layout does only support LocalTimeValue, tried to create key from " + value );
+        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalTimeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalTimeSchemaKey.java
@@ -62,7 +62,7 @@ class LocalTimeSchemaKey extends ComparableNativeSchemaKey<LocalTimeSchemaKey>
     @Override
     public String toString()
     {
-        return format( "value=%s,entityId=%d,nanoOfDay=%s", asValue(), getEntityId(), nanoOfDay );
+        return format( "value=%s,entityId=%d,nanoOfDay=%d", asValue(), getEntityId(), nanoOfDay );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalTimeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalTimeSchemaKey.java
@@ -19,29 +19,29 @@
  */
 package org.neo4j.kernel.impl.index.schema;
 
-import org.neo4j.values.storable.DateValue;
+import org.neo4j.values.storable.LocalTimeValue;
 import org.neo4j.values.storable.Value;
 
 import static java.lang.String.format;
 
 /**
- * Includes value and entity id (to be able to handle non-unique values). A value can be any {@link DateValue}.
+ * Includes value and entity id (to be able to handle non-unique values). A value can be any {@link LocalTimeValue}.
  */
-class DateSchemaKey extends NativeSchemaKey
+class LocalTimeSchemaKey extends NativeSchemaKey
 {
     static final int SIZE =
-            Long.BYTES + /* epochDay */
+            Long.BYTES + /* nanoOfDay */
             Long.BYTES;  /* entityId */
 
-    long epochDay;
+    long nanoOfDay;
 
     @Override
-    void from( Value... values )
+    public void from( Value... values )
     {
         assertValidValue( values ).writeTo( this );
     }
 
-    private DateValue assertValidValue( Value... values )
+    private LocalTimeValue assertValidValue( Value... values )
     {
         if ( values.length > 1 )
         {
@@ -51,53 +51,53 @@ class DateSchemaKey extends NativeSchemaKey
         {
             throw new IllegalArgumentException( "Tried to create key without value" );
         }
-        if ( !(values[0] instanceof DateValue) )
+        if ( !(values[0] instanceof LocalTimeValue) )
         {
             throw new IllegalArgumentException(
-                    "Key layout does only support DateValue, tried to create key from " + values[0] );
+                    "Key layout does only support LocalTimeValue, tried to create key from " + values[0] );
         }
-        return (DateValue) values[0];
+        return (LocalTimeValue) values[0];
     }
 
     @Override
     public Value asValue()
     {
-        return DateValue.epochDate( epochDay );
+        return LocalTimeValue.localTime( nanoOfDay );
     }
 
     @Override
-    void initValueAsLowest()
+    public void initValueAsLowest()
     {
-        epochDay = Long.MIN_VALUE;
+        nanoOfDay = Long.MIN_VALUE;
     }
 
     @Override
-    void initValueAsHighest()
+    public void initValueAsHighest()
     {
-        epochDay = Long.MAX_VALUE;
+        nanoOfDay = Long.MAX_VALUE;
     }
 
     /**
      * Compares the value of this key to that of another key.
      * This method is expected to be called in scenarios where inconsistent reads may happen (and later retried).
      *
-     * @param other the {@link DateSchemaKey} to compare to.
-     * @return comparison against the {@code other} {@link DateSchemaKey}.
+     * @param other the {@link LocalTimeSchemaKey} to compare to.
+     * @return comparison against the {@code other} {@link LocalTimeSchemaKey}.
      */
-    int compareValueTo( DateSchemaKey other )
+    int compareValueTo( LocalTimeSchemaKey other )
     {
-        return Long.compare( epochDay, other.epochDay );
+        return Long.compare( nanoOfDay, other.nanoOfDay );
     }
 
     @Override
     public String toString()
     {
-        return format( "value=%s,entityId=%d,epochDay=%s", asValue(), getEntityId(), epochDay );
+        return format( "value=%s,entityId=%d,nanoOfDay=%s", asValue(), getEntityId(), nanoOfDay );
     }
 
     @Override
-    public void writeDate( long epochDay )
+    public void writeLocalTime( long nanoOfDay )
     {
-        this.epochDay = epochDay;
+        this.nanoOfDay = nanoOfDay;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalTimeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/LocalTimeSchemaKey.java
@@ -27,7 +27,7 @@ import static java.lang.String.format;
 /**
  * Includes value and entity id (to be able to handle non-unique values). A value can be any {@link LocalTimeValue}.
  */
-class LocalTimeSchemaKey extends NativeSchemaKey
+class LocalTimeSchemaKey extends ComparableNativeSchemaKey<LocalTimeSchemaKey>
 {
     static final int SIZE =
             Long.BYTES + /* nanoOfDay */
@@ -53,14 +53,8 @@ class LocalTimeSchemaKey extends NativeSchemaKey
         nanoOfDay = Long.MAX_VALUE;
     }
 
-    /**
-     * Compares the value of this key to that of another key.
-     * This method is expected to be called in scenarios where inconsistent reads may happen (and later retried).
-     *
-     * @param other the {@link LocalTimeSchemaKey} to compare to.
-     * @return comparison against the {@code other} {@link LocalTimeSchemaKey}.
-     */
-    int compareValueTo( LocalTimeSchemaKey other )
+    @Override
+    public int compareValueTo( LocalTimeSchemaKey other )
     {
         return Long.compare( nanoOfDay, other.nanoOfDay );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaKey.java
@@ -80,12 +80,10 @@ abstract class NativeSchemaKey extends ValueWriter.Adapter<RuntimeException>
         {
             throw new IllegalArgumentException( "Tried to create key without value" );
         }
-        Value value = values[0];
-        assertCorrectType( value );
-        return value;
+        return assertCorrectType( values[0] );
     }
 
-    protected abstract void assertCorrectType( Value value );
+    protected abstract Value assertCorrectType( Value value );
 
     String propertiesAsString()
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaKey.java
@@ -66,10 +66,26 @@ abstract class NativeSchemaKey extends ValueWriter.Adapter<RuntimeException>
     {
         compareId = DEFAULT_COMPARE_ID;
         this.entityId = entityId;
-        from( values );
+        // copy value state and store in this key instance
+        assertValidValue( values ).writeTo( this );
     }
 
-    abstract void from( Value[] values );
+    private Value assertValidValue( Value... values )
+    {
+        if ( values.length > 1 )
+        {
+            throw new IllegalArgumentException( "Tried to create composite key with non-composite schema key layout" );
+        }
+        if ( values.length < 1 )
+        {
+            throw new IllegalArgumentException( "Tried to create key without value" );
+        }
+        Value value = values[0];
+        assertCorrectType( value );
+        return value;
+    }
+
+    protected abstract void assertCorrectType( Value value );
 
     String propertiesAsString()
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberSchemaKey.java
@@ -46,13 +46,14 @@ class NumberSchemaKey extends NativeSchemaKey
     long rawValueBits;
 
     @Override
-    protected void assertCorrectType( Value value )
+    protected Value assertCorrectType( Value value )
     {
         if ( !Values.isNumberValue( value ) )
         {
             throw new IllegalArgumentException(
                     "Key layout does only support numbers, tried to create key from " + value );
         }
+        return value;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberSchemaKey.java
@@ -46,28 +46,13 @@ class NumberSchemaKey extends NativeSchemaKey
     long rawValueBits;
 
     @Override
-    void from( Value... values )
+    protected void assertCorrectType( Value value )
     {
-        extractRawBitsAndType( assertValidValue( values ) );
-    }
-
-    private NumberValue assertValidValue( Value... values )
-    {
-        // TODO: support multiple values, right?
-        if ( values.length > 1 )
-        {
-            throw new IllegalArgumentException( "Tried to create composite key with non-composite schema key layout" );
-        }
-        if ( values.length < 1 )
-        {
-            throw new IllegalArgumentException( "Tried to create key without value" );
-        }
-        if ( !Values.isNumberValue( values[0] ) )
+        if ( !Values.isNumberValue( value ) )
         {
             throw new IllegalArgumentException(
-                    "Key layout does only support numbers, tried to create key from " + values[0] );
+                    "Key layout does only support numbers, tried to create key from " + value );
         }
-        return (NumberValue) values[0];
     }
 
     @Override
@@ -98,16 +83,6 @@ class NumberSchemaKey extends NativeSchemaKey
     int compareValueTo( NumberSchemaKey other )
     {
         return RawBits.compare( rawValueBits, type, other.rawValueBits, other.type );
-    }
-
-    /**
-     * Extracts raw bits and type from a {@link NumberValue} and store as state of this {@link NumberSchemaKey} instance.
-     *
-     * @param value actual {@link NumberValue} value.
-     */
-    private void extractRawBitsAndType( NumberValue value )
-    {
-        value.writeTo( this );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialSchemaKey.java
@@ -96,13 +96,14 @@ class SpatialSchemaKey extends NativeSchemaKey
     }
 
     @Override
-    protected void assertCorrectType( Value value )
+    protected Value assertCorrectType( Value value )
     {
         if ( !Values.isGeometryValue( value ) )
         {
             throw new IllegalArgumentException(
                     "Key layout does only support geometries, tried to create key from " + value );
         }
+        return value;
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringSchemaKey.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 
 import org.neo4j.index.internal.gbptree.GBPTree;
 import org.neo4j.string.UTF8;
-import org.neo4j.values.storable.TextValue;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
 
@@ -48,27 +47,13 @@ class StringSchemaKey extends NativeSchemaKey
     }
 
     @Override
-    void from( Value... values )
+    protected void assertCorrectType( Value value )
     {
-        assertValidValue( values ).writeTo( this );
-    }
-
-    private TextValue assertValidValue( Value... values )
-    {
-        if ( values.length > 1 )
-        {
-            throw new IllegalArgumentException( "Tried to create composite key with non-composite schema key layout" );
-        }
-        if ( values.length < 1 )
-        {
-            throw new IllegalArgumentException( "Tried to create key without value" );
-        }
-        if ( !Values.isTextValue( values[0] ) )
+        if ( !Values.isTextValue( value ) )
         {
             throw new IllegalArgumentException(
-                    "Key layout does only support strings, tried to create key from " + values[0] );
+                    "Key layout does only support strings, tried to create key from " + value );
         }
-        return (TextValue) values[0];
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringSchemaKey.java
@@ -47,13 +47,14 @@ class StringSchemaKey extends NativeSchemaKey
     }
 
     @Override
-    protected void assertCorrectType( Value value )
+    protected Value assertCorrectType( Value value )
     {
         if ( !Values.isTextValue( value ) )
         {
             throw new IllegalArgumentException(
                     "Key layout does only support strings, tried to create key from " + value );
         }
+        return value;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
@@ -258,7 +258,7 @@ class TemporalIndexAccessor extends TemporalIndexCache<TemporalIndexAccessor.Par
         }
 
         @Override
-        public PartAccessor<?> newDuration()
+        public PartAccessor<?> newDuration() throws IOException
         {
             return createPartAccessor( temporalIndexFiles.duration() );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
@@ -230,10 +230,7 @@ class TemporalIndexAccessor extends TemporalIndexCache<TemporalIndexAccessor.Par
         @Override
         public PartAccessor<?> newDate() throws IOException
         {
-            TemporalIndexFiles.FileLayout<DateSchemaKey> fileLayout = temporalIndexFiles.date();
-            ensureIndexExists( fileLayout );
-            return new PartAccessor<>( pageCache, fs, fileLayout,
-                    recoveryCleanupWorkCollector, monitor, descriptor, indexId, samplingConfig );
+            return createPartAccessor( temporalIndexFiles.date() );
         }
 
         @Override
@@ -249,9 +246,10 @@ class TemporalIndexAccessor extends TemporalIndexCache<TemporalIndexAccessor.Par
         }
 
         @Override
-        public PartAccessor<?> newTime()
+        public PartAccessor<?> newTime() throws IOException
         {
-            throw new UnsupportedOperationException( "no comprende" );
+            return createPartAccessor( temporalIndexFiles.time() );
+
         }
 
         @Override
@@ -266,12 +264,13 @@ class TemporalIndexAccessor extends TemporalIndexCache<TemporalIndexAccessor.Par
             throw new UnsupportedOperationException( "no comprende" );
         }
 
-        private <KEY extends NativeSchemaKey> void ensureIndexExists( TemporalIndexFiles.FileLayout<KEY> fileLayout ) throws IOException
+        private <KEY extends NativeSchemaKey> PartAccessor<KEY> createPartAccessor( TemporalIndexFiles.FileLayout<KEY> fileLayout ) throws IOException
         {
             if ( !fs.fileExists( fileLayout.indexFile ) )
             {
                 createEmptyIndex( fileLayout );
             }
+            return new PartAccessor<>( pageCache, fs, fileLayout, recoveryCleanupWorkCollector, monitor, descriptor, indexId, samplingConfig );
         }
 
         private <KEY extends NativeSchemaKey> void createEmptyIndex( TemporalIndexFiles.FileLayout<KEY> fileLayout ) throws IOException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
@@ -260,7 +260,7 @@ class TemporalIndexAccessor extends TemporalIndexCache<TemporalIndexAccessor.Par
         @Override
         public PartAccessor<?> newDuration()
         {
-            throw new UnsupportedOperationException( "no comprende" );
+            return createPartAccessor( temporalIndexFiles.duration() );
         }
 
         private <KEY extends NativeSchemaKey> PartAccessor<KEY> createPartAccessor( TemporalIndexFiles.FileLayout<KEY> fileLayout ) throws IOException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
@@ -236,7 +236,7 @@ class TemporalIndexAccessor extends TemporalIndexCache<TemporalIndexAccessor.Par
         @Override
         public PartAccessor<?> newDateTime()
         {
-            throw new UnsupportedOperationException( "no comprende" );
+            return createPartAccessor( temporalIndexFiles.dateTime() );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
@@ -234,7 +234,7 @@ class TemporalIndexAccessor extends TemporalIndexCache<TemporalIndexAccessor.Par
         }
 
         @Override
-        public PartAccessor<?> newDateTime()
+        public PartAccessor<?> newDateTime() throws IOException
         {
             return createPartAccessor( temporalIndexFiles.dateTime() );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
@@ -234,26 +234,25 @@ class TemporalIndexAccessor extends TemporalIndexCache<TemporalIndexAccessor.Par
         }
 
         @Override
-        public PartAccessor<?> newDateTime() throws IOException
+        public PartAccessor<?> newLocalDateTime() throws IOException
         {
-            return createPartAccessor( temporalIndexFiles.dateTime() );
+            return createPartAccessor( temporalIndexFiles.localDateTime() );
         }
 
         @Override
-        public PartAccessor<?> newDateTimeZoned()
+        public PartAccessor<?> newZonedDateTime() throws IOException
         {
             throw new UnsupportedOperationException( "no comprende" );
         }
 
         @Override
-        public PartAccessor<?> newTime() throws IOException
+        public PartAccessor<?> newLocalTime() throws IOException
         {
-            return createPartAccessor( temporalIndexFiles.time() );
-
+            return createPartAccessor( temporalIndexFiles.localTime() );
         }
 
         @Override
-        public PartAccessor<?> newTimeZoned()
+        public PartAccessor<?> newZonedTime() throws IOException
         {
             throw new UnsupportedOperationException( "no comprende" );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
@@ -242,7 +242,7 @@ class TemporalIndexAccessor extends TemporalIndexCache<TemporalIndexAccessor.Par
         @Override
         public PartAccessor<?> newZonedDateTime() throws IOException
         {
-            throw new UnsupportedOperationException( "no comprende" );
+            return createPartAccessor( temporalIndexFiles.zonedDateTime() );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
@@ -254,7 +254,7 @@ class TemporalIndexAccessor extends TemporalIndexCache<TemporalIndexAccessor.Par
         @Override
         public PartAccessor<?> newZonedTime() throws IOException
         {
-            throw new UnsupportedOperationException( "no comprende" );
+            return createPartAccessor( temporalIndexFiles.zonedTime() );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexCache.java
@@ -19,7 +19,9 @@
  */
 package org.neo4j.kernel.impl.index.schema;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -47,9 +49,12 @@ class TemporalIndexCache<T, E extends Exception> implements Iterable<T>
     private volatile T timeZoned;
     private volatile T duration;
 
+    private List<T> parts;
+
     TemporalIndexCache( Factory<T, E> factory )
     {
         this.factory = factory;
+        this.parts = new ArrayList<>();
     }
 
     /**
@@ -148,6 +153,7 @@ class TemporalIndexCache<T, E extends Exception> implements Iterable<T>
         if ( date == null )
         {
             date = factory.newDate();
+            parts.add( date );
         }
         return date;
     }
@@ -157,6 +163,7 @@ class TemporalIndexCache<T, E extends Exception> implements Iterable<T>
         if ( dateTime == null )
         {
             dateTime = factory.newDateTime();
+            parts.add( dateTime );
         }
         return dateTime;
     }
@@ -166,6 +173,7 @@ class TemporalIndexCache<T, E extends Exception> implements Iterable<T>
         if ( dateTimeZoned == null )
         {
             dateTimeZoned = factory.newDateTimeZoned();
+            parts.add( dateTimeZoned );
         }
         return dateTimeZoned;
     }
@@ -175,6 +183,7 @@ class TemporalIndexCache<T, E extends Exception> implements Iterable<T>
         if ( time == null )
         {
             time = factory.newTime();
+            parts.add( time );
         }
         return time;
     }
@@ -184,6 +193,7 @@ class TemporalIndexCache<T, E extends Exception> implements Iterable<T>
         if ( timeZoned == null )
         {
             timeZoned = factory.newTimeZoned();
+            parts.add( timeZoned );
         }
         return timeZoned;
     }
@@ -193,6 +203,7 @@ class TemporalIndexCache<T, E extends Exception> implements Iterable<T>
         if ( duration == null )
         {
             duration = factory.newDuration();
+            parts.add( duration );
         }
         return duration;
     }
@@ -200,8 +211,7 @@ class TemporalIndexCache<T, E extends Exception> implements Iterable<T>
     @Override
     public Iterator<T> iterator()
     {
-        return Iterators.filter(
-                Objects::nonNull, Iterators.iterator( date, dateTime, dateTimeZoned, time, timeZoned, duration ) );
+        return parts.iterator();
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexCache.java
@@ -22,10 +22,8 @@ package org.neo4j.kernel.impl.index.schema;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Function;
 
-import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.values.storable.ValueGroup;
 
 /**
@@ -43,10 +41,10 @@ class TemporalIndexCache<T, E extends Exception> implements Iterable<T>
     private final Factory<T, E> factory;
 
     private volatile T date;
-    private volatile T dateTime;
-    private volatile T dateTimeZoned;
-    private volatile T time;
-    private volatile T timeZoned;
+    private volatile T localDateTime;
+    private volatile T zonedDateTime;
+    private volatile T localTime;
+    private volatile T zonedTime;
     private volatile T duration;
 
     private List<T> parts;
@@ -92,16 +90,16 @@ class TemporalIndexCache<T, E extends Exception> implements Iterable<T>
             return date();
 
         case LOCAL_DATE_TIME:
-            return dateTime();
+            return localDateTime();
 
         case ZONED_DATE_TIME:
-            return dateTimeZoned();
+            return zonedDateTime();
 
         case LOCAL_TIME:
-            return time();
+            return localTime();
 
         case ZONED_TIME:
-            return timeZoned();
+            return zonedTime();
 
         case DURATION:
             return duration();
@@ -129,16 +127,16 @@ class TemporalIndexCache<T, E extends Exception> implements Iterable<T>
             return date != null ? function.apply( date ) : orElse;
 
         case LOCAL_DATE_TIME:
-            return dateTime != null ? function.apply( dateTime ) : orElse;
+            return localDateTime != null ? function.apply( localDateTime ) : orElse;
 
         case ZONED_DATE_TIME:
-            return dateTimeZoned != null ? function.apply( dateTimeZoned ) : orElse;
+            return zonedDateTime != null ? function.apply( zonedDateTime ) : orElse;
 
         case LOCAL_TIME:
-            return time != null ? function.apply( time ) : orElse;
+            return localTime != null ? function.apply( localTime ) : orElse;
 
         case ZONED_TIME:
-            return timeZoned != null ? function.apply( timeZoned ) : orElse;
+            return zonedTime != null ? function.apply( zonedTime ) : orElse;
 
         case DURATION:
             return duration != null ? function.apply( duration ) : orElse;
@@ -158,44 +156,44 @@ class TemporalIndexCache<T, E extends Exception> implements Iterable<T>
         return date;
     }
 
-    T dateTime() throws E
+    T localDateTime() throws E
     {
-        if ( dateTime == null )
+        if ( localDateTime == null )
         {
-            dateTime = factory.newDateTime();
-            parts.add( dateTime );
+            localDateTime = factory.newLocalDateTime();
+            parts.add( localDateTime );
         }
-        return dateTime;
+        return localDateTime;
     }
 
-    T dateTimeZoned() throws E
+    T zonedDateTime() throws E
     {
-        if ( dateTimeZoned == null )
+        if ( zonedDateTime == null )
         {
-            dateTimeZoned = factory.newDateTimeZoned();
-            parts.add( dateTimeZoned );
+            zonedDateTime = factory.newZonedDateTime();
+            parts.add( zonedDateTime );
         }
-        return dateTimeZoned;
+        return zonedDateTime;
     }
 
-    T time() throws E
+    T localTime() throws E
     {
-        if ( time == null )
+        if ( localTime == null )
         {
-            time = factory.newTime();
-            parts.add( time );
+            localTime = factory.newLocalTime();
+            parts.add( localTime );
         }
-        return time;
+        return localTime;
     }
 
-    T timeZoned() throws E
+    T zonedTime() throws E
     {
-        if ( timeZoned == null )
+        if ( zonedTime == null )
         {
-            timeZoned = factory.newTimeZoned();
-            parts.add( timeZoned );
+            zonedTime = factory.newZonedTime();
+            parts.add( zonedTime );
         }
-        return timeZoned;
+        return zonedTime;
     }
 
     T duration() throws E
@@ -223,10 +221,10 @@ class TemporalIndexCache<T, E extends Exception> implements Iterable<T>
     interface Factory<T, E extends Exception>
     {
         T newDate() throws E;
-        T newDateTime() throws E;
-        T newDateTimeZoned() throws E;
-        T newTime() throws E;
-        T newTimeZoned() throws E;
+        T newLocalDateTime() throws E;
+        T newZonedDateTime() throws E;
+        T newLocalTime() throws E;
+        T newZonedTime() throws E;
         T newDuration() throws E;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexFiles.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexFiles.java
@@ -44,6 +44,7 @@ class TemporalIndexFiles
         this.fs = fs;
         File indexDirectory = directoryStructure.directoryForIndex( indexId );
         dateFileLayout = new FileLayout<>( new File( indexDirectory, "date" ), DateLayout.of( descriptor ), ValueGroup.DATE );
+        timeFileLayout = new FileLayout<>( new File( indexDirectory, "time" ), LocalTimeLayout.of( descriptor ), ValueGroup.LOCAL_TIME );
     }
 
     Iterable<FileLayout> existing()
@@ -82,6 +83,11 @@ class TemporalIndexFiles
     public FileLayout<DateSchemaKey> date()
     {
         return dateFileLayout;
+    }
+
+    public FileLayout<DateSchemaKey> time()
+    {
+        return timeFileLayout;
     }
 
     // .... we will add more explicit accessor methods later

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexFiles.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexFiles.java
@@ -36,7 +36,7 @@ class TemporalIndexFiles
     private FileLayout<LocalDateTimeSchemaKey> localDateTime;
     private FileLayout<ZonedDateTimeSchemaKey> zonedDateTime;
     private FileLayout<LocalTimeSchemaKey> localTime;
-    private FileLayout zonedTime;
+    private FileLayout<ZonedTimeSchemaKey> zonedTime;
     private FileLayout duration;
 
     TemporalIndexFiles( IndexDirectoryStructure directoryStructure, long indexId, IndexDescriptor descriptor, FileSystemAbstraction fs )
@@ -45,6 +45,7 @@ class TemporalIndexFiles
         File indexDirectory = directoryStructure.directoryForIndex( indexId );
         this.date = new FileLayout<>( new File( indexDirectory, "date" ), DateLayout.of( descriptor ), ValueGroup.DATE );
         this.localTime = new FileLayout<>( new File( indexDirectory, "localTime" ), LocalTimeLayout.of( descriptor ), ValueGroup.LOCAL_TIME );
+        this.zonedTime = new FileLayout<>( new File( indexDirectory, "zonedTime" ), ZonedTimeLayout.of( descriptor ), ValueGroup.ZONED_TIME );
         this.localDateTime = new FileLayout<>( new File( indexDirectory, "localDateTime" ), LocalDateTimeLayout.of( descriptor ), ValueGroup.LOCAL_DATE_TIME );
         this.zonedDateTime = new FileLayout<>( new File( indexDirectory, "zonedDateTime" ), ZonedDateTimeLayout.of( descriptor ), ValueGroup.ZONED_DATE_TIME );
     }
@@ -77,6 +78,11 @@ class TemporalIndexFiles
     FileLayout<LocalTimeSchemaKey> localTime()
     {
         return localTime;
+    }
+
+    FileLayout<ZonedTimeSchemaKey> zonedTime()
+    {
+        return zonedTime;
     }
 
     FileLayout<LocalDateTimeSchemaKey> localDateTime()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexFiles.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexFiles.java
@@ -37,7 +37,7 @@ class TemporalIndexFiles
     private FileLayout<ZonedDateTimeSchemaKey> zonedDateTime;
     private FileLayout<LocalTimeSchemaKey> localTime;
     private FileLayout<ZonedTimeSchemaKey> zonedTime;
-    private FileLayout duration;
+    private FileLayout<DurationSchemaKey> duration;
 
     TemporalIndexFiles( IndexDirectoryStructure directoryStructure, long indexId, IndexDescriptor descriptor, FileSystemAbstraction fs )
     {
@@ -48,6 +48,7 @@ class TemporalIndexFiles
         this.zonedTime = new FileLayout<>( new File( indexDirectory, "zonedTime" ), ZonedTimeLayout.of( descriptor ), ValueGroup.ZONED_TIME );
         this.localDateTime = new FileLayout<>( new File( indexDirectory, "localDateTime" ), LocalDateTimeLayout.of( descriptor ), ValueGroup.LOCAL_DATE_TIME );
         this.zonedDateTime = new FileLayout<>( new File( indexDirectory, "zonedDateTime" ), ZonedDateTimeLayout.of( descriptor ), ValueGroup.ZONED_DATE_TIME );
+        this.duration = new FileLayout<>( new File( indexDirectory, "duration" ), DurationLayout.of( descriptor ), ValueGroup.DURATION );
     }
 
     Iterable<FileLayout> existing()
@@ -93,6 +94,11 @@ class TemporalIndexFiles
     FileLayout<ZonedDateTimeSchemaKey> zonedDateTime()
     {
         return zonedDateTime;
+    }
+
+    FileLayout<DurationSchemaKey> duration()
+    {
+        return duration;
     }
 
     private void addIfExists( List<FileLayout> existing, FileLayout fileLayout )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexFiles.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexFiles.java
@@ -33,9 +33,9 @@ class TemporalIndexFiles
 {
     private final FileSystemAbstraction fs;
     private FileLayout<DateSchemaKey> dateFileLayout;
-    private FileLayout dateTimeFileLayout;
+    private FileLayout<LocalDateTimeSchemaKey> dateTimeFileLayout;
     private FileLayout dateTimeZonedFileLayout;
-    private FileLayout timeFileLayout;
+    private FileLayout<LocalTimeSchemaKey> timeFileLayout;
     private FileLayout timeZonedFileLayout;
     private FileLayout durationFileLayout;
 
@@ -45,6 +45,7 @@ class TemporalIndexFiles
         File indexDirectory = directoryStructure.directoryForIndex( indexId );
         dateFileLayout = new FileLayout<>( new File( indexDirectory, "date" ), DateLayout.of( descriptor ), ValueGroup.DATE );
         timeFileLayout = new FileLayout<>( new File( indexDirectory, "time" ), LocalTimeLayout.of( descriptor ), ValueGroup.LOCAL_TIME );
+        dateTimeFileLayout = new FileLayout<>( new File( indexDirectory, "datetime" ), LocalDateTimeLayout.of( descriptor ), ValueGroup.LOCAL_DATE_TIME );
     }
 
     Iterable<FileLayout> existing()
@@ -85,9 +86,14 @@ class TemporalIndexFiles
         return dateFileLayout;
     }
 
-    public FileLayout<DateSchemaKey> time()
+    public FileLayout<LocalTimeSchemaKey> time()
     {
         return timeFileLayout;
+    }
+
+    public FileLayout<LocalDateTimeSchemaKey> dateTime()
+    {
+        return dateTimeFileLayout;
     }
 
     // .... we will add more explicit accessor methods later

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexFiles.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexFiles.java
@@ -34,7 +34,7 @@ class TemporalIndexFiles
     private final FileSystemAbstraction fs;
     private FileLayout<DateSchemaKey> date;
     private FileLayout<LocalDateTimeSchemaKey> localDateTime;
-    private FileLayout zonedDateTime;
+    private FileLayout<ZonedDateTimeSchemaKey> zonedDateTime;
     private FileLayout<LocalTimeSchemaKey> localTime;
     private FileLayout zonedTime;
     private FileLayout duration;
@@ -44,8 +44,9 @@ class TemporalIndexFiles
         this.fs = fs;
         File indexDirectory = directoryStructure.directoryForIndex( indexId );
         this.date = new FileLayout<>( new File( indexDirectory, "date" ), DateLayout.of( descriptor ), ValueGroup.DATE );
-        this.localTime = new FileLayout<>( new File( indexDirectory, "time" ), LocalTimeLayout.of( descriptor ), ValueGroup.LOCAL_TIME );
-        this.localDateTime = new FileLayout<>( new File( indexDirectory, "datetime" ), LocalDateTimeLayout.of( descriptor ), ValueGroup.LOCAL_DATE_TIME );
+        this.localTime = new FileLayout<>( new File( indexDirectory, "localTime" ), LocalTimeLayout.of( descriptor ), ValueGroup.LOCAL_TIME );
+        this.localDateTime = new FileLayout<>( new File( indexDirectory, "localDateTime" ), LocalDateTimeLayout.of( descriptor ), ValueGroup.LOCAL_DATE_TIME );
+        this.zonedDateTime = new FileLayout<>( new File( indexDirectory, "zonedDateTime" ), ZonedDateTimeLayout.of( descriptor ), ValueGroup.ZONED_DATE_TIME );
     }
 
     Iterable<FileLayout> existing()
@@ -81,6 +82,11 @@ class TemporalIndexFiles
     FileLayout<LocalDateTimeSchemaKey> localDateTime()
     {
         return localDateTime;
+    }
+
+    FileLayout<ZonedDateTimeSchemaKey> zonedDateTime()
+    {
+        return zonedDateTime;
     }
 
     private void addIfExists( List<FileLayout> existing, FileLayout fileLayout )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexFiles.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexFiles.java
@@ -32,31 +32,31 @@ import org.neo4j.values.storable.ValueGroup;
 class TemporalIndexFiles
 {
     private final FileSystemAbstraction fs;
-    private FileLayout<DateSchemaKey> dateFileLayout;
-    private FileLayout<LocalDateTimeSchemaKey> dateTimeFileLayout;
-    private FileLayout dateTimeZonedFileLayout;
-    private FileLayout<LocalTimeSchemaKey> timeFileLayout;
-    private FileLayout timeZonedFileLayout;
-    private FileLayout durationFileLayout;
+    private FileLayout<DateSchemaKey> date;
+    private FileLayout<LocalDateTimeSchemaKey> localDateTime;
+    private FileLayout zonedDateTime;
+    private FileLayout<LocalTimeSchemaKey> localTime;
+    private FileLayout zonedTime;
+    private FileLayout duration;
 
     TemporalIndexFiles( IndexDirectoryStructure directoryStructure, long indexId, IndexDescriptor descriptor, FileSystemAbstraction fs )
     {
         this.fs = fs;
         File indexDirectory = directoryStructure.directoryForIndex( indexId );
-        dateFileLayout = new FileLayout<>( new File( indexDirectory, "date" ), DateLayout.of( descriptor ), ValueGroup.DATE );
-        timeFileLayout = new FileLayout<>( new File( indexDirectory, "time" ), LocalTimeLayout.of( descriptor ), ValueGroup.LOCAL_TIME );
-        dateTimeFileLayout = new FileLayout<>( new File( indexDirectory, "datetime" ), LocalDateTimeLayout.of( descriptor ), ValueGroup.LOCAL_DATE_TIME );
+        this.date = new FileLayout<>( new File( indexDirectory, "date" ), DateLayout.of( descriptor ), ValueGroup.DATE );
+        this.localTime = new FileLayout<>( new File( indexDirectory, "time" ), LocalTimeLayout.of( descriptor ), ValueGroup.LOCAL_TIME );
+        this.localDateTime = new FileLayout<>( new File( indexDirectory, "datetime" ), LocalDateTimeLayout.of( descriptor ), ValueGroup.LOCAL_DATE_TIME );
     }
 
     Iterable<FileLayout> existing()
     {
         List<FileLayout> existing = new ArrayList<>();
-        addIfExists( existing, dateFileLayout );
-        addIfExists( existing, dateTimeFileLayout );
-        addIfExists( existing, dateTimeZonedFileLayout );
-        addIfExists( existing, timeFileLayout );
-        addIfExists( existing, timeZonedFileLayout );
-        addIfExists( existing, durationFileLayout );
+        addIfExists( existing, date );
+        addIfExists( existing, localDateTime );
+        addIfExists( existing, zonedDateTime );
+        addIfExists( existing, localTime );
+        addIfExists( existing, zonedTime );
+        addIfExists( existing, duration );
         return existing;
     }
 
@@ -66,6 +66,21 @@ class TemporalIndexFiles
         {
             indexCache.select( fileLayout.valueGroup );
         }
+    }
+
+    FileLayout<DateSchemaKey> date()
+    {
+        return date;
+    }
+
+    FileLayout<LocalTimeSchemaKey> localTime()
+    {
+        return localTime;
+    }
+
+    FileLayout<LocalDateTimeSchemaKey> localDateTime()
+    {
+        return localDateTime;
     }
 
     private void addIfExists( List<FileLayout> existing, FileLayout fileLayout )
@@ -79,21 +94,6 @@ class TemporalIndexFiles
     private boolean exists( FileLayout fileLayout )
     {
         return fileLayout != null && fs.fileExists( fileLayout.indexFile );
-    }
-
-    public FileLayout<DateSchemaKey> date()
-    {
-        return dateFileLayout;
-    }
-
-    public FileLayout<LocalTimeSchemaKey> time()
-    {
-        return timeFileLayout;
-    }
-
-    public FileLayout<LocalDateTimeSchemaKey> dateTime()
-    {
-        return dateTimeFileLayout;
     }
 
     // .... we will add more explicit accessor methods later

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulatingUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulatingUpdater.java
@@ -96,25 +96,25 @@ public class TemporalIndexPopulatingUpdater extends TemporalIndexCache<IndexUpda
         }
 
         @Override
-        public IndexUpdater newDateTime() throws IOException
+        public IndexUpdater newLocalDateTime() throws IOException
         {
-            return populator.dateTime().newPopulatingUpdater( propertyAccessor );
+            return populator.localDateTime().newPopulatingUpdater( propertyAccessor );
         }
 
         @Override
-        public IndexUpdater newDateTimeZoned() throws IOException
+        public IndexUpdater newZonedDateTime() throws IOException
         {
             throw new UnsupportedOperationException( "too tired to write" );
         }
 
         @Override
-        public IndexUpdater newTime() throws IOException
+        public IndexUpdater newLocalTime() throws IOException
         {
-            return populator.time().newPopulatingUpdater( propertyAccessor );
+            return populator.localTime().newPopulatingUpdater( propertyAccessor );
         }
 
         @Override
-        public IndexUpdater newTimeZoned() throws IOException
+        public IndexUpdater newZonedTime() throws IOException
         {
             throw new UnsupportedOperationException( "too tired to write" );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulatingUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulatingUpdater.java
@@ -98,7 +98,7 @@ public class TemporalIndexPopulatingUpdater extends TemporalIndexCache<IndexUpda
         @Override
         public IndexUpdater newDateTime() throws IOException
         {
-            throw new UnsupportedOperationException( "too tired to write" );
+            return populator.dateTime().newPopulatingUpdater( propertyAccessor );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulatingUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulatingUpdater.java
@@ -122,7 +122,7 @@ public class TemporalIndexPopulatingUpdater extends TemporalIndexCache<IndexUpda
         @Override
         public IndexUpdater newDuration() throws IOException
         {
-            throw new UnsupportedOperationException( "too tired to write" );
+            return populator.duration().newPopulatingUpdater( propertyAccessor );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulatingUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulatingUpdater.java
@@ -104,7 +104,7 @@ public class TemporalIndexPopulatingUpdater extends TemporalIndexCache<IndexUpda
         @Override
         public IndexUpdater newZonedDateTime() throws IOException
         {
-            throw new UnsupportedOperationException( "too tired to write" );
+            return populator.zonedDateTime().newPopulatingUpdater( propertyAccessor );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulatingUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulatingUpdater.java
@@ -116,7 +116,7 @@ public class TemporalIndexPopulatingUpdater extends TemporalIndexCache<IndexUpda
         @Override
         public IndexUpdater newZonedTime() throws IOException
         {
-            throw new UnsupportedOperationException( "too tired to write" );
+            return populator.zonedTime().newPopulatingUpdater( propertyAccessor );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulatingUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulatingUpdater.java
@@ -110,7 +110,7 @@ public class TemporalIndexPopulatingUpdater extends TemporalIndexCache<IndexUpda
         @Override
         public IndexUpdater newTime() throws IOException
         {
-            throw new UnsupportedOperationException( "too tired to write" );
+            return populator.time().newPopulatingUpdater( propertyAccessor );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulator.java
@@ -256,7 +256,7 @@ class TemporalIndexPopulator extends TemporalIndexCache<TemporalIndexPopulator.P
         @Override
         public PartPopulator<?> newZonedDateTime() throws IOException
         {
-            throw new UnsupportedOperationException( "not implementedur still" );
+            return create( temporalIndexFiles.zonedDateTime() );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulator.java
@@ -250,7 +250,7 @@ class TemporalIndexPopulator extends TemporalIndexCache<TemporalIndexPopulator.P
         @Override
         public PartPopulator<?> newDateTime() throws IOException
         {
-            throw new UnsupportedOperationException( "not implementedur still" );
+            return create( temporalIndexFiles.dateTime() );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulator.java
@@ -274,7 +274,7 @@ class TemporalIndexPopulator extends TemporalIndexCache<TemporalIndexPopulator.P
         @Override
         public PartPopulator<?> newDuration() throws IOException
         {
-            throw new UnsupportedOperationException( "not implementedur still" );
+            return create( temporalIndexFiles.duration() );
         }
 
         private <KEY extends NativeSchemaKey> PartPopulator<KEY> create( TemporalIndexFiles.FileLayout<KEY> fileLayout ) throws IOException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulator.java
@@ -268,7 +268,7 @@ class TemporalIndexPopulator extends TemporalIndexCache<TemporalIndexPopulator.P
         @Override
         public PartPopulator<?> newZonedTime() throws IOException
         {
-            throw new UnsupportedOperationException( "not implementedur still" );
+            return create( temporalIndexFiles.zonedTime() );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulator.java
@@ -262,7 +262,7 @@ class TemporalIndexPopulator extends TemporalIndexCache<TemporalIndexPopulator.P
         @Override
         public PartPopulator<?> newTime() throws IOException
         {
-            throw new UnsupportedOperationException( "not implementedur still" );
+            return create( temporalIndexFiles.time() );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulator.java
@@ -248,25 +248,25 @@ class TemporalIndexPopulator extends TemporalIndexCache<TemporalIndexPopulator.P
         }
 
         @Override
-        public PartPopulator<?> newDateTime() throws IOException
+        public PartPopulator<?> newLocalDateTime() throws IOException
         {
-            return create( temporalIndexFiles.dateTime() );
+            return create( temporalIndexFiles.localDateTime() );
         }
 
         @Override
-        public PartPopulator<?> newDateTimeZoned() throws IOException
+        public PartPopulator<?> newZonedDateTime() throws IOException
         {
             throw new UnsupportedOperationException( "not implementedur still" );
         }
 
         @Override
-        public PartPopulator<?> newTime() throws IOException
+        public PartPopulator<?> newLocalTime() throws IOException
         {
-            return create( temporalIndexFiles.time() );
+            return create( temporalIndexFiles.localTime() );
         }
 
         @Override
-        public PartPopulator<?> newTimeZoned() throws IOException
+        public PartPopulator<?> newZonedTime() throws IOException
         {
             throw new UnsupportedOperationException( "not implementedur still" );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexReader.java
@@ -120,7 +120,7 @@ class TemporalIndexReader extends TemporalIndexCache<TemporalIndexPartReader<?>,
 
     private boolean validPredicates( IndexQuery[] predicates )
     {
-        return predicates[0] instanceof ExactPredicate || predicates[0] instanceof GeometryRangePredicate;
+        return predicates[0] instanceof ExactPredicate;
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexReader.java
@@ -151,7 +151,7 @@ class TemporalIndexReader extends TemporalIndexCache<TemporalIndexPartReader<?>,
         @Override
         public TemporalIndexPartReader<?> newZonedDateTime()
         {
-            throw new UnsupportedOperationException( "Illiterate" );
+            return accessor.selectOrElse( ValueGroup.ZONED_DATE_TIME, TemporalIndexAccessor.PartAccessor::newReader, null );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexReader.java
@@ -157,7 +157,7 @@ class TemporalIndexReader extends TemporalIndexCache<TemporalIndexPartReader<?>,
         @Override
         public TemporalIndexPartReader<?> newTime()
         {
-            throw new UnsupportedOperationException( "Illiterate" );
+            return accessor.selectOrElse( ValueGroup.LOCAL_TIME, TemporalIndexAccessor.PartAccessor::newReader, null );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexReader.java
@@ -163,7 +163,7 @@ class TemporalIndexReader extends TemporalIndexCache<TemporalIndexPartReader<?>,
         @Override
         public TemporalIndexPartReader<?> newZonedTime()
         {
-            throw new UnsupportedOperationException( "Illiterate" );
+            return accessor.selectOrElse( ValueGroup.ZONED_TIME, TemporalIndexAccessor.PartAccessor::newReader, null );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexReader.java
@@ -169,7 +169,7 @@ class TemporalIndexReader extends TemporalIndexCache<TemporalIndexPartReader<?>,
         @Override
         public TemporalIndexPartReader<?> newDuration()
         {
-            throw new UnsupportedOperationException( "Illiterate" );
+            return accessor.selectOrElse( ValueGroup.DURATION, TemporalIndexAccessor.PartAccessor::newReader, null );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexReader.java
@@ -145,7 +145,7 @@ class TemporalIndexReader extends TemporalIndexCache<TemporalIndexPartReader<?>,
         @Override
         public TemporalIndexPartReader<?> newDateTime()
         {
-            throw new UnsupportedOperationException( "Illiterate" );
+            return accessor.selectOrElse( ValueGroup.LOCAL_DATE_TIME, TemporalIndexAccessor.PartAccessor::newReader, null );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexReader.java
@@ -137,31 +137,31 @@ class TemporalIndexReader extends TemporalIndexCache<TemporalIndexPartReader<?>,
         }
 
         @Override
-        public TemporalIndexPartReader<?> newDate() throws IOException
+        public TemporalIndexPartReader<?> newDate()
         {
             return accessor.selectOrElse( ValueGroup.DATE, TemporalIndexAccessor.PartAccessor::newReader, null );
         }
 
         @Override
-        public TemporalIndexPartReader<?> newDateTime()
+        public TemporalIndexPartReader<?> newLocalDateTime()
         {
             return accessor.selectOrElse( ValueGroup.LOCAL_DATE_TIME, TemporalIndexAccessor.PartAccessor::newReader, null );
         }
 
         @Override
-        public TemporalIndexPartReader<?> newDateTimeZoned()
+        public TemporalIndexPartReader<?> newZonedDateTime()
         {
             throw new UnsupportedOperationException( "Illiterate" );
         }
 
         @Override
-        public TemporalIndexPartReader<?> newTime()
+        public TemporalIndexPartReader<?> newLocalTime()
         {
             return accessor.selectOrElse( ValueGroup.LOCAL_TIME, TemporalIndexAccessor.PartAccessor::newReader, null );
         }
 
         @Override
-        public TemporalIndexPartReader<?> newTimeZoned()
+        public TemporalIndexPartReader<?> newZonedTime()
         {
             throw new UnsupportedOperationException( "Illiterate" );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexUpdater.java
@@ -103,7 +103,7 @@ public class TemporalIndexUpdater extends TemporalIndexCache<NativeSchemaIndexUp
         @Override
         public NativeSchemaIndexUpdater<?, NativeSchemaValue> newTime() throws IOException
         {
-            throw new UnsupportedOperationException( "ma-a-da dayo" );
+            return accessor.time().newUpdater( mode );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexUpdater.java
@@ -109,7 +109,7 @@ public class TemporalIndexUpdater extends TemporalIndexCache<NativeSchemaIndexUp
         @Override
         public NativeSchemaIndexUpdater<?, NativeSchemaValue> newZonedTime() throws IOException
         {
-            throw new UnsupportedOperationException( "ma-a-da dayo" );
+            return accessor.zonedTime().newUpdater( mode );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexUpdater.java
@@ -115,7 +115,7 @@ public class TemporalIndexUpdater extends TemporalIndexCache<NativeSchemaIndexUp
         @Override
         public NativeSchemaIndexUpdater<?, NativeSchemaValue> newDuration() throws IOException
         {
-            throw new UnsupportedOperationException( "ma-a-da dayo" );
+            return accessor.duration().newUpdater( mode );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexUpdater.java
@@ -65,7 +65,7 @@ public class TemporalIndexUpdater extends TemporalIndexCache<NativeSchemaIndexUp
     }
 
     @Override
-    public void close() throws IOException, IndexEntryConflictException
+    public void close() throws IOException
     {
         FusionIndexUtils.forAll( NativeSchemaIndexUpdater::close, this );
     }
@@ -89,25 +89,25 @@ public class TemporalIndexUpdater extends TemporalIndexCache<NativeSchemaIndexUp
         }
 
         @Override
-        public NativeSchemaIndexUpdater<?, NativeSchemaValue> newDateTime() throws IOException
+        public NativeSchemaIndexUpdater<?, NativeSchemaValue> newLocalDateTime() throws IOException
         {
-            return accessor.dateTime().newUpdater( mode );
+            return accessor.localDateTime().newUpdater( mode );
         }
 
         @Override
-        public NativeSchemaIndexUpdater<?, NativeSchemaValue> newDateTimeZoned() throws IOException
+        public NativeSchemaIndexUpdater<?, NativeSchemaValue> newZonedDateTime() throws IOException
         {
             throw new UnsupportedOperationException( "ma-a-da dayo" );
         }
 
         @Override
-        public NativeSchemaIndexUpdater<?, NativeSchemaValue> newTime() throws IOException
+        public NativeSchemaIndexUpdater<?, NativeSchemaValue> newLocalTime() throws IOException
         {
-            return accessor.time().newUpdater( mode );
+            return accessor.localTime().newUpdater( mode );
         }
 
         @Override
-        public NativeSchemaIndexUpdater<?, NativeSchemaValue> newTimeZoned() throws IOException
+        public NativeSchemaIndexUpdater<?, NativeSchemaValue> newZonedTime() throws IOException
         {
             throw new UnsupportedOperationException( "ma-a-da dayo" );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexUpdater.java
@@ -97,7 +97,7 @@ public class TemporalIndexUpdater extends TemporalIndexCache<NativeSchemaIndexUp
         @Override
         public NativeSchemaIndexUpdater<?, NativeSchemaValue> newZonedDateTime() throws IOException
         {
-            throw new UnsupportedOperationException( "ma-a-da dayo" );
+            return accessor.zonedDateTime().newUpdater( mode );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexUpdater.java
@@ -91,7 +91,7 @@ public class TemporalIndexUpdater extends TemporalIndexCache<NativeSchemaIndexUp
         @Override
         public NativeSchemaIndexUpdater<?, NativeSchemaValue> newDateTime() throws IOException
         {
-            throw new UnsupportedOperationException( "ma-a-da dayo" );
+            return accessor.dateTime().newUpdater( mode );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeLayout.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema;
+
+import java.util.Comparator;
+
+import org.neo4j.index.internal.gbptree.Layout;
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.kernel.api.schema.index.IndexDescriptor;
+
+/**
+ * {@link Layout} for absolute date times.
+ */
+class ZonedDateTimeLayout extends BaseLayout<ZonedDateTimeSchemaKey>
+{
+    private static final int ZONE_ID_FLAG = 0x0100_0000;
+    private static final int NO_ZONE_ID_FLAG = 0x0000_FFFF;
+
+    public static Layout<ZonedDateTimeSchemaKey,NativeSchemaValue> of( IndexDescriptor descriptor )
+    {
+        return descriptor.type() == IndexDescriptor.Type.UNIQUE ? ZonedDateTimeLayout.UNIQUE : ZonedDateTimeLayout.NON_UNIQUE;
+    }
+
+    private static final ZonedDateTimeLayout UNIQUE = new ZonedDateTimeLayout( "UTdt", 0, 1 );
+    private static final ZonedDateTimeLayout NON_UNIQUE = new ZonedDateTimeLayout( "NTdt", 0, 1 );
+
+    private ZonedDateTimeLayout(
+            String layoutName, int majorVersion, int minorVersion )
+    {
+        super( layoutName, majorVersion, minorVersion );
+    }
+
+    @Override
+    public ZonedDateTimeSchemaKey newKey()
+    {
+        return new ZonedDateTimeSchemaKey();
+    }
+
+    @Override
+    public ZonedDateTimeSchemaKey copyKey( ZonedDateTimeSchemaKey key, ZonedDateTimeSchemaKey into )
+    {
+        into.epochSecondUTC = key.epochSecondUTC;
+        into.nanoOfSecond = key.nanoOfSecond;
+        into.zoneId = key.zoneId;
+        into.zoneOffsetSeconds = key.zoneOffsetSeconds;
+        into.setEntityId( key.getEntityId() );
+        into.setCompareId( key.getCompareId() );
+        return into;
+    }
+
+    @Override
+    public int keySize( ZonedDateTimeSchemaKey key )
+    {
+        return ZonedDateTimeSchemaKey.SIZE;
+    }
+
+    @Override
+    public void writeKey( PageCursor cursor, ZonedDateTimeSchemaKey key )
+    {
+        cursor.putLong( key.epochSecondUTC );
+        cursor.putInt( key.nanoOfSecond );
+        if ( key.zoneId >= 0 )
+        {
+            cursor.putInt( key.zoneId | ZONE_ID_FLAG );
+        }
+        else
+        {
+            cursor.putInt( key.zoneOffsetSeconds );
+        }
+        cursor.putLong( key.getEntityId() );
+    }
+
+    @Override
+    public void readKey( PageCursor cursor, ZonedDateTimeSchemaKey into, int keySize )
+    {
+        into.epochSecondUTC = cursor.getLong();
+        into.nanoOfSecond = cursor.getInt();
+        int encodedZone = cursor.getInt();
+        if ( ( encodedZone & ZONE_ID_FLAG ) != 0 )
+        {
+            into.zoneId = (short) ( encodedZone & NO_ZONE_ID_FLAG );
+            into.zoneOffsetSeconds = 0;
+        }
+        else
+        {
+            into.zoneId = -1;
+            into.zoneOffsetSeconds = encodedZone;
+        }
+        into.setEntityId( cursor.getLong() );
+    }
+
+    @Override
+    public boolean fixedSize()
+    {
+        return true;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeLayout.java
@@ -106,12 +106,6 @@ class ZonedDateTimeLayout extends BaseLayout<ZonedDateTimeSchemaKey>
         into.setEntityId( cursor.getLong() );
     }
 
-    @Override
-    public boolean fixedSize()
-    {
-        return true;
-    }
-
     private int asZoneOffset( int encodedZone )
     {
         return encodedZone;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeSchemaKey.java
@@ -62,6 +62,8 @@ class ZonedDateTimeSchemaKey extends ComparableNativeSchemaKey<ZonedDateTimeSche
     {
         epochSecondUTC = Long.MIN_VALUE;
         nanoOfSecond = Integer.MIN_VALUE;
+        zoneId = Short.MIN_VALUE;
+        zoneOffsetSeconds = Integer.MIN_VALUE;
     }
 
     @Override
@@ -69,6 +71,8 @@ class ZonedDateTimeSchemaKey extends ComparableNativeSchemaKey<ZonedDateTimeSche
     {
         epochSecondUTC = Long.MAX_VALUE;
         nanoOfSecond = Integer.MAX_VALUE;
+        zoneId = Short.MAX_VALUE;
+        zoneOffsetSeconds = Integer.MAX_VALUE;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeSchemaKey.java
@@ -109,6 +109,7 @@ class ZonedDateTimeSchemaKey extends ComparableNativeSchemaKey<ZonedDateTimeSche
         this.epochSecondUTC = epochSecondUTC;
         this.nanoOfSecond = nano;
         this.zoneId = TimeZoneMapping.map( zoneId );
+        this.zoneOffsetSeconds = 0;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedTimeLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedTimeLayout.java
@@ -78,10 +78,4 @@ class ZonedTimeLayout extends BaseLayout<ZonedTimeSchemaKey>
         into.zoneOffsetSeconds = cursor.getInt();
         into.setEntityId( cursor.getLong() );
     }
-
-    @Override
-    public boolean fixedSize()
-    {
-        return true;
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedTimeLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedTimeLayout.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.index.schema;
 
-import java.util.Comparator;
-
 import org.neo4j.index.internal.gbptree.Layout;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
@@ -35,13 +33,12 @@ class ZonedTimeLayout extends BaseLayout<ZonedTimeSchemaKey>
         return descriptor.type() == IndexDescriptor.Type.UNIQUE ? ZonedTimeLayout.UNIQUE : ZonedTimeLayout.NON_UNIQUE;
     }
 
-    private static final ZonedTimeLayout UNIQUE = new ZonedTimeLayout( "UTzt", 0, 1, ComparableNativeSchemaKey.UNIQUE() );
-    private static final ZonedTimeLayout NON_UNIQUE = new ZonedTimeLayout( "NTzt", 0, 1, ComparableNativeSchemaKey.NON_UNIQUE() );
+    private static final ZonedTimeLayout UNIQUE = new ZonedTimeLayout( "UTzt", 0, 1 );
+    private static final ZonedTimeLayout NON_UNIQUE = new ZonedTimeLayout( "NTzt", 0, 1 );
 
-    private ZonedTimeLayout(
-            String layoutName, int majorVersion, int minorVersion, Comparator<ZonedTimeSchemaKey> comparator )
+    private ZonedTimeLayout( String layoutName, int majorVersion, int minorVersion )
     {
-        super( layoutName, majorVersion, minorVersion, comparator );
+        super( layoutName, majorVersion, minorVersion );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedTimeLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedTimeLayout.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema;
+
+import java.util.Comparator;
+
+import org.neo4j.index.internal.gbptree.Layout;
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.kernel.api.schema.index.IndexDescriptor;
+
+/**
+ * {@link Layout} for absolute times.
+ */
+class ZonedTimeLayout extends BaseLayout<ZonedTimeSchemaKey>
+{
+    public static Layout<ZonedTimeSchemaKey,NativeSchemaValue> of( IndexDescriptor descriptor )
+    {
+        return descriptor.type() == IndexDescriptor.Type.UNIQUE ? ZonedTimeLayout.UNIQUE : ZonedTimeLayout.NON_UNIQUE;
+    }
+
+    private static final ZonedTimeLayout UNIQUE = new ZonedTimeLayout( "UTzt", 0, 1, ComparableNativeSchemaKey.UNIQUE() );
+    private static final ZonedTimeLayout NON_UNIQUE = new ZonedTimeLayout( "NTzt", 0, 1, ComparableNativeSchemaKey.NON_UNIQUE() );
+
+    private ZonedTimeLayout(
+            String layoutName, int majorVersion, int minorVersion, Comparator<ZonedTimeSchemaKey> comparator )
+    {
+        super( layoutName, majorVersion, minorVersion, comparator );
+    }
+
+    @Override
+    public ZonedTimeSchemaKey newKey()
+    {
+        return new ZonedTimeSchemaKey();
+    }
+
+    @Override
+    public ZonedTimeSchemaKey copyKey( ZonedTimeSchemaKey key, ZonedTimeSchemaKey into )
+    {
+        into.nanosOfDayUTC = key.nanosOfDayUTC;
+        into.zoneOffsetSeconds = key.zoneOffsetSeconds;
+        into.setEntityId( key.getEntityId() );
+        into.setCompareId( key.getCompareId() );
+        return into;
+    }
+
+    @Override
+    public int keySize( ZonedTimeSchemaKey key )
+    {
+        return ZonedTimeSchemaKey.SIZE;
+    }
+
+    @Override
+    public void writeKey( PageCursor cursor, ZonedTimeSchemaKey key )
+    {
+        cursor.putLong( key.nanosOfDayUTC );
+        cursor.putInt( key.zoneOffsetSeconds );
+        cursor.putLong( key.getEntityId() );
+    }
+
+    @Override
+    public void readKey( PageCursor cursor, ZonedTimeSchemaKey into, int keySize )
+    {
+        into.nanosOfDayUTC = cursor.getLong();
+        into.zoneOffsetSeconds = cursor.getInt();
+        into.setEntityId( cursor.getLong() );
+    }
+
+    @Override
+    public boolean fixedSize()
+    {
+        return true;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedTimeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedTimeSchemaKey.java
@@ -31,7 +31,7 @@ import static java.lang.String.format;
  *
  * With these keys the TimeValues are sorted by UTC time of day, and then by time zone.
  */
-class ZonedTimeSchemaKey extends TemporalSchemaKey implements ComparableNativeSchemaKey<ZonedTimeSchemaKey>
+class ZonedTimeSchemaKey extends ComparableNativeSchemaKey<ZonedTimeSchemaKey>
 {
     static final int SIZE =
             Long.BYTES +    /* nanosOfDayUTC */
@@ -48,17 +48,15 @@ class ZonedTimeSchemaKey extends TemporalSchemaKey implements ComparableNativeSc
     }
 
     @Override
-    public void initAsLowest()
+    public void initValueAsLowest()
     {
-        super.initAsLowest();
         nanosOfDayUTC = Long.MIN_VALUE;
         zoneOffsetSeconds = Integer.MIN_VALUE;
     }
 
     @Override
-    public void initAsHighest()
+    public void initValueAsHighest()
     {
-        super.initAsHighest();
         nanosOfDayUTC = Long.MAX_VALUE;
         zoneOffsetSeconds = Integer.MAX_VALUE;
     }
@@ -78,7 +76,7 @@ class ZonedTimeSchemaKey extends TemporalSchemaKey implements ComparableNativeSc
     public String toString()
     {
         return format( "value=%s,entityId=%d,nanosOfDayUTC=%d,zoneOffsetSeconds=%d",
-                        asValue(), entityId, nanosOfDayUTC, zoneOffsetSeconds );
+                        asValue(), getEntityId(), nanosOfDayUTC, zoneOffsetSeconds );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedTimeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedTimeSchemaKey.java
@@ -23,6 +23,7 @@ import java.time.ZoneOffset;
 
 import org.neo4j.values.storable.TimeValue;
 import org.neo4j.values.storable.Value;
+import org.neo4j.values.storable.Values;
 
 import static java.lang.String.format;
 
@@ -65,9 +66,9 @@ class ZonedTimeSchemaKey extends ComparableNativeSchemaKey<ZonedTimeSchemaKey>
     public int compareValueTo( ZonedTimeSchemaKey other )
     {
         int compare = Long.compare( nanosOfDayUTC, other.nanosOfDayUTC );
-        if ( compare == 0 )
+        if ( compare == 0 && zoneOffsetSeconds != other.zoneOffsetSeconds )
         {
-            compare = Integer.compare( zoneOffsetSeconds, other.zoneOffsetSeconds );
+            compare = Values.COMPARATOR.compare( asValue(), other.asValue() );
         }
         return compare;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedTimeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedTimeSchemaKey.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema;
+
+import java.time.ZoneOffset;
+
+import org.neo4j.values.storable.TimeValue;
+import org.neo4j.values.storable.Value;
+
+import static java.lang.String.format;
+
+/**
+ * Includes value and entity id (to be able to handle non-unique values). A value can be any {@link TimeValue}.
+ *
+ * With these keys the TimeValues are sorted by UTC time of day, and then by time zone.
+ */
+class ZonedTimeSchemaKey extends TemporalSchemaKey implements ComparableNativeSchemaKey<ZonedTimeSchemaKey>
+{
+    static final int SIZE =
+            Long.BYTES +    /* nanosOfDayUTC */
+            Integer.BYTES + /* zoneOffsetSeconds */
+            Long.BYTES;     /* entityId */
+
+    long nanosOfDayUTC;
+    int zoneOffsetSeconds;
+
+    @Override
+    public Value asValue()
+    {
+        return TimeValue.time( nanosOfDayUTC, ZoneOffset.ofTotalSeconds( zoneOffsetSeconds ) );
+    }
+
+    @Override
+    public void initAsLowest()
+    {
+        super.initAsLowest();
+        nanosOfDayUTC = Long.MIN_VALUE;
+        zoneOffsetSeconds = Integer.MIN_VALUE;
+    }
+
+    @Override
+    public void initAsHighest()
+    {
+        super.initAsHighest();
+        nanosOfDayUTC = Long.MAX_VALUE;
+        zoneOffsetSeconds = Integer.MAX_VALUE;
+    }
+
+    @Override
+    public int compareValueTo( ZonedTimeSchemaKey other )
+    {
+        int compare = Long.compare( nanosOfDayUTC, other.nanosOfDayUTC );
+        if ( compare == 0 )
+        {
+            compare = Integer.compare( zoneOffsetSeconds, other.zoneOffsetSeconds );
+        }
+        return compare;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "value=%s,entityId=%d,nanosOfDayUTC=%d,zoneOffsetSeconds=%d",
+                        asValue(), entityId, nanosOfDayUTC, zoneOffsetSeconds );
+    }
+
+    @Override
+    public void writeTime( long nanosOfDayUTC, int offsetSeconds )
+    {
+        this.nanosOfDayUTC = nanosOfDayUTC;
+        this.zoneOffsetSeconds = offsetSeconds;
+    }
+
+    @Override
+    protected Value assertCorrectType( Value value )
+    {
+        if ( !(value instanceof TimeValue) )
+        {
+            throw new IllegalArgumentException(
+                    "Key layout does only support TimeValue, tried to create key from " + value );
+        }
+        return value;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSchemaIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSchemaIndexProvider.java
@@ -43,15 +43,14 @@ import static org.neo4j.internal.kernel.api.InternalIndexState.FAILED;
 import static org.neo4j.internal.kernel.api.InternalIndexState.POPULATING;
 
 /**
- * This {@link SchemaIndexProvider index provider} act as one logical index but is backed by two physical
- * indexes, the native index and the lucene index. All index entries that can be handled by the native index will be directed
- * there and the rest will be directed to the lucene index.
+ * This {@link SchemaIndexProvider index provider} act as one logical index but is backed by four physical
+ * indexes, the number, spatial, temporal native indexes, and the general purpose lucene index.
  */
 public class FusionSchemaIndexProvider extends SchemaIndexProvider
 {
     interface Selector
     {
-        <T> T select( T nativeInstance, T spatialInstance, T temporalInstance, T luceneInstance, Value... values );
+        <T> T select( T numberInstance, T spatialInstance, T temporalInstance, T luceneInstance, Value... values );
     }
 
     private final SchemaIndexProvider numberProvider;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSelector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSelector.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.index.schema.fusion;
 
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.ValueGroup;
+import org.neo4j.values.storable.Values;
 
 public class FusionSelector implements FusionSchemaIndexProvider.Selector
 {
@@ -40,14 +41,13 @@ public class FusionSelector implements FusionSchemaIndexProvider.Selector
             return numberInstance;
         }
 
-        if ( singleValue.valueGroup() == ValueGroup.GEOMETRY )
+        if ( Values.isGeometryValue( singleValue ) )
         {
             // It's a geometry, the spatial index can handle this
             return spatialInstance;
         }
 
-        // TODO this needs to check all temporal groups
-        if ( singleValue.valueGroup() == ValueGroup.DATE )
+        if ( Values.isTemporalValue( singleValue ) )
         {
             return temporalInstance;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TemporalType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TemporalType.java
@@ -251,7 +251,7 @@ public enum TemporalType
                         long epochSecond = valueBlocks[1 + offset];
                         short zoneNumber = (short) valueBlocks[2 + offset];
                         return DateTimeValue.datetime( epochSecond, nanoOfSecond,
-                                ZoneId.of( TimeZoneMapping.map( zoneNumber ) ) );
+                                ZoneId.of( TimeZones.map( zoneNumber ) ) );
                     }
                 }
 
@@ -283,7 +283,7 @@ public enum TemporalType
                             {
                                 short zoneNumber = (short) (zoneValue >>> 1);
                                 dateTimes[i] = ZonedDateTime.ofInstant( Instant.ofEpochSecond( epochSecond, nanos ),
-                                        ZoneId.of( TimeZoneMapping.map( zoneNumber ) ) );
+                                        ZoneId.of( TimeZones.map( zoneNumber ) ) );
                             }
                         }
                         return Values.dateTimeArray( dateTimes );
@@ -478,7 +478,7 @@ public enum TemporalType
     public static long[] encodeDateTime( int keyId, long epochSecond, long nanoOfSecond, String zoneId )
     {
         int idBits = StandardFormatSettings.PROPERTY_TOKEN_MAXIMUM_ID_BITS;
-        short zoneNumber = TimeZoneMapping.map( zoneId );
+        short zoneNumber = TimeZones.map( zoneId );
 
         long keyAndType = keyId | (((long) (PropertyType.TEMPORAL.intValue()) << idBits));
         long temporalTypeBits = TemporalType.TEMPORAL_DATE_TIME.temporalType << (idBits + 4);
@@ -629,7 +629,7 @@ public enum TemporalType
             else
             {
                 String timeZoneId = dateTimes[i].getZone().getId();
-                short zoneNumber = TimeZoneMapping.map( timeZoneId );
+                short zoneNumber = TimeZones.map( timeZoneId );
                 // Set lowest bit to 0 means zone id
                 data[i * BLOCKS_DATETIME + 2] = zoneNumber << 1;
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TimeZones.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TimeZones.java
@@ -32,17 +32,30 @@ import java.util.regex.Pattern;
 
 import static java.util.Collections.unmodifiableSet;
 
-public class TimeZoneMapping
+public class TimeZones
 {
     /**
      * Prevent instance creation.
      */
-    private TimeZoneMapping()
+    private TimeZones()
     {
     }
 
     private static final List<String> TIME_ZONE_SHORT_TO_STRING = new ArrayList<>( 1024 );
     private static final Map<String,Short> TIME_ZONE_STRING_TO_SHORT = new HashMap<>( 1024 );
+
+    private static final long MIN_ZONE_OFFSET_SECONDS = -18 * 3600;
+    private static final long MAX_ZONE_OFFSET_SECONDS = 18 * 3600;
+
+    public static boolean validZoneOffset( int zoneOffsetSeconds )
+    {
+        return zoneOffsetSeconds >= MIN_ZONE_OFFSET_SECONDS && zoneOffsetSeconds <= MAX_ZONE_OFFSET_SECONDS;
+    }
+
+    public static boolean validZoneId( short zoneId )
+    {
+        return zoneId >= 0 && zoneId < TIME_ZONE_SHORT_TO_STRING.size();
+    }
 
     static final String LATEST_SUPPORTED_IANA_VERSION;
 
@@ -72,7 +85,7 @@ public class TimeZoneMapping
     {
         String latestVersion = "";
         Pattern version = Pattern.compile( "# tzdata([0-9]{4}[a-z])" );
-        try ( BufferedReader reader = new BufferedReader( new InputStreamReader( TimeZoneMapping.class.getResourceAsStream( "/TZIDS" ) ) ) )
+        try ( BufferedReader reader = new BufferedReader( new InputStreamReader( TimeZones.class.getResourceAsStream( "/TZIDS" ) ) ) )
         {
             for ( String line; (line = reader.readLine()) != null; )
             {

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
@@ -38,6 +38,7 @@ import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 import org.neo4j.test.runner.ParameterizedSuiteRunner;
 import org.neo4j.values.storable.CoordinateReferenceSystem;
 import org.neo4j.values.storable.DateValue;
+import org.neo4j.values.storable.LocalTimeValue;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
 
@@ -91,7 +92,8 @@ public abstract class IndexProviderCompatibilityTestSuite
                     testSuite.supportsSpatial(),
                     testSuite.supportsTemporal(),
                     Arrays.asList( Values.of( "string1" ), Values.of( 42 ) ),
-                    Arrays.asList( DateValue.epochDate( 2 ), DateValue.epochDate( 5 ) ),
+                    Arrays.asList( DateValue.epochDate( 2 ),
+                                   LocalTimeValue.localTime( 100000 ) ),
                     Arrays.asList( Values.pointValue( CoordinateReferenceSystem.Cartesian, 0, 0 ),
                                    Values.pointValue( CoordinateReferenceSystem.WGS84, 12.78, 56.7 ) ) );
 
@@ -99,7 +101,9 @@ public abstract class IndexProviderCompatibilityTestSuite
                     testSuite.supportsSpatial(),
                     testSuite.supportsTemporal(),
                     Arrays.asList( Values.of( "string2" ), Values.of( 1337 ) ),
-                    Arrays.asList( DateValue.epochDate( 42 ), DateValue.epochDate( 1337 ) ),
+                    Arrays.asList(
+                            DateValue.epochDate( 42 ),
+                            LocalTimeValue.localTime( 2000 ) ),
                     Arrays.asList( Values.pointValue( CoordinateReferenceSystem.Cartesian, 10, 10 ),
                             Values.pointValue( CoordinateReferenceSystem.WGS84, 87.21, 7.65 ) ) );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
@@ -25,6 +25,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 import java.io.File;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -41,6 +43,7 @@ import org.neo4j.values.storable.DateTimeValue;
 import org.neo4j.values.storable.DateValue;
 import org.neo4j.values.storable.LocalDateTimeValue;
 import org.neo4j.values.storable.LocalTimeValue;
+import org.neo4j.values.storable.TimeValue;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
 
@@ -97,6 +100,10 @@ public abstract class IndexProviderCompatibilityTestSuite
                     Arrays.asList(
                             DateValue.epochDate( 2 ),
                             LocalTimeValue.localTime( 100000 ),
+                            TimeValue.time( 43_200_000_000_000L, ZoneOffset.UTC ), // Noon
+                            TimeValue.time( 43_201_000_000_000L, ZoneOffset.UTC ),
+                            TimeValue.time( 43_200_000_000_000L, ZoneId.of( "+01:00" ) ), // Noon in the next time-zone
+                            TimeValue.time( 46_800_000_000_000L, ZoneOffset.UTC ), // Same time UTC as prev time
                             LocalDateTimeValue.localDateTime( 2018, 3, 1, 13, 50, 42, 1337 ),
                             DateTimeValue.datetime( 2014, 3, 25, 12, 45, 13, 7474, "UTC" ),
                             DateTimeValue.datetime( 2014, 3, 25, 12, 45, 13, 7474, "Europe/Stockholm" ),
@@ -118,6 +125,7 @@ public abstract class IndexProviderCompatibilityTestSuite
                     Arrays.asList(
                             DateValue.epochDate( 42 ),
                             LocalTimeValue.localTime( 2000 ),
+                            TimeValue.time( 100L, ZoneOffset.UTC ), // Just around midnight
                             LocalDateTimeValue.localDateTime( 2018, 2, 28, 11, 5, 1, 42 ),
                             DateTimeValue.datetime( 1999, 12, 31, 23, 59, 59, 123456789, "Europe/London" ) ),
                     Arrays.asList( Values.pointValue( CoordinateReferenceSystem.Cartesian, 10, 10 ),

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
@@ -38,6 +38,7 @@ import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 import org.neo4j.test.runner.ParameterizedSuiteRunner;
 import org.neo4j.values.storable.CoordinateReferenceSystem;
 import org.neo4j.values.storable.DateValue;
+import org.neo4j.values.storable.LocalDateTimeValue;
 import org.neo4j.values.storable.LocalTimeValue;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
@@ -92,8 +93,10 @@ public abstract class IndexProviderCompatibilityTestSuite
                     testSuite.supportsSpatial(),
                     testSuite.supportsTemporal(),
                     Arrays.asList( Values.of( "string1" ), Values.of( 42 ) ),
-                    Arrays.asList( DateValue.epochDate( 2 ),
-                                   LocalTimeValue.localTime( 100000 ) ),
+                    Arrays.asList(
+                            DateValue.epochDate( 2 ),
+                            LocalTimeValue.localTime( 100000 ),
+                            LocalDateTimeValue.localDateTime( 2018, 3, 1, 13, 50, 42, 1337 ) ),
                     Arrays.asList( Values.pointValue( CoordinateReferenceSystem.Cartesian, 0, 0 ),
                                    Values.pointValue( CoordinateReferenceSystem.WGS84, 12.78, 56.7 ) ) );
 
@@ -103,7 +106,8 @@ public abstract class IndexProviderCompatibilityTestSuite
                     Arrays.asList( Values.of( "string2" ), Values.of( 1337 ) ),
                     Arrays.asList(
                             DateValue.epochDate( 42 ),
-                            LocalTimeValue.localTime( 2000 ) ),
+                            LocalTimeValue.localTime( 2000 ),
+                            LocalDateTimeValue.localDateTime( 2018, 2, 28, 11, 5, 1, 42 ) ),
                     Arrays.asList( Values.pointValue( CoordinateReferenceSystem.Cartesian, 10, 10 ),
                             Values.pointValue( CoordinateReferenceSystem.WGS84, 87.21, 7.65 ) ) );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
@@ -41,6 +41,7 @@ import org.neo4j.test.runner.ParameterizedSuiteRunner;
 import org.neo4j.values.storable.CoordinateReferenceSystem;
 import org.neo4j.values.storable.DateTimeValue;
 import org.neo4j.values.storable.DateValue;
+import org.neo4j.values.storable.DurationValue;
 import org.neo4j.values.storable.LocalDateTimeValue;
 import org.neo4j.values.storable.LocalTimeValue;
 import org.neo4j.values.storable.TimeValue;
@@ -114,7 +115,12 @@ public abstract class IndexProviderCompatibilityTestSuite
                             DateTimeValue.datetime( 2014, 3, 25, 13, 45, 13, 7474, "+05:00" ),
                             DateTimeValue.datetime( 2014, 3, 25, 12, 46, 13, 7474, "+05:00" ),
                             DateTimeValue.datetime( 2014, 3, 25, 12, 45, 14, 7474, "+05:00" ),
-                            DateTimeValue.datetime( 2014, 3, 25, 12, 45, 14, 7475, "+05:00" )),
+                            DateTimeValue.datetime( 2014, 3, 25, 12, 45, 14, 7475, "+05:00" ),
+                            DurationValue.duration( 10, 20, 30, 40 ),
+                            DurationValue.duration( 11, 20, 30, 40 ),
+                            DurationValue.duration( 10, 21, 30, 40 ),
+                            DurationValue.duration( 10, 20, 31, 40 ),
+                            DurationValue.duration( 10, 20, 30, 41 ) ),
                     Arrays.asList( Values.pointValue( CoordinateReferenceSystem.Cartesian, 0, 0 ),
                                    Values.pointValue( CoordinateReferenceSystem.WGS84, 12.78, 56.7 ) ) );
 
@@ -127,7 +133,8 @@ public abstract class IndexProviderCompatibilityTestSuite
                             LocalTimeValue.localTime( 2000 ),
                             TimeValue.time( 100L, ZoneOffset.UTC ), // Just around midnight
                             LocalDateTimeValue.localDateTime( 2018, 2, 28, 11, 5, 1, 42 ),
-                            DateTimeValue.datetime( 1999, 12, 31, 23, 59, 59, 123456789, "Europe/London" ) ),
+                            DateTimeValue.datetime( 1999, 12, 31, 23, 59, 59, 123456789, "Europe/London" ),
+                            DurationValue.duration( 4, 3, 2, 1 ) ),
                     Arrays.asList( Values.pointValue( CoordinateReferenceSystem.Cartesian, 10, 10 ),
                             Values.pointValue( CoordinateReferenceSystem.WGS84, 87.21, 7.65 ) ) );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
@@ -37,6 +37,7 @@ import org.neo4j.test.rule.PageCacheAndDependenciesRule;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 import org.neo4j.test.runner.ParameterizedSuiteRunner;
 import org.neo4j.values.storable.CoordinateReferenceSystem;
+import org.neo4j.values.storable.DateTimeValue;
 import org.neo4j.values.storable.DateValue;
 import org.neo4j.values.storable.LocalDateTimeValue;
 import org.neo4j.values.storable.LocalTimeValue;
@@ -96,7 +97,17 @@ public abstract class IndexProviderCompatibilityTestSuite
                     Arrays.asList(
                             DateValue.epochDate( 2 ),
                             LocalTimeValue.localTime( 100000 ),
-                            LocalDateTimeValue.localDateTime( 2018, 3, 1, 13, 50, 42, 1337 ) ),
+                            LocalDateTimeValue.localDateTime( 2018, 3, 1, 13, 50, 42, 1337 ),
+                            DateTimeValue.datetime( 2014, 3, 25, 12, 45, 13, 7474, "UTC" ),
+                            DateTimeValue.datetime( 2014, 3, 25, 12, 45, 13, 7474, "Europe/Stockholm" ),
+                            DateTimeValue.datetime( 2014, 3, 25, 12, 45, 13, 7474, "+05:00" ),
+                            DateTimeValue.datetime( 2015, 3, 25, 12, 45, 13, 7474, "+05:00" ),
+                            DateTimeValue.datetime( 2014, 4, 25, 12, 45, 13, 7474, "+05:00" ),
+                            DateTimeValue.datetime( 2014, 3, 26, 12, 45, 13, 7474, "+05:00" ),
+                            DateTimeValue.datetime( 2014, 3, 25, 13, 45, 13, 7474, "+05:00" ),
+                            DateTimeValue.datetime( 2014, 3, 25, 12, 46, 13, 7474, "+05:00" ),
+                            DateTimeValue.datetime( 2014, 3, 25, 12, 45, 14, 7474, "+05:00" ),
+                            DateTimeValue.datetime( 2014, 3, 25, 12, 45, 14, 7475, "+05:00" )),
                     Arrays.asList( Values.pointValue( CoordinateReferenceSystem.Cartesian, 0, 0 ),
                                    Values.pointValue( CoordinateReferenceSystem.WGS84, 12.78, 56.7 ) ) );
 
@@ -107,7 +118,8 @@ public abstract class IndexProviderCompatibilityTestSuite
                     Arrays.asList(
                             DateValue.epochDate( 42 ),
                             LocalTimeValue.localTime( 2000 ),
-                            LocalDateTimeValue.localDateTime( 2018, 2, 28, 11, 5, 1, 42 ) ),
+                            LocalDateTimeValue.localDateTime( 2018, 2, 28, 11, 5, 1, 42 ),
+                            DateTimeValue.datetime( 1999, 12, 31, 23, 59, 59, 123456789, "Europe/London" ) ),
                     Arrays.asList( Values.pointValue( CoordinateReferenceSystem.Cartesian, 10, 10 ),
                             Values.pointValue( CoordinateReferenceSystem.WGS84, 87.21, 7.65 ) ) );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialCRSSchemaIndexTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialCRSSchemaIndexTest.java
@@ -37,7 +37,6 @@ import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
-import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.test.rule.PageCacheRule;
 import org.neo4j.test.rule.RandomRule;
 import org.neo4j.test.rule.TestDirectory;
@@ -51,11 +50,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.rules.RuleChain.outerRule;
-import static org.mockito.Mockito.mock;
 import static org.neo4j.kernel.impl.index.schema.fusion.SpatialFusionSchemaIndexProvider.SPATIAL_PROVIDER_DESCRIPTOR;
 import static org.neo4j.test.rule.PageCacheRule.config;
 
-public class SpatialKnownIndexTest
+public class SpatialCRSSchemaIndexTest
 {
     private final FileSystemRule fsRule = new EphemeralFileSystemRule();
     private final TestDirectory directory = TestDirectory.testDirectory( getClass(), fsRule.get() );
@@ -66,7 +64,6 @@ public class SpatialKnownIndexTest
 
     private SpatialCRSSchemaIndex index;
     private IndexDescriptor descriptor;
-    private IndexSamplingConfig samplingConfig;
     private FileSystemAbstraction fs;
     private File storeDir;
     private File indexDir;
@@ -86,7 +83,6 @@ public class SpatialKnownIndexTest
         descriptor = IndexDescriptorFactory.forLabel( 42, 1337 );
         index = new SpatialCRSSchemaIndex( descriptor, dirStructure, crs, 1L, pageCacheRule.getPageCache( fs ), fs,
                 SchemaIndexProvider.Monitor.EMPTY, RecoveryCleanupWorkCollector.IMMEDIATE, new StandardConfiguration(), 60 );
-        samplingConfig = mock( IndexSamplingConfig.class );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TemporalIndexCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TemporalIndexCacheTest.java
@@ -32,8 +32,8 @@ public class TemporalIndexCacheTest
     {
         // GIVEN
         TemporalIndexCache<String, Exception> cache = new TemporalIndexCache<>( new StringFactory() );
-        cache.dateTime();
-        cache.dateTimeZoned();
+        cache.localDateTime();
+        cache.zonedDateTime();
 
         // THEN
         assertEquals( Iterables.count( cache ), 2 );
@@ -48,27 +48,27 @@ public class TemporalIndexCacheTest
         }
 
         @Override
-        public String newDateTime() throws Exception
+        public String newLocalDateTime() throws Exception
         {
-            return "newDateTime";
+            return "newLocalDateTime";
         }
 
         @Override
-        public String newDateTimeZoned() throws Exception
+        public String newZonedDateTime() throws Exception
         {
-            return "newDateTimeZoned";
+            return "newZonedDateTime";
         }
 
         @Override
-        public String newTime() throws Exception
+        public String newLocalTime() throws Exception
         {
-            return "newTime";
+            return "newLocalTime";
         }
 
         @Override
-        public String newTimeZoned() throws Exception
+        public String newZonedTime() throws Exception
         {
-            return "newTimeZoned";
+            return "newZonedTime";
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TemporalIndexCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TemporalIndexCacheTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema;
+
+import org.junit.Test;
+
+import org.neo4j.helpers.collection.Iterables;
+
+import static org.junit.Assert.assertEquals;
+
+public class TemporalIndexCacheTest
+{
+    @Test
+    public void shouldIterateOverCreatedParts() throws Exception
+    {
+        // GIVEN
+        TemporalIndexCache<String, Exception> cache = new TemporalIndexCache<>( new StringFactory() );
+        cache.dateTime();
+        cache.dateTimeZoned();
+
+        // THEN
+        assertEquals( Iterables.count( cache ), 2 );
+    }
+
+    static class StringFactory implements TemporalIndexCache.Factory<String, Exception>
+    {
+        @Override
+        public String newDate() throws Exception
+        {
+            return "newDate";
+        }
+
+        @Override
+        public String newDateTime() throws Exception
+        {
+            return "newDateTime";
+        }
+
+        @Override
+        public String newDateTimeZoned() throws Exception
+        {
+            return "newDateTimeZoned";
+        }
+
+        @Override
+        public String newTime() throws Exception
+        {
+            return "newTime";
+        }
+
+        @Override
+        public String newTimeZoned() throws Exception
+        {
+            return "newTimeZoned";
+        }
+
+        @Override
+        public String newDuration() throws Exception
+        {
+            return "newDuration";
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TemporalIndexCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TemporalIndexCacheTest.java
@@ -23,58 +23,70 @@ import org.junit.Test;
 
 import org.neo4j.helpers.collection.Iterables;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class TemporalIndexCacheTest
 {
     @Test
     public void shouldIterateOverCreatedParts() throws Exception
     {
-        // GIVEN
         TemporalIndexCache<String, Exception> cache = new TemporalIndexCache<>( new StringFactory() );
-        cache.localDateTime();
-        cache.zonedDateTime();
 
-        // THEN
-        assertEquals( Iterables.count( cache ), 2 );
+        assertEquals( Iterables.count( cache ), 0 );
+
+        cache.localDateTime();
+        cache.zonedTime();
+
+        assertThat( cache, containsInAnyOrder( "LocalDateTime", "ZonedTime" ) );
+
+        cache.date();
+        cache.localTime();
+        cache.localDateTime();
+        cache.zonedTime();
+        cache.zonedDateTime();
+        cache.duration();
+
+        assertThat( cache, containsInAnyOrder( "Date", "LocalDateTime", "ZonedDateTime", "LocalTime", "ZonedTime", "Duration" ) );
     }
 
     static class StringFactory implements TemporalIndexCache.Factory<String, Exception>
     {
         @Override
-        public String newDate() throws Exception
+        public String newDate()
         {
-            return "newDate";
+            return "Date";
         }
 
         @Override
-        public String newLocalDateTime() throws Exception
+        public String newLocalDateTime()
         {
-            return "newLocalDateTime";
+            return "LocalDateTime";
         }
 
         @Override
-        public String newZonedDateTime() throws Exception
+        public String newZonedDateTime()
         {
-            return "newZonedDateTime";
+            return "ZonedDateTime";
         }
 
         @Override
-        public String newLocalTime() throws Exception
+        public String newLocalTime()
         {
-            return "newLocalTime";
+            return "LocalTime";
         }
 
         @Override
-        public String newZonedTime() throws Exception
+        public String newZonedTime()
         {
-            return "newZonedTime";
+            return "ZonedTime";
         }
 
         @Override
-        public String newDuration() throws Exception
+        public String newDuration()
         {
-            return "newDuration";
+            return "Duration";
         }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeSchemaKeyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeSchemaKeyTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema;
+
+import org.junit.Test;
+
+import java.time.ZoneId;
+
+import org.neo4j.values.storable.DateTimeValue;
+import org.neo4j.values.storable.Value;
+import org.neo4j.values.storable.Values;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+
+public class ZonedDateTimeSchemaKeyTest
+{
+    @Test
+    public void compareToSameAsValue()
+    {
+        Value[] values = {DateTimeValue.datetime( 9999, 100, ZoneId.of( "+18:00" ) ),
+                          DateTimeValue.datetime( 10000, 100, ZoneId.of( "-18:00" ) ),
+                          DateTimeValue.datetime( 10000, 100, ZoneId.of( "UTC" ) ),
+                          DateTimeValue.datetime( 10000, 100, ZoneId.of( "Europe/Stockholm" ) ),
+                          DateTimeValue.datetime( 10000, 100, ZoneId.of( "+01:00" ) ),
+                          DateTimeValue.datetime( 10000, 100, ZoneId.of( "+03:00" ) ),
+                          DateTimeValue.datetime( 10000, 101, ZoneId.of( "-18:00" ) )};
+
+        ZonedDateTimeSchemaKey keyI = new ZonedDateTimeSchemaKey();
+        ZonedDateTimeSchemaKey keyJ = new ZonedDateTimeSchemaKey();
+
+        for ( Value vi : values )
+        {
+            for ( Value vj : values )
+            {
+                vi.writeTo( keyI );
+                vj.writeTo( keyJ );
+
+                int expected = Values.COMPARATOR.compare( vi, vj );
+                assertEquals( format( "comparing %s and %s", vi, vj ), expected, keyI.compareValueTo( keyJ ) );
+            }
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeSchemaKeyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeSchemaKeyTest.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.index.schema;
 import org.junit.Test;
 
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 
 import org.neo4j.values.storable.DateTimeValue;
 import org.neo4j.values.storable.Value;
@@ -35,26 +36,32 @@ public class ZonedDateTimeSchemaKeyTest
     @Test
     public void compareToSameAsValue()
     {
-        Value[] values = {DateTimeValue.datetime( 9999, 100, ZoneId.of( "+18:00" ) ),
+        Value[] values = {DateTimeValue.datetime( 9999, 100,  ZoneId.of( "+18:00" ) ),
                           DateTimeValue.datetime( 10000, 100, ZoneId.of( "-18:00" ) ),
+                          DateTimeValue.datetime( 10000, 100, ZoneOffset.of( "-17:59:59" ) ),
                           DateTimeValue.datetime( 10000, 100, ZoneId.of( "UTC" ) ),
-                          DateTimeValue.datetime( 10000, 100, ZoneId.of( "Europe/Stockholm" ) ),
                           DateTimeValue.datetime( 10000, 100, ZoneId.of( "+01:00" ) ),
+                          DateTimeValue.datetime( 10000, 100, ZoneId.of( "Europe/Stockholm" ) ),
                           DateTimeValue.datetime( 10000, 100, ZoneId.of( "+03:00" ) ),
                           DateTimeValue.datetime( 10000, 101, ZoneId.of( "-18:00" ) )};
 
         ZonedDateTimeSchemaKey keyI = new ZonedDateTimeSchemaKey();
         ZonedDateTimeSchemaKey keyJ = new ZonedDateTimeSchemaKey();
 
-        for ( Value vi : values )
+        int len = values.length;
+
+        for ( int i = 0; i < len; i++ )
         {
-            for ( Value vj : values )
+            for ( int j = 0; j < len; j++ )
             {
+                Value vi = values[i];
+                Value vj = values[j];
                 vi.writeTo( keyI );
                 vj.writeTo( keyJ );
 
-                int expected = Values.COMPARATOR.compare( vi, vj );
-                assertEquals( format( "comparing %s and %s", vi, vj ), expected, keyI.compareValueTo( keyJ ) );
+                int expected = Integer.signum( Values.COMPARATOR.compare( vi, vj ) );
+                assertEquals( format( "comparing %s and %s", vi, vj ), expected, Integer.signum( i - j ) );
+                assertEquals( format( "comparing %s and %s", vi, vj ), expected, Integer.signum( keyI.compareValueTo( keyJ ) ) );
             }
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/ZonedTimeSchemaKeyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/ZonedTimeSchemaKeyTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema;
+
+import org.junit.Test;
+
+import java.time.ZoneId;
+
+import org.neo4j.values.storable.TimeValue;
+import org.neo4j.values.storable.Value;
+import org.neo4j.values.storable.Values;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+
+public class ZonedTimeSchemaKeyTest
+{
+    @Test
+    public void compareToSameAsValue()
+    {
+        Value[] values = {TimeValue.time( 9999, ZoneId.of( "+18:00" ) ),
+                          TimeValue.time( 10000, ZoneId.of( "-18:00" ) ),
+                          TimeValue.time( 10000, ZoneId.of( "UTC" ) ),
+                          TimeValue.time( 10000, ZoneId.of( "Europe/Stockholm" ) ),
+                          TimeValue.time( 10000, ZoneId.of( "+01:00" ) ),
+                          TimeValue.time( 10000, ZoneId.of( "+03:00" ) ),
+                          TimeValue.time( 10000, ZoneId.of( "-18:00" ) )};
+
+        ZonedTimeSchemaKey keyI = new ZonedTimeSchemaKey();
+        ZonedTimeSchemaKey keyJ = new ZonedTimeSchemaKey();
+
+        for ( Value vi : values )
+        {
+            for ( Value vj : values )
+            {
+                vi.writeTo( keyI );
+                vj.writeTo( keyJ );
+
+                int expected = Values.COMPARATOR.compare( vi, vj );
+                assertEquals( format( "comparing %s and %s", vi, vj ), expected, keyI.compareValueTo( keyJ ) );
+            }
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TimeZonesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TimeZonesTest.java
@@ -47,23 +47,23 @@ import static org.hamcrest.Matchers.isEmptyString;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
-public class TimeZoneMappingTest
+public class TimeZonesTest
 {
     @Test
     public void weSupportAllJavaZoneIds()
     {
         ZoneId.getAvailableZoneIds().forEach( s ->
         {
-            short num = TimeZoneMapping.map( s );
+            short num = TimeZones.map( s );
             assertThat( "Our time zone table does not have a mapping for " + s, num, greaterThanOrEqualTo( (short) 0 ) );
 
-            String nameFromTable = TimeZoneMapping.map( num );
+            String nameFromTable = TimeZones.map( num );
             if ( !s.equals( nameFromTable ) )
             {
                 // The test is running on an older Java version and `s` has been removed since, thus it points to a different zone now.
                 // That zone should point to itself, however.
-                assertThat( "Our time zone table has inconsistent mapping for " + nameFromTable, TimeZoneMapping.map( TimeZoneMapping.map( nameFromTable ) ),
-                        equalTo( nameFromTable ) );
+                assertThat( "Our time zone table has inconsistent mapping for " + nameFromTable,
+                        TimeZones.map( TimeZones.map( nameFromTable ) ), equalTo( nameFromTable ) );
             }
         } );
     }
@@ -73,9 +73,9 @@ public class TimeZoneMappingTest
     {
         try
         {
-            short eastSaskatchewan = TimeZoneMapping.map( "Canada/East-Saskatchewan" );
-            assertThat( "Our time zone table does not remap Canada/East-Saskatchewan to Canada/Saskatchewan", TimeZoneMapping.map( eastSaskatchewan ),
-                    equalTo( "Canada/Saskatchewan" ) );
+            short eastSaskatchewan = TimeZones.map( "Canada/East-Saskatchewan" );
+            assertThat( "Our time zone table does not remap Canada/East-Saskatchewan to Canada/Saskatchewan",
+                    TimeZones.map( eastSaskatchewan ), equalTo( "Canada/Saskatchewan" ) );
         }
         catch ( IllegalArgumentException e )
         {
@@ -94,7 +94,7 @@ public class TimeZoneMappingTest
             {
                 String substring = line.substring( line.indexOf( ' ' ) + 1 );
                 String release = substring.substring( 0, substring.indexOf( ' ' ) );
-                if ( TimeZoneMapping.LATEST_SUPPORTED_IANA_VERSION.equals( release ) )
+                if ( TimeZones.LATEST_SUPPORTED_IANA_VERSION.equals( release ) )
                 {
                     return false; // stop reading
                 }
@@ -122,7 +122,7 @@ public class TimeZoneMappingTest
     @Test
     public void tzidsOrderMustNotChange() throws IOException
     {
-        try ( BufferedReader reader = new BufferedReader( new InputStreamReader( TimeZoneMapping.class.getResourceAsStream( "/TZIDS" ) ) ) )
+        try ( BufferedReader reader = new BufferedReader( new InputStreamReader( TimeZones.class.getResourceAsStream( "/TZIDS" ) ) ) )
         {
             String text = reader.lines().collect( Collectors.joining( "\n" ) );
             MessageDigest digest = MessageDigest.getInstance( "SHA-256" );
@@ -155,7 +155,7 @@ public class TimeZoneMappingTest
         } );
 
         // TODO assertion for removals
-        Set<String> neo4jSupportedTzs = TimeZoneMapping.supportedTimeZones();
+        Set<String> neo4jSupportedTzs = TimeZones.supportedTimeZones();
         Set<String> removedTzs = new HashSet<>( neo4jSupportedTzs );
         removedTzs.removeAll( ianaSupportedTzs );
         //assertThat( "There were removals from the IANA database. Please upgrade manually.", removedTzs, empty() );

--- a/community/values/src/main/java/org/neo4j/values/storable/TemporalValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TemporalValue.java
@@ -69,8 +69,6 @@ public abstract class TemporalValue<T extends Temporal, V extends TemporalValue<
         // (therefore the type itself is public)
     }
 
-    private static final String DEFAULT_WHEN = "statement";
-
     public abstract TemporalValue add( DurationValue duration );
 
     public abstract TemporalValue sub( DurationValue duration );

--- a/community/values/src/main/java/org/neo4j/values/storable/Values.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Values.java
@@ -123,6 +123,11 @@ public final class Values
         return value instanceof PointValue;
     }
 
+    public static boolean isTemporalValue( Value value )
+    {
+        return value instanceof TemporalValue || value instanceof DurationValue;
+    }
+
     public static double coerceToDouble( Value value )
     {
         if ( value instanceof IntegralValue )


### PR DESCRIPTION
Introduce support for the remaining temporal index parts: `LocalTime`, `LocalDateTime`, `ZonedDateTime`, `ZonedTime` and `Duration`.

Also perform some attempts at sharing more code between the parts, which could probably also be used by other native indexes. We decided no to push that now though, to try to avoid conflicting with String index work. 

I put `team-kernel` on this FYI. Review if you are interested, we otherwise think we have enough indexing know-how to review this internally now.