### PR TITLE
More Kernel API for Core API

### DIFF
--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
@@ -735,7 +735,7 @@ sealed class TransactionBoundQueryContext(val transactionalContext: Transactiona
       val cursor = relationshipScanCursor
       reads().singleRelationship(id, cursor)
       if (cursor.next())
-        Some(fromRelationshipProxy(entityAccessor.newRelationshipProxy(id, cursor.sourceNodeReference(), cursor.label(),
+        Some(fromRelationshipProxy(entityAccessor.newRelationshipProxy(id, cursor.sourceNodeReference(), cursor.`type`(),
                                                                        cursor.targetNodeReference())))
       else
         None
@@ -748,7 +748,7 @@ sealed class TransactionBoundQueryContext(val transactionalContext: Transactiona
         override protected def fetchNext(): RelationshipValue = {
           if (relCursor.next())
             fromRelationshipProxy(entityAccessor.newRelationshipProxy(relCursor.relationshipReference(),
-                                                                      relCursor.sourceNodeReference(), relCursor.label(),
+                                                                      relCursor.sourceNodeReference(), relCursor.`type`(),
                                                                       relCursor.targetNodeReference()))
           else null
         }

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipDataAccessor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipDataAccessor.java
@@ -27,7 +27,7 @@ public interface RelationshipDataAccessor
     long relationshipReference(); // not sure relationships will have independent references,
     // so exposing this might be leakage.
 
-    int label();
+    int type();
 
     boolean hasProperties();
 

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/Nodes.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/Nodes.java
@@ -190,7 +190,7 @@ public final class Nodes
                 nodeCursor.allRelationships( traversal );
                 while ( traversal.next() )
                 {
-                    if ( traversal.sourceNodeReference() == nodeCursor.nodeReference() && traversal.label() == type )
+                    if ( traversal.sourceNodeReference() == nodeCursor.nodeReference() && traversal.type() == type )
                     {
                         count++;
                     }
@@ -236,7 +236,7 @@ public final class Nodes
                 nodeCursor.allRelationships( traversal );
                 while ( traversal.next() )
                 {
-                    if ( traversal.targetNodeReference() == nodeCursor.nodeReference() && traversal.label() == type )
+                    if ( traversal.targetNodeReference() == nodeCursor.nodeReference() && traversal.type() == type )
                     {
                         count++;
                     }
@@ -280,7 +280,7 @@ public final class Nodes
                 nodeCursor.allRelationships( traversal );
                 while ( traversal.next() )
                 {
-                    if ( traversal.label() == type )
+                    if ( traversal.type() == type )
                     {
                         count++;
                     }

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionCursor.java
@@ -44,7 +44,7 @@ public final class RelationshipDenseSelectionCursor extends RelationshipDenseSel
     @Override
     public int type()
     {
-        return relationshipCursor.label();
+        return relationshipCursor.type();
     }
 
     @Override

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionIterator.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionIterator.java
@@ -64,7 +64,7 @@ public final class RelationshipDenseSelectionIterator<R> extends RelationshipDen
         }
         R current = factory.relationship( next,
                                           relationshipCursor.sourceNodeReference(),
-                                          relationshipCursor.label(),
+                                          relationshipCursor.type(),
                                           relationshipCursor.targetNodeReference() );
 
         if ( !fetchNext() )

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelection.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelection.java
@@ -147,7 +147,7 @@ abstract class RelationshipSparseSelection
 
     private boolean correctType()
     {
-        return types == null || ArrayUtils.contains( types, cursor.label() );
+        return types == null || ArrayUtils.contains( types, cursor.type() );
     }
 
     public void close()

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionCursor.java
@@ -44,7 +44,7 @@ public final class RelationshipSparseSelectionCursor extends RelationshipSparseS
     @Override
     public int type()
     {
-        return cursor.label();
+        return cursor.type();
     }
 
     @Override

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionIterator.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionIterator.java
@@ -65,7 +65,7 @@ public final class RelationshipSparseSelectionIterator<R> extends RelationshipSp
         }
         R current = factory.relationship( next,
                                           cursor.sourceNodeReference(),
-                                          cursor.label(),
+                                          cursor.type(),
                                           cursor.targetNodeReference() );
 
         if ( !fetchNext() )

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipScanCursorTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipScanCursorTestBase.java
@@ -150,7 +150,7 @@ public abstract class RelationshipScanCursorTestBase<G extends KernelAPIReadTest
             read.allRelationshipsScan( relationships );
             while ( relationships.next() )
             {
-                counts.compute( relationships.label(), ( k, v ) -> v == null ? 1 : v + 1 );
+                counts.compute( relationships.type(), ( k, v ) -> v == null ? 1 : v + 1 );
             }
         }
 

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTestSupport.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTestSupport.java
@@ -153,7 +153,7 @@ public class RelationshipTestSupport
 
         while ( relationship.next() )
         {
-            assertEquals( "same type", expectedType, relationship.label() );
+            assertEquals( "same type", expectedType, relationship.type() );
             count++;
         }
 
@@ -239,7 +239,7 @@ public class RelationshipTestSupport
             d = Direction.INCOMING;
         }
 
-        return computeKey( transaction.token().relationshipTypeName( r.label() ), d );
+        return computeKey( transaction.token().relationshipTypeName( r.type() ), d );
     }
 
     static String computeKey( String type, Direction direction )

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTransactionStateTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTransactionStateTestBase.java
@@ -80,7 +80,7 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
                 tx.dataRead().singleRelationship( r, relationship );
                 assertTrue( "should find relationship", relationship.next() );
 
-                assertEquals( label, relationship.label() );
+                assertEquals( label, relationship.type() );
                 assertEquals( n1, relationship.sourceNodeReference() );
                 assertEquals( n2, relationship.targetNodeReference() );
                 assertEquals( r, relationship.relationshipReference() );
@@ -1285,7 +1285,7 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
         while ( relationship.next() )
         {
             assertEquals( sourceNode, relationship.sourceNodeReference() );
-            assertEquals( type, relationship.label() );
+            assertEquals( type, relationship.type() );
             assertEquals( targetNode, relationship.targetNodeReference() );
             count++;
         }

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTraversalCursorTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTraversalCursorTestBase.java
@@ -122,7 +122,7 @@ public abstract class RelationshipTraversalCursorTestBase<G extends KernelAPIRea
                     {
                         assertEquals( "node #" + node.nodeReference() +
                                         " relationship should have same label as group", group.type(),
-                                relationship.label() );
+                                relationship.type() );
                         degree.outgoing++;
                     }
                     group.incoming( relationship );
@@ -130,7 +130,7 @@ public abstract class RelationshipTraversalCursorTestBase<G extends KernelAPIRea
                     {
                         assertEquals( "node #" + node.nodeReference() +
                                         "relationship should have same label as group", group.type(),
-                                relationship.label() );
+                                relationship.type() );
                         degree.incoming++;
                     }
                     group.loops( relationship );
@@ -138,7 +138,7 @@ public abstract class RelationshipTraversalCursorTestBase<G extends KernelAPIRea
                     {
                         assertEquals( "node #" + node.nodeReference() +
                                         "relationship should have same label as group", group.type(),
-                                relationship.label() );
+                                relationship.type() );
                         degree.loop++;
                     }
 
