### PR TITLE
Add temporal types to semantic checker.

### DIFF
--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/ArithmeticExpressions.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/ArithmeticExpressions.scala
@@ -42,7 +42,13 @@ case class Subtract(lhs: Expression, rhs: Expression)(val position: InputPositio
   override val signatures = Vector(
     TypeSignature(argumentTypes = Vector(CTInteger, CTInteger), outputType = CTInteger),
     TypeSignature(argumentTypes = Vector(CTInteger, CTFloat), outputType = CTFloat),
-    TypeSignature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTFloat)
+    TypeSignature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTFloat),
+    TypeSignature(argumentTypes = Vector(CTDuration, CTDuration), outputType = CTDuration),
+    TypeSignature(argumentTypes = Vector(CTLocalTime, CTDuration), outputType = CTLocalTime),
+    TypeSignature(argumentTypes = Vector(CTTime, CTDuration), outputType = CTTime),
+    TypeSignature(argumentTypes = Vector(CTDate, CTDuration), outputType = CTDate),
+    TypeSignature(argumentTypes = Vector(CTLocalDateTime, CTDuration), outputType = CTLocalDateTime),
+    TypeSignature(argumentTypes = Vector(CTDateTime, CTDuration), outputType = CTDateTime)
   )
 
   override def canonicalOperatorSymbol = "-"
@@ -69,7 +75,11 @@ case class Multiply(lhs: Expression, rhs: Expression)(val position: InputPositio
   override val signatures = Vector(
     TypeSignature(argumentTypes = Vector(CTInteger, CTInteger), outputType = CTInteger),
     TypeSignature(argumentTypes = Vector(CTInteger, CTFloat), outputType = CTFloat),
-    TypeSignature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTFloat)
+    TypeSignature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTFloat),
+    TypeSignature(argumentTypes = Vector(CTDuration, CTFloat), outputType = CTDuration),
+    TypeSignature(argumentTypes = Vector(CTDuration, CTInteger), outputType = CTDuration),
+    TypeSignature(argumentTypes = Vector(CTFloat, CTDuration), outputType = CTDuration),
+    TypeSignature(argumentTypes = Vector(CTInteger, CTDuration), outputType = CTDuration)
   )
 
   override def canonicalOperatorSymbol = "*"
@@ -85,7 +95,9 @@ case class Divide(lhs: Expression, rhs: Expression)(val position: InputPosition)
   override val signatures = Vector(
     TypeSignature(argumentTypes = Vector(CTInteger, CTInteger), outputType = CTInteger),
     TypeSignature(argumentTypes = Vector(CTInteger, CTFloat), outputType = CTFloat),
-    TypeSignature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTFloat)
+    TypeSignature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTFloat),
+    TypeSignature(argumentTypes = Vector(CTDuration, CTFloat), outputType = CTDuration),
+    TypeSignature(argumentTypes = Vector(CTDuration, CTInteger), outputType = CTDuration)
   )
 
   override def canonicalOperatorSymbol = "/"

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/PredicateExpressions.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/PredicateExpressions.scala
@@ -158,7 +158,13 @@ sealed trait InequalityExpression extends Expression with BinaryOperatorExpressi
     TypeSignature(argumentTypes = Vector(CTInteger, CTInteger), outputType = CTBoolean),
     TypeSignature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTBoolean),
     TypeSignature(argumentTypes = Vector(CTString, CTString), outputType = CTBoolean),
