### PR TITLE
Support byte[] as input and output for procedures

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/helpers/ValueConversion.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/helpers/ValueConversion.scala
@@ -45,7 +45,10 @@ object ValueConversion {
       case symbols.CTString => l => Values.stringValue(l.asInstanceOf[String])
       case symbols.CTPath => p => ValueUtils.asPathValue(p.asInstanceOf[Path])
       case symbols.CTMap => m => ValueUtils.asMapValue(m.asInstanceOf[java.util.Map[String, AnyRef]])
-      case symbols.ListType(_)  => l => ValueUtils.asListValue(l.asInstanceOf[java.util.Collection[_]])
+      case symbols.ListType(_) => {
+        case a: Array[Byte] => Values.byteArray(a)  // procedures can produce byte[] as a valid output type
+        case l => ValueUtils.asListValue(l.asInstanceOf[java.util.Collection[_]])
+      }
       case symbols.CTAny => o => ValueUtils.of(o)
       case symbols.CTPoint => o => ValueUtils.asPointValue(o.asInstanceOf[Point])
       case symbols.CTGeometry => o => ValueUtils.asPointValue(o.asInstanceOf[Geometry])
@@ -74,7 +77,7 @@ object ValueConversion {
     case c: java.util.Collection[_] => ValueUtils.asListValue(c)
     case a: Array[_] =>
       a.getClass.getComponentType.getName match {
-      case "byte" => fromArray(byteArray(a.asInstanceOf[Array[Byte]]))
+      case "byte" => byteArray(a.asInstanceOf[Array[Byte]]) // byte[] is supported in procedures and BOLT
       case "short" => fromArray(Values.shortArray(a.asInstanceOf[Array[Short]]))
       case "char" => fromArray(Values.charArray(a.asInstanceOf[Array[Char]]))
       case "int" => fromArray(Values.intArray(a.asInstanceOf[Array[Int]]))

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/valueHelper.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/valueHelper.scala
@@ -44,6 +44,7 @@ object valueHelper {
     }
     case n: NodeProxyWrappingNodeValue => n.nodeProxy()
     case n: RelationshipProxyWrappingEdgeValue => n.relationshipProxy()
+    case a: ByteArray => a.asObjectCopy()
     case a: ListValue => Vector(a.asArray().map(fromValue): _*)
     case Values.NO_VALUE => null
   }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundPlanContext.scala
@@ -190,6 +190,7 @@ class TransactionBoundPlanContext(tc: TransactionalContextWrapper, logger: Inter
     case Neo4jTypes.NTGeometry => symbols.CTGeometry
     case Neo4jTypes.NTMap => symbols.CTMap
     case Neo4jTypes.NTAny => symbols.CTAny
+    case Neo4jTypes.NTByteArray => symbols.CTList(symbols.CTInteger)
   }
 
   override def notificationLogger(): InternalNotificationLogger = logger

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundPlanContext.scala
@@ -190,7 +190,7 @@ class TransactionBoundPlanContext(tc: TransactionalContextWrapper, logger: Inter
     case Neo4jTypes.NTGeometry => symbols.CTGeometry
     case Neo4jTypes.NTMap => symbols.CTMap
     case Neo4jTypes.NTAny => symbols.CTAny
-    case Neo4jTypes.NTByteArray => symbols.CTList(symbols.CTInteger)
+    case Neo4jTypes.NTByteArray => symbols.CTList(symbols.CTAny)
   }
 
   override def notificationLogger(): InternalNotificationLogger = logger

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/FieldSignature.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/FieldSignature.java
@@ -39,6 +39,33 @@ public class FieldSignature
         return new FieldSignature( name, type, requireNonNull( defaultValue, "defaultValue" ), false );
     }
 
+    public interface InputMapper
+    {
+        Object map( Object input );
+    }
+
+    public static FieldSignature inputField( String name, Neo4jTypes.AnyType type, InputMapper mapper )
+    {
+        return new FieldSignature( name, type, null, false )
+        {
+            public Object map( Object input )
+            {
+                return mapper.map( input );
+            }
+        };
+    }
+
+    public static FieldSignature inputField( String name, Neo4jTypes.AnyType type, Neo4jValue defaultValue, InputMapper mapper )
+    {
+        return new FieldSignature( name, type, requireNonNull( defaultValue, "defaultValue" ), false )
+        {
+            public Object map( Object input )
+            {
+                return mapper.map( input );
+            }
+        };
+    }
+
     public static FieldSignature outputField( String name, Neo4jTypes.AnyType type )
     {
         return outputField( name, type, false );
@@ -69,6 +96,12 @@ public class FieldSignature
                         type.toString(), defaultValue.neo4jType().toString() ) );
             }
         }
