### PR TITLE
 Add support for temporal types to batch importer

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
@@ -369,6 +369,28 @@ public class Extractors
         protected abstract boolean extract0( char[] data, int offset, int length );
     }
 
+    private abstract static class AbstractSingleAnyValueExtractor extends AbstractSingleValueExtractor<AnyValue>
+    {
+        protected AnyValue value;
+
+        AbstractSingleAnyValueExtractor( String toString )
+        {
+            super( toString );
+        }
+
+        @Override
+        protected void clear()
+        {
+            value = Values.NO_VALUE;
+        }
+
+        @Override
+        public AnyValue value()
+        {
+            return value;
+        }
+    }
+
     public static class StringExtractor extends AbstractSingleValueExtractor<String>
     {
         private String value;
@@ -979,19 +1001,11 @@ public class Extractors
         }
     }
 
-    public static class PointExtractor extends AbstractSingleValueExtractor<AnyValue>
+    public static class PointExtractor extends AbstractSingleAnyValueExtractor
     {
-        private AnyValue value;
-
         PointExtractor()
         {
             super( "Point" );
-        }
-
-        @Override
-        protected void clear()
-        {
-            value = Values.NO_VALUE;
         }
 
         @Override
@@ -1008,21 +1022,12 @@ public class Extractors
         }
     }
 
-    public static class DateExtractor extends AbstractSingleValueExtractor<AnyValue>
+    public static class DateExtractor extends AbstractSingleAnyValueExtractor
     {
-        private AnyValue value;
-
         DateExtractor()
         {
             super( "Date" );
         }
-
-        @Override
-        protected void clear()
-        {
-            value = Values.NO_VALUE;
-        }
-
         @Override
         protected boolean extract0( char[] data, int offset, int length )
         {
@@ -1037,21 +1042,14 @@ public class Extractors
         }
     }
 
-    public static class TimeExtractor extends AbstractSingleValueExtractor<AnyValue>
+    public static class TimeExtractor extends AbstractSingleAnyValueExtractor
     {
-        private AnyValue value;
         private Supplier<ZoneId> defaultTimeZone;
 
         TimeExtractor( Supplier<ZoneId> defaultTimeZone )
         {
             super( "Time" );
             this.defaultTimeZone = defaultTimeZone;
-        }
-
-        @Override
-        protected void clear()
-        {
-            value = Values.NO_VALUE;
         }
 
         @Override
@@ -1068,21 +1066,14 @@ public class Extractors
         }
     }
 
-    public static class DateTimeExtractor extends AbstractSingleValueExtractor<AnyValue>
+    public static class DateTimeExtractor extends AbstractSingleAnyValueExtractor
     {
-        private AnyValue value;
         private Supplier<ZoneId> defaultTimeZone;
 
         DateTimeExtractor( Supplier<ZoneId> defaultTimeZone )
         {
             super( "DateTime" );
             this.defaultTimeZone = defaultTimeZone;
-        }
-
-        @Override
-        protected void clear()
-        {
-            value = Values.NO_VALUE;
         }
 
         @Override
@@ -1099,19 +1090,11 @@ public class Extractors
         }
     }
 
-    public static class LocalTimeExtractor extends AbstractSingleValueExtractor<AnyValue>
+    public static class LocalTimeExtractor extends AbstractSingleAnyValueExtractor
     {
-        private AnyValue value;
-
         LocalTimeExtractor()
         {
             super( "LocalTime" );
-        }
-
-        @Override
-        protected void clear()
-        {
-            value = Values.NO_VALUE;
         }
 
         @Override
@@ -1128,19 +1111,11 @@ public class Extractors
         }
     }
 
-    public static class LocalDateTimeExtractor extends AbstractSingleValueExtractor<AnyValue>
+    public static class LocalDateTimeExtractor extends AbstractSingleAnyValueExtractor
     {
-        private AnyValue value;
-
         LocalDateTimeExtractor()
         {
             super( "LocalDateTime" );
-        }
-
-        @Override
-        protected void clear()
-        {
-            value = Values.NO_VALUE;
         }
 
         @Override
@@ -1157,19 +1132,11 @@ public class Extractors
         }
     }
 
