### PR TITLE
Return Temporal, TemporalAmount in REST endpoint

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/graphdb/SpatialMocks.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/SpatialMocks.java
@@ -139,5 +139,11 @@ public class SpatialMocks
         {
             return crs;
         }
+
+        @Override
+        public String toString()
+        {
+            return geometryType;
+        }
     }
 }

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/Neo4jJsonCodec.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/Neo4jJsonCodec.java
@@ -114,23 +114,14 @@ public class Neo4jJsonCodec extends ObjectMapper
             writeMap( out, genericMap( new LinkedHashMap<>(), "name", crs.getType(), "type", "link", "properties",
                     genericMap( new LinkedHashMap<>(), "href", crs.getHref() + "ogcwkt/", "type", "ogcwkt" ) ) );
         }
-        else if ( value instanceof Temporal )
+        else if ( value instanceof Temporal || value instanceof TemporalAmount )
         {
-            writeObject( out, parseTemporalType( (Temporal) value ), value.toString() );
-        }
-        else if ( value instanceof TemporalAmount )
-        {
-            writeObject( out, Neo4jJsonMetaType.duration, value.toString() );
+            super.writeValue( out, value.toString() );
         }
         else
         {
             super.writeValue( out, value );
         }
-    }
-
-    private void writeObject( JsonGenerator out, Neo4jJsonMetaType type, String value ) throws IOException
-    {
-        writeMap( out, genericMap( new LinkedHashMap<>(), "type", type.name(), "value", value ) );
     }
 
     private void writeMap( JsonGenerator out, Map value ) throws IOException
@@ -280,7 +271,7 @@ public class Neo4jJsonCodec extends ObjectMapper
         }
         else if ( value instanceof Geometry )
         {
-            writeGeometryTypeMeta( out, (Geometry) value );
+            writeObjectMeta( out, parseGeometryType( (Geometry) value ) );
         }
         else if ( value instanceof Temporal )
         {
@@ -296,7 +287,7 @@ public class Neo4jJsonCodec extends ObjectMapper
         }
     }
 
-    private void writeGeometryTypeMeta( JsonGenerator out, Geometry value ) throws IOException
+    private Neo4jJsonMetaType parseGeometryType( Geometry value ) throws IOException
     {
         Neo4jJsonMetaType type = null;
         if ( value instanceof Point )
@@ -308,7 +299,7 @@ public class Neo4jJsonCodec extends ObjectMapper
             throw new IllegalArgumentException(
                     String.format( "Unsupported Geometry type: type=%s, value=%s", value.getClass().getSimpleName(), value ) );
         }
-        writeObjectMeta( out, type );
+        return type;
     }
 
     private Neo4jJsonMetaType parseTemporalType( Temporal value )

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/Neo4jJsonCodec.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/Neo4jJsonCodec.java
@@ -52,7 +52,27 @@ public class Neo4jJsonCodec extends ObjectMapper
 {
     private enum Neo4jJsonMetaType
     {
-        node, relationship, datetime, time, localdatetime, date, localtime, duration, point
+        NODE( "node" ),
+        RELATIONSHIP( "relationship" ),
+        DATE_TIME( "datetime" ),
+        TIME( "time" ),
+        LOCAL_DATE_TIME( "localdatetime" ),
+        DATE( "date" ),
+        LOCAL_TIME( "localtime" ),
+        DURATION( "duration" ),
+        POINT( "point" );
+
+        private final String code;
+
+        Neo4jJsonMetaType( final String code )
+        {
+            this.code = code;
+        }
+
+        String code()
+        {
+            return this.code;
+        }
     }
 
     private TransitionalPeriodTransactionMessContainer container;
@@ -238,7 +258,7 @@ public class Neo4jJsonCodec extends ObjectMapper
             Node node = (Node) value;
             try ( TransactionStateChecker stateChecker = TransactionStateChecker.create( container ) )
             {
-                writeNodeOrRelationshipMeta( out, node.getId(), Neo4jJsonMetaType.node, stateChecker.isNodeDeletedInCurrentTx( node.getId() ) );
+                writeNodeOrRelationshipMeta( out, node.getId(), Neo4jJsonMetaType.NODE, stateChecker.isNodeDeletedInCurrentTx( node.getId() ) );
             }
         }
         else if ( value instanceof Relationship )
