### PR TITLE
Fix slotted execution context mergeWith

### DIFF
--- a/community/cypher/util-3.4/src/main/java/org/neo4j/cypher/internal/util/v3_4/AssertionRunner.java
+++ b/community/cypher/util-3.4/src/main/java/org/neo4j/cypher/internal/util/v3_4/AssertionRunner.java
@@ -46,4 +46,11 @@ public class AssertionRunner
     {
         void apply();
     }
+
+    public static boolean isAssertionsEnabled()
+    {
+        boolean assertionsEnabled = false;
+        assert assertionsEnabled = true;
+        return assertionsEnabled;
+    }
 }

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/AssertionUtils.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/AssertionUtils.scala
@@ -24,4 +24,6 @@ object AssertionUtils {
       override def apply() = f
     })
   }
+
+  def assertionsEnabled = AssertionRunner.isAssertionsEnabled
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/JoinAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/JoinAcceptanceTest.scala
@@ -89,6 +89,44 @@ class JoinAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSu
       planComparisonStrategy = ComparePlansWithAssertion(_ should useOperators("NodeRightOuterHashJoin"), Configs.AllRulePlanners + Configs.BackwardsCompatibility))
   }
 
+  test("should handle node left outer hash join with different types for the node variable") {
+    val a = createLabeledNode(Map[String, Any]("name" -> "a"), "A")
+    createLabeledNode(Map[String, Any]("name" -> "a2"), "A")
+    for(i <- 0 until 50) { // This number is sensitive in that it has to exceed the cardinality estimation of the UNWIND
+      val b = createLabeledNode(Map[String, Any]("name" -> s"${i}b"), "B")
+      if(i != 0) relate(a, b)
+    }
+
+    val query = """MATCH (a:A)
+                  |UNWIND [a] as refA
+                  |OPTIONAL MATCH (refA)-->(b:B)
+                  |USING JOIN ON refA
+                  |RETURN a.name, b.name""".stripMargin
+
+    val expectSucceed = Configs.Interpreted - Configs.Cost2_3 - Configs.Cost3_1
+    executeWith(expectSucceed, query,
+      planComparisonStrategy = ComparePlansWithAssertion(_ should useOperators("NodeLeftOuterHashJoin"), expectPlansToFail))
+  }
+
+  test("should handle node right outer hash join with different types for the node variable") {
+    val b = createLabeledNode(Map[String, Any]("name" -> "b"), "B")
+    createLabeledNode(Map[String, Any]("name" -> "b2"), "B")
+    for(i <- 0 until 10) {
+      val a = createLabeledNode(Map[String, Any]("name" -> s"${i}a"), "A")
+      if(i == 0) relate(a, b)
+    }
+
+    val query = """MATCH (a:A)
+                  |UNWIND [a] as refA
+                  |OPTIONAL MATCH (refA)-->(b:B)
+                  |USING JOIN ON refA
+                  |RETURN a.name, b.name""".stripMargin
+
+    val expectSucceed = Configs.Interpreted - Configs.Cost2_3 - Configs.Cost3_1
+    val result = executeWith(expectSucceed, query,
+      planComparisonStrategy = ComparePlansWithAssertion(_ should useOperators("NodeRightOuterHashJoin"), Configs.AllRulePlanners + Configs.BackwardsCompatibility))
+  }
+
   test("optional match join should not crash") {
     val query =
       """MATCH (a:A)-->(b:B)-->(c:C)

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/SlottedPipeBuilder.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/SlottedPipeBuilder.scala
@@ -99,7 +99,18 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
       case (key, slot) =>
         val getter = SlottedPipeBuilderUtils.makeGetValueFromSlotFunctionFor(slot)
         val setter = SlottedPipeBuilderUtils.makeSetValueInSlotFunctionFor(slot)
-        slots.updateAccessorFunctions(key, getter, setter)
+        val primitiveNodeSetter =
+          if (slot.typ.isAssignableFrom(CTNode))
+            Some(SlottedPipeBuilderUtils.makeSetPrimitiveNodeInSlotFunctionFor(slot))
+          else
+            None
+        val primitiveRelationshipSetter =
+          if (slot.typ.isAssignableFrom(CTRelationship))
+            Some(SlottedPipeBuilderUtils.makeSetPrimitiveRelationshipInSlotFunctionFor(slot))
+          else
+            None
+
+       slots.updateAccessorFunctions(key, getter, setter, primitiveNodeSetter, primitiveRelationshipSetter)
     }
   }
 


### PR DESCRIPTION
Make SlottedExecutionContext mergeWith work between long slots
and ref slots. This is needed for some plans with outer hash join.

- Generate primitive node/relationship setters in slot configuration
- Check violation of assignment of null to non-nullable slot if
assertions are enabled

Fixes #11067