### PR TITLE
Make sure cursors are closed

### DIFF
--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
@@ -124,10 +124,12 @@ sealed class TransactionBoundQueryContext(val transactionalContext: Transactiona
       val context = transactionalContext.getOrBeginNewIfClosed()
       var success = false
       try {
-        val result = work(new TransactionBoundQueryContext(context))
+        val newContext = new TransactionBoundQueryContext(context, resources)
+        val result = work(newContext)
         success = true
         result
       } finally {
+        resources.close(success)
         context.close(success)
       }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultCursors.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultCursors.java
@@ -29,6 +29,7 @@ import org.neo4j.internal.kernel.api.AutoCloseablePlus;
 import org.neo4j.internal.kernel.api.CursorFactory;
 
 import static java.lang.String.format;
+import static org.neo4j.util.FeatureToggles.flag;
 
 public class DefaultCursors implements CursorFactory
 {
@@ -42,7 +43,7 @@ public class DefaultCursors implements CursorFactory
     private DefaultNodeExplicitIndexCursor nodeExplicitIndexCursor;
     private DefaultRelationshipExplicitIndexCursor relationshipExplicitIndexCursor;
 
-    private static final boolean DEBUG_CLOSING = false;
+    private static final boolean DEBUG_CLOSING = flag( DefaultCursors.class, "trackCursors", false );
     private List<CloseableStacktrace> closeables = new ArrayList<>();
 
     @Override

--- a/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/v3_4/executionplan/GeneratedQuery.java
+++ b/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/v3_4/executionplan/GeneratedQuery.java
@@ -23,14 +23,12 @@ import org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan.Provid
 import org.neo4j.cypher.internal.runtime.ExecutionMode;
 import org.neo4j.cypher.internal.runtime.QueryContext;
 import org.neo4j.cypher.internal.runtime.planDescription.InternalPlanDescription;
-import org.neo4j.cypher.internal.util.v3_4.TaskCloser;
 import org.neo4j.cypher.internal.v3_4.codegen.QueryExecutionTracer;
 import org.neo4j.values.virtual.MapValue;
 
 public interface GeneratedQuery
 {
     org.neo4j.cypher.internal.v3_4.executionplan.GeneratedQueryExecution execute(
-            TaskCloser closer,
             QueryContext queryContext,
             ExecutionMode executionMode,
             Provider<InternalPlanDescription> description,

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/CodeGenerator.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/CodeGenerator.scala
@@ -82,8 +82,8 @@ class CodeGenerator(val structure: CodeStructure[GeneratedQuery], clock: Clock, 
                     descriptionProvider: DescriptionProvider, params: MapValue,
                     closer: TaskCloser): InternalExecutionResult = {
             val (provider, tracer) = descriptionProvider(description)
-            val execution: GeneratedQueryExecution = query.query.execute(closer, queryContext, execMode,
-              provider, tracer.getOrElse(QueryExecutionTracer.NONE),params)
+            val execution: GeneratedQueryExecution = query.query.execute(queryContext, execMode, provider,
+                                                                         tracer.getOrElse(QueryExecutionTracer.NONE),params)
             closer.addTask(queryContext.resources.close)
             new CompiledExecutionResult(closer, queryContext, execution, provider)
           }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/CodeGenerator.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/CodeGenerator.scala
@@ -22,20 +22,20 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.codegen
 import java.time.Clock
 import java.util
 
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.CompiledRuntimeName
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.ExecutionPlanBuilder.DescriptionProvider
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.codegen.ir._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.codegen.spi.{CodeStructure, CodeStructureResult}
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.{CompiledExecutionResult, CompiledPlan, RunnablePlan}
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan.{PlanFingerprint, Provider}
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.CompiledRuntimeName
 import org.neo4j.cypher.internal.compiler.v3_4.planner.CantCompileQueryException
 import org.neo4j.cypher.internal.frontend.v3_4.PlannerName
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.SemanticTable
 import org.neo4j.cypher.internal.planner.v3_4.spi.PlanningAttributes.{Cardinalities, ReadOnlies}
 import org.neo4j.cypher.internal.planner.v3_4.spi.{InstrumentedGraphStatistics, PlanContext}
 import org.neo4j.cypher.internal.runtime.planDescription.InternalPlanDescription.Arguments.{Runtime, RuntimeImpl}
-import org.neo4j.cypher.internal.runtime.{ExecutionMode, InternalExecutionResult, QueryContext}
 import org.neo4j.cypher.internal.runtime.planDescription.{InternalPlanDescription, LogicalPlan2PlanDescription}
+import org.neo4j.cypher.internal.runtime.{ExecutionMode, InternalExecutionResult, QueryContext}
 import org.neo4j.cypher.internal.util.v3_4.attribution.Id
 import org.neo4j.cypher.internal.util.v3_4.{Eagerly, TaskCloser}
 import org.neo4j.cypher.internal.v3_4.codegen.QueryExecutionTracer
@@ -84,6 +84,7 @@ class CodeGenerator(val structure: CodeStructure[GeneratedQuery], clock: Clock, 
             val (provider, tracer) = descriptionProvider(description)
             val execution: GeneratedQueryExecution = query.query.execute(closer, queryContext, execMode,
               provider, tracer.getOrElse(QueryExecutionTracer.NONE),params)
+            closer.addTask(queryContext.resources.close)
             new CompiledExecutionResult(closer, queryContext, execution, provider)
           }
         }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ExpandAllLoopDataGenerator.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ExpandAllLoopDataGenerator.scala
@@ -33,19 +33,22 @@ case class ExpandAllLoopDataGenerator(opName: String, fromVar: Variable, dir: Se
     }
   }
 
-  override def produceLoopData[E](iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
+  override def produceLoopData[E](cursorName: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
     if(types.isEmpty)
-      generator.nodeGetRelationshipsWithDirection(iterVar, fromVar.name, fromVar.codeGenType, dir)
+      generator.nodeGetRelationshipsWithDirection(cursorName, fromVar.name, fromVar.codeGenType, dir)
     else
-      generator.nodeGetRelationshipsWithDirectionAndTypes(iterVar, fromVar.name, fromVar.codeGenType, dir, types.keys.toIndexedSeq)
+      generator.nodeGetRelationshipsWithDirectionAndTypes(cursorName, fromVar.name, fromVar.codeGenType, dir, types.keys.toIndexedSeq)
     generator.incrementDbHits()
   }
 
-  override def getNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
+  override def getNext[E](nextVar: Variable, cursorName: String, generator: MethodStructure[E])
                          (implicit context: CodeGenContext) = {
     generator.incrementDbHits()
-    generator.nextRelationshipAndNode(toVar.name, iterVar, dir, fromVar.name, relVar.name)
+    generator.nextRelationshipAndNode(toVar.name, cursorName, dir, fromVar.name, relVar.name)
   }
 
-  override def checkNext[E](generator: MethodStructure[E], iterVar: String): E =  generator.advanceRelationshipSelectionCursor(iterVar)
+  override def checkNext[E](generator: MethodStructure[E], cursorName: String): E =  generator.advanceRelationshipSelectionCursor(cursorName)
+
+  override def close[E](cursorName: String,
+                        generator: MethodStructure[E]): Unit = generator.closeRelationshipSelectionCursor(cursorName)
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ExpandIntoLoopDataGenerator.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ExpandIntoLoopDataGenerator.scala
@@ -33,19 +33,21 @@ case class ExpandIntoLoopDataGenerator(opName: String, fromVar: Variable, dir: S
     }
   }
 
-  override def produceLoopData[E](iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
+  override def produceLoopData[E](cursorName: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
     if(types.isEmpty)
-      generator.connectingRelationships(iterVar, fromVar.name, fromVar.codeGenType, dir, toVar.name, toVar.codeGenType)
+      generator.connectingRelationships(cursorName, fromVar.name, fromVar.codeGenType, dir, toVar.name, toVar.codeGenType)
     else
-      generator.connectingRelationships(iterVar, fromVar.name, fromVar.codeGenType, dir, types.keys.toIndexedSeq, toVar.name, toVar.codeGenType)
+      generator.connectingRelationships(cursorName, fromVar.name, fromVar.codeGenType, dir, types.keys.toIndexedSeq, toVar.name, toVar.codeGenType)
     generator.incrementDbHits()
   }
 
-  override def getNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
+  override def getNext[E](nextVar: Variable, cursorName: String, generator: MethodStructure[E])
                          (implicit context: CodeGenContext) = {
     generator.incrementDbHits()
-    generator.nextRelationship(iterVar, dir, relVar.name)
+    generator.nextRelationship(cursorName, dir, relVar.name)
   }
 
-  override def checkNext[E](generator: MethodStructure[E], iterVar: String): E = generator.advanceRelationshipSelectionCursor(iterVar)
+  override def checkNext[E](generator: MethodStructure[E], cursorName: String): E = generator.advanceRelationshipSelectionCursor(cursorName)
+
+  override def close[E](cursorName: String, generator: MethodStructure[E]): Unit = generator.closeRelationshipSelectionCursor(cursorName)
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/IndexSeek.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/IndexSeek.scala
@@ -36,16 +36,18 @@ case class IndexSeek(opName: String, labelName: String, propNames: Seq[String], 
     generator.newIndexReference(descriptorVar, labelVar, propKeyVar)
   }
 
-  override def produceLoopData[E](iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
-      generator.indexSeek(iterVar, descriptorVar, expression.generateExpression(generator), expression.codeGenType)
+  override def produceLoopData[E](cursorName: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
+      generator.indexSeek(cursorName, descriptorVar, expression.generateExpression(generator), expression.codeGenType)
       generator.incrementDbHits()
   }
 
-  override def getNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
+  override def getNext[E](nextVar: Variable, cursorName: String, generator: MethodStructure[E])
                          (implicit context: CodeGenContext) = {
     generator.incrementDbHits()
-    generator.nodeFromNodeValueIndexCursor(nextVar.name, iterVar)
+    generator.nodeFromNodeValueIndexCursor(nextVar.name, cursorName)
   }
 
-  override def checkNext[E](generator: MethodStructure[E], iterVar: String): E = generator.advanceNodeValueIndexCursor(iterVar)
+  override def checkNext[E](generator: MethodStructure[E], cursorName: String): E = generator.advanceNodeValueIndexCursor(cursorName)
+
+  override def close[E](cursorName: String, generator: MethodStructure[E]): Unit = generator.closeNodeValueIndexCursor(cursorName)
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/LoopDataGenerator.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/LoopDataGenerator.scala
@@ -33,5 +33,7 @@ trait LoopDataGenerator {
 
   def produceLoopData[E](iterVarName: String, generator: MethodStructure[E])(implicit context: CodeGenContext): Unit
 
+  def close[E](iterVarName: String, generator: MethodStructure[E]): Unit
+
   def opName: String
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ScanAllNodes.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ScanAllNodes.scala
@@ -26,16 +26,18 @@ case class ScanAllNodes(opName: String) extends LoopDataGenerator {
 
   override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {}
 
-  override def produceLoopData[E](iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
-    generator.allNodesScan(iterVar)
+  override def produceLoopData[E](cursorName: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
+    generator.allNodesScan(cursorName)
     generator.incrementDbHits()
   }
 
-  override def getNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
+  override def getNext[E](nextVar: Variable, cursorName: String, generator: MethodStructure[E])
                          (implicit context: CodeGenContext) = {
     generator.incrementDbHits()
-    generator.nodeFromNodeCursor(nextVar.name, iterVar)
+    generator.nodeFromNodeCursor(nextVar.name, cursorName)
   }
 
-  override def checkNext[E](generator: MethodStructure[E], iterVar: String): E = generator.advanceNodeCursor(iterVar)
+  override def checkNext[E](generator: MethodStructure[E], cursorName: String): E = generator.advanceNodeCursor(cursorName)
+
+  override def close[E](cursorName: String, generator: MethodStructure[E]): Unit = generator.closeNodeCursor(cursorName)
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ScanForLabel.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ScanForLabel.scala
@@ -27,17 +27,18 @@ case class ScanForLabel(opName: String, labelName: String, labelVar: String) ext
   override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) =
     generator.lookupLabelId(labelVar, labelName)
 
-  override def produceLoopData[E](iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
-    generator.labelScan(iterVar, labelVar)
+  override def produceLoopData[E](cursorName: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
+    generator.labelScan(cursorName, labelVar)
     generator.incrementDbHits()
   }
 
-  override def getNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
+  override def getNext[E](nextVar: Variable, cursorName: String, generator: MethodStructure[E])
                          (implicit context: CodeGenContext) = {
     generator.incrementDbHits()
-    generator.nodeFromNodeLabelIndexCursor(nextVar.name, iterVar)
+    generator.nodeFromNodeLabelIndexCursor(nextVar.name, cursorName)
   }
 
-  override def checkNext[E](generator: MethodStructure[E], iterVar: String): E =
-    generator.advanceNodeLabelIndexCursor(iterVar)
+  override def checkNext[E](generator: MethodStructure[E], cursorName: String): E = generator.advanceNodeLabelIndexCursor(cursorName)
+
+  override def close[E](cursorName: String, generator: MethodStructure[E]): Unit = generator.closeNodeLabelIndexCursor(cursorName)
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/UnwindCollection.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/UnwindCollection.scala
@@ -42,4 +42,7 @@ case class UnwindCollection(opName: String, collection: CodeGenExpression) exten
 
   override def checkNext[E](generator: MethodStructure[E], iterVar: String): E =
     generator.iteratorHasNext(generator.loadVariable(iterVar))
+
+  override def close[E](iterVarName: String,
+                        generator: MethodStructure[E]): Unit = {/*nothing to close*/}
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/UnwindPrimitiveCollection.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/UnwindPrimitiveCollection.scala
@@ -47,4 +47,7 @@ case class UnwindPrimitiveCollection(opName: String, collection: CodeGenExpressi
 
   override def checkNext[E](generator: MethodStructure[E], iterVar: String): E =
     generator.iteratorHasNext(generator.loadVariable(iterVar))
+
+  override def close[E](iterVarName: String,
+                        generator: MethodStructure[E]): Unit = {/*nothing to close*/}
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/WhileLoop.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/WhileLoop.scala
@@ -33,6 +33,7 @@ case class WhileLoop(variable: Variable, producer: LoopDataGenerator, action: In
         producer.getNext(variable, iterator, loopBody)
         action.body(loopBody)
       }
+      producer.close(iterator, generator)
     }
   }
 

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/spi/MethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/spi/MethodStructure.scala
@@ -164,10 +164,14 @@ trait MethodStructure[E] {
   def nextRelationshipAndNode(toNodeVar: String, iterVar: String, direction: SemanticDirection, fromNodeVar: String, relVar: String): Unit
   def nextRelationship(iterVar: String, direction: SemanticDirection, relVar: String): Unit
 
-  def advanceNodeCursor(iterVar: String): E
-  def advanceNodeLabelIndexCursor(iterVar: String): E
-  def advanceRelationshipSelectionCursor(iterVar: String): E
-  def advanceNodeValueIndexCursor(iterVar: String): E
+  def advanceNodeCursor(cursorName: String): E
+  def closeNodeCursor(cursorName: String): Unit
+  def advanceNodeLabelIndexCursor(cursorName: String): E
+  def closeNodeLabelIndexCursor(cursorName: String): Unit
+  def advanceRelationshipSelectionCursor(cursorName: String): E
+  def closeRelationshipSelectionCursor(cursorName: String): Unit
+  def advanceNodeValueIndexCursor(cursorName: String): E
+  def closeNodeValueIndexCursor(cursorName: String): Unit
 
   def nodeGetPropertyById(nodeVar: String, nodeVarType: CodeGenType, propId: Int, propValueVar: String): Unit
   def nodeGetPropertyForVar(nodeVar: String, nodeVarType: CodeGenType, propIdVar: String, propValueVar: String): Unit

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Fields.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Fields.scala
@@ -21,8 +21,7 @@ package org.neo4j.cypher.internal.spi.v3_4.codegen
 
 import org.neo4j.codegen.FieldReference
 
-case class Fields(closer: FieldReference,
-                  entityAccessor: FieldReference,
+case class Fields(entityAccessor: FieldReference,
                   executionMode: FieldReference,
                   description: FieldReference,
                   tracer: FieldReference,

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedQueryStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedQueryStructure.scala
@@ -39,7 +39,7 @@ import org.neo4j.cypher.internal.javacompat.ResultRecord
 import org.neo4j.cypher.internal.runtime.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.runtime.{ExecutionMode, QueryContext}
 import org.neo4j.cypher.internal.util.v3_4.attribution.Id
-import org.neo4j.cypher.internal.util.v3_4.{TaskCloser, symbols}
+import org.neo4j.cypher.internal.util.v3_4.symbols
 import org.neo4j.cypher.internal.v3_4.codegen.QueryExecutionTracer
 import org.neo4j.cypher.internal.v3_4.executionplan.{GeneratedQuery, GeneratedQueryExecution}
 import org.neo4j.cypher.result.QueryResult.QueryResultVisitor
@@ -113,7 +113,6 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
     }
     val query = using(generator.generateClass(conf.packageName, className, typeRef[GeneratedQuery])) { clazz =>
       using(clazz.generateMethod(typeRef[GeneratedQueryExecution], "execute",
-        param[TaskCloser]("closer"),
         param[QueryContext]("queryContext"),
         param[ExecutionMode]("executionMode"),
         param[Provider[InternalPlanDescription]]("description"),
@@ -123,13 +122,11 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
           invoke(
             newInstance(execution),
             constructorReference(execution,
-              typeRef[TaskCloser],
               typeRef[QueryContext],
               typeRef[ExecutionMode],
               typeRef[Provider[InternalPlanDescription]],
               typeRef[QueryExecutionTracer],
               typeRef[MapValue]),
-            execute.load("closer"),
             execute.load("queryContext"),
             execute.load("executionMode"),
             execute.load("description"),
@@ -202,7 +199,6 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
                       "COLUMNS", newArray(typeRef[String], columns.map(key => constant(key)):_*))
 
     Fields(
-      closer = clazz.field(typeRef[TaskCloser], "closer"),
       entityAccessor = clazz.field(typeRef[EmbeddedProxySPI], "proxySpi"),
       executionMode = clazz.field(typeRef[ExecutionMode], "executionMode"),
       description = clazz.field(typeRef[Provider[InternalPlanDescription]], "description"),

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedQueryStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedQueryStructure.scala
@@ -160,10 +160,10 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
       throwsException(typeParameter("E")))) { (codeBlock: CodeBlock) =>
       val structure = new GeneratedMethodStructure(fields, codeBlock, new AuxGenerator(conf.packageName, generator), onClose =
         Seq((success: Boolean) => (block: CodeBlock) => {
+          block.expression(invoke(block.self(), methodReference(block.owner(), TypeReference.VOID, "closeCursors")))
           val target = Expression.get(block.self(), fields.closeable)
           val reference = method[Completable, Unit]("completed", typeRef[Boolean])
           block.expression(invoke(target, reference, Expression.constant(success)))
-          block.expression(invoke(block.self(), methodReference(block.owner(), TypeReference.VOID, "closeCursors")))
         }))
       codeBlock.assign(typeRef[ResultRecord], "row",
                        invoke(newInstance(typeRef[ResultRecord]),

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Templates.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Templates.scala
@@ -34,7 +34,7 @@ import org.neo4j.cypher.internal.frontend.v3_4.helpers.using
 import org.neo4j.cypher.internal.javacompat.ResultRowImpl
 import org.neo4j.cypher.internal.runtime.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.runtime.{ExecutionMode, QueryContext, QueryTransactionalContext}
-import org.neo4j.cypher.internal.util.v3_4.{CypherExecutionException, TaskCloser}
+import org.neo4j.cypher.internal.util.v3_4.CypherExecutionException
 import org.neo4j.cypher.internal.v3_4.codegen.QueryExecutionTracer
 import org.neo4j.graphdb.Direction
 import org.neo4j.internal.kernel.api._
@@ -182,7 +182,6 @@ object Templates {
             MethodReference.constructorReference(typeRef[RelationshipDataExtractor]))
 
   def constructor(classHandle: ClassHandle) = MethodTemplate.constructor(
-    param[TaskCloser]("closer"),
     param[QueryContext]("queryContext"),
     param[ExecutionMode]("executionMode"),
     param[Provider[InternalPlanDescription]]("description"),
@@ -190,7 +189,6 @@ object Templates {
 
     param[MapValue]("params")).
     invokeSuper().
-    put(self(classHandle), typeRef[TaskCloser], "closer", load("closer", typeRef[TaskCloser])).
     put(self(classHandle), typeRef[QueryContext], "queryContext", load("queryContext", typeRef[QueryContext])).
     put(self(classHandle), typeRef[ExecutionMode], "executionMode", load("executionMode", typeRef[ExecutionMode])).
     put(self(classHandle), typeRef[Provider[InternalPlanDescription]], "description", load("description", typeRef[InternalPlanDescription])).

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_4/GeneratedMethodStructureTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_4/GeneratedMethodStructureTest.scala
@@ -34,8 +34,8 @@ import org.neo4j.cypher.internal.runtime.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.runtime.{ExecutionMode, QueryContext}
 import org.neo4j.cypher.internal.spi.v3_4.codegen.GeneratedQueryStructure.typeRef
 import org.neo4j.cypher.internal.spi.v3_4.codegen.{GeneratedMethodStructure, Methods, _}
+import org.neo4j.cypher.internal.util.v3_4.symbols
 import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
-import org.neo4j.cypher.internal.util.v3_4.{TaskCloser, symbols}
 import org.neo4j.cypher.internal.v3_4.codegen.QueryExecutionTracer
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection
 import org.neo4j.internal.kernel.api.helpers.RelationshipSelectionCursor
@@ -228,7 +228,6 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
     implicit val context = new CodeGenContext(SemanticTable(), Map.empty)
     val clazz = using(codeGen.generateClass(packageName, "Test")) { body =>
       val fields = Fields(
-        closer = body.field(typeRef[TaskCloser], "closer"),
         entityAccessor = body.field(typeRef[EmbeddedProxySPI], "proxySpi"),
         executionMode = body.field(typeRef[ExecutionMode], "executionMode"),
         description = body.field(typeRef[Provider[InternalPlanDescription]], "description"),

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/ir/CodeGenSugar.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/ir/CodeGenSugar.scala
@@ -29,12 +29,11 @@ import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.{CompiledEx
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan.Provider
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanConstructionTestSupport
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.SemanticTable
-import org.neo4j.cypher.internal.planner.v3_4.spi.PlanningAttributes.{Cardinalities, ReadOnlies}
 import org.neo4j.cypher.internal.planner.v3_4.spi.{CostBasedPlannerName, GraphStatistics, PlanContext}
 import org.neo4j.cypher.internal.runtime.interpreted.TransactionBoundQueryContext.IndexSearchMonitor
 import org.neo4j.cypher.internal.runtime.interpreted.{TransactionBoundQueryContext, TransactionalContextWrapper}
-import org.neo4j.cypher.internal.runtime.{ExecutionMode, InternalExecutionResult, NormalMode, QueryContext}
 import org.neo4j.cypher.internal.runtime.planDescription.InternalPlanDescription
+import org.neo4j.cypher.internal.runtime.{ExecutionMode, InternalExecutionResult, NormalMode, QueryContext}
 import org.neo4j.cypher.internal.spi.v3_4.codegen.GeneratedQueryStructure
 import org.neo4j.cypher.internal.util.v3_4.TaskCloser
 import org.neo4j.cypher.internal.util.v3_4.attribution.Id
@@ -45,8 +44,8 @@ import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.graphdb.Result.{ResultRow, ResultVisitor}
 import org.neo4j.internal.kernel.api.Transaction.Type
 import org.neo4j.kernel.GraphDatabaseQueryService
-import org.neo4j.kernel.api.security.AnonymousContext
 import org.neo4j.kernel.api.Statement
+import org.neo4j.kernel.api.security.AnonymousContext
 import org.neo4j.kernel.impl.coreapi.PropertyContainerLocker
 import org.neo4j.kernel.impl.query.Neo4jTransactionalContextFactory
 import org.neo4j.kernel.impl.query.clientconnection.ClientConnectionInfo
@@ -137,7 +136,7 @@ trait CodeGenSugar extends MockitoSugar with LogicalPlanConstructionTestSupport 
                   provider: Provider[InternalPlanDescription] = null,
                   queryExecutionTracer: QueryExecutionTracer = QueryExecutionTracer.NONE,
                   params: MapValue = EMPTY_MAP): InternalExecutionResult = {
-    val generated = clazz.execute(taskCloser, queryContext,
+    val generated = clazz.execute(queryContext,
                                   executionMode, provider, queryExecutionTracer, params)
     new CompiledExecutionResult(taskCloser, queryContext, generated, provider)
   }

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
       -Dorg.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.CHECK_NATIVE_ACCESS=true
       -Dorg.neo4j.io.pagecache.impl.muninn.usePreciseCursorErrorStackTraces=true
       -Dorg.neo4j.kernel.impl.api.KernelStatement.trackStatements=true
+      -Dorg.org.neo4j.kernel.impl.newapi.DefaultCursors.trackCursors=true
       -XX:+UnlockExperimentalVMOptions -XX:+TrustFinalNonStaticFields ${java9.exports} ${test.runner.jvm.settings.additional}
     </test.runner.jvm.settings>
     <jetty.version>9.4.8.v20171121</jetty.version>


### PR DESCRIPTION
Running tests with cursor-tracking enabled spotted a couple of places where we don't close cursors

- Compiled runtime in the happy path 😞 
- Compiled runtime, cursors were closed after the transaction was already closed
- When we use the `withAnyOpenQueryContext` resources weren't closed
- For the compiled runtime we need to keep track of the QueryContext resources since compiled runtime use the QueryContext for `dumpToString`
- Also add a feature toggle so we can run tests with tracking enabled easily