### PR TITLE
Backup enabled setting tied to transaction protocol in CC

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupServer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupServer.java
@@ -115,7 +115,7 @@ public class CatchupServer extends LifecycleAdapter
                           Supplier<TransactionIdStore> transactionIdStoreSupplier,
                           Supplier<LogicalTransactionStore> logicalTransactionStoreSupplier,
                           Supplier<NeoStoreDataSource> dataSourceSupplier, BooleanSupplier dataSourceAvailabilitySupplier,
-                          CoreSnapshotService snapshotService, Config config, Monitors monitors, Supplier<CheckPointer> checkPointerSupplier,
+                          CoreSnapshotService snapshotService, Monitors monitors, Supplier<CheckPointer> checkPointerSupplier,
                           FileSystemAbstraction fs, PageCache pageCache, ListenSocketAddress listenAddress,
                           StoreCopyCheckPointMutex storeCopyCheckPointMutex, PipelineWrapper pipelineWrapper )
     {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupServer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupServer.java
@@ -116,12 +116,12 @@ public class CatchupServer extends LifecycleAdapter
                           Supplier<LogicalTransactionStore> logicalTransactionStoreSupplier,
                           Supplier<NeoStoreDataSource> dataSourceSupplier, BooleanSupplier dataSourceAvailabilitySupplier,
                           CoreSnapshotService snapshotService, Config config, Monitors monitors, Supplier<CheckPointer> checkPointerSupplier,
-                          FileSystemAbstraction fs, PageCache pageCache,
+                          FileSystemAbstraction fs, PageCache pageCache, ListenSocketAddress listenAddress,
                           StoreCopyCheckPointMutex storeCopyCheckPointMutex, PipelineWrapper pipelineWrapper )
     {
         this.snapshotService = snapshotService;
         this.storeCopyCheckPointMutex = storeCopyCheckPointMutex;
-        this.listenAddress = config.get( CausalClusteringSettings.transaction_listen_address );
+        this.listenAddress = listenAddress;
         this.transactionIdStoreSupplier = transactionIdStoreSupplier;
         this.storeIdSupplier = storeIdSupplier;
         this.dataSourceAvailabilitySupplier = dataSourceAvailabilitySupplier;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/RaftServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/RaftServerModule.java
@@ -107,6 +107,7 @@ class RaftServerModule
         platformModule.life.add( raftServer ); // must start before core state so that it can trigger snapshot downloads when necessary
         platformModule.life.add( coreServerModule.createCoreLife( messageHandlerChain ) );
         platformModule.life.add( coreServerModule.catchupServer() ); // must start last and stop first, since it handles external requests
+        coreServerModule.backupCatchupServer().ifPresent( platformModule.life::add );
         platformModule.life.add( coreServerModule.downloadService() );
 
         return raftServer;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/TransactionBackupServiceProvider.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/TransactionBackupServiceProvider.java
@@ -19,9 +19,9 @@
  */
 package org.neo4j.causalclustering.core;
 
+import java.util.Optional;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
-import javax.annotation.Nullable;
 
 import org.neo4j.causalclustering.catchup.CatchupServer;
 import org.neo4j.causalclustering.catchup.CheckpointerSupplier;
@@ -68,19 +68,19 @@ public class TransactionBackupServiceProvider
         this.serverPipelineWrapper = serverPipelineWrapper;
     }
 
