### PR TITLE
Fixes a native uniqueness index creation issue in clustering

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/MultipleIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/MultipleIndexPopulator.java
@@ -523,7 +523,12 @@ public class MultipleIndexPopulator implements IndexPopulator
                 IndexSample sample = populator.sampleResult();
                 storeView.replaceIndexCounts( indexId, sample.uniqueValues(), sample.sampleSize(),
                         sample.indexSize() );
-                populator.close( true );
+                if ( populations.contains( IndexPopulation.this ) )
+                {
+                    populator.close( true );
+                }
+                // else it has failed when applying the last updates from queue. This is done because a multi-populator
+                // may have multiple populators running and they should not affect each other
                 return null;
             }, failedIndexProxyFactory );
             log.info( "Index population completed. Index is now online: [%s]", indexUserDescription );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/TentativeConstraintIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/TentativeConstraintIndexProxy.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.api.index;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
@@ -31,9 +32,11 @@ import org.neo4j.kernel.api.exceptions.schema.UniquePropertyValueValidationExcep
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.InternalIndexState;
+import org.neo4j.kernel.api.index.PropertyAccessor;
 import org.neo4j.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema.constaints.ConstraintDescriptorFactory;
 import org.neo4j.kernel.impl.api.index.updater.DelegatingIndexUpdater;
+import org.neo4j.kernel.impl.index.schema.DeferredConflictCheckingIndexUpdater;
 import org.neo4j.storageengine.api.schema.IndexReader;
 
 /**
@@ -73,7 +76,8 @@ public class TentativeConstraintIndexProxy extends AbstractDelegatingIndexProxy
         switch ( mode )
         {
             case ONLINE:
-                return new DelegatingIndexUpdater( target.accessor.newUpdater( mode ) )
+                return new DelegatingIndexUpdater( new DeferredConflictCheckingIndexUpdater(
+                        target.accessor.newUpdater( mode ), target::newReader, target.getDescriptor() ) )
                 {
                     @Override
                     public void process( IndexEntryUpdate<?> update )
@@ -134,6 +138,22 @@ public class TentativeConstraintIndexProxy extends AbstractDelegatingIndexProxy
     protected IndexProxy getDelegate()
     {
         return target;
+    }
+
+    @Override
+    public void verifyDeferredConstraints( PropertyAccessor accessor ) throws IndexEntryConflictException, IOException
+    {
+        // If we've seen constraint violation failures in here when updates came in then fail immediately with those
+        if ( !failures.isEmpty() )
+        {
+            Iterator<IndexEntryConflictException> failureIterator = failures.iterator();
+            IndexEntryConflictException conflict = failureIterator.next();
+            failureIterator.forEachRemaining( conflict::addSuppressed );
+            throw conflict;
+        }
+
+        // Otherwise consolidate the usual verification
+        super.verifyDeferredConstraints( accessor );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ConflictDetectingValueMerger.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ConflictDetectingValueMerger.java
@@ -19,8 +19,8 @@
  */
 package org.neo4j.kernel.impl.index.schema;
 
+import org.neo4j.index.internal.gbptree.GBPTree;
 import org.neo4j.index.internal.gbptree.ValueMerger;
-import org.neo4j.index.internal.gbptree.ValueMergers;
 import org.neo4j.index.internal.gbptree.Writer;
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.values.storable.Value;
@@ -34,58 +34,49 @@ import org.neo4j.values.storable.ValueTuple;
  *
  * @param <VALUE> type of values being merged.
  */
