### PR TITLE
removed unused class

### DIFF
--- a/community/cypher/cypher-logical-plans-3.3/src/main/scala/org/neo4j/cypher/internal/v3_3/logical/plans/QueryExpression.scala
+++ b/community/cypher/cypher-logical-plans-3.3/src/main/scala/org/neo4j/cypher/internal/v3_3/logical/plans/QueryExpression.scala
@@ -33,10 +33,6 @@ trait SingleExpression[+T] {
   def expressions = Seq(expression)
 }
 
-case class ScanQueryExpression[T](expression: T) extends QueryExpression[T] with SingleExpression[T] {
-  def map[R](f: T => R) = ScanQueryExpression(f(expression))
-}
-
 case class SingleQueryExpression[T](expression: T) extends QueryExpression[T] with SingleExpression[T] {
   def map[R](f: T => R) = SingleQueryExpression(f(expression))
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/EntityProducerFactory.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/EntityProducerFactory.scala
@@ -26,7 +26,6 @@ import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes.{EntityProduce
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.Argument
 import org.neo4j.cypher.internal.compiler.v3_3.spi.PlanContext
 import org.neo4j.cypher.internal.frontend.v3_3.{IndexHintException, InternalException}
-import org.neo4j.cypher.internal.v3_3.logical.plans.ScanQueryExpression
 import org.neo4j.graphdb.{Node, PropertyContainer, Relationship}
 
 class EntityProducerFactory extends GraphElementPropertyFunctions {
@@ -71,17 +70,6 @@ class EntityProducerFactory extends GraphElementPropertyFunctions {
   }
 
   def nodeByIndexHint(readOnly: Boolean): PartialFunction[(PlanContext, StartItem), EntityProducer[Node]] = {
-    case (planContext, startItem @ SchemaIndex(variable, labelName, propertyNames, AnyIndex, Some(ScanQueryExpression(_)), _)) =>
-
-      val indexGetter = planContext.indexGet(labelName, propertyNames)
-
-      val index = indexGetter getOrElse
-        (throw new IndexHintException(variable, labelName, propertyNames, "No such index found."))
-
-      asProducer[Node](startItem) { (m: ExecutionContext, state: QueryState) =>
-        val resultNodes: Iterator[Node] = state.query.indexScan(index)
-        resultNodes
-      }
 
     case (planContext, startItem @ SchemaIndex(variable, labelName, propertyNames, AnyIndex, valueExp, _)) =>
 


### PR DESCRIPTION
Scans are handled by NodeScanPipe, which doesn't use QueryExpressions. We want to remove it in 3.3 because otherwise we have to support it in 3.4 due to legacy 3.3 support.