### PR TITLE
Skip HA tests in normal builds, run them only when requested

### DIFF
--- a/enterprise/ha/pom.xml
+++ b/enterprise/ha/pom.xml
@@ -50,6 +50,48 @@
     </license>
   </licenses>
 
+  <profiles>
+    <profile>
+      <id>test-ha</id>
+      <activation>
+        <property>
+          <name>test-ha</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>false</skipTests>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <skipTests>false</skipTests>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skipTests>true</skipTests>
+          </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.neo4j</groupId>


### PR DESCRIPTION
HA skips tests by default, by properly setting the surefire plugin.
This, in turn, is overriden by a new profile enabled with the -Dtest-ha
option from the command line. The result is that a normal

mvn clean install

for example will run all tests except HA and a

mvn clean install -Dtest-ha -DskipTests will skip all tests except
fof HA.