### PR TITLE
Optimize slotted runtime result production

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/CypherAdapterStream.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/CypherAdapterStream.java
@@ -46,14 +46,12 @@ class CypherAdapterStream extends BoltResult
 {
     private final QueryResult delegate;
     private final String[] fieldNames;
-    private CypherAdapterRecord currentRecord;
     private final Clock clock;
 
     CypherAdapterStream( QueryResult delegate, Clock clock )
     {
         this.delegate = delegate;
         this.fieldNames = delegate.fieldNames();
-        this.currentRecord = new CypherAdapterRecord( fieldNames.length );
         this.clock = clock;
     }
 
@@ -75,7 +73,7 @@ class CypherAdapterStream extends BoltResult
         long start = clock.millis();
         delegate.accept( row ->
         {
-            visitor.visit( currentRecord.reset( row ) );
+            visitor.visit( row );
             return true;
         } );
         visitor.addMetadata( "result_consumed_after", longValue( clock.millis() - start ) );
@@ -144,29 +142,6 @@ class CypherAdapterStream extends BoltResult
 
         default:
             return queryType.name();
-        }
-    }
-
-    //TODO is this copy necessary
-    private static class CypherAdapterRecord implements QueryResult.Record
-    {
-        private final AnyValue[] fields; // This exists solely to avoid re-creating a new array for each record
-
-        private CypherAdapterRecord( int size )
-        {
-            this.fields = new AnyValue[size];
-        }
-
-        @Override
-        public AnyValue[] fields()
-        {
-            return fields;
-        }
-
-        public CypherAdapterRecord reset( QueryResult.Record cypherRecord )
-        {
-            System.arraycopy( cypherRecord.fields(), 0, this.fields, 0, this.fields.length );
-            return this;
         }
     }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/PipeExecutionResult.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/PipeExecutionResult.scala