-    TypeSignature(argumentTypes = Vector(CTPoint, CTPoint), outputType = CTBoolean)
+    TypeSignature(argumentTypes = Vector(CTPoint, CTPoint), outputType = CTBoolean),
+    TypeSignature(argumentTypes = Vector(CTDuration, CTDuration), outputType = CTBoolean),
+    TypeSignature(argumentTypes = Vector(CTDate, CTDate), outputType = CTBoolean),
+    TypeSignature(argumentTypes = Vector(CTTime, CTTime), outputType = CTBoolean),
+    TypeSignature(argumentTypes = Vector(CTDateTime, CTDateTime), outputType = CTBoolean),
+    TypeSignature(argumentTypes = Vector(CTLocalTime, CTLocalTime), outputType = CTBoolean),
+    TypeSignature(argumentTypes = Vector(CTLocalDateTime, CTLocalDateTime), outputType = CTBoolean)
   )
 
   def includeEquality: Boolean

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/PredicateExpressions.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/PredicateExpressions.scala
@@ -159,7 +159,6 @@ sealed trait InequalityExpression extends Expression with BinaryOperatorExpressi
     TypeSignature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTBoolean),
     TypeSignature(argumentTypes = Vector(CTString, CTString), outputType = CTBoolean),
     TypeSignature(argumentTypes = Vector(CTPoint, CTPoint), outputType = CTBoolean),