-    public @Nullable CatchupServer resolveIfBackupEnabled( Config config )
+    public Optional<CatchupServer> resolveIfBackupEnabled( Config config )
     {
         if ( config.get( OnlineBackupSettings.online_backup_enabled ) )
         {
-            return new CatchupServer( logProvider, userLogProvider, localDatabaseStoreIdSupplier,
+            return Optional.of( new CatchupServer( logProvider, userLogProvider, localDatabaseStoreIdSupplier,
                     platformModule.dependencies.provideDependency( TransactionIdStore.class ),
                     platformModule.dependencies.provideDependency( LogicalTransactionStore.class ), localDatabaseDataSourceSupplier, localDatabaseIsAvailable,
                     coreSnapshotService, platformModule.monitors, new CheckpointerSupplier( platformModule.dependencies ), fileSystem, platformModule.pageCache,
-                    backupAddressForTxProtocol( config ), platformModule.storeCopyCheckPointMutex, serverPipelineWrapper );
+                    backupAddressForTxProtocol( config ), platformModule.storeCopyCheckPointMutex, serverPipelineWrapper ) );
         }
         else
         {
-            return null;
+            return Optional.empty();
         }
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/TransactionBackupServiceProvider.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/TransactionBackupServiceProvider.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core;
+
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+
+import org.neo4j.causalclustering.catchup.CatchupServer;
+import org.neo4j.causalclustering.catchup.CheckpointerSupplier;
+import org.neo4j.causalclustering.core.state.CoreSnapshotService;
+import org.neo4j.causalclustering.handlers.PipelineWrapper;
+import org.neo4j.causalclustering.identity.StoreId;
+import org.neo4j.helpers.AdvertisedSocketAddress;
+import org.neo4j.helpers.HostnamePort;
+import org.neo4j.helpers.ListenSocketAddress;
+import org.neo4j.helpers.SocketAddressParser;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.NeoStoreDataSource;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.enterprise.configuration.OnlineBackupSettings;
+import org.neo4j.kernel.impl.factory.PlatformModule;
+import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+import org.neo4j.logging.LogProvider;
+
+public class TransactionBackupServiceProvider
+{
+    private final LogProvider logProvider;
+    private final LogProvider userLogProvider;
+    private final Supplier<StoreId> localDatabaseStoreIdSupplier;
+    private final PlatformModule platformModule;
+    private final Supplier<NeoStoreDataSource> localDatabaseDataSourceSupplier;
+    private final BooleanSupplier localDatabaseIsAvailable;
+    private final CoreSnapshotService coreSnapshotService;
+    private final FileSystemAbstraction fileSystem;
+    private final PipelineWrapper serverPipelineWrapper;
+
+    public TransactionBackupServiceProvider( LogProvider logProvider, LogProvider userLogProvider, Supplier<StoreId> localDatabaseStoreIdSupplier,
+            PlatformModule platformModule, Supplier<NeoStoreDataSource> localDatabaseDataSourceSupplier, BooleanSupplier localDatabaseIsAvailable,
+            CoreSnapshotService coreSnapshotService, FileSystemAbstraction fileSystem, PipelineWrapper serverPipelineWrapper )
+    {
+        this.logProvider = logProvider;
+        this.userLogProvider = userLogProvider;
+        this.localDatabaseStoreIdSupplier = localDatabaseStoreIdSupplier;
+        this.platformModule = platformModule;
+        this.localDatabaseDataSourceSupplier = localDatabaseDataSourceSupplier;
+        this.localDatabaseIsAvailable = localDatabaseIsAvailable;
+        this.coreSnapshotService = coreSnapshotService;
+        this.fileSystem = fileSystem;
+        this.serverPipelineWrapper = serverPipelineWrapper;
+    }
+
+    public @Nullable CatchupServer resolveIfBackupEnabled( Config config )
+    {
+        if ( config.get( OnlineBackupSettings.online_backup_enabled ) )
+        {
+            return new CatchupServer( logProvider, userLogProvider, localDatabaseStoreIdSupplier,
+                    platformModule.dependencies.provideDependency( TransactionIdStore.class ),
+                    platformModule.dependencies.provideDependency( LogicalTransactionStore.class ), localDatabaseDataSourceSupplier, localDatabaseIsAvailable,
+                    coreSnapshotService, platformModule.monitors, new CheckpointerSupplier( platformModule.dependencies ), fileSystem, platformModule.pageCache,
+                    backupAddressForTxProtocol( config ), platformModule.storeCopyCheckPointMutex, serverPipelineWrapper );
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    private static ListenSocketAddress backupAddressForTxProtocol( Config config )
+    {
+        // We cannot use the backup address setting directly as IPv6 isn't processed during config read
+        String settingName = OnlineBackupSettings.online_backup_server.name();
+        String literalValue = config.getRaw( settingName ).orElse( OnlineBackupSettings.online_backup_server.getDefaultValue() );
+        HostnamePort resolvedValueFromConfig = config.get( OnlineBackupSettings.online_backup_server );
+        String defaultHostname = resolvedValueFromConfig.getHost();
+        Integer defaultPort = resolvedValueFromConfig.getPort();
+        AdvertisedSocketAddress advertisedSocketAddress =
+                SocketAddressParser.deriveSocketAddress( settingName, literalValue, defaultHostname, defaultPort, AdvertisedSocketAddress::new );
+        return new ListenSocketAddress( advertisedSocketAddress.getHostname(), advertisedSocketAddress.getPort() );
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
@@ -80,7 +80,7 @@ public class CoreServerModule
 
     public final MembershipWaiterLifecycle membershipWaiterLifecycle;
     private final CatchupServer catchupServer;
-    private final CatchupServer backupCatchupServer;
+    private final Optional<CatchupServer> backupCatchupServer;
     private final IdentityModule identityModule;
     private final CoreStateMachinesModule coreStateMachinesModule;
     private final ConsensusModule consensusModule;
@@ -175,7 +175,7 @@ public class CoreServerModule
         dependencies.satisfyDependency( catchupServer );
 
         servicesToStopOnStoreCopy.add( catchupServer );
-        Optional.ofNullable( backupCatchupServer ).ifPresent( servicesToStopOnStoreCopy::add );
+        backupCatchupServer.ifPresent( servicesToStopOnStoreCopy::add );
     }
 
     private CoreStateDownloader createCoreStateDownloader( LifeSupport servicesToStopOnStoreCopy )
@@ -215,7 +215,7 @@ public class CoreServerModule
 
     public Optional<CatchupServer> backupCatchupServer()
     {
-        return Optional.ofNullable( backupCatchupServer );
+        return backupCatchupServer;
     }
 
     public CoreLife createCoreLife( LifecycleMessageHandler<RaftMessages.ReceivedInstantClusterIdAwareMessage<?>> handler )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
@@ -115,6 +115,7 @@ import org.neo4j.storageengine.api.StorageEngine;
 import org.neo4j.time.Clocks;
 import org.neo4j.udc.UsageData;
 
+import static org.neo4j.causalclustering.core.server.CoreServerModule.asCCAddress;
 import static org.neo4j.causalclustering.discovery.ResolutionResolverFactory.chooseResolver;
 
 /**
@@ -281,7 +282,12 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
                         platformModule.dependencies.provideDependency( TransactionIdStore.class ),
                         platformModule.dependencies.provideDependency( LogicalTransactionStore.class ), localDatabase::dataSource, localDatabase::isAvailable,
                         null, config, platformModule.monitors, new CheckpointerSupplier( platformModule.dependencies ), fileSystem, pageCache,
-                        platformModule.storeCopyCheckPointMutex, serverPipelineWrapper );
+                        config.get( CausalClusteringSettings.transaction_listen_address ), platformModule.storeCopyCheckPointMutex, serverPipelineWrapper );
+        CatchupServer backupCatchupServer = new CatchupServer( logProvider, userLogProvider, localDatabase::storeId,
+                platformModule.dependencies.provideDependency( TransactionIdStore.class ),
+                platformModule.dependencies.provideDependency( LogicalTransactionStore.class ), localDatabase::dataSource, localDatabase::isAvailable,
+                null, config, platformModule.monitors, new CheckpointerSupplier( platformModule.dependencies ), fileSystem, platformModule.pageCache,
+                asCCAddress( config.get( OnlineBackupSettings.online_backup_server ) ), platformModule.storeCopyCheckPointMutex, serverPipelineWrapper );
 
         servicesToStopOnStoreCopy.add( catchupServer );
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
@@ -287,7 +287,7 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
         TransactionBackupServiceProvider transactionBackupServiceProvider =
                 new TransactionBackupServiceProvider( logProvider, userLogProvider, localDatabase::storeId, platformModule, localDatabase::dataSource,
                         localDatabase::isAvailable, null, fileSystem, serverPipelineWrapper );
-        Optional<CatchupServer> backupCatchupServer = Optional.ofNullable( transactionBackupServiceProvider.resolveIfBackupEnabled( config ) );
+        Optional<CatchupServer> backupCatchupServer = transactionBackupServiceProvider.resolveIfBackupEnabled( config );
 
         servicesToStopOnStoreCopy.add( catchupServer );
         backupCatchupServer.ifPresent( servicesToStopOnStoreCopy::add );
@@ -296,7 +296,6 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
 
         life.add( catchupServer ); // must start last and stop first, since it handles external requests
         backupCatchupServer.ifPresent( life::add );
-        Optional.ofNullable( transactionBackupServiceProvider.resolveIfBackupEnabled( config ) ).ifPresent( life::add );
     }
 
     protected void configureDiscoveryService( DiscoveryServiceFactory discoveryServiceFactory, Dependencies dependencies,

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
@@ -437,7 +437,6 @@ public class Cluster
                 if ( isTransientFailure( e ) )
                 {
                     // this is not the best, but it helps in debugging
-                    System.err.println( "Transient failure in leader transaction, trying again." );
                     e.printStackTrace();
                     return null;
                 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ConnectionInfoIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ConnectionInfoIT.java
@@ -35,14 +35,13 @@ import org.neo4j.causalclustering.core.state.CoreSnapshotService;
 import org.neo4j.helpers.ListenSocketAddress;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
-import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.StoreCopyCheckPointMutex;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.AssertableLogProvider;
+import org.neo4j.ports.allocation.PortAuthority;
 import org.neo4j.test.causalclustering.ClusterRule;
 
 import static org.mockito.Mockito.mock;
-import static org.neo4j.causalclustering.core.CausalClusteringSettings.transaction_listen_address;
 
 public class ConnectionInfoIT
 {
@@ -65,18 +64,17 @@ public class ConnectionInfoIT
     public void catchupServerMessage() throws Throwable
     {
         // given
-        testSocket = bindPort( "localhost", 4242 );
+        testSocket = bindPort( "localhost", PortAuthority.allocatePort() );
 
         // when
         AssertableLogProvider logProvider = new AssertableLogProvider();
         AssertableLogProvider userLogProvider = new AssertableLogProvider();
         CoreSnapshotService snapshotService = mock( CoreSnapshotService.class );
-        Config config = Config.defaults( transaction_listen_address, ":" + testSocket.getLocalPort() );
-        ListenSocketAddress listenSocketAddress = new ListenSocketAddress( "localhost", testSocket.getPort() );
+        ListenSocketAddress listenSocketAddress = new ListenSocketAddress( "localhost", testSocket.getLocalPort() );
 
         CatchupServer catchupServer =
                 new CatchupServer( logProvider, userLogProvider, mockSupplier(), mockSupplier(), mockSupplier(), mockSupplier(), mock( BooleanSupplier.class ),
-                        snapshotService, config, new Monitors(), mock( CheckpointerSupplier.class ), mock( FileSystemAbstraction.class ),
+                        snapshotService, new Monitors(), mock( CheckpointerSupplier.class ), mock( FileSystemAbstraction.class ),
                         mock( PageCache.class ), listenSocketAddress, new StoreCopyCheckPointMutex(), null );
 
         //then

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ConnectionInfoIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ConnectionInfoIT.java
@@ -32,6 +32,7 @@ import java.util.function.Supplier;
 import org.neo4j.causalclustering.catchup.CatchupServer;
 import org.neo4j.causalclustering.catchup.CheckpointerSupplier;
 import org.neo4j.causalclustering.core.state.CoreSnapshotService;
+import org.neo4j.helpers.ListenSocketAddress;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
@@ -71,12 +72,12 @@ public class ConnectionInfoIT
         AssertableLogProvider userLogProvider = new AssertableLogProvider();
         CoreSnapshotService snapshotService = mock( CoreSnapshotService.class );
         Config config = Config.defaults( transaction_listen_address, ":" + testSocket.getLocalPort() );
+        ListenSocketAddress listenSocketAddress = new ListenSocketAddress( "localhost", testSocket.getPort() );
 
         CatchupServer catchupServer =
-                new CatchupServer( logProvider, userLogProvider, mockSupplier(), mockSupplier(), mockSupplier(),
-                        mockSupplier(), mock( BooleanSupplier.class ), snapshotService, config, new Monitors(),
-                        mock( CheckpointerSupplier.class), mock( FileSystemAbstraction.class ), mock( PageCache.class ),
-                        new StoreCopyCheckPointMutex(), null );
+                new CatchupServer( logProvider, userLogProvider, mockSupplier(), mockSupplier(), mockSupplier(), mockSupplier(), mock( BooleanSupplier.class ),
+                        snapshotService, config, new Monitors(), mock( CheckpointerSupplier.class ), mock( FileSystemAbstraction.class ),
+                        mock( PageCache.class ), listenSocketAddress, new StoreCopyCheckPointMutex(), null );
 
         //then
         try


### PR DESCRIPTION
Before this commit we are reusing the transaction protocol for backups. This is bad because we are needing to expose the cluster unnecessarily.

This PR adds logic that switches on an additional transaction protocol but this time on the backup port. This behaviour resembles 3.3 better.