### PR TITLE
Spatial accessors x,y,z,longitude,latitude,height,crs

### DIFF
--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticExpressionCheck.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticExpressionCheck.scala
@@ -189,7 +189,7 @@ object SemanticExpressionCheck extends SemanticAnalysisTooling {
 
       case x:Property =>
         check(ctx, x.map) chain
-          expectType(CTMap.covariant | CTAny.invariant, x.map) chain
+          expectType(CTMap.covariant | CTNode.covariant | CTRelationship.covariant | CTPoint.covariant | CTAny.invariant, x.map) chain
           specifyType(CTAny.covariant, x)
 
       // Check the variable is defined and, if not, define it so that later errors are suppressed

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/PropertyTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/PropertyTest.scala
@@ -65,6 +65,17 @@ class PropertyTest extends SemanticFunSuite {
     result.errors shouldBe empty
   }
 
+  test("accepts property access on a Point") {
+    val mapExpr: Variable = variable("map")
+    val propertyKey: PropertyKeyName = propertyKeyName("prop")
+
+    val beforeState = SemanticState.clean.newChildScope.declareVariable(mapExpr, CTPoint).right.get
+
+    val result = SemanticExpressionCheck.simple(property(mapExpr, propertyKey))(beforeState)
+
+    result.errors shouldBe empty
+  }
+
   test("refuses property access on an Integer") {
     val mapExpr: Variable = variable("map")
     val propertyKey: PropertyKeyName = propertyKeyName("prop")
@@ -73,6 +84,6 @@ class PropertyTest extends SemanticFunSuite {
 
     val result = SemanticExpressionCheck.simple(property(mapExpr, propertyKey))(beforeState)
 
-    result.errors should equal(List(SemanticError("Type mismatch: expected Any, Map, Node or Relationship but was Integer", pos)))
+    result.errors should equal(Seq(SemanticError("Type mismatch: expected Any, Map, Node, Relationship or Point but was Integer", pos)))
   }
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Property.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Property.scala
@@ -19,14 +19,16 @@
  */
 package org.neo4j.cypher.internal.runtime.interpreted.commands.expressions
 
-import org.neo4j.cypher.internal.util.v3_4.CypherTypeException
+import org.neo4j.cypher.internal.util.v3_4.{CypherTypeException, InvalidArgumentException}
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.commands.values.KeyToken
 import org.neo4j.cypher.internal.runtime.interpreted.IsMap
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.QueryState
 import org.neo4j.values.AnyValue
-import org.neo4j.values.storable.{DurationValue, TemporalValue, Values}
+import org.neo4j.values.storable.{DurationValue, PointValue, TemporalValue, Values}
 import org.neo4j.values.virtual.{VirtualNodeValue, VirtualRelationshipValue}
+
+import scala.util.{Failure, Success, Try}
 
 case class Property(mapExpr: Expression, propertyKey: KeyToken)
   extends Expression with Product with Serializable
@@ -46,6 +48,10 @@ case class Property(mapExpr: Expression, propertyKey: KeyToken)
     case IsMap(mapFunc) => mapFunc(state.query).get(propertyKey.name)
     case t: TemporalValue[_,_] => t.get(propertyKey.name)
     case d: DurationValue => d.get(propertyKey.name)
+    case p: PointValue => Try(p.get(propertyKey.name)) match {
+      case Success(v) => v
+      case Failure(e) => throw new InvalidArgumentException(e.getMessage, e)
+    }
     case other => throw new CypherTypeException(s"Type mismatch: expected a map but was $other")
   }
 

--- a/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
@@ -479,4 +479,46 @@ public class PointValue extends ScalarValue implements Point, Comparable<PointVa
 
         private ValueGroup valueType;
     }
+
+    /**
+     * For accessors from cypher.
+     */
+    public AnyValue get( String fieldName )
+    {
+        switch ( fieldName.toLowerCase() )
+        {
+        case "x":
+            return getNthCoordinate( 0, fieldName, false );
+        case "y":
+            return getNthCoordinate( 1, fieldName, false );
+        case "z":
+            return getNthCoordinate( 2, fieldName, false );
+        case "longitude":
+            return getNthCoordinate( 0, fieldName, true );
+        case "latitude":
+            return getNthCoordinate( 1, fieldName, true );
+        case "height":
+            return getNthCoordinate( 2, fieldName, true );
+        case "crs":
+            return Values.stringValue( crs.toString() );
+        default:
+            throw new IllegalArgumentException( "No such field: " + fieldName );
+        }
+    }
+
+    private DoubleValue getNthCoordinate( int n, String fieldName, boolean onlyGeographic )
+    {
+        if ( onlyGeographic && !this.getCoordinateReferenceSystem().isGeographic() )
+        {
+            throw new IllegalArgumentException( "Field: " + fieldName + " is not available on cartesian point: " + this );
+        }
+        else if ( n >= this.coordinate().length )
+        {
+            throw new IllegalArgumentException( "Field: " + fieldName + " is not available on point: " + this );
+        }
+        else
+        {
+            return Values.doubleValue( coordinate[n] );
+        }
+    }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
@@ -548,15 +548,18 @@ class SpatialFunctionsAcceptanceTest extends ExecutionEngineFunSuite with Cypher
   }
 
   test("accessors on 2D geographic points") {
-    val result = executeWith(latestPointConfig, "WITH point({longitude: 1, latitude: 2}) AS p RETURN p.longitude, p.latitude, p.crs")
-    result.toList should be(List(Map("p.longitude" -> 1.0, "p.latitude" -> 2.0, "p.crs" -> "WGS-84")))
+    val result = executeWith(latestPointConfig, "WITH point({longitude: 1, latitude: 2}) AS p RETURN p.longitude, p.latitude, p.crs, p.x, p.y")
+    result.toList should be(List(Map("p.longitude" -> 1.0, "p.latitude" -> 2.0, "p.crs" -> "WGS-84", "p.x" -> 1.0, "p.y" -> 2.0)))
 
     failWithError(latestPointConfig + Configs.Procs, "WITH point({x: 1, y: 2}) AS p RETURN p.height", Seq("Field: height is not available"))
+    failWithError(latestPointConfig + Configs.Procs, "WITH point({x: 1, y: 2}) AS p RETURN p.z", Seq("Field: z is not available"))
   }
 
   test("accessors on 3D geographic points") {
-    val result = executeWith(latestPointConfig, "WITH point({longitude: 1, latitude: 2, height:3}) AS p RETURN p.longitude, p.latitude, p.height, p.crs")
-    result.toList should be(List(Map("p.longitude" -> 1.0, "p.latitude" -> 2.0, "p.height" -> 3.0, "p.crs" -> "WGS-84-3D")))
+    val result = executeWith(latestPointConfig,
+      "WITH point({longitude: 1, latitude: 2, height:3}) AS p RETURN p.longitude, p.latitude, p.height, p.crs, p.x, p.y, p.z")
+    result.toList should be(List(Map("p.longitude" -> 1.0, "p.latitude" -> 2.0, "p.height" -> 3.0, "p.crs" -> "WGS-84-3D",
+                                     "p.x" -> 1.0, "p.y" -> 2.0, "p.z" -> 3.0)))
   }
 
 }


### PR DESCRIPTION
changelog: Accessors for Points are now available: p.crs, p.x, p.y, p.z (for 3D points). For WGS84 points the aliases p.longitude, p.lattitude and p.height for p.x, p.y and p.z are also valid.