-    public static class DurationExtractor extends AbstractSingleValueExtractor<AnyValue>
+    public static class DurationExtractor extends AbstractSingleAnyValueExtractor
     {
-        private AnyValue value;
-
         DurationExtractor()
         {
             super( "Duration" );
-        }
-
-        @Override
-        protected void clear()
-        {
-            value = Values.NO_VALUE;
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
@@ -275,7 +275,7 @@ public class CsvInputBatchImportIT
                 {
                     sb.append( node.propertyValue( i ) + "," );
                 }
-                sb.append( (csvLabels != null && csvLabels.length() > 0 ? csvLabels : "") );
+                sb.append( csvLabels != null && csvLabels.length() > 0 ? csvLabels : "" );
                 println( writer, sb.toString() );
             }
         }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
@@ -34,7 +34,9 @@ import java.time.Period;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAmount;
+import java.time.temporal.TemporalQueries;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -49,6 +51,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
@@ -65,6 +68,7 @@ import org.neo4j.kernel.impl.store.TokenStore;
 import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.util.AutoCreatingHashMap;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.logging.LogTimeZone;
 import org.neo4j.storageengine.api.Token;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.rule.TestDirectory;
@@ -87,6 +91,7 @@ import static java.lang.String.format;
 import static java.lang.System.currentTimeMillis;
 import static java.nio.charset.Charset.defaultCharset;
 
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.db_timezone;
 import static org.neo4j.helpers.collection.Iterators.asSet;
 import static org.neo4j.kernel.impl.util.AutoCreatingHashMap.nested;
 import static org.neo4j.kernel.impl.util.AutoCreatingHashMap.values;
@@ -121,11 +126,13 @@ public class CsvInputBatchImportIT
     private final long seed = currentTimeMillis();
     private final Random random = new Random( seed );
 
+    private static final Supplier<ZoneId> testDefaultTimeZone = () -> ZoneId.of( "Asia/Shanghai" );
+
     @Test
     public void shouldImportDataComingFromCsvFiles() throws Exception
     {
         // GIVEN
-        Config dbConfig = Config.defaults();
+        Config dbConfig = Config.builder().withSetting( db_timezone, LogTimeZone.SYSTEM.name() ).build();
         BatchImporter importer = new ParallelBatchImporter( directory.graphDbDir(), fileSystemRule.get(), null,
                 smallBatchSizeConfig(), NullLogService.getInstance(), invisible(), AdditionalInitialIds.EMPTY, dbConfig,
                 RecordFormatSelector.defaultFormat(), NO_MONITOR );
@@ -155,9 +162,12 @@ public class CsvInputBatchImportIT
             org.neo4j.unsafe.impl.batchimport.input.csv.Configuration configuration, Collector badCollector )
     {
         return new CsvInput(
-                datas( data( NO_DECORATOR, defaultCharset(), nodes ) ), defaultFormatNodeFileHeader(),
+                datas( data( NO_DECORATOR, defaultCharset(), nodes ) ),
+                defaultFormatNodeFileHeader( testDefaultTimeZone ),
                 datas( data( NO_DECORATOR, defaultCharset(), relationships ) ),
-                defaultFormatRelationshipFileHeader(), idType, configuration,
+                defaultFormatRelationshipFileHeader( testDefaultTimeZone ),
+                idType,
+                configuration,
                 badCollector );
     }
 
@@ -191,6 +201,8 @@ public class CsvInputBatchImportIT
             node.property( "time", OffsetTime.of( 1, i % 60, 0, 0, ZoneOffset.ofHours( 9 ) ) );
             node.property( "dateTime",
                     ZonedDateTime.of( 2011, 9, 11, 8, i % 60, 0, 0, ZoneId.of( "Europe/Stockholm" ) ) );
+            node.property( "dateTime2",
+                    LocalDateTime.of( 2011, 9, 11, 8, i % 60, 0, 0 ) ); // No zone specified
             node.property( "localTime", LocalTime.of( 1, i % 60, 0 ) );
             node.property( "localDateTime", LocalDateTime.of( 2011, 9, 11, 8, i % 60 ) );
             node.property( "duration", Period.of( 2, -3, i % 30 ) );
