### PR TITLE
Default to do sequential bg flushing in importer

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
@@ -129,7 +129,7 @@ public interface Configuration
      */
     default boolean sequentialBackgroundFlushing()
     {
-        return !parallelRecordReadsWhenWriting();
+        return true;
     }
 
     /**


### PR DESCRIPTION
Since it benefits basically all use cases.

It was optimistically recently changed to be disabled in high-io environments, but done so from too little investigation/measurements.