@@ -109,7 +109,11 @@ class PipeExecutionResult(val result: ResultIterator,
 
   def accept[EX <: Exception](visitor: QueryResultVisitor[EX]): Unit = {
     try {
-      javaValues.feedIteratorToVisitable(result.map(r => fieldNames.map(r))).accept(visitor)
+      val maybeRecordIterator = result.recordIterator
+      if (maybeRecordIterator.isDefined)
+        javaValues.feedQueryResultRecordIteratorToVisitable(maybeRecordIterator.get).accept(visitor)
+      else
+        javaValues.feedIteratorToVisitable(result.map(r => fieldNames.map(r))).accept(visitor)
     } finally {
       self.close()
     }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ResultIterator.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ResultIterator.scala
@@ -20,12 +20,14 @@
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime
 
 import org.neo4j.cypher.internal.util.v3_4.{CypherException, TaskCloser}
+import org.neo4j.cypher.result.QueryResult
 import org.neo4j.values.AnyValue
 
 trait ResultIterator extends Iterator[collection.Map[String, AnyValue]] {
   def toEager: EagerResultIterator
   def wasMaterialized: Boolean
   def close()
+  def recordIterator: Option[Iterator[QueryResult.Record]] = None
 }
 
 class EagerResultIterator(result: ResultIterator) extends ResultIterator {
@@ -102,4 +104,13 @@ class ClosingIterator(inner: Iterator[collection.Map[String, AnyValue]],
     case e: CypherException =>
       throw exceptionDecorator(e)
   }
+}
+
+class ClosingQueryResultRecordIterator(inner: Iterator[collection.Map[String, AnyValue]],
+                                       closer: TaskCloser,
+                                       exceptionDecorator: CypherException => CypherException)
+  extends ClosingIterator(inner, closer, exceptionDecorator) {
+
+  override def recordIterator =
+    Some(this.asInstanceOf[Iterator[QueryResult.Record]])
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/DefaultExecutionResultBuilderFactory.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/DefaultExecutionResultBuilderFactory.scala
@@ -118,11 +118,7 @@ abstract class BaseExecutionResultBuilderFactory(pipeInfo: PipeInfo,
 
     protected def queryContext = maybeQueryContext.get
 
-    private def buildResultIterator(results: Iterator[ExecutionContext], isUpdating: Boolean): ResultIterator = {
-      val closingIterator = new ClosingIterator(results, taskCloser, exceptionDecorator)
-      val resultIterator = if (isUpdating) closingIterator.toEager else closingIterator
-      resultIterator
-    }
+    protected def buildResultIterator(results: Iterator[ExecutionContext], isUpdating: Boolean): ResultIterator
 
     private def buildDescriptor(planDescription: () => InternalPlanDescription, verifyProfileReady: () => Unit): () => InternalPlanDescription =
       pipeDecorator.decorate(planDescription, verifyProfileReady)
@@ -155,6 +151,12 @@ case class InterpretedExecutionResultBuilderFactory(pipeInfo: PipeInfo,
     override def createQueryState(params: MapValue) = {
       new QueryState(queryContext, externalResource, params, pipeDecorator,
         triadicState = mutable.Map.empty, repeatableReads = mutable.Map.empty)
+    }
+
+    override def buildResultIterator(results: Iterator[ExecutionContext], isUpdating: Boolean): ResultIterator = {
+      val closingIterator = new ClosingIterator(results, taskCloser, exceptionDecorator)
+      val resultIterator = if (isUpdating) closingIterator.toEager else closingIterator
+      resultIterator
     }
   }
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ExecutionContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ExecutionContext.scala
@@ -36,6 +36,10 @@ object ExecutionContext {
 }
 
 trait ExecutionContext extends MutableMap[String, AnyValue] {
+  // For instance caching
+  def release(): Unit // Release for possible reuse by an instance cache
+  def reset(): Unit   // Clean up internal state for reuse
+
   def copyTo(target: ExecutionContext, fromLongOffset: Int = 0, fromRefOffset: Int = 0, toLongOffset: Int = 0, toRefOffset: Int = 0): Unit
   def copyFrom(input: ExecutionContext, nLongs: Int, nRefs: Int): Unit
   def setLongAt(offset: Int, value: Long): Unit
@@ -80,7 +84,7 @@ case class MapExecutionContext(m: MutableMap[String, AnyValue])
   override def getRefAt(offset: Int): AnyValue = fail()
   override def refs(): Array[AnyValue] = fail()
 
-  private def fail(): Nothing = throw new InternalException("Tried using a map context as a primitive context")
+  private def fail(): Nothing = throw new InternalException("Tried using a map context as a slotted context")
 
   override def get(key: String): Option[AnyValue] = m.get(key)
 
@@ -172,4 +176,8 @@ case class MapExecutionContext(m: MutableMap[String, AnyValue])
       case Some(Values.NO_VALUE) => true
       case _ => false
     }
+
+  override def release(): Unit = ()
+
+  override def reset(): Unit = ()
 }

--- a/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/result/QueryResult.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/result/QueryResult.java
@@ -43,6 +43,7 @@ public interface QueryResult
     interface Record
     {
         AnyValue[] fields();
+        default void releaseMe() {}
     }
 
     QueryExecutionType executionType();

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/RuntimeJavaValueConverter.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/RuntimeJavaValueConverter.scala
@@ -57,6 +57,17 @@ class RuntimeJavaValueConverter(skip: Any => Boolean) {
     }
   }
 
+  case class feedQueryResultRecordIteratorToVisitable[EX <: Exception](recordIterator: Iterator[Record]) {
+    def accept(visitor: QueryResultVisitor[EX]) = {
+      var continue = true
+      while (continue && recordIterator.hasNext) {
+        val row = recordIterator.next()
+        continue = visitor.visit(row)
+        row.releaseMe()
+      }
+    }
+  }
+
   private class ResultRecord extends Record {
     var _fields: Array[AnyValue] = Array.empty
     override def fields(): Array[AnyValue] = _fields

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/MorselExecutionContext.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/MorselExecutionContext.scala
@@ -76,4 +76,8 @@ class MorselExecutionContext(morsel: Morsel, longsPerRow: Int, refsPerRow: Int, 
   override def boundEntities(materializeNode: Long => AnyValue, materializeRelationship: Long => AnyValue): Map[String, AnyValue] = ???
 
   override def isNull(key: String): Boolean = ???
+
+  override def release(): Unit = ()
+
+  override def reset(): Unit = ()
 }

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotConfiguration.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotConfiguration.scala
@@ -153,7 +153,7 @@ object SlotConfiguration {
   */
 class SlotConfiguration(private val slots: mutable.Map[String, Slot],
                         var numberOfLongs: Int,
-                        var numberOfReferences: Int) {
+                        var numberOfReferences: Int) extends ExecutionContextInstanceCache[SlotConfiguration, ExecutionContext] {
 
   private val aliases: mutable.Set[String] = mutable.Set()
   private val slotAliases = new mutable.HashMap[Slot, mutable.Set[String]] with mutable.MultiMap[Slot, String]
@@ -219,6 +219,8 @@ class SlotConfiguration(private val slots: mutable.Map[String, Slot],
           LongSlot(offset, nullable, newSlot.typ)
         case ((RefSlot(offset, nullable, _), false, true)) =>
           RefSlot(offset, nullable, newSlot.typ)
+        case _ =>
+          existingSlot // This should never happen but it eliminates a warning
       }
       replaceExistingSlot(key, existingSlot, modifiedSlot);
     }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/SlottedPipeBuilder.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/SlottedPipeBuilder.scala
@@ -543,7 +543,7 @@ object SlottedPipeBuilder {
       throw new InternalException(s"Do not know how to project $slot")
   }
 
-  type RowMapping = (ExecutionContext, QueryState) => ExecutionContext
+  type RowMapping = (ExecutionContext, QueryState, ExecutionContextFactory) => ExecutionContext
 
   //compute mapping from incoming to outgoing pipe line, the slot order may differ
   //between the output and the input (lhs and rhs) and it may be the case that
@@ -566,7 +566,7 @@ object SlottedPipeBuilder {
 
     //If we overlap we can just pass the result right through
     if (overlaps) {
-      (incoming: ExecutionContext, _: QueryState) =>
+      (incoming: ExecutionContext, _: QueryState, _: ExecutionContextFactory) =>
         incoming
     }
     else {
@@ -590,9 +590,10 @@ object SlottedPipeBuilder {
           }
       }
       //Create a new context and apply all transformations
-      (incoming: ExecutionContext, state: QueryState) =>
-        val outgoing = SlottedExecutionContext(out)
+      (incoming: ExecutionContext, state: QueryState, factory: ExecutionContextFactory) =>
+        val outgoing = factory.newExecutionContext()
         mapSlots.foreach(f => f(incoming, outgoing, state))
+        incoming.release()
         outgoing
     }
 

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/SlottedQueryState.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/SlottedQueryState.scala
@@ -57,11 +57,13 @@ class SlottedQueryState(query: QueryContext,
 }
 
 case class SlottedExecutionContextFactory(slots: SlotConfiguration) extends ExecutionContextFactory {
+  slots.setExecutionContextConstructor(SlottedExecutionContext.apply)
+
   override def newExecutionContext(m: mutable.Map[String, AnyValue] = MutableMaps.empty): ExecutionContext =
     throw new UnsupportedOperationException("Please implement")
 
   override def newExecutionContext(): ExecutionContext =
-    SlottedExecutionContext(slots)
+    slots.allocateExecutionContext
 
   override def copyWith(row: ExecutionContext): ExecutionContext = {
     val newCtx = SlottedExecutionContext(slots)

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/AbstractHashJoinPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/AbstractHashJoinPipe.scala
@@ -55,8 +55,9 @@ abstract class AbstractHashJoinPipe[Key, T](left: Pipe,
         val matchesFromLhs: mutable.Seq[ExecutionContext] = table.getOrElse(joinKey, mutable.MutableList.empty)
 
         matchesFromLhs.map { lhs =>
-          val newRow = SlottedExecutionContext(slots)
+          val newRow = executionContextFactory.newExecutionContext().asInstanceOf[SlottedExecutionContext]
           lhs.copyTo(newRow)
+          lhs.release()
           copyDataFromRhs(newRow, rhs)
           newRow
         }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/AllNodesScanSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/AllNodesScanSlottedPipe.scala
@@ -34,7 +34,7 @@ case class AllNodesScanSlottedPipe(ident: String, slots: SlotConfiguration, argu
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     PrimitiveLongHelper.map(state.query.nodeOps.allPrimitive, { nodeId =>
-      val context = SlottedExecutionContext(slots)
+      val context = executionContextFactory.newExecutionContext()
       state.copyArgumentStateTo(context, argumentSize.nLongs, argumentSize.nReferences)
       context.setLongAt(offset, nodeId)
       context

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/CartesianProductSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/CartesianProductSlottedPipe.scala
@@ -36,11 +36,13 @@ case class CartesianProductSlottedPipe(lhs: Pipe, rhs: Pipe,
       lhsCtx =>
         rhs.createResults(state) map {
           rhsCtx =>
-            val context = SlottedExecutionContext(slots)
+            val context = executionContextFactory.newExecutionContext()
             lhsCtx.copyTo(context)
+            lhsCtx.release()
             rhsCtx.copyTo(context,
               fromLongOffset = argumentSize.nLongs, fromRefOffset = argumentSize.nReferences, // Skip over arguments since they should be identical to lhsCtx
-              toLongOffset = lhsLongCount, toRefOffset = lhsRefCount)
+            toLongOffset = lhsLongCount, toRefOffset = lhsRefCount)
+            rhsCtx.release()
             context
         }
     }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/CartesianProductSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/CartesianProductSlottedPipe.scala
@@ -41,7 +41,7 @@ case class CartesianProductSlottedPipe(lhs: Pipe, rhs: Pipe,
             lhsCtx.release()
             rhsCtx.copyTo(context,
               fromLongOffset = argumentSize.nLongs, fromRefOffset = argumentSize.nReferences, // Skip over arguments since they should be identical to lhsCtx
-            toLongOffset = lhsLongCount, toRefOffset = lhsRefCount)
+              toLongOffset = lhsLongCount, toRefOffset = lhsRefCount)
             rhsCtx.release()
             context
         }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ConditionalApplySlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ConditionalApplySlottedPipe.scala
@@ -42,11 +42,13 @@ case class ConditionalApplySlottedPipe(lhs: Pipe,
 
         if (condition(lhsContext)) {
           val rhsState = state.withInitialContext(lhsContext)
+          lhsContext.release()
           rhs.createResults(rhsState)
         }
         else {
-          val output = SlottedExecutionContext(slots)
+          val output = executionContextFactory.newExecutionContext()
           lhsContext.copyTo(output)
+          lhsContext.release()
           Iterator.single(output)
         }
     }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/DistinctSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/DistinctSlottedPipe.scala
@@ -61,8 +61,9 @@ case class DistinctSlottedPipe(source: Pipe,
                                       state: QueryState): Iterator[ExecutionContext] = {
     // For each incoming row, run expression and put it into the correct slot in the context
     val result = input.map(incoming => {
-      val outgoing = SlottedExecutionContext(slots)
+      val outgoing = executionContextFactory.newExecutionContext()
       groupingSetInSlotFunctions.foreach { _(incoming, state, outgoing) }
+      incoming.release()
       outgoing
     })
 

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/EagerSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/EagerSlottedPipe.scala
@@ -31,8 +31,9 @@ case class EagerSlottedPipe(source: Pipe, slots: SlotConfiguration)(val id: Id =
   override protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     input.map { inputRow =>
       // this is necessary because Eager is the beginning of a new pipeline
-      val outputRow = SlottedExecutionContext(slots)
+      val outputRow = executionContextFactory.newExecutionContext()
       inputRow.copyTo(outputRow)
+      inputRow.release()
       outputRow
     }.toIndexedSeq.iterator
   }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ExpandAllSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ExpandAllSlottedPipe.scala
@@ -70,8 +70,9 @@ case class ExpandAllSlottedPipe(source: Pipe,
 
           PrimitiveLongHelper.map(relationships, relId => {
             relationships.relationshipVisit(relId, relVisitor)
-            val outputRow = SlottedExecutionContext(slots)
+            val outputRow = executionContextFactory.newExecutionContext()
             inputRow.copyTo(outputRow)
+            inputRow.release()
             outputRow.setLongAt(relOffset, relId)
             outputRow.setLongAt(toOffset, otherSide)
             outputRow

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ExpandIntoSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ExpandIntoSlottedPipe.scala
@@ -76,8 +76,9 @@ case class ExpandIntoSlottedPipe(source: Pipe,
             .getOrElse(findRelationships(state.query, fromNode, toNode, relCache, dir, lazyTypes.types(state.query)))
 
           PrimitiveLongHelper.map(relationships, (relId: Long) => {
-            val outputRow = SlottedExecutionContext(slots)
+            val outputRow = executionContextFactory.newExecutionContext()
             inputRow.copyTo(outputRow)
+            inputRow.release()
             outputRow.setLongAt(relOffset, relId)
             outputRow
           })

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/NodeIndexScanSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/NodeIndexScanSlottedPipe.scala
@@ -51,7 +51,7 @@ case class NodeIndexScanSlottedPipe(ident: String,
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     val nodes = state.query.indexScanPrimitive(reference(state.query))
     PrimitiveLongHelper.map(nodes, { node =>
-      val context = SlottedExecutionContext(slots)
+      val context = executionContextFactory.newExecutionContext()
       state.copyArgumentStateTo(context, argumentSize.nLongs, argumentSize.nReferences)
       context.setLongAt(offset, node)
       context

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/NodeIndexSeekSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/NodeIndexSeekSlottedPipe.scala
@@ -62,7 +62,7 @@ case class NodeIndexSeekSlottedPipe(ident: String,
     val baseContext = state.createOrGetInitialContext(executionContextFactory)
     val resultNodes = indexQuery(valueExpr, baseContext, state, index, label.name, propertyKeys.map(_.name))
     resultNodes.map { node =>
-      val context = SlottedExecutionContext(slots)
+      val context = executionContextFactory.newExecutionContext()
       state.copyArgumentStateTo(context, argumentSize.nLongs, argumentSize.nReferences)
       context.setLongAt(offset, node.id)
       context

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/NodesByLabelScanSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/NodesByLabelScanSlottedPipe.scala
@@ -38,7 +38,7 @@ case class NodesByLabelScanSlottedPipe(ident: String,
     label.getOptId(state.query) match {
       case Some(labelId) =>
         PrimitiveLongHelper.map(state.query.getNodesByLabelPrimitive(labelId.id), { nodeId =>
-          val context = SlottedExecutionContext(slots)
+          val context = executionContextFactory.newExecutionContext()
           state.copyArgumentStateTo(context, argumentSize.nLongs, argumentSize.nReferences)
           context.setLongAt(offset, nodeId)
           context

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/OptionalSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/OptionalSlottedPipe.scala
@@ -53,7 +53,7 @@ case class OptionalSlottedPipe(source: Pipe,
     }
 
   private def notFoundExecutionContext(state: QueryState): ExecutionContext = {
-    val context = SlottedExecutionContext(slots)
+    val context = executionContextFactory.newExecutionContext()
     state.copyArgumentStateTo(context, argumentSize.nLongs, argumentSize.nReferences)
     setNullableSlotsToNull(context)
     context

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ProduceResultSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ProduceResultSlottedPipe.scala
@@ -21,23 +21,23 @@ package org.neo4j.cypher.internal.runtime.slotted.pipes
 
 import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Expression
 import org.neo4j.cypher.internal.runtime.interpreted.pipes._
-import org.neo4j.cypher.internal.runtime.interpreted.{ExecutionContext, MutableMaps}
+import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
+import org.neo4j.cypher.internal.runtime.slotted.ArrayResultExecutionContextFactory
 import org.neo4j.cypher.internal.util.v3_4.attribution.Id
 
 case class ProduceResultSlottedPipe(source: Pipe, columns: Seq[(String, Expression)])
                                    (val id: Id = Id.INVALID_ID) extends PipeWithSource(source) with Pipe {
+  val resultFactory = ArrayResultExecutionContextFactory(columns)
+
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     // do not register this pipe as parent as it does not do anything except filtering of already fetched
     // key-value pairs and thus should not have any stats
 
     input.map {
       original =>
-        val m = MutableMaps.create(columns.size)
-        columns.foreach {
-          case (name, exp) => m.put(name, exp(original, state))
-        }
-
-        ExecutionContext(m)
+        val result = resultFactory.newResult(original, state)
+        original.release()
+        result
     }
   }
 }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/UnionSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/UnionSlottedPipe.scala
@@ -37,9 +37,9 @@ case class UnionSlottedPipe(lhs: Pipe, rhs: Pipe,
       override def hasNext: Boolean = left.hasNext || right.hasNext
       override def next(): ExecutionContext =
         if (left.hasNext)
-          lhsMapping(left.next(), state)
+          lhsMapping(left.next(), state, executionContextFactory)
         else
-          rhsMapping(right.next(), state)
+          rhsMapping(right.next(), state, executionContextFactory)
     }
   }
 }

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/NodeHashJoinSlottedPipeTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/NodeHashJoinSlottedPipeTest.scala
@@ -25,6 +25,7 @@ import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.runtime.slotted.pipes.HashJoinSlottedPipeTestHelper.{RowL, mockPipeFor, testableResult}
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.Pipe
 import org.neo4j.cypher.internal.runtime.interpreted.{ExecutionContext, QueryStateHelper}
+import org.neo4j.cypher.internal.runtime.slotted.SlottedExecutionContextFactory
 import org.neo4j.cypher.internal.util.v3_4.symbols._
 import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 
@@ -42,8 +43,11 @@ class NodeHashJoinSlottedPipeTest extends CypherFunSuite {
     val left = mockPipeFor(slots, RowL(node1), RowL(node2))
     val right = mockPipeFor(slots, RowL(node2), RowL(node3))
 
+    val nodeHashJoinPipe = NodeHashJoinSlottedPipe(Array(0), Array(0), left, right, slots, Array(), Array())()
+    nodeHashJoinPipe.setExecutionContextFactory(SlottedExecutionContextFactory(slots))
+
     // when
-    val result = NodeHashJoinSlottedPipe(Array(0), Array(0), left, right, slots, Array(), Array())().createResults(queryState)
+    val result = nodeHashJoinPipe.createResults(queryState)
 
     // then
     val list: Iterator[ExecutionContext] = result
@@ -83,9 +87,11 @@ class NodeHashJoinSlottedPipeTest extends CypherFunSuite {
       RowL(NULL, node2, node4)
     )
 
+    val nodeHashJoinPipe = NodeHashJoinSlottedPipe(Array(0, 1), Array(0, 1), left, right, hashSlots, Array((2, 3)), Array())()
+    nodeHashJoinPipe.setExecutionContextFactory(SlottedExecutionContextFactory(hashSlots))
+
     // when
-    val result = NodeHashJoinSlottedPipe(Array(0, 1), Array(0, 1), left, right, hashSlots, Array((2, 3)), Array())().
-      createResults(queryState)
+    val result = nodeHashJoinPipe.createResults(queryState)
 
     // then
     testableResult(result, hashSlots).toSet should equal(Set(
@@ -107,9 +113,11 @@ class NodeHashJoinSlottedPipeTest extends CypherFunSuite {
 
     val right = mock[Pipe]
 
+    val nodeHashJoinPipe = NodeHashJoinSlottedPipe(Array(0, 1), Array(0, 1), left, right, slots, Array(), Array())()
+    nodeHashJoinPipe.setExecutionContextFactory(SlottedExecutionContextFactory(slots))
+
     // when
-    val result = NodeHashJoinSlottedPipe(Array(0, 1), Array(0, 1), left, right, slots, Array(), Array())().
-      createResults(queryState)
+    val result = nodeHashJoinPipe.createResults(queryState)
 
     // then
     result should be(empty)
@@ -126,9 +134,11 @@ class NodeHashJoinSlottedPipeTest extends CypherFunSuite {
     val left = mockPipeFor(slots, RowL(NULL))
     val right = mockPipeFor(slots, RowL(node0))
 
+    val nodeHashJoinPipe = NodeHashJoinSlottedPipe(Array(0, 1), Array(0, 1), left, right, slots, Array(), Array())()
+    nodeHashJoinPipe.setExecutionContextFactory(SlottedExecutionContextFactory(slots))
+
     // when
-    val result = NodeHashJoinSlottedPipe(Array(0, 1), Array(0, 1), left, right, slots, Array(), Array())().
-      createResults(queryState)
+    val result = nodeHashJoinPipe.createResults(queryState)
 
     // then
     result should be(empty)

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/UnionSlottedPipeTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/UnionSlottedPipeTest.scala
@@ -25,7 +25,7 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.{LongSlot, SlotConfiguration}
 import org.neo4j.cypher.internal.runtime.interpreted.QueryStateHelper
-import org.neo4j.cypher.internal.runtime.slotted.SlottedExecutionContext
+import org.neo4j.cypher.internal.runtime.slotted.{SlottedExecutionContext, SlottedExecutionContextFactory}
 import org.neo4j.cypher.internal.runtime.slotted.SlottedPipeBuilder.computeUnionMapping
 import org.neo4j.cypher.internal.runtime.{Operations, QueryContext}
 import org.neo4j.cypher.internal.util.v3_4.symbols._
@@ -47,6 +47,7 @@ class UnionSlottedPipeTest extends CypherFunSuite {
     val lhs = FakeSlottedPipe(lhsData.toIterator, lhsSlots)
     val rhs = FakeSlottedPipe(rhsData.toIterator, rhsSlots)
     val union = UnionSlottedPipe(lhs, rhs, computeUnionMapping(lhsSlots, out), computeUnionMapping(rhsSlots, out) )()
+    union.setExecutionContextFactory(SlottedExecutionContextFactory(out))
     val context = mock[QueryContext]
     val nodeOps = mock[Operations[NodeValue]]
     when(nodeOps.getById(any())).thenAnswer(new Answer[NodeValue] {

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/UnwindSlottedPipeTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/UnwindSlottedPipeTest.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.runtime.slotted.pipes
 
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.runtime.interpreted.QueryStateHelper
-import org.neo4j.cypher.internal.runtime.slotted.SlottedExecutionContext
+import org.neo4j.cypher.internal.runtime.slotted.{SlottedExecutionContext, SlottedExecutionContextFactory}
 import org.neo4j.cypher.internal.runtime.slotted.expressions.ReferenceFromSlot
 import org.neo4j.cypher.internal.util.v3_4.symbols._
 import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
@@ -46,6 +46,7 @@ class UnwindSlottedPipeTest extends CypherFunSuite {
 
     val source = FakeSlottedPipe(data.toIterator, inputPipeline)
     val unwindPipe = UnwindSlottedPipe(source, ReferenceFromSlot(x), y, outputPipeline)()
+    unwindPipe.setExecutionContextFactory(SlottedExecutionContextFactory(outputPipeline))
     unwindPipe.createResults(QueryStateHelper.empty).map {
       case c: SlottedExecutionContext =>
         Map("x" -> c.getRefAt(x), "y" -> c.getRefAt(y))

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ValueHashJoinSlottedPipeTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ValueHashJoinSlottedPipeTest.scala
@@ -24,6 +24,7 @@ import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.runtime.interpreted.QueryStateHelper
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.Pipe
+import org.neo4j.cypher.internal.runtime.slotted.SlottedExecutionContextFactory
 import org.neo4j.cypher.internal.runtime.slotted.expressions.ReferenceFromSlot
 import org.neo4j.cypher.internal.runtime.slotted.pipes.HashJoinSlottedPipeTestHelper.{Longs, Refs, RowR, RowRL, mockPipeFor, testableResult}
 import org.neo4j.cypher.internal.util.v3_4.symbols._
@@ -52,6 +53,8 @@ class ValueHashJoinSlottedPipeTest extends CypherFunSuite {
     )
 
     val pipe = ValueHashJoinSlottedPipe(ReferenceFromSlot(0), ReferenceFromSlot(0), left, right, slotInfoForJoin, 0, 1, SlotConfiguration.Size.zero)()
+    pipe.setExecutionContextFactory(SlottedExecutionContextFactory(slotInfoForJoin))
+
     // when
     val result = pipe.createResults(queryState)
 
@@ -85,6 +88,8 @@ class ValueHashJoinSlottedPipeTest extends CypherFunSuite {
     )
 
     val pipe = ValueHashJoinSlottedPipe(ReferenceFromSlot(0), ReferenceFromSlot(0), left, right, slotInfoForJoin, 0, 2, SlotConfiguration.Size.zero)()
+    pipe.setExecutionContextFactory(SlottedExecutionContextFactory(slotInfoForJoin))
+
     // when
     val result = pipe.createResults(queryState)
 
@@ -109,6 +114,7 @@ class ValueHashJoinSlottedPipeTest extends CypherFunSuite {
 
     val right = mock[Pipe]
     val pipe = ValueHashJoinSlottedPipe(ReferenceFromSlot(0), ReferenceFromSlot(0), left, right, slotInfo, 0, 1, SlotConfiguration.Size.zero)()
+    pipe.setExecutionContextFactory(SlottedExecutionContextFactory(slotInfo))
 
     // when
     val result = pipe.createResults(queryState)
@@ -129,6 +135,7 @@ class ValueHashJoinSlottedPipeTest extends CypherFunSuite {
     val right = mockPipeFor(slotInfo, RowR(intValue(42)))
 
     val pipe = ValueHashJoinSlottedPipe(ReferenceFromSlot(0), ReferenceFromSlot(0), left, right, slotInfo, 0, 1, SlotConfiguration.Size.zero)()
+    pipe.setExecutionContextFactory(SlottedExecutionContextFactory(slotInfo))
 
     // when
     val result = pipe.createResults(queryState)
@@ -166,6 +173,7 @@ class ValueHashJoinSlottedPipeTest extends CypherFunSuite {
 
     val pipe = ValueHashJoinSlottedPipe(ReferenceFromSlot(1), ReferenceFromSlot(1), left, right, slotInfoForJoin,
       longOffset = 1, refsOffset = 2, SlotConfiguration.Size(1, 1))()
+    pipe.setExecutionContextFactory(SlottedExecutionContextFactory(slotInfoForJoin))
 
     // when
     val result = pipe.createResults(queryState)


### PR DESCRIPTION
Make ProduceResultSlottedPipe return an iterator that can materialize
the results directly into an array of columns that can be consumed by
Bolt directly without going through a generic Map interface.
This lets us avoid unnecessary copies and hash map creations.

- Introduce an ArrayResultExecutionContext that implements
QueryResult.Record, and stores the columns in an ordered array
for fast direct consumption, with support for the old Map interface
as a secondary concern.

Use instance caches for slotted execution contexts to reduce the
overhead of object creation and initialization.

- Introduce an instance cache for slotted execution contexts
which reuses one instance per slot configuration.
For many lazy pipeline stages one instance should be all it ever needs.

- Use an instance cache also for the ArrayResultExecutionContext