@@ -251,7 +263,7 @@ public class CsvInputBatchImportIT
         try ( Writer writer = fileSystemRule.get().openAsWriter( file, StandardCharsets.UTF_8, false ) )
         {
             // Header
-            println( writer, "id:ID,name,point:Point,date:Date,time:Time,dateTime:DateTime,localTime:LocalTime," +
+            println( writer, "id:ID,name,point:Point,date:Date,time:Time,dateTime:DateTime,dateTime2:DateTime,localTime:LocalTime," +
                              "localDateTime:LocalDateTime,duration:Duration,some-labels:LABEL" );
 
             // Data
@@ -515,6 +527,34 @@ public class CsvInputBatchImportIT
                         LocalDateTime expected = referenceTemporal.plus( (TemporalAmount) expectedValue );
                         LocalDateTime actual = referenceTemporal.plus( (TemporalAmount) actualValue );
                         assertEquals( expected, actual );
+                    };
+                }
+                else if ( expectedValue instanceof Temporal )
+                {
+                    final LocalDate expectedDate = ((Temporal) expectedValue).query( TemporalQueries.localDate() );
+                    final LocalTime expectedTime = ((Temporal) expectedValue).query( TemporalQueries.localTime() );
+                    final ZoneId expectedZoneId = ((Temporal) expectedValue).query( TemporalQueries.zone() );
+
+                    verify = actualValue ->
+                    {
+                        LocalDate actualDate = ((Temporal) actualValue).query( TemporalQueries.localDate() );
+                        LocalTime actualTime = ((Temporal) actualValue).query( TemporalQueries.localTime() );
+                        ZoneId actualZoneId = ((Temporal) actualValue).query( TemporalQueries.zone() );
+
+                        assertEquals( expectedDate, actualDate );
+                        assertEquals( expectedTime, actualTime );
+                        if ( expectedZoneId == null )
+                        {
+                            if ( actualZoneId != null )
+                            {
+                                // If the actual value is zoned it should have the default zone
+                                assertEquals( testDefaultTimeZone.get(), actualZoneId );
+                            }
+                        }
+                        else
+                        {
+                            assertEquals( expectedZoneId, actualZoneId );
+                        }
                     };
                 }
                 else

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
@@ -520,7 +520,8 @@ public class CsvInputTest
         DataFactory data = data(
                 ":ID,name,time:Time\n" +
                 "0,Mattias,13:37\n" +
-                "1,Johan,\"16:20:01\"\n" );
+                "1,Johan,\"16:20:01\"\n" +
+                "2,Bob,07:30-05:00\n" );
         Iterable<DataFactory> dataIterable = dataIterable( data );
         Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), datas(),
                 defaultFormatRelationshipFileHeader(),
@@ -534,6 +535,8 @@ public class CsvInputTest
                     TimeValue.time( 13, 37, 0, 0, "+00:00" )}, labels() );
             assertNextNode( nodes, 1L, new Object[]{"name", "Johan", "time",
                     TimeValue.time( 16, 20, 1, 0, "+00:00" )}, labels() );
+            assertNextNode( nodes, 2L, new Object[]{"name", "Bob", "time",
+                    TimeValue.time( 7, 30, 0, 0, "-05:00" )}, labels() );
             assertFalse( readNext( nodes ) );
         }
     }
@@ -545,7 +548,9 @@ public class CsvInputTest
         DataFactory data = data(
                 ":ID,name,time:DateTime\n" +
                 "0,Mattias,2018-02-27T13:37\n" +
-                "1,Johan,\"2018-03-01T16:20:01\"\n" );
+                "1,Johan,\"2018-03-01T16:20:01\"\n" +
+                "2,Bob,1981-05-11T07:30-05:00\n" );
+
         Iterable<DataFactory> dataIterable = dataIterable( data );
         Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), datas(),
                 defaultFormatRelationshipFileHeader(),
@@ -559,6 +564,8 @@ public class CsvInputTest
                     DateTimeValue.datetime( 2018, 2, 27, 13, 37, 0, 0, "+00:00" )}, labels() );
             assertNextNode( nodes, 1L, new Object[]{"name", "Johan", "time",
                     DateTimeValue.datetime( 2018, 3, 1, 16, 20, 1, 0, "+00:00" )}, labels() );
