### PR TITLE
CoreTopologyService constructor visibility change

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
@@ -95,7 +95,7 @@ public class HazelcastCoreTopologyService extends AbstractTopologyService implem
     private Thread startingThread;
     private volatile boolean stopped;
 
-    HazelcastCoreTopologyService( Config config, MemberId myself, JobScheduler jobScheduler,
+    public HazelcastCoreTopologyService( Config config, MemberId myself, JobScheduler jobScheduler,
             LogProvider logProvider, LogProvider userLogProvider, HostnameResolver hostnameResolver,
             TopologyServiceRetryStrategy topologyServiceRetryStrategy )
     {


### PR DESCRIPTION
Reverses a change to make the constructor of `HazelcastCoreTopologyService` package-private, included in https://github.com/neo4j/neo4j/pull/11156 , merged earlier today. This change broke the neo4j-commercial build.