@@ -191,7 +191,7 @@ public abstract class RelationshipTraversalCursorTestBase<G extends KernelAPIRea
             assertEquals( "neighbouring node", end, relationship.neighbourNodeReference() );
 
             assertEquals( "relationship should have same label as group", group.type(),
-                    relationship.label() );
+                    relationship.type() );
 
             assertFalse( "only a single relationship", relationship.next() );
 
@@ -218,7 +218,7 @@ public abstract class RelationshipTraversalCursorTestBase<G extends KernelAPIRea
             assertEquals( "neighbouring node", start, relationship.neighbourNodeReference() );
 
             assertEquals( "relationship should have same label as group", group.type(),
-                    relationship.label() );
+                    relationship.type() );
 
             assertFalse( "only a single relationship", relationship.next() );
 

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubRelationshipCursor.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubRelationshipCursor.java
@@ -66,7 +66,7 @@ class StubRelationshipCursor implements RelationshipTraversalCursor
     }
 
     @Override
-    public int label()
+    public int type()
     {
         return store.get( chainId ).get( offset ).type;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -757,7 +757,7 @@ public class NodeProxy implements Node, RelationshipFactory<Relationship>
             List<RelationshipType> types = new ArrayList<>();
             while ( relationships.next() )
             {
-                types.add( RelationshipType.withName( tokenRead.relationshipTypeName( relationships.label() ) ) );
+                types.add( RelationshipType.withName( tokenRead.relationshipTypeName( relationships.type() ) ) );
             }
 
             return types;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.graphdb.ConstraintViolationException;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -42,7 +41,7 @@ import org.neo4j.graphdb.TransactionTerminatedException;
 import org.neo4j.internal.kernel.api.LabelSet;
 import org.neo4j.internal.kernel.api.NodeCursor;
 import org.neo4j.internal.kernel.api.PropertyCursor;
-import org.neo4j.internal.kernel.api.RelationshipGroupCursor;
+import org.neo4j.internal.kernel.api.RelationshipTraversalCursor;
 import org.neo4j.internal.kernel.api.TokenRead;
 import org.neo4j.internal.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.internal.kernel.api.exceptions.InvalidTransactionTypeKernelException;
@@ -58,7 +57,6 @@ import org.neo4j.internal.kernel.api.helpers.RelationshipFactory;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.SilentTokenNameLookup;
 import org.neo4j.kernel.api.Statement;
-import org.neo4j.kernel.api.exceptions.RelationshipTypeIdNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.impl.api.operations.KeyReadOperations;
 import org.neo4j.storageengine.api.EntityType;
@@ -66,9 +64,7 @@ import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
 
 import static java.lang.String.format;
-import static org.neo4j.collection.primitive.PrimitiveIntCollections.map;
 import static org.neo4j.graphdb.Label.label;
-import static org.neo4j.helpers.collection.Iterators.asList;
 import static org.neo4j.internal.kernel.api.helpers.RelationshipSelections.allIterator;
 import static org.neo4j.internal.kernel.api.helpers.RelationshipSelections.incomingIterator;
 import static org.neo4j.internal.kernel.api.helpers.RelationshipSelections.outgoingIterator;
@@ -746,14 +742,29 @@ public class NodeProxy implements Node, RelationshipFactory<Relationship>
     @Override
     public Iterable<RelationshipType> getRelationshipTypes()
     {
-        try ( Statement statement = spi.statement() )
+        KernelTransaction transaction = safeAcquireTransaction();
+        try ( RelationshipTraversalCursor relationships = transaction.cursors().allocateRelationshipTraversalCursor();
+              Statement ignore = transaction.acquireStatement() )
         {
-            PrimitiveIntIterator relTypes = statement.readOperations().nodeGetRelationshipTypes( nodeId );
-            return asList( map( relTypeId -> convertToRelationshipType( statement, relTypeId ), relTypes ) );
+            NodeCursor nodes = transaction.nodeCursor();
+            TokenRead tokenRead = transaction.tokenRead();
+            singleNode( transaction, nodes );
+            if ( !nodes.next() )
+            {
+                throw new NotFoundException( "Node not found." );
+            }
+            nodes.allRelationships( relationships );
+            List<RelationshipType> types = new ArrayList<>();
+            while ( relationships.next() )
+            {
+                types.add( RelationshipType.withName( tokenRead.relationshipTypeName( relationships.label() ) ) );
+            }
+
+            return types;
         }
-        catch ( EntityNotFoundException e )
+        catch ( KernelException e )
         {
-            throw new NotFoundException( "Node not found.", e );
+            throw new NotFoundException( "Relationship name not found.", e );
         }
     }
 
@@ -799,18 +810,6 @@ public class NodeProxy implements Node, RelationshipFactory<Relationship>
             ids = Arrays.copyOf( ids, outIndex );
         }
         return ids;
