### PR TITLE
Fixed thread stickiness condition and add a couple of tests

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
@@ -378,7 +378,11 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
 
     public boolean shouldStickOnThread()
     {
-        return state == State.STREAMING || statementProcessor().hasTransaction();
+        // Currently, we're doing our best to keep things together
+        // We should not switch threads when there's an active statement (executing/streaming)
+        // Also, we're currently sticking to the thread when there's an open transaction due to
+        // cursor errors we receive when a transaction is picked up by another thread linearly.
+        return statementProcessor().hasTransaction() || statementProcessor().hasOpenStatement();
     }
 
     public boolean hasOpenStatement()

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineTest.java
@@ -22,6 +22,7 @@ package org.neo4j.bolt.v1.runtime;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import org.neo4j.bolt.v1.runtime.spi.BoltResult;
@@ -420,6 +421,123 @@ public class TransactionStateMachineTest
         }
     }
 
+    @Test
+    public void shouldCloseResultHandlesWhenExecutionFails() throws Exception
+    {
+        KernelTransaction transaction = newTransaction();
+        TransactionStateMachine.BoltResultHandle resultHandle = newResultHandle( new RuntimeException( "some error" ) );
+        TransactionStateMachineSPI stateMachineSPI = newTransactionStateMachineSPI( transaction, resultHandle );
+        TransactionStateMachine stateMachine = newTransactionStateMachine( stateMachineSPI );
+
+        try
+        {
+            stateMachine.run( "SOME STATEMENT", null );
+
+            fail( "exception expected" );
+        }
+        catch ( RuntimeException t )
+        {
+            assertEquals( t.getMessage(), "some error" );
+        }
+
+        assertNull( stateMachine.ctx.currentResultHandle );
+        assertNull( stateMachine.ctx.currentResult );
+    }
+
+    @Test
+    public void shouldCloseResultHandlesWhenConsumeFails() throws Exception
+    {
+        KernelTransaction transaction = newTransaction();
+        TransactionStateMachineSPI stateMachineSPI = newTransactionStateMachineSPI( transaction );
+        TransactionStateMachine stateMachine = newTransactionStateMachine( stateMachineSPI );
+
+        stateMachine.run( "SOME STATEMENT", null );
+
+        assertNotNull( stateMachine.ctx.currentResultHandle );
+        assertNotNull( stateMachine.ctx.currentResult );
+
+        try
+        {
+            stateMachine.streamResult( boltResult ->
+            {
+                throw new RuntimeException( "some error" );
+            } );
+
+            fail( "exception expected" );
+        }
+        catch ( RuntimeException t )
+        {
+            assertEquals( t.getMessage(), "some error" );
+        }
+
+        assertNull( stateMachine.ctx.currentResultHandle );
+        assertNull( stateMachine.ctx.currentResult );
+    }
+
+    @Test
+    public void shouldCloseResultHandlesWhenExecutionFailsInExplicitTransaction() throws Exception
+    {
+        KernelTransaction transaction = newTransaction();
+        TransactionStateMachine.BoltResultHandle resultHandle = newResultHandle( new RuntimeException( "some error" ) );
+        TransactionStateMachineSPI stateMachineSPI = newTransactionStateMachineSPI( transaction, resultHandle );
+        TransactionStateMachine stateMachine = newTransactionStateMachine( stateMachineSPI );
+
+        try
+        {
+            stateMachine.run( "BEGIN", ValueUtils.asMapValue( Collections.emptyMap() ) );
+            stateMachine.streamResult( boltResult ->
+            {
+
+            });
+            stateMachine.run( "SOME STATEMENT", null );
+
+            fail( "exception expected" );
+        }
+        catch ( RuntimeException t )
+        {
+            assertEquals( t.getMessage(), "some error" );
+        }
+
+        assertNull( stateMachine.ctx.currentResultHandle );
+        assertNull( stateMachine.ctx.currentResult );
+    }
+
+    @Test
+    public void shouldCloseResultHandlesWhenConsumeFailsInExplicitTransaction() throws Exception
+    {
+        KernelTransaction transaction = newTransaction();
+        TransactionStateMachineSPI stateMachineSPI = newTransactionStateMachineSPI( transaction );
+        TransactionStateMachine stateMachine = newTransactionStateMachine( stateMachineSPI );
+
+        stateMachine.run( "BEGIN", ValueUtils.asMapValue( Collections.emptyMap() ) );
+        stateMachine.streamResult( boltResult ->
+        {
+
+        });
+        stateMachine.run( "SOME STATEMENT", null );
+
+        assertNotNull( stateMachine.ctx.currentResultHandle );
+        assertNotNull( stateMachine.ctx.currentResult );
+
+        try
+        {
+            stateMachine.streamResult( boltResult ->
+            {
+                throw new RuntimeException( "some error" );
+            } );
+
+            fail( "exception expected" );
+        }
+        catch ( RuntimeException t )
+        {
+            assertEquals( t.getMessage(), "some error" );
+        }
+
+        assertNull( stateMachine.ctx.currentResultHandle );
+        assertNull( stateMachine.ctx.currentResult );
+    }
+
+
     private static KernelTransaction newTransaction()
     {
         KernelTransaction transaction = mock( KernelTransaction.class );
@@ -471,11 +589,31 @@ public class TransactionStateMachineTest
         return stateMachineSPI;
     }
 
+    private static TransactionStateMachineSPI newTransactionStateMachineSPI( KernelTransaction transaction,
+            TransactionStateMachine.BoltResultHandle resultHandle ) throws KernelException
+    {
+        TransactionStateMachineSPI stateMachineSPI = mock( TransactionStateMachineSPI.class );
+
+        when( stateMachineSPI.beginTransaction( any() ) ).thenReturn( transaction );
+        when( stateMachineSPI.executeQuery( any(), any(), anyString(), any(), any() ) ).thenReturn( resultHandle );
+
+        return stateMachineSPI;
+    }
+
     private static TransactionStateMachine.BoltResultHandle newResultHandle() throws KernelException
     {
         TransactionStateMachine.BoltResultHandle resultHandle = mock( TransactionStateMachine.BoltResultHandle.class );
 
         when( resultHandle.start() ).thenReturn( BoltResult.EMPTY );
+
+        return resultHandle;
+    }
+
+    private static TransactionStateMachine.BoltResultHandle newResultHandle( Throwable t ) throws KernelException
+    {
+        TransactionStateMachine.BoltResultHandle resultHandle = mock( TransactionStateMachine.BoltResultHandle.class );
+
+        when( resultHandle.start() ).thenThrow( t );
 
         return resultHandle;
     }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineTest.java
@@ -537,7 +537,6 @@ public class TransactionStateMachineTest
         assertNull( stateMachine.ctx.currentResult );
     }
 
-
     private static KernelTransaction newTransaction()
     {
         KernelTransaction transaction = mock( KernelTransaction.class );


### PR DESCRIPTION
In its initial version, thread stickiness of a bolt connection was decided based on the condition
```java
state == State.STREAMING || statementProcessor().hasTransaction()
```
which was causing problems when the state machine is interrupted with a `RESET` message. Now, the condition is changed to
```java
statementProcessor().hasTransaction() || statementProcessor().hasOpenStatement()
```
which delegates the decision to actual statement processor that knows of both active transaction and statement (result) handle.