+    }
+
+    /** Fields that are not supported full stack (ie. by Cypher) need to be mapped from Cypher to internal types */
+    public Object map( Object input )
+    {
+        return input;
     }
 
     public String name()

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/Neo4jTypes.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/Neo4jTypes.java
@@ -35,6 +35,7 @@ public class Neo4jTypes
     public static final FloatType NTFloat = new FloatType();
     public static final BooleanType NTBoolean = new BooleanType();
     public static final MapType NTMap = new MapType();
+    public static final ByteArrayType NTByteArray = new ByteArrayType();
     public static final NodeType NTNode = new NodeType();
     public static final RelationshipType NTRelationship = new RelationshipType();
     public static final PathType NTPath = new PathType();
@@ -162,6 +163,19 @@ public class Neo4jTypes
         }
 
         protected MapType( String name )
+        {
+            super( name );
+        }
+    }
+
+    public static class ByteArrayType extends AnyType
+    {
+        public ByteArrayType()
+        {
+            super( "BYTEARRAY?" );
+        }
+
+        protected ByteArrayType( String name )
         {
             super( name );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ByteArrayConverter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ByteArrayConverter.java
@@ -63,9 +63,15 @@ public class ByteArrayConverter implements Function<String,Neo4jValue>, FieldSig
             for ( int a = 0; a < bytes.length; a++ )
             {
                 Object value = list.get( a );
-                if ( value instanceof Number )
+                // We do not check for Number here in order to rule out floats
+                if ( value instanceof Long || value instanceof Integer || value instanceof Byte )
                 {
+                    Number number = (Number) value;
                     bytes[a] = ((Number) value).byteValue();
+                    if ( ((Byte) bytes[a]).longValue() != number.longValue() )
+                    {
+                        throw new IllegalArgumentException( "Cannot convert " + value + " to byte for input to procedure - valid values are -128 to +127" );
+                    }
                 }
                 else
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ByteArrayConverter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ByteArrayConverter.java
@@ -56,7 +56,7 @@ public class ByteArrayConverter implements Function<String,Neo4jValue>, FieldSig
         {
             return input;
         }
-        if ( input instanceof List )
+        if ( input instanceof List<?> )
         {
             List list = (List) input;
             byte[] bytes = new byte[list.size()];

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ByteArrayConverter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ByteArrayConverter.java
@@ -63,15 +63,9 @@ public class ByteArrayConverter implements Function<String,Neo4jValue>, FieldSig
             for ( int a = 0; a < bytes.length; a++ )
             {
                 Object value = list.get( a );
-                // We do not check for Number here in order to rule out floats
-                if ( value instanceof Long || value instanceof Integer || value instanceof Byte )
+                if ( value instanceof Byte )
                 {
-                    Number number = (Number) value;
-                    bytes[a] = ((Number) value).byteValue();
-                    if ( ((Byte) bytes[a]).longValue() != number.longValue() )
-                    {
-                        throw new IllegalArgumentException( "Cannot convert " + value + " to byte for input to procedure - valid values are -128 to +127" );
-                    }
+                    bytes[a] = (Byte) value;
                 }
                 else
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ByteArrayConverter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ByteArrayConverter.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.proc;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.neo4j.kernel.api.proc.FieldSignature;
+
+import static org.neo4j.kernel.impl.proc.Neo4jValue.ntByteArray;
+import static org.neo4j.kernel.impl.proc.ParseUtil.parseList;
+
+public class ByteArrayConverter implements Function<String,Neo4jValue>, FieldSignature.InputMapper
+{
+    @Override
+    public Neo4jValue apply( String s )
+    {
+        String value = s.trim();
+        if ( value.equalsIgnoreCase( "null" ) )
+        {
+            return ntByteArray( null );
+        }
+        else
+        {
+            List<Long> values = parseList( value, Long.class );
+            byte[] bytes = new byte[values.size()];
+            for ( int i = 0; i < bytes.length; i++ )
+            {
+                bytes[i] = values.get( i ).byteValue();
+            }
+            return ntByteArray( bytes );
+        }
+    }
+
+    @Override
+    public Object map( Object input )
+    {
+        if ( input instanceof byte[] )
+        {
+            return input;
+        }
+        if ( input instanceof List )
+        {
+            List list = (List) input;
+            byte[] bytes = new byte[list.size()];
+            for ( int a = 0; a < bytes.length; a++ )
+            {
+                Object value = list.get( a );
+                if ( value instanceof Number )
+                {
+                    bytes[a] = ((Number) value).byteValue();
+                }
+                else
+                {
+                    throw new IllegalArgumentException( "Cannot convert " + value + " to byte for input to procedure" );
+                }
+            }
+            return bytes;
+        }
+        else
+        {
+            throw new IllegalArgumentException( "Cannot convert " + input.getClass().getSimpleName() + " to byte[] for input to procedure" );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/MethodSignatureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/MethodSignatureCompiler.java
@@ -104,9 +104,20 @@ public class MethodSignatureCompiler
                 }
 
                 seenDefault = defaultValue.isPresent();
-                signature.add( defaultValue.isPresent()
-                        ? inputField( name, valueConverter.type(), defaultValue.get() )
-                        : inputField( name, valueConverter.type() ) );
+
+                // Currently only byte[] is not supported as a Cypher type, so we have specific conversion here.
+                // Should we add more unsupported types we should generalize this.
+                if ( type == byte[].class )
+                {
+                    FieldSignature.InputMapper mapper = new ByteArrayConverter();
+                    signature.add( defaultValue.map( neo4jValue -> inputField( name, valueConverter.type(), neo4jValue, mapper ) ).orElseGet(
+                            () -> inputField( name, valueConverter.type(), mapper ) ) );
+                }
+                else
+                {
+                    signature.add( defaultValue.map( neo4jValue -> inputField( name, valueConverter.type(), neo4jValue ) ).orElseGet(
+                            () -> inputField( name, valueConverter.type() ) ) );
+                }
             }
             catch ( ProcedureException e )
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Neo4jValue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Neo4jValue.java
@@ -70,6 +70,11 @@ public class Neo4jValue
         return new Neo4jValue( value, Neo4jTypes.NTMap );
     }
 
+    public static Neo4jValue ntByteArray( byte[] value )
+    {
+        return new Neo4jValue( value, Neo4jTypes.NTByteArray );
+    }
+
     public static Neo4jValue ntList( List<?> value, Neo4jTypes.AnyType inner )
     {
         return new Neo4jValue( value, Neo4jTypes.NTList( inner ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
@@ -588,6 +588,12 @@ class ReflectiveProcedureCompiler
                             numberOfDeclaredArguments, input.length );
                 }
 
+                // Some input fields are not supported by Cypher and need to be mapped
+                for ( int i = 0; i < input.length; i++ )
+                {
+                    input[i] = signature.inputSignature().get( i ).map( input[i] );
+                }
+
                 Object cls = constructor.invoke();
                 //API injection
                 inject( ctx, cls );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
@@ -547,6 +547,23 @@ class ReflectiveProcedureCompiler
         }
     }
 
+    private static Object[] verifyInput( String type, QualifiedName name, List<FieldSignature> inputSignature, Object[] input ) throws ProcedureException
+    {
+        // Verify that the number of passed arguments matches the number expected in the mthod signature
+        if ( inputSignature.size() != input.length )
+        {
+            throw new ProcedureException( Status.Procedure.ProcedureCallFailed, "%s `%s` takes %d arguments but %d was provided.", type, name,
+                    inputSignature.size(), input.length );
+        }
+
+        // Some input fields are not supported by Cypher and need to be mapped
+        for ( int i = 0; i < input.length; i++ )
+        {
+            input[i] = inputSignature.get( i ).map( input[i] );
+        }
+        return input;
+    }
+
     private static class ReflectiveProcedure extends ReflectiveBase implements CallableProcedure
     {
         private final ProcedureSignature signature;
@@ -579,20 +596,8 @@ class ReflectiveProcedureCompiler
             // at least the executing session, but we don't yet have good interfaces to the kernel to model that with.
             try
             {
-                int numberOfDeclaredArguments = signature.inputSignature().size();
-                if ( numberOfDeclaredArguments != input.length )
-                {
-                    throw new ProcedureException( Status.Procedure.ProcedureCallFailed,
-                            "Procedure `%s` takes %d arguments but %d was provided.",
-                            signature.name(),
-                            numberOfDeclaredArguments, input.length );
-                }
-
-                // Some input fields are not supported by Cypher and need to be mapped
-                for ( int i = 0; i < input.length; i++ )
-                {
-                    input[i] = signature.inputSignature().get( i ).map( input[i] );
-                }
+                // verify and possibly map the input
+                input = verifyInput( "Procedure", signature.name(), signature.inputSignature(), input );
 
                 Object cls = constructor.invoke();
                 //API injection
@@ -756,14 +761,8 @@ class ReflectiveProcedureCompiler
             // at least the executing session, but we don't yet have good interfaces to the kernel to model that with.
             try
             {
-                int numberOfDeclaredArguments = signature.inputSignature().size();
-                if ( numberOfDeclaredArguments != input.length )
-                {
-                    throw new ProcedureException( Status.Procedure.ProcedureCallFailed,
-                            "Function `%s` takes %d arguments but %d was provided.",
-                            signature.name(),
-                            numberOfDeclaredArguments, input.length );
-                }
+                // verify and possibly map the input
+                input = verifyInput( "Function", signature.name(), signature.inputSignature(), input );
 
                 Object cls = constructor.invoke();
                 //API injection
@@ -844,14 +843,9 @@ class ReflectiveProcedureCompiler
                     {
                         try
                         {
-                            int numberOfDeclaredArguments = signature.inputSignature().size();
-                            if ( numberOfDeclaredArguments != input.length )
-                            {
-                                throw new ProcedureException( Status.Procedure.ProcedureCallFailed,
-                                        "Function `%s` takes %d arguments but %d was provided.",
-                                        signature.name(),
-                                        numberOfDeclaredArguments, input.length );
-                            }
+                            // verify and possibly map the input
+                            input = verifyInput( "Function", signature.name(), signature.inputSignature(), input );
+
                             // Call the method
                             updateMethod.invoke( aggregator, input );
                         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/TypeMappers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/TypeMappers.java
@@ -40,6 +40,7 @@ import static java.lang.Double.parseDouble;
 import static java.lang.Long.parseLong;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTAny;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTBoolean;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTByteArray;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTFloat;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTInteger;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTList;
@@ -93,6 +94,7 @@ public class TypeMappers
         registerType( Map.class, TO_MAP );
         registerType( List.class, TO_LIST );
         registerType( Object.class, TO_ANY );
+        registerType( byte[].class, TO_BYTEARRAY );
     }
 
     public AnyType neoTypeFor( Type javaType ) throws ProcedureException
@@ -158,6 +160,7 @@ public class TypeMappers
             new SimpleConverter( NTBoolean, Boolean.class, s -> ntBoolean( parseBoolean( s ) ) );
     private final NeoValueConverter TO_MAP = new SimpleConverter( NTMap, Map.class, new MapConverter() );
     private final NeoValueConverter TO_LIST = toList( TO_ANY, Object.class );
+    private final NeoValueConverter TO_BYTEARRAY = new SimpleConverter( NTByteArray, byte[].class, new ByteArrayConverter() );
 
     private NeoValueConverter toList( NeoValueConverter inner, Type type )
     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserAggregationFunctionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserAggregationFunctionTest.java
@@ -285,7 +285,7 @@ public class ReflectiveUserAggregationFunctionTest
         exception.expect( ProcedureException.class );
         exception.expectMessage( String.format("Don't know how to map `char[]` to the Neo4j Type System.%n" +
                                  "Please refer to to the documentation for full details.%n" +
-                                 "For your reference, known types are: [boolean, double, java.lang.Boolean, java.lang" +
+                                 "For your reference, known types are: [boolean, byte[], double, java.lang.Boolean, java.lang" +
                                  ".Double, java.lang.Long, java.lang.Number, java.lang.Object, java.lang.String, java" +
                                  ".util.List, java.util.Map, long]" ));
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserFunctionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserFunctionTest.java
@@ -188,7 +188,7 @@ public class ReflectiveUserFunctionTest
         exception.expect( ProcedureException.class );
         exception.expectMessage( String.format("Don't know how to map `char[]` to the Neo4j Type System.%n" +
                                  "Please refer to to the documentation for full details.%n" +
-                                 "For your reference, known types are: [boolean, double, java.lang.Boolean, java.lang" +
+                                 "For your reference, known types are: [boolean, byte[], double, java.lang.Boolean, java.lang" +
                                  ".Double, java.lang.Long, java.lang.Number, java.lang.Object, java.lang.String, java" +
                                  ".util.List, java.util.Map, long]" ));
 

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -469,6 +469,22 @@ public class ProcedureIT
     }
 
     @Test
+    public void shouldNotAllowNonByteValuesInImplicitByteArrayConversionInProcedures() throws Throwable
+    {
+        //Expect
+        exception.expect( QueryExecutionException.class );
+        exception.expectMessage( "Cannot convert 500 to byte for input to procedure" );
+
+        // When
+        try ( Transaction ignore = db.beginTx() )
+        {
+            //Make sure argument here is not auto parameterized away as that will drop all type information on the floor
+            Result result = db.execute( "CALL org.neo4j.procedure.incrBytesWithDefault([1,2,500])" );
+            result.next();
+        }
+    }
+
+    @Test
     public void shouldCallProcedureListWithNull() throws Throwable
     {
         // Given
@@ -1400,6 +1416,54 @@ public class ProcedureIT
             assertFalse( res.hasNext() );
             assertThat( results.get( "bytes" ), equalTo( new byte[]{9, 10, 11} ) );
             assertThat( results.get( "param" ), equalTo( asList( 10L, 11L, 12L ) ) );
+        }
+    }
+
+    @Test
+    public void shouldNotAllowNonByteValuesInImplicitByteArrayConversionWithUserDefinedFunction() throws Throwable
+    {
+        //Expect
+        exception.expect( QueryExecutionException.class );
+        exception.expectMessage( "Cannot convert 500 to byte for input to procedure" );
+
+        // When
+        try ( Transaction ignore = db.beginTx() )
+        {
+            //Make sure argument here is not auto parameterized away as that will drop all type information on the floor
+            Result result = db.execute( "RETURN org.neo4j.procedure.decrBytesWithDefault([1,2,500]) AS bytes" );
+            result.next();
+        }
+    }
+
+    @Test
+    public void shouldNotAllowNonIntegerValuesInImplicitByteArrayConversionWithUserDefinedFunction() throws Throwable
+    {
+        //Expect
+        exception.expect( QueryExecutionException.class );
+        exception.expectMessage( "Cannot convert 3.4 to byte for input to procedure" );
+
+        // When
+        try ( Transaction ignore = db.beginTx() )
+        {
+            //Make sure argument here is not auto parameterized away as that will drop all type information on the floor
+            Result result = db.execute( "RETURN org.neo4j.procedure.decrBytesWithDefault([1,2,3.4]) AS bytes" );
+            result.next();
+        }
+    }
+
+    @Test
+    public void shouldNotAllowNonNumberValuesInImplicitByteArrayConversionWithUserDefinedFunction() throws Throwable
+    {
+        //Expect
+        exception.expect( QueryExecutionException.class );
+        exception.expectMessage( "Cannot convert X to byte for input to procedure" );
+
+        // When
+        try ( Transaction ignore = db.beginTx() )
+        {
+            //Make sure argument here is not auto parameterized away as that will drop all type information on the floor
+            Result result = db.execute( "RETURN org.neo4j.procedure.decrBytesWithDefault([1,2,'X']) AS bytes" );
+            result.next();
         }
     }
 

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -2004,7 +2004,7 @@ public class ProcedureIT
 
         public static class ByteArrayAggregator
         {
-            byte[] aggregated = null;
+            byte[] aggregated;
 
             @UserAggregationUpdate
             public void update( @Name( "bytes" ) byte[] bytes )

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -1363,7 +1363,8 @@ public class ProcedureIT
         try ( Transaction ignore = db.beginTx() )
         {
             // When
-            Result res = db.execute( "WITH $param as param RETURN org.neo4j.procedure.decrBytes(param) AS bytes, param", map( "param", new byte[]{10, 11, 12} ) );
+            Result res =
+                    db.execute( "WITH $param AS param RETURN org.neo4j.procedure.decrBytes(param) AS bytes, param", map( "param", new byte[]{10, 11, 12} ) );
 
             // Then
             assertTrue(res.hasNext());


### PR DESCRIPTION
changelog: Support byte[] as valid input and output types for procedures, user defined functions and aggregation functions