-    }
-
-    private RelationshipType convertToRelationshipType( final Statement statement, int relTypeId )
-    {
-        try
-        {
-            return RelationshipType.withName( statement.readOperations().relationshipTypeGetName( relTypeId ) );
-        }
-        catch ( RelationshipTypeIdNotFoundKernelException e )
-        {
-            throw new IllegalStateException( "Kernel API returned non-existent relationship type: " + relTypeId );
-        }
     }
 
     private void singleNode( KernelTransaction transaction, NodeCursor nodes )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.neo4j.collection.primitive.Primitive;
+import org.neo4j.collection.primitive.PrimitiveIntSet;
 import org.neo4j.graphdb.ConstraintViolationException;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -750,10 +752,16 @@ public class NodeProxy implements Node, RelationshipFactory<Relationship>
             TokenRead tokenRead = transaction.tokenRead();
             singleNode( transaction, nodes );
             nodes.allRelationships( relationships );
+            PrimitiveIntSet seen = Primitive.intSet();
             List<RelationshipType> types = new ArrayList<>();
             while ( relationships.next() )
             {
-                types.add( RelationshipType.withName( tokenRead.relationshipTypeName( relationships.type() ) ) );
+                int type = relationships.type();
+                if ( !seen.contains( type ) )
+                {
+                    types.add( RelationshipType.withName( tokenRead.relationshipTypeName( relationships.type() ) ) );
+                    seen.add( type );
+                }
             }
 
             return types;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -749,10 +749,6 @@ public class NodeProxy implements Node, RelationshipFactory<Relationship>
             NodeCursor nodes = transaction.nodeCursor();
             TokenRead tokenRead = transaction.tokenRead();
             singleNode( transaction, nodes );
