### PR TITLE
Fixes an issue splitting nodes containing large keys

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNodeDynamicSize.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNodeDynamicSize.java
@@ -616,7 +616,7 @@ public class TreeNodeDynamicSize<KEY, VALUE> extends TreeNode<KEY,VALUE>
     {
         // Find middle
         int keyCountAfterInsert = leftKeyCount + 1;
-        int middlePos = middleLeaf( leftCursor, insertPos, newKey, newValue );
+        int middlePos = middleLeaf( leftCursor, insertPos, newKey, newValue, keyCountAfterInsert );
 
         if ( middlePos == insertPos )
         {
@@ -662,7 +662,7 @@ public class TreeNodeDynamicSize<KEY, VALUE> extends TreeNode<KEY,VALUE>
             long newRightChild, long stableGeneration, long unstableGeneration, KEY newSplitter )
     {
         int keyCountAfterInsert = leftKeyCount + 1;
-        int middlePos = middleInternal( leftCursor, insertPos, newKey );
+        int middlePos = middleInternal( leftCursor, insertPos, newKey, keyCountAfterInsert );
 
         if ( middlePos == insertPos )
         {
@@ -955,7 +955,7 @@ public class TreeNodeDynamicSize<KEY, VALUE> extends TreeNode<KEY,VALUE>
         return toAllocOffset;
     }
 
-    private int middleInternal( PageCursor cursor, int insertPos, KEY newKey )
+    private int middleInternal( PageCursor cursor, int insertPos, KEY newKey, int keyCountAfterInsert )
     {
         int halfSpace = this.halfSpace;
         int middle = 0;
@@ -968,8 +968,6 @@ public class TreeNodeDynamicSize<KEY, VALUE> extends TreeNode<KEY,VALUE>
         do
         {
             // We may come closer to split by keeping one more in left
-            middle++;
-            currentPos++;
             int space;
             if ( currentPos == insertPos & !includedNew )
             {
@@ -984,13 +982,15 @@ public class TreeNodeDynamicSize<KEY, VALUE> extends TreeNode<KEY,VALUE>
             middleSpace += space;
             prevDelta = currentDelta;
             currentDelta = Math.abs( middleSpace - halfSpace );
+            middle++;
+            currentPos++;
         }
-        while ( currentDelta < prevDelta );
+        while ( currentDelta < prevDelta && currentPos < keyCountAfterInsert );
         middle--; // Step back to the pos that most equally divide the available space in two
         return middle;
     }
 
-    private int middleLeaf( PageCursor cursor, int insertPos, KEY newKey, VALUE newValue )
+    private int middleLeaf( PageCursor cursor, int insertPos, KEY newKey, VALUE newValue, int keyCountAfterInsert )
     {
         int halfSpace = this.halfSpace;
         int middle = 0;
@@ -1003,8 +1003,6 @@ public class TreeNodeDynamicSize<KEY, VALUE> extends TreeNode<KEY,VALUE>
         do
         {
             // We may come closer to split by keeping one more in left
-            middle++;
-            currentPos++;
             int space;
             if ( currentPos == insertPos & !includedNew )
             {
@@ -1019,8 +1017,10 @@ public class TreeNodeDynamicSize<KEY, VALUE> extends TreeNode<KEY,VALUE>
             middleSpace += space;
             prevDelta = currentDelta;
             currentDelta = Math.abs( middleSpace - halfSpace );
+            currentPos++;
+            middle++;
         }
-        while ( currentDelta < prevDelta );
+        while ( currentDelta < prevDelta && currentPos < keyCountAfterInsert );
         middle--; // Step back to the pos that most equally divide the available space in two
         return middle;
     }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/LargeDynamicKeysIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/LargeDynamicKeysIT.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index.internal.gbptree;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.neo4j.cursor.RawCursor;
+import org.neo4j.helpers.collection.Pair;
+import org.neo4j.string.UTF8;
+import org.neo4j.test.rule.PageCacheAndDependenciesRule;
+import org.neo4j.test.rule.RandomRule;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.test.Randoms.CSA_LETTERS_AND_DIGITS;
+
+public class LargeDynamicKeysIT
+{
+    @Rule
+    public final PageCacheAndDependenciesRule storage = new PageCacheAndDependenciesRule( DefaultFileSystemRule::new, getClass() );
+
+    @Rule
+    public final RandomRule random = new RandomRule();
+
+    @Test
+    public void shouldWriteAndReadKeysOfSizesCloseToTheLimits() throws IOException
+    {
+        // given
+        try ( GBPTree<RawBytes,RawBytes> tree =
+                new GBPTreeBuilder<>( storage.pageCache(), storage.directory().file( "index" ), new SimpleByteArrayLayout() ).build() )
+        {
+            // when
+            Set<String> generatedStrings = new HashSet<>();
+            List<Pair<RawBytes,RawBytes>> entries = new ArrayList<>();
+            try ( Writer<RawBytes,RawBytes> writer = tree.writer() )
+            {
+                for ( int i = 0; i < 1_000; i++ )
+                {
+                    // value, based on i
+                    RawBytes value = new RawBytes();
+                    value.bytes = new byte[Integer.BYTES];
+                    ByteBuffer.wrap( value.bytes ).putInt( i );
+
+                    // key, randomly generated
+                    String string;
+                    do
+                    {
+                        string = random.string( 3_000, 4_000, CSA_LETTERS_AND_DIGITS );
+                    }
+                    while ( !generatedStrings.add( string ) );
+                    RawBytes key = new RawBytes();
+                    key.bytes = UTF8.encode( string );
+                    entries.add( Pair.of( key, value ) );
+
+                    // write
+                    writer.put( key, value );
+                }
+            }
+
+            // then
+            for ( Pair<RawBytes,RawBytes> entry : entries )
+            {
+                try ( RawCursor<Hit<RawBytes,RawBytes>,IOException> seek = tree.seek( entry.first(), entry.first() ) )
+                {
+                    assertTrue( seek.next() );
+                    assertArrayEquals( entry.first().bytes, seek.get().key().bytes );
+                    assertArrayEquals( entry.other().bytes, seek.get().value().bytes );
+                    assertFalse( seek.next() );
+                }
+            }
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeStringIndexingIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeStringIndexingIT.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.neo4j.collection.primitive.PrimitiveLongResourceIterator;
+import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
+import org.neo4j.kernel.api.exceptions.index.IndexNotApplicableKernelException;
+import org.neo4j.kernel.api.index.IndexEntryUpdate;
+import org.neo4j.kernel.api.schema.index.IndexDescriptor;
+import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
+import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
+import org.neo4j.storageengine.api.schema.IndexReader;
+import org.neo4j.test.rule.PageCacheAndDependenciesRule;
+import org.neo4j.test.rule.RandomRule;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.collection.primitive.PrimitiveLongCollections.single;
+import static org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector.IGNORE;
+import static org.neo4j.internal.kernel.api.IndexQuery.exact;
+import static org.neo4j.kernel.api.index.SchemaIndexProvider.Monitor.EMPTY;
+import static org.neo4j.test.Randoms.CSA_LETTERS_AND_DIGITS;
+import static org.neo4j.values.storable.Values.stringValue;
+
+public class NativeStringIndexingIT
+{
+    @Rule
+    public final PageCacheAndDependenciesRule storage = new PageCacheAndDependenciesRule( DefaultFileSystemRule::new, getClass() );
+
+    @Rule
+    public final RandomRule random = new RandomRule();
+
+    @Test
+    public void shouldHandleKeySizesCloseToTheSizeLimit() throws IOException, IndexEntryConflictException, IndexNotApplicableKernelException
+    {
+        // given
+        IndexDescriptor descriptor = IndexDescriptorFactory.forLabel( 1, 2 );
+        try ( StringSchemaIndexAccessor accessor = new StringSchemaIndexAccessor( storage.pageCache(), storage.fileSystem(),
+                storage.directory().file( "index" ), new StringLayoutNonUnique(), IGNORE, EMPTY, descriptor, 0,
+                new IndexSamplingConfig( Config.defaults() ) ) )
+        {
+            // when
+            List<String> strings = new ArrayList<>();
+            try ( NativeSchemaIndexUpdater<StringSchemaKey,NativeSchemaValue> updater = accessor.newUpdater( IndexUpdateMode.ONLINE ) )
+            {
+                for ( int i = 0; i < 1_000; i++ )
+                {
+                    String string = random.string( 3_000, 4_000, CSA_LETTERS_AND_DIGITS );
+                    strings.add( string );
+                    updater.process( IndexEntryUpdate.add( i, descriptor, stringValue( string ) ) );
+                }
+            }
+
+            // then
+            try ( IndexReader reader = accessor.newReader() )
+            {
+                for ( int i = 0; i < strings.size(); i++ )
+                {
+                    try ( PrimitiveLongResourceIterator result = reader.query( exact( descriptor.schema().getPropertyIds()[0], strings.get( i ) ) ) )
+                    {
+                        assertEquals( i, single( result, -1 ) );
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
There was a logical error in calculating the middle position
to split at, which surfaced only when node only contained
large keys.