-    TypeSignature(argumentTypes = Vector(CTDuration, CTDuration), outputType = CTBoolean),
     TypeSignature(argumentTypes = Vector(CTDate, CTDate), outputType = CTBoolean),
     TypeSignature(argumentTypes = Vector(CTTime, CTTime), outputType = CTBoolean),
     TypeSignature(argumentTypes = Vector(CTDateTime, CTDateTime), outputType = CTBoolean),

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/ToString.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/ToString.scala
@@ -26,6 +26,12 @@ case object ToString extends Function with TypeSignatures {
     TypeSignature(argumentTypes = Vector(CTFloat), outputType = CTString),
     TypeSignature(argumentTypes = Vector(CTInteger), outputType = CTString),
     TypeSignature(argumentTypes = Vector(CTBoolean), outputType = CTString),
-    TypeSignature(argumentTypes = Vector(CTString), outputType = CTString)
+    TypeSignature(argumentTypes = Vector(CTString), outputType = CTString),
+    TypeSignature(argumentTypes = Vector(CTDuration), outputType = CTString),
+    TypeSignature(argumentTypes = Vector(CTDate), outputType = CTString),
+    TypeSignature(argumentTypes = Vector(CTTime), outputType = CTString),
+    TypeSignature(argumentTypes = Vector(CTDateTime), outputType = CTString),
+    TypeSignature(argumentTypes = Vector(CTLocalTime), outputType = CTString),
+    TypeSignature(argumentTypes = Vector(CTLocalDateTime), outputType = CTString)
   )
 }

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/AddTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/AddTest.scala
@@ -46,6 +46,17 @@ class AddTest extends InfixExpressionTestBase(Add(_, _)(DummyPosition(0))) {
     testValidTypes(CTFloat, CTString)(CTString)
     testValidTypes(CTFloat, CTInteger)(CTFloat)
     testValidTypes(CTFloat, CTFloat)(CTFloat)
+    testValidTypes(CTDuration, CTDuration)(CTDuration)
+    testValidTypes(CTDate, CTDuration)(CTDate)
+    testValidTypes(CTDuration, CTDate)(CTDate)
+    testValidTypes(CTTime, CTDuration)(CTTime)
+    testValidTypes(CTDuration, CTTime)(CTTime)
+    testValidTypes(CTLocalTime, CTDuration)(CTLocalTime)
+    testValidTypes(CTDuration, CTLocalTime)(CTLocalTime)
+    testValidTypes(CTDateTime, CTDuration)(CTDateTime)
+    testValidTypes(CTDuration, CTDateTime)(CTDateTime)
+    testValidTypes(CTLocalDateTime, CTDuration)(CTLocalDateTime)
+    testValidTypes(CTDuration, CTLocalDateTime)(CTLocalDateTime)
 
     testValidTypes(CTList(CTNode), CTList(CTNode))(CTList(CTNode))
     testValidTypes(CTList(CTFloat), CTList(CTFloat))(CTList(CTFloat))
@@ -90,6 +101,9 @@ class AddTest extends InfixExpressionTestBase(Add(_, _)(DummyPosition(0))) {
   test("shouldFailTypeCheckForIncompatibleArguments") {
     testInvalidApplication(CTInteger, CTBoolean)(
       "Type mismatch: expected Float, Integer, String or List<T> but was Boolean"
+    )
+    testInvalidApplication(CTDuration, CTBoolean)(
+      "Type mismatch: expected Duration, Date, Time, LocalTime, LocalDateTime, DateTime or List<T> but was Boolean"
     )
   }
 

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/DivideTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/DivideTest.scala
@@ -33,18 +33,20 @@ class DivideTest extends InfixExpressionTestBase(Divide(_, _)(DummyPosition(0)))
     testValidTypes(CTInteger, CTFloat)(CTFloat)
     testValidTypes(CTFloat, CTInteger)(CTFloat)
     testValidTypes(CTFloat, CTFloat)(CTFloat)
+    testValidTypes(CTDuration, CTFloat)(CTDuration)
+    testValidTypes(CTDuration, CTInteger)(CTDuration)
   }
 
   test("shouldHandleCombinedSpecializations") {
     testValidTypes(CTFloat | CTInteger, CTFloat | CTInteger)(CTFloat | CTInteger)
   }
 
-  test("shouldFailTypeCheckWhenAddingIncompatible") {
+  test("shouldFailTypeCheckWhenIncompatible") {
     testInvalidApplication(CTInteger, CTBoolean)(
       "Type mismatch: expected Float or Integer but was Boolean"
     )
     testInvalidApplication(CTBoolean, CTInteger)(
-      "Type mismatch: expected Float or Integer but was Boolean"
+      "Type mismatch: expected Float, Integer or Duration but was Boolean"
     )
   }
 }

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/GreaterThanOrEqualTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/GreaterThanOrEqualTest.scala
@@ -34,8 +34,20 @@ class GreaterThanOrEqualTest extends InfixExpressionTestBase(GreaterThanOrEqual(
     testValidTypes(CTString, CTString)(CTBoolean)
   }
 
+  test("shouldSupportComparingPoints") {
+    testValidTypes(CTPoint, CTPoint)(CTBoolean)
+  }
+
+  test("shouldSupportComparingTemporals") {
+    testValidTypes(CTDate, CTDate)(CTBoolean)
+    testValidTypes(CTTime, CTTime)(CTBoolean)
+    testValidTypes(CTLocalTime, CTLocalTime)(CTBoolean)
+    testValidTypes(CTDateTime, CTDateTime)(CTBoolean)
+    testValidTypes(CTLocalDateTime, CTLocalDateTime)(CTBoolean)
+  }
+
   test("shouldReturnErrorIfInvalidArgumentTypes") {
-    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer, Point or String but was Node")
+    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer, Point, String, Duration, Date, Time, LocalTime, LocalDateTime or DateTime but was Node")
     testInvalidApplication(CTInteger, CTNode)("Type mismatch: expected Float or Integer but was Node")
   }
 }

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/GreaterThanOrEqualTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/GreaterThanOrEqualTest.scala
@@ -47,7 +47,8 @@ class GreaterThanOrEqualTest extends InfixExpressionTestBase(GreaterThanOrEqual(
   }
 
   test("shouldReturnErrorIfInvalidArgumentTypes") {
-    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer, Point, String, Duration, Date, Time, LocalTime, LocalDateTime or DateTime but was Node")
+    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer, Point, String, Date, Time, LocalTime, LocalDateTime or DateTime but was Node")
     testInvalidApplication(CTInteger, CTNode)("Type mismatch: expected Float or Integer but was Node")
+    testInvalidApplication(CTDuration, CTDuration)("Type mismatch: expected Float, Integer, Point, String, Date, Time, LocalTime, LocalDateTime or DateTime but was Duration")
   }
 }

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/GreaterThanTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/GreaterThanTest.scala
@@ -34,8 +34,20 @@ class GreaterThanTest extends InfixExpressionTestBase(GreaterThan(_, _)(DummyPos
     testValidTypes(CTString, CTString)(CTBoolean)
   }
 
+  test("shouldSupportComparingPoints") {
+    testValidTypes(CTPoint, CTPoint)(CTBoolean)
+  }
+
+  test("shouldSupportComparingTemporals") {
+    testValidTypes(CTDate, CTDate)(CTBoolean)
+    testValidTypes(CTTime, CTTime)(CTBoolean)
+    testValidTypes(CTLocalTime, CTLocalTime)(CTBoolean)
+    testValidTypes(CTDateTime, CTDateTime)(CTBoolean)
+    testValidTypes(CTLocalDateTime, CTLocalDateTime)(CTBoolean)
+  }
+
   test("shouldReturnErrorIfInvalidArgumentTypes") {
-    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer, Point or String but was Node")
+    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer, Point, String, Duration, Date, Time, LocalTime, LocalDateTime or DateTime but was Node")
     testInvalidApplication(CTInteger, CTNode)("Type mismatch: expected Float or Integer but was Node")
   }
 }

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/GreaterThanTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/GreaterThanTest.scala
@@ -47,7 +47,8 @@ class GreaterThanTest extends InfixExpressionTestBase(GreaterThan(_, _)(DummyPos
   }
 
   test("shouldReturnErrorIfInvalidArgumentTypes") {
-    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer, Point, String, Duration, Date, Time, LocalTime, LocalDateTime or DateTime but was Node")
+    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer, Point, String, Date, Time, LocalTime, LocalDateTime or DateTime but was Node")
     testInvalidApplication(CTInteger, CTNode)("Type mismatch: expected Float or Integer but was Node")
+    testInvalidApplication(CTDuration, CTDuration)("Type mismatch: expected Float, Integer, Point, String, Date, Time, LocalTime, LocalDateTime or DateTime but was Duration")
   }
 }

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/LessThanOrEqualTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/LessThanOrEqualTest.scala
@@ -47,7 +47,8 @@ class LessThanOrEqualTest extends InfixExpressionTestBase(LessThanOrEqual(_, _)(
   }
 
   test("shouldReturnErrorIfInvalidArgumentTypes") {
-    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer, Point, String, Duration, Date, Time, LocalTime, LocalDateTime or DateTime but was Node")
+    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer, Point, String, Date, Time, LocalTime, LocalDateTime or DateTime but was Node")
     testInvalidApplication(CTInteger, CTNode)("Type mismatch: expected Float or Integer but was Node")
+    testInvalidApplication(CTDuration, CTDuration)("Type mismatch: expected Float, Integer, Point, String, Date, Time, LocalTime, LocalDateTime or DateTime but was Duration")
   }
 }

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/LessThanOrEqualTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/LessThanOrEqualTest.scala
@@ -34,8 +34,20 @@ class LessThanOrEqualTest extends InfixExpressionTestBase(LessThanOrEqual(_, _)(
     testValidTypes(CTString, CTString)(CTBoolean)
   }
 
+  test("shouldSupportComparingPoints") {
+    testValidTypes(CTPoint, CTPoint)(CTBoolean)
+  }
+
+  test("shouldSupportComparingTemporals") {
+    testValidTypes(CTDate, CTDate)(CTBoolean)
+    testValidTypes(CTTime, CTTime)(CTBoolean)
+    testValidTypes(CTLocalTime, CTLocalTime)(CTBoolean)
+    testValidTypes(CTDateTime, CTDateTime)(CTBoolean)
+    testValidTypes(CTLocalDateTime, CTLocalDateTime)(CTBoolean)
+  }
+
   test("shouldReturnErrorIfInvalidArgumentTypes") {
-    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer, Point or String but was Node")
+    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer, Point, String, Duration, Date, Time, LocalTime, LocalDateTime or DateTime but was Node")
     testInvalidApplication(CTInteger, CTNode)("Type mismatch: expected Float or Integer but was Node")
   }
 }

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/LessThanTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/LessThanTest.scala
@@ -47,7 +47,8 @@ class LessThanTest extends InfixExpressionTestBase(LessThan(_, _)(DummyPosition(
   }
 
   test("shouldReturnErrorIfInvalidArgumentTypes") {
-    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer, Point, String, Duration, Date, Time, LocalTime, LocalDateTime or DateTime but was Node")
+    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer, Point, String, Date, Time, LocalTime, LocalDateTime or DateTime but was Node")
     testInvalidApplication(CTInteger, CTNode)("Type mismatch: expected Float or Integer but was Node")
+    testInvalidApplication(CTDuration, CTDuration)("Type mismatch: expected Float, Integer, Point, String, Date, Time, LocalTime, LocalDateTime or DateTime but was Duration")
   }
 }

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/LessThanTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/LessThanTest.scala
@@ -34,8 +34,20 @@ class LessThanTest extends InfixExpressionTestBase(LessThan(_, _)(DummyPosition(
     testValidTypes(CTString, CTString)(CTBoolean)
   }
 
+  test("shouldSupportComparingPoints") {
+    testValidTypes(CTPoint, CTPoint)(CTBoolean)
+  }
+
+  test("shouldSupportComparingTemporals") {
+    testValidTypes(CTDate, CTDate)(CTBoolean)
+    testValidTypes(CTTime, CTTime)(CTBoolean)
+    testValidTypes(CTLocalTime, CTLocalTime)(CTBoolean)
+    testValidTypes(CTDateTime, CTDateTime)(CTBoolean)
+    testValidTypes(CTLocalDateTime, CTLocalDateTime)(CTBoolean)
+  }
+
   test("shouldReturnErrorIfInvalidArgumentTypes") {
-    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer, Point or String but was Node")
+    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer, Point, String, Duration, Date, Time, LocalTime, LocalDateTime or DateTime but was Node")
     testInvalidApplication(CTInteger, CTNode)("Type mismatch: expected Float or Integer but was Node")
   }
 }

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/MultiplyTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/MultiplyTest.scala
@@ -33,6 +33,10 @@ class MultiplyTest extends InfixExpressionTestBase(Multiply(_, _)(DummyPosition(
     testValidTypes(CTInteger, CTFloat)(CTFloat)
     testValidTypes(CTFloat, CTInteger)(CTFloat)
     testValidTypes(CTFloat, CTFloat)(CTFloat)
+    testValidTypes(CTDuration, CTFloat)(CTDuration)
+    testValidTypes(CTDuration, CTInteger)(CTDuration)
+    testValidTypes(CTFloat, CTDuration)(CTDuration)
+    testValidTypes(CTInteger, CTDuration)(CTDuration)
   }
 
   test("shouldHandleCombinedSpecializations") {
@@ -41,10 +45,10 @@ class MultiplyTest extends InfixExpressionTestBase(Multiply(_, _)(DummyPosition(
 
   test("shouldFailTypeCheckWhenAddingIncompatible") {
     testInvalidApplication(CTInteger, CTBoolean)(
-      "Type mismatch: expected Float or Integer but was Boolean"
+      "Type mismatch: expected Float, Integer or Duration but was Boolean"
     )
     testInvalidApplication(CTBoolean, CTInteger)(
-      "Type mismatch: expected Float or Integer but was Boolean"
+      "Type mismatch: expected Float, Integer or Duration but was Boolean"
     )
   }
 }

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/PropertyTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/PropertyTest.scala
@@ -76,6 +76,17 @@ class PropertyTest extends SemanticFunSuite {
     result.errors shouldBe empty
   }
 
+  test("accepts property access on an Date") {
+    val mapExpr: Variable = variable("map")
+    val propertyKey: PropertyKeyName = propertyKeyName("prop")
+
+    val beforeState = SemanticState.clean.newChildScope.declareVariable(mapExpr, CTDate).right.get
+
+    val result = SemanticExpressionCheck.simple(property(mapExpr, propertyKey))(beforeState)
+
+    result.errors shouldBe empty
+  }
+
   test("refuses property access on an Integer") {
     val mapExpr: Variable = variable("map")
     val propertyKey: PropertyKeyName = propertyKeyName("prop")
@@ -84,6 +95,6 @@ class PropertyTest extends SemanticFunSuite {
 
     val result = SemanticExpressionCheck.simple(property(mapExpr, propertyKey))(beforeState)
 
-    result.errors should equal(Seq(SemanticError("Type mismatch: expected Any, Map, Node, Relationship or Point but was Integer", pos)))
+    result.errors should equal(Seq(SemanticError("Type mismatch: expected Any, Map, Node, Relationship, Point, Duration, Date, Time, LocalTime, LocalDateTime or DateTime but was Integer", pos)))
   }
 }

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SubtractTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SubtractTest.scala
@@ -33,6 +33,12 @@ class SubtractTest extends InfixExpressionTestBase(Subtract(_, _)(DummyPosition(
     testValidTypes(CTInteger, CTFloat)(CTFloat)
     testValidTypes(CTFloat, CTInteger)(CTFloat)
     testValidTypes(CTFloat, CTFloat)(CTFloat)
+    testValidTypes(CTDuration, CTDuration)(CTDuration)
+    testValidTypes(CTDate, CTDuration)(CTDate)
+    testValidTypes(CTTime, CTDuration)(CTTime)
+    testValidTypes(CTLocalTime, CTDuration)(CTLocalTime)
+    testValidTypes(CTDateTime, CTDuration)(CTDateTime)
+    testValidTypes(CTLocalDateTime, CTDuration)(CTLocalDateTime)
   }
 
   test("shouldHandleCombinedSpecializations") {
@@ -44,7 +50,7 @@ class SubtractTest extends InfixExpressionTestBase(Subtract(_, _)(DummyPosition(
       "Type mismatch: expected Float or Integer but was Boolean"
     )
     testInvalidApplication(CTBoolean, CTInteger)(
-      "Type mismatch: expected Float or Integer but was Boolean"
+      "Type mismatch: expected Float, Integer, Duration, Date, Time, LocalTime, LocalDateTime or DateTime but was Boolean"
     )
   }
 }

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/ToStringTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/ToStringTest.scala
@@ -27,15 +27,21 @@ class ToStringTest extends FunctionTestBase("toString")  {
     testValidTypes(CTBoolean)(CTString)
     testValidTypes(CTAny.covariant)(CTString)
     testValidTypes(CTNumber.covariant)(CTString)
+    testValidTypes(CTDuration)(CTString)
+    testValidTypes(CTDate)(CTString)
+    testValidTypes(CTTime)(CTString)
+    testValidTypes(CTLocalTime)(CTString)
+    testValidTypes(CTLocalDateTime)(CTString)
+    testValidTypes(CTDateTime)(CTString)
   }
 
   test("should fail type check for incompatible arguments") {
     testInvalidApplication(CTRelationship)(
-      "Type mismatch: expected Boolean, Float, Integer or String but was Relationship"
+      "Type mismatch: expected Boolean, Float, Integer, String, Duration, Date, Time, LocalTime, LocalDateTime or DateTime but was Relationship"
     )
 
     testInvalidApplication(CTNode)(
-      "Type mismatch: expected Boolean, Float, Integer or String but was Node"
+      "Type mismatch: expected Boolean, Float, Integer, String, Duration, Date, Time, LocalTime, LocalDateTime or DateTime but was Node"
     )
   }
 

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/TypeSpec.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/TypeSpec.scala
@@ -42,7 +42,13 @@ object TypeSpec {
     CTPoint,
     CTGeometry,
     CTString,
-    CTGraphRef
+    CTGraphRef,
+    CTDuration,
+    CTDate,
+    CTTime,
+    CTLocalTime,
+    CTLocalDateTime,
+    CTDateTime
   )
 
   private def apply(range: TypeRange): TypeSpec = new TypeSpec(Vector(range))

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SemanticErrorAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SemanticErrorAcceptanceTest.scala
@@ -126,7 +126,7 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
   test("cant use toString() on nodes") {
     executeAndEnsureError(
       "MATCH (n) RETURN toString(n)",
-      "Type mismatch: expected Boolean, Float, Integer or String but was Node (line 1, column 27 (offset: 26))"
+      "Type mismatch: expected Boolean, Float, Integer, String, Duration, Date, Time, LocalTime, LocalDateTime or DateTime but was Node (line 1, column 27 (offset: 26))"
     )
   }
 


### PR DESCRIPTION
This basically changes only the error messages, since the actual signatures from the user-defined functions do not get through to the SemanticAnalysis, yet.