+            assertNextNode( nodes, 2L, new Object[]{"name", "Bob", "time",
+                    DateTimeValue.datetime( 1981, 5, 11, 7, 30, 0, 0, "-05:00" )}, labels() );
             assertFalse( readNext( nodes ) );
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
@@ -53,6 +53,12 @@ import org.neo4j.unsafe.impl.batchimport.input.InputEntityDecorators;
 import org.neo4j.unsafe.impl.batchimport.input.InputEntityVisitor;
 import org.neo4j.unsafe.impl.batchimport.input.InputException;
 import org.neo4j.values.storable.CoordinateReferenceSystem;
+import org.neo4j.values.storable.DateTimeValue;
+import org.neo4j.values.storable.DateValue;
+import org.neo4j.values.storable.DurationValue;
+import org.neo4j.values.storable.LocalDateTimeValue;
+import org.neo4j.values.storable.LocalTimeValue;
+import org.neo4j.values.storable.TimeValue;
 import org.neo4j.values.storable.Values;
 
 import static java.util.Arrays.asList;
@@ -478,6 +484,156 @@ public class CsvInputTest
                     Values.pointValue( CoordinateReferenceSystem.Cartesian, 2.7, 3.2) }, labels() );
             assertNextNode( nodes, 1L, new Object[]{"name", "Johan", "point",
                     Values.pointValue( CoordinateReferenceSystem.WGS84_3D, 5, -4.2, 0.01)}, labels() );