@@ -246,7 +266,7 @@ public class Neo4jJsonCodec extends ObjectMapper
             Relationship relationship = (Relationship) value;
             try ( TransactionStateChecker transactionStateChecker = TransactionStateChecker.create( container ) )
             {
-                writeNodeOrRelationshipMeta( out, relationship.getId(), Neo4jJsonMetaType.relationship,
+                writeNodeOrRelationshipMeta( out, relationship.getId(), Neo4jJsonMetaType.RELATIONSHIP,
                         transactionStateChecker.isRelationshipDeletedInCurrentTx( relationship.getId() ) );
             }
         }
@@ -279,7 +299,7 @@ public class Neo4jJsonCodec extends ObjectMapper
         }
         else if ( value instanceof TemporalAmount )
         {
-            writeObjectMeta( out, Neo4jJsonMetaType.duration );
+            writeObjectMeta( out, Neo4jJsonMetaType.DURATION );
         }
         else
         {
@@ -292,7 +312,7 @@ public class Neo4jJsonCodec extends ObjectMapper
         Neo4jJsonMetaType type = null;
         if ( value instanceof Point )
         {
-            type = Neo4jJsonMetaType.point;
+            type = Neo4jJsonMetaType.POINT;
         }
         if ( type == null )
         {
@@ -307,23 +327,23 @@ public class Neo4jJsonCodec extends ObjectMapper
         Neo4jJsonMetaType type = null;
         if ( value instanceof ZonedDateTime )
         {
-            type = Neo4jJsonMetaType.datetime;
+            type = Neo4jJsonMetaType.DATE_TIME;
         }
         else if ( value instanceof LocalDate )
         {
-            type = Neo4jJsonMetaType.date;
+            type = Neo4jJsonMetaType.DATE;
         }
         else if ( value instanceof OffsetTime )
         {
-            type = Neo4jJsonMetaType.time;
+            type = Neo4jJsonMetaType.TIME;
         }
         else if ( value instanceof LocalDateTime )
         {
-            type = Neo4jJsonMetaType.localdatetime;
+            type = Neo4jJsonMetaType.LOCAL_DATE_TIME;
         }
         else if ( value instanceof LocalTime )
         {
-            type = Neo4jJsonMetaType.localtime;
+            type = Neo4jJsonMetaType.LOCAL_TIME;
         }
         if ( type == null )
         {
@@ -356,7 +376,7 @@ public class Neo4jJsonCodec extends ObjectMapper
         out.writeStartObject();
         try
         {
-            out.writeStringField( "type", type.name() );
+            out.writeStringField( "type", type.code() );
         }
         finally
         {
@@ -372,7 +392,7 @@ public class Neo4jJsonCodec extends ObjectMapper
         try
         {
             out.writeNumberField( "id", id );
-            out.writeStringField( "type", type.name() );
+            out.writeStringField( "type", type.code() );
             out.writeBooleanField( "deleted", isDeleted );
         }
         finally

--- a/community/server/src/test/java/org/neo4j/server/rest/AbstractRestFunctionalTestBase.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/AbstractRestFunctionalTestBase.java
@@ -52,6 +52,8 @@ import static org.neo4j.server.rest.web.Surface.PATH_RELATIONSHIPS;
 import static org.neo4j.server.rest.web.Surface.PATH_RELATIONSHIP_INDEX;
 import static org.neo4j.server.rest.web.Surface.PATH_SCHEMA_CONSTRAINT;
 import static org.neo4j.server.rest.web.Surface.PATH_SCHEMA_INDEX;
+import static org.neo4j.test.server.HTTP.POST;
+import static org.neo4j.test.server.HTTP.RawPayload.quotedJson;
 
 public class AbstractRestFunctionalTestBase extends SharedServerTestBase implements GraphHolder
 {
@@ -283,5 +285,17 @@ public class AbstractRestFunctionalTestBase extends SharedServerTestBase impleme
         ConnectorPortRegister connectorPortRegister = server().getDatabase().getGraph().getDependencyResolver()
                 .resolveDependency( ConnectorPortRegister.class );
         return connectorPortRegister.getLocalAddress( "http" ).getPort();
+    }
+
+
+    public static HTTP.Response runQuery( String query )
+    {
+        return POST( txCommitUri(), quotedJson( "{'statements': [{'statement': '" + query + "'}]}" ) );
+    }
+
+    public static void assertNoErrors( HTTP.Response response ) throws JsonParseException
+    {
+        assertEquals( "[]", response.get( "errors" ).toString() );
+        assertEquals( 0, response.get( "errors" ).size() );
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/AbstractRestFunctionalTestBase.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/AbstractRestFunctionalTestBase.java
@@ -282,8 +282,8 @@ public class AbstractRestFunctionalTestBase extends SharedServerTestBase impleme
 
     public static int getLocalHttpPort()
     {
-        ConnectorPortRegister connectorPortRegister = server().getDatabase().getGraph().getDependencyResolver()
-                .resolveDependency( ConnectorPortRegister.class );
+        ConnectorPortRegister connectorPortRegister =
+                server().getDatabase().getGraph().getDependencyResolver().resolveDependency( ConnectorPortRegister.class );
         return connectorPortRegister.getLocalAddress( "http" ).getPort();
     }
 

--- a/community/server/src/test/java/org/neo4j/server/rest/AbstractRestFunctionalTestBase.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/AbstractRestFunctionalTestBase.java
@@ -287,7 +287,6 @@ public class AbstractRestFunctionalTestBase extends SharedServerTestBase impleme
         return connectorPortRegister.getLocalAddress( "http" ).getPort();
     }
 
-
     public static HTTP.Response runQuery( String query )
     {
         return POST( txCommitUri(), quotedJson( "{'statements': [{'statement': '" + query + "'}]}" ) );

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/ExecutionResultSerializerTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/ExecutionResultSerializerTest.java
@@ -471,12 +471,12 @@ public class ExecutionResultSerializerTest extends TxStateCheckerTestSupport
         // then
         String result = output.toString( UTF_8.name() );
         assertEquals( "{\"results\":[{\"columns\":[\"temporal\"],\"data\":[" +
-                        "{\"row\":[{\"type\":\"date\",\"value\":\"2018-03-12\"}],\"meta\":[{\"type\":\"date\"}]}," +
-                        "{\"row\":[{\"type\":\"datetime\",\"value\":\"2018-03-12T13:02:10.000000010+01:00[UTC+01:00]\"}],\"meta\":[{\"type\":\"datetime\"}]}," +
-                        "{\"row\":[{\"type\":\"time\",\"value\":\"12:02:04.000000071Z\"}],\"meta\":[{\"type\":\"time\"}]}," +
-                        "{\"row\":[{\"type\":\"localdatetime\",\"value\":\"2018-03-12T13:02:10.000000010\"}],\"meta\":[{\"type\":\"localdatetime\"}]}," +
-                        "{\"row\":[{\"type\":\"localtime\",\"value\":\"13:02:10.000000010\"}],\"meta\":[{\"type\":\"localtime\"}]}," +
-                        "{\"row\":[{\"type\":\"duration\",\"value\":\"PT12H\"}],\"meta\":[{\"type\":\"duration\"}]}" +
+                        "{\"row\":[\"2018-03-12\"],\"meta\":[{\"type\":\"date\"}]}," +
+                        "{\"row\":[\"2018-03-12T13:02:10.000000010+01:00[UTC+01:00]\"],\"meta\":[{\"type\":\"datetime\"}]}," +
+                        "{\"row\":[\"12:02:04.000000071Z\"],\"meta\":[{\"type\":\"time\"}]}," +
+                        "{\"row\":[\"2018-03-12T13:02:10.000000010\"],\"meta\":[{\"type\":\"localdatetime\"}]}," +
+                        "{\"row\":[\"13:02:10.000000010\"],\"meta\":[{\"type\":\"localtime\"}]}," +
+                        "{\"row\":[\"PT12H\"],\"meta\":[{\"type\":\"duration\"}]}" +
                         "]}],\"errors\":[]}",
                 result );
     }

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/Neo4jJsonCodecTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/Neo4jJsonCodecTest.java
@@ -296,16 +296,4 @@ public class Neo4jJsonCodecTest extends TxStateCheckerTestSupport
         //Then
         verify( jsonGenerator, times( 3 ) ).writeEndObject();
     }
-
-    @Test
-    public void testDateTimeWriting() throws Throwable
-    {
-        // Given
-
-
-
-        // When
-
-        // Then
-    }
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/Neo4jJsonCodecTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/Neo4jJsonCodecTest.java
@@ -296,4 +296,16 @@ public class Neo4jJsonCodecTest extends TxStateCheckerTestSupport
         //Then
         verify( jsonGenerator, times( 3 ) ).writeEndObject();
     }
+
+    @Test
+    public void testDateTimeWriting() throws Throwable
+    {
+        // Given
+
+
+
+        // When
+
+        // Then
+    }
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/PointTypeIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/PointTypeIT.java
@@ -72,13 +72,13 @@ public class PointTypeIT extends AbstractRestFunctionalTestBase
     @Test
     public void shouldReturnPoint2DWithXAndY() throws Exception
     {
-        testPoint( "RETURN point({x: 42.05, y: 90.99})", new double[]{42.05, 90.99}, Cartesian, "point2d" );
+        testPoint( "RETURN point({x: 42.05, y: 90.99})", new double[]{42.05, 90.99}, Cartesian, "point" );
     }
 
     @Test
     public void shouldReturnPoint2DWithLatitudeAndLongitude() throws Exception
     {
-        testPoint( "RETURN point({longitude: 56.7, latitude: 12.78})", new double[]{56.7, 12.78}, WGS84, "point2d" );
+        testPoint( "RETURN point({longitude: 56.7, latitude: 12.78})", new double[]{56.7, 12.78}, WGS84, "point" );
     }
 
     private static void testPoint( String query, double[] expectedCoordinate, CoordinateReferenceSystem expectedCrs, String expectedType ) throws Exception

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TemporalTypeIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TemporalTypeIT.java
@@ -109,8 +109,7 @@ public class TemporalTypeIT extends AbstractRestFunctionalTestBase
         JsonNode data = getSingleData( response );
 
         JsonNode row = getSingle( data, "row" );
-        assertThat( row.get( "creationTime" ).get( "type" ).asText(), equalTo( "localdatetime" ) );
-        assertThat( row.get( "creationTime" ).get( "value" ).asText(), equalTo( "1984-10-21T12:34" ) );
+        assertThat( row.get( "creationTime" ).asText(), equalTo( "1984-10-21T12:34" ) );
         assertThat( row.get( "name" ).asText(), equalTo( "zhen" ) );
 
         JsonNode meta = getSingle( data, "meta" );
@@ -120,8 +119,7 @@ public class TemporalTypeIT extends AbstractRestFunctionalTestBase
     private void assertTemporalEquals( JsonNode data, String value, String type )
     {
         JsonNode row = getSingle( data, "row" );
-        assertThat( row.get( "type" ).asText(), equalTo( type ) );
-        assertThat( row.get( "value" ).asText(), equalTo( value ) );
+        assertThat( row.asText(), equalTo( value ) );
 
         JsonNode meta = getSingle( data, "meta" );
         assertEquals( type, meta.get( "type" ).asText() );

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TemporalTypeIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TemporalTypeIT.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.transactional.integration;
+
+import org.codehaus.jackson.JsonNode;
+import org.junit.Test;
+
+import org.neo4j.server.rest.AbstractRestFunctionalTestBase;
+import org.neo4j.server.rest.domain.JsonParseException;
+import org.neo4j.test.server.HTTP;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+
+public class TemporalTypeIT extends AbstractRestFunctionalTestBase
+{
+    @Test
+    public void shouldWorkWithDateTime() throws Throwable
+    {
+        HTTP.Response response = runQuery( "RETURN datetime({year: 1, month:10, day:2, timezone:\\\"+01:00\\\"})" );
+
+        assertEquals( 200, response.status() );
+        assertNoErrors( response );
+        JsonNode data = getSingleData( response );
+        assertEquals( "0001-10-02T00:00+01:00", getSingle( data, "row" ).asText() );
+        assertEquals( "datetime", getSingle( data, "meta" ).get( "type" ).asText() );
+    }
+
+    @Test
+    public void shouldWorkWithTime() throws Throwable
+    {
+        HTTP.Response response = runQuery( "RETURN time({hour: 23, minute: 19, second: 55, timezone:\\\"-07:00\\\"})" );
+
+        assertEquals( 200, response.status() );
+        assertNoErrors( response );
+        JsonNode data = getSingleData( response );
+        assertEquals( "23:19:55-07:00", getSingle( data, "row" ).asText() );
+        assertEquals( "time", getSingle( data, "meta" ).get( "type" ).asText() );
+    }
+
+    @Test
+    public void shouldWorkWithLocalDateTime() throws Throwable
+    {
+        HTTP.Response response = runQuery( "RETURN localdatetime({year: 1984, month: 10, day: 21, hour: 12, minute: 34})" );
+
+        assertEquals( 200, response.status() );
+        assertNoErrors( response );
+        JsonNode data = getSingleData( response );
+        assertEquals( "1984-10-21T12:34", getSingle( data, "row" ).asText() );
+        assertEquals( "localdatetime", getSingle( data, "meta" ).get( "type" ).asText() );
+    }
+
+    @Test
+    public void shouldWorkWithDate() throws Throwable
+    {
+        HTTP.Response response = runQuery( "RETURN date({year: 1984, month: 10, day: 11})" );
+
+        assertEquals( 200, response.status() );
+        assertNoErrors( response );
+        JsonNode data = getSingleData( response );
+        assertEquals( "1984-10-11", getSingle( data, "row" ).asText() );
+        assertEquals( "date", getSingle( data, "meta" ).get( "type" ).asText() );
+    }
+
+    @Test
+    public void shouldWorkWithLocalTime() throws Throwable
+    {
+        HTTP.Response response = runQuery( "RETURN localtime({hour:12, minute:31, second:14, nanosecond: 645876123})" );
+
+        assertEquals( 200, response.status() );
+        assertNoErrors( response );
+        JsonNode data = getSingleData( response );
+        assertEquals( "12:31:14.645876123", getSingle( data, "row" ).asText() );
+        assertEquals( "localtime", getSingle( data, "meta" ).get( "type" ).asText() );
+    }
+
+    @Test
+    public void shouldWorkWithDuration() throws Throwable
+    {
+        HTTP.Response response = runQuery( "RETURN duration({weeks:2, days:3})" );
+
+        assertEquals( 200, response.status() );
+        assertNoErrors( response );
+        JsonNode data = getSingleData( response );
+        assertEquals( "P17D", getSingle( data, "row" ).asText() );
+        assertEquals( "duration", getSingle( data, "meta" ).get( "type" ).asText() );
+    }
+
+    @Test
+    public void shouldOnlyGetNodeTypeInMetaAsNodeProperties() throws Throwable
+    {
+        HTTP.Response response =
+                runQuery( "CREATE (account {creationTime: localdatetime({year: 1984, month: 10, day: 21, hour: 12, minute: 34})}) RETURN account" );
+
+        assertEquals( 200, response.status() );
+        assertNoErrors( response );
+        JsonNode data = getSingleData( response );
+
+        JsonNode row = getSingle( data, "row" );
+        assertThat( row.get( "creationTime" ).asText(), equalTo( "1984-10-21T12:34" ) );
+
+        JsonNode meta = getSingle( data, "meta" );
+        assertThat( meta.get( "type" ).asText(), equalTo( "node" ) );
+    }
+
+    private static JsonNode getSingleData( HTTP.Response response ) throws JsonParseException
+    {
+        JsonNode data = response.get( "results" ).get( 0 ).get( "data" );
+        assertEquals( 1, data.size() );
+        return data.get( 0 );
+    }
+
+    private static JsonNode getSingle( JsonNode node, String key )
+    {
+        JsonNode data = node.get( key );
+        assertEquals( 1, data.size() );
+        return data.get( 0 );
+    }
+}


### PR DESCRIPTION
Return `Temporal` and `TemporalAmount` as ISO 8601 standard strings from REST endpoint.
Added return type in meta for `Temporal`, `TemporalAmount`, and `Point`.

For example, if the result contains a single `Duration`, the entity of Rest response will be like:
```
{
  "results":[{
    "columns":["d"],
    "data":[{
      "row":["P17D"],
      "meta":[{"type":"duration"}]
    }]
  }],
  "errors":[]
}
```

If the result contains a node who has a property of `LocalDateTime` type, then the return json response would be like
```
{
  "results":[{
    "columns":["account"],
    "data":[{
      "row":[{
        "creationTime": "2000-10-21T12:34",
        "name":"zhen"
      }],
      "meta":[{
        "id":0,
        "type":"node",
        "deleted":false
      }]
    }]
  }],
  "errors":[]
}
```