-abstract class ConflictDetectingValueMerger<KEY extends SchemaNumberKey, VALUE extends SchemaNumberValue> implements ValueMerger<KEY,VALUE>
+class ConflictDetectingValueMerger<KEY extends SchemaNumberKey, VALUE extends SchemaNumberValue> implements ValueMerger<KEY,VALUE>
 {
-    /**
-     * @throw IndexEntryConflictException if merge conflicted with an existing key. This call also clears the conflict flag.
-     */
-    abstract void checkConflict( Value[] values ) throws IndexEntryConflictException;
+    private final boolean compareEntityIds;
 
-    private static ConflictDetectingValueMerger DONT_CHECK = new ConflictDetectingValueMerger()
+    private boolean conflict;
+    private long existingNodeId;
+    private long addedNodeId;
+
+    ConflictDetectingValueMerger( boolean compareEntityIds )
     {
-        @Override
-        public Object merge( Object existingKey, Object newKey, Object existingValue, Object newValue )
-        {
-            return null;
-        }
-
-        @Override
-        void checkConflict( Value[] values )
-        {
-            // do nothing
-        }
-    };
-
-    static <KEY extends SchemaNumberKey, VALUE extends SchemaNumberValue> ConflictDetectingValueMerger<KEY, VALUE> dontCheck()
-    {
-        return DONT_CHECK;
+        this.compareEntityIds = compareEntityIds;
     }
 
-    static class Check<KEY extends SchemaNumberKey, VALUE extends SchemaNumberValue> extends ConflictDetectingValueMerger<KEY, VALUE>
+    @Override
+    public VALUE merge( KEY existingKey, KEY newKey, VALUE existingValue, VALUE newValue )
     {
-        private boolean conflict;
-        private long existingNodeId;
-        private long addedNodeId;
-
-        @Override
-        public VALUE merge( KEY existingKey, KEY newKey, VALUE existingValue, VALUE newValue )
+        if ( existingKey.entityId != newKey.entityId )
         {
-            if ( existingKey.entityId != newKey.entityId )
-            {
-                conflict = true;
-                existingNodeId = existingKey.entityId;
-                addedNodeId = newKey.entityId;
-            }
-            return null;
+            conflict = true;
+            existingNodeId = existingKey.entityId;
+            addedNodeId = newKey.entityId;
         }
+        return null;
+    }
 
-        void checkConflict( Value[] values ) throws IndexEntryConflictException
+    /**
+     * To be called for a populated key that is about to be sent off to a {@link Writer}.
+     * {@link GBPTree}'s ability to check for conflicts while applying updates is an opportunity,
+     * but also complicates some scenarios. This is why the strictness can be tweaked like this.
+     *
+     * @param key key to let know about conflict detection strictness.
+     */
+    void controlConflictDetection( KEY key )
+    {
+        key.entityIdIsSpecialTieBreaker = compareEntityIds;
+    }
+
+    void checkConflict( Value[] values ) throws IndexEntryConflictException
+    {
+        if ( conflict )
         {
-            if ( conflict )
-            {
-                conflict = false;
-                throw new IndexEntryConflictException( existingNodeId, addedNodeId, ValueTuple.of( values ) );
-            }
+            conflict = false;
+            throw new IndexEntryConflictException( existingNodeId, addedNodeId, ValueTuple.of( values ) );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DeferredConflictCheckingIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/DeferredConflictCheckingIndexUpdater.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
+import org.neo4j.kernel.api.exceptions.index.IndexNotApplicableKernelException;
+import org.neo4j.kernel.api.index.IndexEntryUpdate;
+import org.neo4j.kernel.api.index.IndexUpdater;
+import org.neo4j.kernel.api.schema.IndexQuery;
+import org.neo4j.kernel.api.schema.index.IndexDescriptor;
+import org.neo4j.storageengine.api.schema.IndexReader;
+import org.neo4j.values.storable.ValueTuple;
+
+import static org.neo4j.kernel.api.schema.IndexQuery.exact;
+import static org.neo4j.kernel.impl.api.index.UpdateMode.REMOVED;
+
+/**
+ * This deferring conflict checker solves e.g. a problem of applying updates to an index that is aware of,
+ * and also prevents, duplicates while applying. Consider this scenario:
+ *
+ * <pre>
+ *    GIVEN:
+ *    Node A w/ property value P
+ *    Node B w/ property value Q
+ *
+ *    WHEN Applying a transaction that:
+ *    Sets A property value to Q
+ *    Deletes B
+ * </pre>
+ *
+ * Then an index that is conscious about conflicts when applying may see intermediary conflicts,
+ * depending on the order in which updates are applied. Remembering which value tuples have been altered and
+ * checking conflicts for those in {@link #close()} works around that problem.
+ *
+ * This updater wrapping should only be used in specific places to solve specific problems, not generally
+ * when applying updates to online indexes.
+ */
+public class DeferredConflictCheckingIndexUpdater implements IndexUpdater
+{
+    private final IndexUpdater actual;
+    private final Supplier<IndexReader> readerSupplier;
+    private final IndexDescriptor indexDescriptor;
+    private final Set<ValueTuple> touchedTuples = new HashSet<>();
+
+    public DeferredConflictCheckingIndexUpdater( IndexUpdater actual, Supplier<IndexReader> readerSupplier, IndexDescriptor indexDescriptor )
+    {
+        this.actual = actual;
+        this.readerSupplier = readerSupplier;
+        this.indexDescriptor = indexDescriptor;
+    }
+
+    @Override
+    public void process( IndexEntryUpdate<?> update ) throws IOException, IndexEntryConflictException
+    {
+        actual.process( update );
+        if ( update.updateMode() != REMOVED )
+        {
+            touchedTuples.add( ValueTuple.of( update.values() ) );
+        }
+    }
+
+    @Override
+    public void close() throws IOException, IndexEntryConflictException
+    {
+        actual.close();
+        try ( IndexReader reader = readerSupplier.get() )
+        {
+            for ( ValueTuple tuple : touchedTuples )
+            {
+                PrimitiveLongIterator results = reader.query( queryOf( tuple ) );
+                if ( results.hasNext() )
+                {
+                    long firstEntityId = results.next();
+                    if ( results.hasNext() )
+                    {
+                        long secondEntityId = results.next();
+                        throw new IndexEntryConflictException( firstEntityId, secondEntityId, tuple );
+                    }
+                }
+            }
+        }
+        catch ( IndexNotApplicableKernelException e )
+        {
+            throw new IllegalArgumentException( "Unexpectedly the index reader couldn't handle this query", e );
+        }
+    }
+
+    private IndexQuery[] queryOf( ValueTuple tuple )
+    {
+        IndexQuery[] predicates = new IndexQuery[tuple.size()];
+        for ( int i = 0; i < predicates.length; i++ )
+        {
+            predicates[i] = exact( indexDescriptor.schema().getPropertyIds()[i], tuple.valueAt( i ) );
+        }
+        return predicates;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeNonUniqueSchemaNumberIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeNonUniqueSchemaNumberIndexPopulator.java
@@ -20,8 +20,6 @@
 package org.neo4j.kernel.impl.index.schema;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 
 import org.neo4j.index.internal.gbptree.Layout;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -40,7 +38,6 @@ import org.neo4j.storageengine.api.schema.IndexSample;
 class NativeNonUniqueSchemaNumberIndexPopulator<KEY extends SchemaNumberKey, VALUE extends SchemaNumberValue>
         extends NativeSchemaNumberIndexPopulator<KEY,VALUE>
 {
-    private final IndexSamplingConfig samplingConfig;
     private boolean updateSampling;
     private NonUniqueIndexSampler sampler;
 
@@ -48,7 +45,6 @@ class NativeNonUniqueSchemaNumberIndexPopulator<KEY extends SchemaNumberKey, VAL
             IndexSamplingConfig samplingConfig, SchemaIndexProvider.Monitor monitor, IndexDescriptor descriptor, long indexId )
     {
         super( pageCache, fs, storeFile, layout, monitor, descriptor, indexId );
-        this.samplingConfig = samplingConfig;
         this.sampler = new DefaultNonUniqueIndexSampler( samplingConfig.sampleSizeLimit() );
     }
 
@@ -61,30 +57,6 @@ class NativeNonUniqueSchemaNumberIndexPopulator<KEY extends SchemaNumberKey, VAL
     @Override
     public IndexSample sampleResult()
     {
-        // Close the writer before scanning
-        try
-        {
-            closeWriter();
-        }
-        catch ( IOException e )
-        {
-            throw new UncheckedIOException( e );
-        }
-
-        try
-        {
-            return sampler.result();
-        }
-        finally
-        {
-            try
-            {
-                instantiateWriter();
-            }
-            catch ( IOException e )
-            {
-                throw new UncheckedIOException( e );
-            }
-        }
+        return sampler.result();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndex.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndex.java
@@ -44,7 +44,7 @@ class NativeSchemaNumberIndex<KEY extends SchemaNumberKey, VALUE extends SchemaN
     final File storeFile;
     final Layout<KEY,VALUE> layout;
     final GBPTreeFileUtil gbpTreeFileUtil;
-    private final IndexDescriptor descriptor;
+    final IndexDescriptor descriptor;
     private final long indexId;
     private final SchemaIndexProvider.Monitor monitor;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexAccessor.java
@@ -80,7 +80,7 @@ public class NativeSchemaNumberIndexAccessor<KEY extends SchemaNumberKey, VALUE 
         assertOpen();
         try
         {
-            return singleUpdater.initialize( tree.writer(), true );
+            return singleUpdater.initialize( tree.writer() );
         }
         catch ( IOException e )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProvider.java
@@ -81,8 +81,8 @@ public class NativeSchemaNumberIndexProvider extends SchemaIndexProvider
             return new NativeNonUniqueSchemaNumberIndexPopulator<>( pageCache, fs, storeFile, new NonUniqueNumberLayout(), samplingConfig,
                     monitor, descriptor, indexId );
         case UNIQUE:
-            return new NativeUniqueSchemaNumberIndexPopulator<>( pageCache, fs, storeFile, new UniqueNumberLayout(), monitor, descriptor,
-                    indexId );
+            return new NativeUniqueSchemaNumberIndexPopulator<>( pageCache, fs, storeFile, new UniqueNumberLayout(), samplingConfig,
+                    monitor, descriptor, indexId );
         default:
             throw new UnsupportedOperationException( "Can not create index populator of type " + descriptor.type() );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexReader.java
@@ -148,7 +148,6 @@ class NativeSchemaNumberIndexReader<KEY extends SchemaNumberKey, VALUE extends S
         else
         {
             treeKeyTo.from( rangePredicate.toInclusive() ? Long.MAX_VALUE : Long.MIN_VALUE, toValue );
-            treeKeyTo.entityIdIsSpecialTieBreaker = true;
         }
     }
 
@@ -162,7 +161,6 @@ class NativeSchemaNumberIndexReader<KEY extends SchemaNumberKey, VALUE extends S
         else
         {
             treeKeyFrom.from( rangePredicate.fromInclusive() ? Long.MIN_VALUE : Long.MAX_VALUE, fromValue );
-            treeKeyFrom.entityIdIsSpecialTieBreaker = true;
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexUpdater.java
@@ -25,20 +25,16 @@ import org.neo4j.index.internal.gbptree.Writer;
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexUpdater;
-import org.neo4j.values.storable.ValueTuple;
-
-import static org.neo4j.kernel.impl.index.schema.ConflictDetectingValueMerger.dontCheck;
 
 class NativeSchemaNumberIndexUpdater<KEY extends SchemaNumberKey, VALUE extends SchemaNumberValue>
         implements IndexUpdater
 {
     private final KEY treeKey;
     private final VALUE treeValue;
-    private final ConflictDetectingValueMerger<KEY,VALUE> conflictDetectingValueMerger = dontCheck();
+    private final ConflictDetectingValueMerger<KEY,VALUE> conflictDetectingValueMerger = new ConflictDetectingValueMerger<>( true );
     private Writer<KEY,VALUE> writer;
 
     private boolean closed = true;
-    private boolean manageClosingOfWriter;
 
     NativeSchemaNumberIndexUpdater( KEY treeKey, VALUE treeValue )
     {
@@ -46,14 +42,13 @@ class NativeSchemaNumberIndexUpdater<KEY extends SchemaNumberKey, VALUE extends 
         this.treeValue = treeValue;
     }
 
-    NativeSchemaNumberIndexUpdater<KEY,VALUE> initialize( Writer<KEY,VALUE> writer, boolean manageClosingOfWriter )
+    NativeSchemaNumberIndexUpdater<KEY,VALUE> initialize( Writer<KEY,VALUE> writer )
     {
         if ( !closed )
         {
             throw new IllegalStateException( "Updater still open" );
         }
 
-        this.manageClosingOfWriter = manageClosingOfWriter;
         this.writer = writer;
         closed = false;
         return this;
@@ -69,10 +64,7 @@ class NativeSchemaNumberIndexUpdater<KEY extends SchemaNumberKey, VALUE extends 
     @Override
     public void close() throws IOException, IndexEntryConflictException
     {
-        if ( manageClosingOfWriter )
-        {
-            writer.close();
-        }
+        writer.close();
         closed = true;
     }
 
@@ -124,6 +116,7 @@ class NativeSchemaNumberIndexUpdater<KEY extends SchemaNumberKey, VALUE extends 
         // Insert new entry
         treeKey.from( update.getEntityId(), update.values() );
         treeValue.from( update.values() );
+        conflictDetectingValueMerger.controlConflictDetection( treeKey );
         writer.merge( treeKey, treeValue, conflictDetectingValueMerger );
         conflictDetectingValueMerger.checkConflict( update.values() );
     }
@@ -135,6 +128,7 @@ class NativeSchemaNumberIndexUpdater<KEY extends SchemaNumberKey, VALUE extends 
     {
         treeKey.from( update.getEntityId(), update.values() );
         treeValue.from( update.values() );
+        conflictDetectingValueMerger.controlConflictDetection( treeKey );
         writer.merge( treeKey, treeValue, conflictDetectingValueMerger );
         conflictDetectingValueMerger.checkConflict( update.values() );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeUniqueSchemaNumberIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeUniqueSchemaNumberIndexPopulator.java
@@ -20,28 +20,34 @@
 package org.neo4j.kernel.impl.index.schema;
 
 import java.io.File;
+import java.io.IOException;
 
 import org.neo4j.index.internal.gbptree.Layout;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
+import org.neo4j.kernel.api.index.IndexUpdater;
+import org.neo4j.kernel.api.index.PropertyAccessor;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
+import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.kernel.impl.api.index.sampling.UniqueIndexSampler;
 import org.neo4j.storageengine.api.schema.IndexSample;
 
 /**
- * {@link NativeSchemaNumberIndexPopulator} which can enforces unique values.
+ * {@link NativeSchemaNumberIndexPopulator} which enforces unique values.
  */
 class NativeUniqueSchemaNumberIndexPopulator<KEY extends SchemaNumberKey, VALUE extends SchemaNumberValue>
         extends NativeSchemaNumberIndexPopulator<KEY,VALUE>
 {
     private final UniqueIndexSampler sampler;
+    private final IndexSamplingConfig samplingConfig;
 
     NativeUniqueSchemaNumberIndexPopulator( PageCache pageCache, FileSystemAbstraction fs, File storeFile, Layout<KEY,VALUE> layout,
-            SchemaIndexProvider.Monitor monitor, IndexDescriptor descriptor, long indexId )
+            IndexSamplingConfig samplingConfig, SchemaIndexProvider.Monitor monitor, IndexDescriptor descriptor, long indexId )
     {
         super( pageCache, fs, storeFile, layout, monitor, descriptor, indexId );
+        this.samplingConfig = samplingConfig;
         this.sampler = new UniqueIndexSampler();
     }
 
@@ -55,5 +61,14 @@ class NativeUniqueSchemaNumberIndexPopulator<KEY extends SchemaNumberKey, VALUE 
     public IndexSample sampleResult()
     {
         return sampler.result();
+    }
+
+    @Override
+    public IndexUpdater newPopulatingUpdater( PropertyAccessor accessor ) throws IOException
+    {
+        // The index population detects conflicts on the fly, however for updates coming in we're in a position
+        // where we cannot detect conflicts while applying, but instead afterwards.
+        return new DeferredConflictCheckingIndexUpdater( super.newPopulatingUpdater( accessor ),
+                () -> new NativeSchemaNumberIndexReader<>( tree, layout, samplingConfig ), descriptor );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NonUniqueNumberLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NonUniqueNumberLayout.java
@@ -45,11 +45,4 @@ public class NonUniqueNumberLayout extends NumberLayout
     {
         return MINOR_VERSION;
     }
-
-    @Override
-    public int compare( SchemaNumberKey o1, SchemaNumberKey o2 )
-    {
-        int comparison = o1.compareValueTo( o2 );
-        return comparison != 0 ? comparison : Long.compare( o1.entityId, o2.entityId );
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberLayout.java
@@ -87,4 +87,19 @@ abstract class NumberLayout extends Layout.Adapter<SchemaNumberKey,SchemaNumberV
     public void readValue( PageCursor cursor, SchemaNumberValue into )
     {
     }
+
+    @Override
+    public int compare( SchemaNumberKey o1, SchemaNumberKey o2 )
+    {
+        int comparison = o1.compareValueTo( o2 );
+        if ( comparison == 0 )
+        {
+            // This is a special case where we need also compare entityId to support inclusive/exclusive
+            if ( o1.entityIdIsSpecialTieBreaker & o2.entityIdIsSpecialTieBreaker )
+            {
+                return Long.compare( o1.entityId, o2.entityId );
+            }
+        }
+        return comparison;
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SchemaNumberKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SchemaNumberKey.java
@@ -55,13 +55,13 @@ class SchemaNumberKey extends ValueWriter.Adapter<RuntimeException>
      * <p>
      * Note that {@code entityIdIsSpecialTieBreaker} is only an in memory state.
      */
-    boolean entityIdIsSpecialTieBreaker;
+    boolean entityIdIsSpecialTieBreaker = true;
 
     void from( long entityId, Value... values )
     {
         extractRawBitsAndType( assertValidSingleNumber( values ) );
         this.entityId = entityId;
-        entityIdIsSpecialTieBreaker = false;
+        entityIdIsSpecialTieBreaker = true;
     }
 
     private static NumberValue assertValidSingleNumber( Value... values )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/UniqueNumberLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/UniqueNumberLayout.java
@@ -49,19 +49,4 @@ class UniqueNumberLayout extends NumberLayout
     {
         return MINOR_VERSION;
     }
-
-    @Override
-    public int compare( SchemaNumberKey o1, SchemaNumberKey o2 )
-    {
-        int comparison = o1.compareValueTo( o2 );
-        if ( comparison == 0 )
-        {
-            // This is a special case where we need also compare entityId to support inclusive/exclusive
-            if ( o1.entityIdIsSpecialTieBreaker || o2.entityIdIsSpecialTieBreaker )
-            {
-                return Long.compare( o1.entityId, o2.entityId );
-            }
-        }
-        return comparison;
-    }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/ConflictDetectingValueMergerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/ConflictDetectingValueMergerTest.java
@@ -26,17 +26,13 @@ import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.neo4j.helpers.ArrayUtil.array;
-import static org.neo4j.values.storable.Values.stringValue;
 
 public class ConflictDetectingValueMergerTest
 {
-    private final ConflictDetectingValueMerger<SchemaNumberKey,SchemaNumberValue> detector = new ConflictDetectingValueMerger.Check<>();
+    private final ConflictDetectingValueMerger<SchemaNumberKey,SchemaNumberValue> detector = new ConflictDetectingValueMerger<>( true );
 
     @Test
     public void shouldReportConflictOnSameValueAndDifferentEntityIds() throws Exception
@@ -47,11 +43,7 @@ public class ConflictDetectingValueMergerTest
         long entityId2 = 20;
 
         // when
-        SchemaNumberValue merged = detector.merge(
-                key( entityId1, value ),
-                key( entityId2, value ),
-                SchemaNumberValue.INSTANCE,
-                SchemaNumberValue.INSTANCE );
+        SchemaNumberValue merged = detector.merge( key( entityId1, value ), key( entityId2, value ), SchemaNumberValue.INSTANCE, SchemaNumberValue.INSTANCE );
 
         // then
         assertNull( merged );
@@ -72,15 +64,11 @@ public class ConflictDetectingValueMergerTest
     public void shouldNotReportConflictOnSameValueSameEntityId() throws Exception
     {
         // given
-        Value value = Values.of( 123);
+        Value value = Values.of( 123 );
         long entityId = 10;
 
         // when
-        SchemaNumberValue merged = detector.merge(
-                key( entityId, value ),
-                key( entityId, value ),
-                SchemaNumberValue.INSTANCE,
-                SchemaNumberValue.INSTANCE );
+        SchemaNumberValue merged = detector.merge( key( entityId, value ), key( entityId, value ), SchemaNumberValue.INSTANCE, SchemaNumberValue.INSTANCE );
 
         // then
         assertNull( merged );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DeferredConflictCheckingIndexUpdaterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/DeferredConflictCheckingIndexUpdaterTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
+import org.neo4j.kernel.api.index.IndexEntryUpdate;
+import org.neo4j.kernel.api.index.IndexUpdater;
+import org.neo4j.kernel.api.schema.IndexQuery;
+import org.neo4j.kernel.api.schema.index.IndexDescriptor;
+import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
+import org.neo4j.kernel.impl.api.index.UpdateMode;
+import org.neo4j.storageengine.api.schema.IndexReader;
+import org.neo4j.values.storable.Value;
+import org.neo4j.values.storable.Values;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.neo4j.collection.primitive.PrimitiveLongCollections.iterator;
+import static org.neo4j.kernel.api.index.IndexEntryUpdate.add;
+import static org.neo4j.kernel.api.index.IndexEntryUpdate.change;
+import static org.neo4j.kernel.api.index.IndexEntryUpdate.remove;
+
+public class DeferredConflictCheckingIndexUpdaterTest
+{
+    private final int labelId = 1;
+    private final int[] propertyKeyIds = {2, 3};
+    private final IndexDescriptor descriptor = IndexDescriptorFactory.forLabel( labelId, propertyKeyIds );
+
+    @Test
+    public void shouldQueryAboutAddedAndChangedValueTuples() throws Exception
+    {
+        // given
+        IndexUpdater actual = mock( IndexUpdater.class );
+        IndexReader reader = mock( IndexReader.class );
+        when( reader.query( anyVararg() ) ).thenAnswer( invocation -> iterator( 0 ) );
+        long nodeId = 0;
+        List<IndexEntryUpdate<IndexDescriptor>> updates = new ArrayList<>();
+        updates.add( add( nodeId++, descriptor, tuple( 10, 11 ) ) );
+        updates.add( change( nodeId++, descriptor, tuple( "abc", "def" ), tuple( "ghi", "klm" ) ) );
+        updates.add( remove( nodeId++, descriptor, tuple( 1001L, 1002L ) ) );
+        updates.add( change( nodeId++, descriptor, tuple( (byte) 2, (byte) 3 ), tuple( (byte) 4, (byte) 5 ) ) );
+        updates.add( add( nodeId++, descriptor, tuple( 5, "5" ) ) );
+        try ( DeferredConflictCheckingIndexUpdater updater = new DeferredConflictCheckingIndexUpdater( actual, () -> reader, descriptor ) )
+        {
+            // when
+            for ( IndexEntryUpdate<IndexDescriptor> update : updates )
+            {
+                updater.process( update );
+                verify( actual ).process( update );
+            }
+        }
+
+        // then
+        for ( IndexEntryUpdate<IndexDescriptor> update : updates )
+        {
+            if ( update.updateMode() == UpdateMode.ADDED || update.updateMode() == UpdateMode.CHANGED )
+            {
+                Value[] tuple = update.values();
+                IndexQuery[] query = new IndexQuery[tuple.length];
+                for ( int i = 0; i < tuple.length; i++ )
+                {
+                    query[i] = IndexQuery.exact( propertyKeyIds[i], tuple[i] );
+                }
+                verify( reader ).query( query );
+            }
+        }
+        verify( reader ).close();
+        verifyNoMoreInteractions( reader );
+    }
+
+    @Test
+    public void shouldThrowOnIndexEntryConflict() throws Exception
+    {
+        // given
+        IndexUpdater actual = mock( IndexUpdater.class );
+        IndexReader reader = mock( IndexReader.class );
+        when( reader.query( anyVararg() ) ).thenAnswer( invocation -> iterator( 101, 202 ) );
+        DeferredConflictCheckingIndexUpdater updater = new DeferredConflictCheckingIndexUpdater( actual, () -> reader, descriptor );
+
+        // when
+        updater.process( add( 0, descriptor, tuple( 10, 11 ) ) );
+        try
+        {
+            updater.close();
+            fail( "Should have failed" );
+        }
+        catch ( IndexEntryConflictException e )
+        {
+            // then good
+            assertThat( e.getMessage(), containsString( "101" ) );
+            assertThat( e.getMessage(), containsString( "202" ) );
+        }
+    }
+
+    private Value[] tuple( Object... values )
+    {
+        Value[] result = new Value[values.length];
+        for ( int i = 0; i < values.length; i++ )
+        {
+            result[i] = Values.of( values[i] );
+        }
+        return result;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeUniqueSchemaNumberIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeUniqueSchemaNumberIndexPopulatorTest.java
@@ -47,7 +47,7 @@ public class NativeUniqueSchemaNumberIndexPopulatorTest extends NativeSchemaNumb
             PageCache pageCache, FileSystemAbstraction fs, File indexFile,
             Layout<SchemaNumberKey,SchemaNumberValue> layout, IndexSamplingConfig samplingConfig )
     {
-        return new NativeUniqueSchemaNumberIndexPopulator<>( pageCache, fs, indexFile, layout, monitor, indexDescriptor, indexId );
+        return new NativeUniqueSchemaNumberIndexPopulator<>( pageCache, fs, indexFile, layout, samplingConfig, monitor, indexDescriptor, indexId );
     }
 
     @Override
@@ -69,10 +69,9 @@ public class NativeUniqueSchemaNumberIndexPopulatorTest extends NativeSchemaNumb
             populator.add( Arrays.asList( updates ) );
             fail( "Updates should have conflicted" );
         }
-        catch ( Throwable e )
+        catch ( IndexEntryConflictException e )
         {
-            // then
-            assertTrue( Exceptions.contains( e, IndexEntryConflictException.class ) );
+            // then good
         }
         finally
         {

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/AccidentalUniquenessConstraintViolationIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/AccidentalUniquenessConstraintViolationIT.java
@@ -32,6 +32,7 @@ import org.neo4j.test.rule.DatabaseRule;
 import org.neo4j.test.rule.ImpermanentDatabaseRule;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 public class AccidentalUniquenessConstraintViolationIT
@@ -85,6 +86,9 @@ public class AccidentalUniquenessConstraintViolationIT
                 // good
             }
             tx.success();
+
+            assertEquals( fourtyTwo, db.findNode( Foo, BAR, 41 ) );
+            assertNull( db.findNode( Foo, BAR, 42 ) );
         }
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/PropertyConstraintsStressIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/PropertyConstraintsStressIT.java
@@ -27,13 +27,16 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntFunction;
 
 import org.neo4j.com.ComException;
 import org.neo4j.graphdb.ConstraintViolationException;
@@ -61,6 +64,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertThat;
 import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.graphdb.RelationshipType.withName;
+import static org.neo4j.helpers.ArrayUtil.array;
 import static org.neo4j.helpers.collection.Iterators.loop;
 
 /**
@@ -69,8 +73,39 @@ import static org.neo4j.helpers.collection.Iterators.loop;
 @RunWith( Parameterized.class )
 public class PropertyConstraintsStressIT
 {
+    private static final IntFunction<String> STRING_VALUE_GENERATOR = new IntFunction<String>()
+    {
+        @Override
+        public String apply( int value )
+        {
+            return "value" + value;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "STRING";
+        }
+    };
+    private static final IntFunction<Number> NUMBER_VALUE_GENERATOR = new IntFunction<Number>()
+    {
+        @Override
+        public Number apply( int value )
+        {
+            return value;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "NUMBER";
+        }
+    };
+
     @Parameter
     public ConstraintOperations constraintOps;
+    @Parameter( 1 )
+    public IntFunction<Object> valueGenerator;
 
     @Rule
     public final SuppressOutput suppressOutput = SuppressOutput.suppressAll();
@@ -102,10 +137,18 @@ public class PropertyConstraintsStressIT
     private final AtomicInteger roundNo = new AtomicInteger( 0 );
 
     @Parameterized.Parameters( name = "{0}:{1}" )
-    public static Iterable<ConstraintOperations> params()
+    public static Iterable<Object[]> params()
     {
-        return Arrays.asList( UNIQUE_PROPERTY_CONSTRAINT_OPS, UNIQUE_PROPERTY_CONSTRAINT_OPS,
-                NODE_PROPERTY_EXISTENCE_CONSTRAINT_OPS, REL_PROPERTY_EXISTENCE_CONSTRAINT_OPS );
+        List<Object[]> data = new ArrayList<>();
+        for ( IntFunction<?> values : array( STRING_VALUE_GENERATOR, NUMBER_VALUE_GENERATOR ) )
+        {
+            for ( ConstraintOperations operations : array( UNIQUE_PROPERTY_CONSTRAINT_OPS, UNIQUE_PROPERTY_CONSTRAINT_OPS,
+                    NODE_PROPERTY_EXISTENCE_CONSTRAINT_OPS, REL_PROPERTY_EXISTENCE_CONSTRAINT_OPS ) )
+            {
+                data.add( array( operations, values ) );
+            }
+        }
+        return data;
     }
 
     @Before
@@ -171,7 +214,7 @@ public class PropertyConstraintsStressIT
 
                 try
                 {
-                    Thread.sleep( 10 );
+                    Thread.sleep( ThreadLocalRandom.current().nextInt( 100 ) );
                 }
                 catch ( InterruptedException ignore )
                 {
@@ -195,7 +238,7 @@ public class PropertyConstraintsStressIT
 
                 try
                 {
-                    Thread.sleep( 10 );
+                    Thread.sleep( ThreadLocalRandom.current().nextInt( 100 ) );
                 }
                 catch ( InterruptedException ignore )
                 {
@@ -363,7 +406,7 @@ public class PropertyConstraintsStressIT
                 {
                     try ( Transaction tx = slave.beginTx() )
                     {
-                        constraintOps.createEntity( slave, labelOrRelType, property, "value" + i,
+                        constraintOps.createEntity( slave, labelOrRelType, property, valueGenerator.apply( i ),
                                 constraintCompliant );
                         tx.success();
                     }


### PR DESCRIPTION
The observed issue is that of clustering, where activation of
uniqueness constraint could race with concurrent uniqueness-violating
transactions on other cluster members without the constraint creator
noticing. The result would be a "successfully" created constraint
containing violations to the constraint.

A couple of changes were made to native indexing to fix this
problem w/o resorting to full scan of the index to verify uniqueness:

 - Unique and non-unique layout now both share the compare method
   from the unique layout. This is so that (gb+)tree uniqueness, i.e.
   (value) or (value,entityId) can be controlled per interaction
   with the tree.
 - Index population uses (value) tree uniqueness for adding data
   from store scan and (value,entityId) w/ deferred conflict checking
   for applying updates during population.
 - TentativeIndexProxy, i.e. limbo between populating and online,
   also uses (value,entityId) w/ deferred conflict checking.
 - Online index always uses (value,entityId) uniqueness,
   even for unique indexes. Kernel is required to do
   uniqueness checking and concurrency control outside the index
   anyway so additionally checking uniqueness inside the index
   introduces problems for no gain.
 - Index seekers always use (value,entity) tree uniqueness,
   i.e. they read what's there, plain and simple.

The reason why most need to use (value,entityId) tree uniqueness
is that batches of updates may, depending on ordering, contain
intermediary conflicts that should not really be considered
conflicts until the whole batch have been applied. Also to consider
here is that batches may come in for any number of transactions
batched into one (clustering catch-up scenario).

Index population can use (value) tree uniqueness since it's only
adding entries and fail-fast is a desirable feature.

There was a change to native index populator to allow for deferred
constraint checking too, which is that the gb+tree writer isn't
open all the time, but gets opened and then closed per "work sync".