+            assertFalse( readNext( nodes ) );
+        }
+    }
+
+    @Test
+    public void shouldParseDatePropertyValues() throws Exception
+    {
+        // GIVEN
+        DataFactory data = data(
+                ":ID,name,date:Date\n" +
+                "0,Mattias,2018-02-27\n" +
+                "1,Johan,2018-03-01\n" );
+        Iterable<DataFactory> dataIterable = dataIterable( data );
+        Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), datas(),
+                defaultFormatRelationshipFileHeader(),
+                IdType.ACTUAL, config( COMMAS ), silentBadCollector( 0 ) );
+
+        // WHEN
+        try ( InputIterator nodes = input.nodes().iterator() )
+        {
+            // THEN
+            assertNextNode( nodes, 0L, new Object[]{"name", "Mattias", "date",
+                    DateValue.date( 2018, 2, 27 )}, labels() );
+            assertNextNode( nodes, 1L, new Object[]{"name", "Johan", "date",
+                    DateValue.date( 2018, 3, 1 )}, labels() );
+            assertFalse( readNext( nodes ) );
+        }
+    }
+
+    @Test
+    public void shouldParseTimePropertyValues() throws Exception
+    {
+        // GIVEN
+        DataFactory data = data(
+                ":ID,name,time:Time\n" +
+                "0,Mattias,13:37\n" +
+                "1,Johan,\"16:20:01\"\n" );
+        Iterable<DataFactory> dataIterable = dataIterable( data );
+        Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), datas(),
+                defaultFormatRelationshipFileHeader(),
+                IdType.ACTUAL, config( COMMAS ), silentBadCollector( 0 ) );
+
+        // WHEN
+        try ( InputIterator nodes = input.nodes().iterator() )
+        {
+            // THEN
+            assertNextNode( nodes, 0L, new Object[]{"name", "Mattias", "time",
+                    TimeValue.time( 13, 37, 0, 0, "+00:00" )}, labels() );
+            assertNextNode( nodes, 1L, new Object[]{"name", "Johan", "time",
+                    TimeValue.time( 16, 20, 1, 0, "+00:00" )}, labels() );
+            assertFalse( readNext( nodes ) );
+        }
+    }
+
+    @Test
+    public void shouldParseDateTimePropertyValues() throws Exception
+    {
+        // GIVEN
+        DataFactory data = data(
+                ":ID,name,time:DateTime\n" +
+                "0,Mattias,2018-02-27T13:37\n" +
+                "1,Johan,\"2018-03-01T16:20:01\"\n" );
+        Iterable<DataFactory> dataIterable = dataIterable( data );
+        Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), datas(),
+                defaultFormatRelationshipFileHeader(),
+                IdType.ACTUAL, config( COMMAS ), silentBadCollector( 0 ) );
+
+        // WHEN
+        try ( InputIterator nodes = input.nodes().iterator() )
+        {
+            // THEN
+            assertNextNode( nodes, 0L, new Object[]{"name", "Mattias", "time",
+                    DateTimeValue.datetime( 2018, 2, 27, 13, 37, 0, 0, "+00:00" )}, labels() );
+            assertNextNode( nodes, 1L, new Object[]{"name", "Johan", "time",
+                    DateTimeValue.datetime( 2018, 3, 1, 16, 20, 1, 0, "+00:00" )}, labels() );
+            assertFalse( readNext( nodes ) );
+        }
+    }
+
+    @Test
+    public void shouldParseLocalTimePropertyValues() throws Exception
+    {
+        // GIVEN
+        DataFactory data = data(
+                ":ID,name,time:LocalTime\n" +
+                "0,Mattias,13:37\n" +
+                "1,Johan,\"16:20:01\"\n" );
+        Iterable<DataFactory> dataIterable = dataIterable( data );
+        Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), datas(),
+                defaultFormatRelationshipFileHeader(),
+                IdType.ACTUAL, config( COMMAS ), silentBadCollector( 0 ) );
+
+        // WHEN
+        try ( InputIterator nodes = input.nodes().iterator() )
+        {
+            // THEN
+            assertNextNode( nodes, 0L, new Object[]{"name", "Mattias", "time",
+                    LocalTimeValue.localTime( 13, 37, 0, 0 )}, labels() );
+            assertNextNode( nodes, 1L, new Object[]{"name", "Johan", "time",
+                    LocalTimeValue.localTime( 16, 20, 1, 0 )}, labels() );
+            assertFalse( readNext( nodes ) );
+        }
+    }
+
+    @Test
+    public void shouldParseLocalDateTimePropertyValues() throws Exception
+    {
+        // GIVEN
+        DataFactory data = data(
+                ":ID,name,time:LocalDateTime\n" +
+                "0,Mattias,2018-02-27T13:37\n" +
+                "1,Johan,\"2018-03-01T16:20:01\"\n" );
+        Iterable<DataFactory> dataIterable = dataIterable( data );
+        Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), datas(),
+                defaultFormatRelationshipFileHeader(),
+                IdType.ACTUAL, config( COMMAS ), silentBadCollector( 0 ) );
+
+        // WHEN
+        try ( InputIterator nodes = input.nodes().iterator() )
+        {
+            // THEN
+            assertNextNode( nodes, 0L, new Object[]{"name", "Mattias", "time",
+                    LocalDateTimeValue.localDateTime( 2018, 2, 27, 13, 37, 0, 0 )}, labels() );
+            assertNextNode( nodes, 1L, new Object[]{"name", "Johan", "time",
+                    LocalDateTimeValue.localDateTime( 2018, 3, 1, 16, 20, 1, 0 )}, labels() );
+            assertFalse( readNext( nodes ) );
+        }
+    }
+
+    @Test
+    public void shouldParseDurationPropertyValues() throws Exception
+    {
+        // GIVEN
+        DataFactory data = data(
+                ":ID,name,duration:Duration\n" +
+                "0,Mattias,P3MT13H37M\n" +
+                "1,Johan,\"P-1YT4H20M\"\n" );
+        Iterable<DataFactory> dataIterable = dataIterable( data );
+        Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), datas(),
+                defaultFormatRelationshipFileHeader(),
+                IdType.ACTUAL, config( COMMAS ), silentBadCollector( 0 ) );
+
+        // WHEN
+        try ( InputIterator nodes = input.nodes().iterator() )
+        {
+            // THEN
+            assertNextNode( nodes, 0L, new Object[]{"name", "Mattias", "duration",
+                    DurationValue.duration( 3, 0, 13 * 3600 + 37 * 60, 0 )}, labels() );
+            assertNextNode( nodes, 1L, new Object[]{"name", "Johan", "duration",
+                    DurationValue.duration( -12, 0, 4 * 3600 + 20 * 60, 0 )}, labels() );
             assertFalse( readNext( nodes ) );
         }
     }


### PR DESCRIPTION
- Date
- Time
- DateTime
- LocalTime
- LocalDateTime
- Duration

The default time zone for `Time` and `DateTime` is derived from the
database setting `dbms.db.timezone`.