-            if ( !nodes.next() )
-            {
-                throw new NotFoundException( "Node not found." );
-            }
             nodes.allRelationships( relationships );
             List<RelationshipType> types = new ArrayList<>();
             while ( relationships.next() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipProxy.java
@@ -93,8 +93,9 @@ public class RelationshipProxy implements Relationship, RelationshipVisitor<Runt
             try ( Statement ignore = transaction.acquireStatement() )
             {
                 RelationshipScanCursor relationships = transaction.relationshipCursor();
-                singleRelationship( transaction, relationships );
-                this.id = relationships.relationshipReference();
+                transaction.dataRead().singleRelationship( id, relationships );
+                //at this point we don't care if it is there or not just load what we got
+                relationships.next();
                 this.type = relationships.type();
                 this.startNode = relationships.sourceNodeReference();
                 this.endNode = relationships.targetNodeReference();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipProxy.java
@@ -89,13 +89,15 @@ public class RelationshipProxy implements Relationship, RelationshipVisitor<Runt
         // it enough to check only start node, since it's absence will indicate that data was not yet loaded
         if ( startNode == AbstractBaseRecord.NO_ID )
         {
-            try ( Statement statement = actions.statement() )
+            KernelTransaction transaction = safeAcquireTransaction();
+            try ( Statement ignore = transaction.acquireStatement() )
             {
-                statement.readOperations().relationshipVisit( getId(), this );
-            }
-            catch ( EntityNotFoundException e )
-            {
-                throw new NotFoundException( e );
+                RelationshipScanCursor relationships = transaction.relationshipCursor();
+                singleRelationship( transaction, relationships );
+                this.id = relationships.relationshipReference();
+                this.type = relationships.type();
+                this.startNode = relationships.sourceNodeReference();
+                this.endNode = relationships.targetNodeReference();
             }
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -476,7 +476,7 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI, EmbeddedProxySPI
                         return newRelationshipProxy(
                                 cursor.relationshipReference(),
                                 cursor.sourceNodeReference(),
-                                cursor.label(),
+                                cursor.type(),
                                 cursor.targetNodeReference() );
                     }
                     else

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipScanCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipScanCursor.java
@@ -29,7 +29,7 @@ import static java.util.Collections.emptySet;
 
 class DefaultRelationshipScanCursor extends RelationshipCursor implements RelationshipScanCursor
 {
-    private int label;
+    private int type;
     private long next;
     private long highMark;
     private PageCursor pageCursor;
@@ -42,7 +42,7 @@ class DefaultRelationshipScanCursor extends RelationshipCursor implements Relati
         this.pool = pool;
     }
 
-    void scan( int label, Read read )
+    void scan( int type, Read read )
     {
         if ( getId() != NO_ID )
         {
@@ -53,7 +53,7 @@ class DefaultRelationshipScanCursor extends RelationshipCursor implements Relati
             pageCursor = read.relationshipPage( 0 );
         }
         next = 0;
-        this.label = label;
+        this.type = type;
         highMark = read.relationshipHighMark();
         init( read );
         this.addedRelationships = emptySet();
@@ -70,7 +70,7 @@ class DefaultRelationshipScanCursor extends RelationshipCursor implements Relati
             pageCursor = read.relationshipPage( reference );
         }
         next = reference;
-        label = -1;
+        type = -1;
         highMark = NO_ID;
         init( read );
         this.addedRelationships = emptySet();
@@ -111,7 +111,7 @@ class DefaultRelationshipScanCursor extends RelationshipCursor implements Relati
                 if ( isSingle() )
                 {
                     next = NO_ID;
-                    return isWantedLabelAndInUse();
+                    return isWantedTypeAndInUse();
                 }
                 else
                 {
@@ -119,19 +119,19 @@ class DefaultRelationshipScanCursor extends RelationshipCursor implements Relati
                     if ( next > highMark )
                     {
                         next = NO_ID;
-                        return isWantedLabelAndInUse();
+                        return isWantedTypeAndInUse();
                     }
                 }
             }
         }
