### PR TITLE
Default port fix for backup

### DIFF
--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/OnlineBackupContextBuilder.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/OnlineBackupContextBuilder.java
@@ -61,7 +61,7 @@ class OnlineBackupContextBuilder
 
     static final String ARG_NAME_BACKUP_SOURCE = "from";
     static final String ARG_DESC_BACKUP_SOURCE = "Host and port of Neo4j.";
-    static final String ARG_DFLT_BACKUP_SOURCE = "localhost:6362";
+    static final String ARG_DFLT_BACKUP_SOURCE = "";
 
     static final String ARG_NAME_TIMEOUT = "timeout";
     static final String ARG_DESC_TIMEOUT =

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupHelpOutput.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupHelpOutput.java
@@ -64,8 +64,7 @@ public class BackupHelpOutput
         lines.add( "  --name=<graph.db-backup>                 Name of backup. If a backup with this" );
         lines.add( "                                           name already exists an incremental" );
         lines.add( "                                           backup will be attempted." );
-        lines.add( "  --from=<address>                         Host and port of Neo4j." );
-        lines.add( "                                           [default:localhost:6362]" );
+        lines.add( "  --from=<address>                         Host and port of Neo4j. [default:]" );
         lines.add( "  --fallback-to-full=<true|false>          If an incremental backup fails backup" );
         lines.add( "                                           will move the old backup to" );
         lines.add( "                                           <name>.err.<N> and fallback to a full" );

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupCommandCcIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupCommandCcIT.java
@@ -109,7 +109,7 @@ public class OnlineBackupCommandCcIT
 
         assertEquals(
                 0,
-                runBackupToolFromOtherJvmToGetExitCode( "--from", customAddress,
+                runBackupToolFromOtherJvmToGetExitCode( "--from=" + customAddress,
                         "--cc-report-dir=" + backupDir,
                         "--backup-dir=" + backupDir,
                         "--name=defaultport" ) );
@@ -118,7 +118,7 @@ public class OnlineBackupCommandCcIT
         createSomeData( cluster );
         assertEquals(
                 0,
-                runBackupToolFromOtherJvmToGetExitCode( "--from", customAddress,
+                runBackupToolFromOtherJvmToGetExitCode( "--from=" + customAddress,
                         "--cc-report-dir=" + backupDir,
                         "--backup-dir=" + backupDir,
                         "--name=defaultport" ) );
@@ -142,7 +142,7 @@ public class OnlineBackupCommandCcIT
 
         // then backup is successful
         String address = TestHelpers.backupAddressCc( clusterLeader( cluster ).database() );
-        assertEquals( 0, runBackupToolFromOtherJvmToGetExitCode( "--from", address, "--cc-report-dir=" + backupDir, "--backup-dir=" + backupDir,
+        assertEquals( 0, runBackupToolFromOtherJvmToGetExitCode( "--from=" + address, "--cc-report-dir=" + backupDir, "--backup-dir=" + backupDir,
                 "--name=defaultport" ) );
     }
 

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupCommandTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupCommandTest.java
@@ -163,8 +163,7 @@ public class OnlineBackupCommandTest
                             "  --name=<graph.db-backup>                 Name of backup. If a backup with this%n" +
                             "                                           name already exists an incremental%n" +
                             "                                           backup will be attempted.%n" +
-                            "  --from=<address>                         Host and port of Neo4j.%n" +
-                            "                                           [default:localhost:6362]%n" +
+                            "  --from=<address>                         Host and port of Neo4j. [default:]%n" +
                             "  --fallback-to-full=<true|false>          If an incremental backup fails backup%n" +
                             "                                           will move the old backup to%n" +
                             "                                           <name>.err.<N> and fallback to a full%n" +


### PR DESCRIPTION
CC and HA use different protocols on different ports for performing backups
Because of this the default port is different for the service that is being backed up from
To establish which default is correct it needs to evaluate just before connecting
The reason it is failing is because that code looks at the value of the parameter and sees that it isn't empty. The default value of the argument is "localhost:6362" which looks like the user had typed it in.