-        while ( !isWantedLabelAndInUse() );
+        while ( !isWantedTypeAndInUse() );
 
         return true;
     }
 
-    private boolean isWantedLabelAndInUse()
+    private boolean isWantedTypeAndInUse()
     {
-        return (label == -1 || type() == label) && inUse();
+        return (type == -1 || type() == type) && inUse();
     }
 
     private boolean containsRelationship( TransactionState txs )
@@ -177,7 +177,7 @@ class DefaultRelationshipScanCursor extends RelationshipCursor implements Relati
         }
         else
         {
-            return "RelationshipScanCursor[id=" + getId() + ", open state with: highMark=" + highMark + ", next=" + next + ", label=" + label +
+            return "RelationshipScanCursor[id=" + getId() + ", open state with: highMark=" + highMark + ", next=" + next + ", type=" + type +
                     ", underlying record=" + super.toString() + " ]";
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipScanCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipScanCursor.java
@@ -131,7 +131,7 @@ class DefaultRelationshipScanCursor extends RelationshipCursor implements Relati
 
     private boolean isWantedLabelAndInUse()
     {
-        return (label == -1 || label() == label) && inUse();
+        return (label == -1 || type() == label) && inUse();
     }
 
     private boolean containsRelationship( TransactionState txs )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
@@ -49,7 +49,7 @@ abstract class RelationshipCursor extends RelationshipRecord implements Relation
     }
 
     @Override
-    public int label()
+    public int type()
     {
         return getType();
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeProxyTest.java
@@ -34,10 +34,14 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.Iterators;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertArrayEquals;
@@ -338,6 +342,28 @@ public class NodeProxyTest extends PropertyContainerProxyTest
         try ( Transaction ignore = db.beginTx() )
         {
             assertThat( node.getProperty( "prop" ), instanceOf( Double.class ) );
+        }
+    }
+
+    @Test
+    public void shouldOnlyReturnTypeOnce()
+    {
+        // Given
+        Node node;
+        try ( Transaction tx = db.beginTx() )
+        {
+            node = db.createNode();
+            node.createRelationshipTo( db.createNode(), RelationshipType.withName( "R" ) );
+            node.createRelationshipTo( db.createNode(), RelationshipType.withName( "R" ) );
+            node.createRelationshipTo( db.createNode(), RelationshipType.withName( "R" ) );
+            tx.success();
+        }
+
+        // Then
+        try ( Transaction tx = db.beginTx() )
+        {
+            assertThat( Iterables.asList( node.getRelationshipTypes() ),
+                    equalTo( singletonList( RelationshipType.withName( "R" ) ) ) );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/OperationsLockTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/OperationsLockTest.java
@@ -431,6 +431,6 @@ public class OperationsLockTest
         when( relationshipCursor.relationshipReference() ).thenReturn( relationshipId );
         when( relationshipCursor.sourceNodeReference() ).thenReturn( sourceNode );
         when( relationshipCursor.targetNodeReference() ).thenReturn( targetNode );
-        when( relationshipCursor.label() ).thenReturn( relationshipLabel );
+        when( relationshipCursor.type() ).thenReturn( relationshipLabel );
     }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateAcceptanceTest.scala
@@ -113,7 +113,7 @@ class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
   test("should allow create, delete and return in one go (relationship)") {
     val typ = "ThisIsTheRelationshipType"
     val query = s"CREATE ()-[r:$typ]->() DELETE r RETURN type(r)"
-    val result = executeWith(Configs.UpdateConf - Configs.SlottedInterpreted, query)
+    val result = executeWith(Configs.UpdateConf, query)
     result.toList should equal(List(Map("type(r)" -> typ)))
   }
 


### PR DESCRIPTION
- Use Kernel API for `Node#getRelationshipTypes`
- Use Kernel API for initializing `RelationshipProxy`
- Use `type` everywhere instead of mixing `label` and `type`