### PR TITLE
Less indirection in result iteration

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/ResultIterator.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/ResultIterator.scala
@@ -22,9 +22,7 @@ package org.neo4j.cypher.internal.compatibility.v3_3.runtime
 import org.neo4j.cypher.internal.frontend.v3_3.CypherException
 import org.neo4j.values.AnyValue
 
-import scala.collection.immutable
-
-trait ResultIterator extends Iterator[immutable.Map[String, AnyValue]] {
+trait ResultIterator extends Iterator[collection.Map[String, AnyValue]] {
   def toEager: EagerResultIterator
   def wasMaterialized: Boolean
   def close()
@@ -53,55 +51,54 @@ class ClosingIterator(inner: Iterator[collection.Map[String, AnyValue]],
 
   override def wasMaterialized = isEmpty
 
-  override def hasNext: Boolean = failIfThrows {
+  override def hasNext: Boolean = {
     if (closer.isClosed) false
     else {
-      val innerHasNext = inner.hasNext
-      if (!innerHasNext) {
-        close(success = true)
+      try {
+        val innerHasNext = inner.hasNext
+        if (!innerHasNext) {
+          close(success = true)
+        }
+        innerHasNext
+      } catch {
+        case t: Throwable => safeClose(t)
       }
-      innerHasNext
     }
   }
 
-  override def next(): Map[String, AnyValue] = failIfThrows {
+  override def next(): collection.Map[String, AnyValue] = {
     if (closer.isClosed) Iterator.empty.next()
+    try {
+      inner.next()
+    } catch {
+      case t: Throwable => safeClose(t)
+    }
+  }
 
-    val value = inner.next()
-    value.toMap
+  private def safeClose(t: Throwable) = {
+    try {
+      close(success = false)
+    } catch {
+      case thrownDuringClose: Throwable =>
+        try {
+          t.addSuppressed(thrownDuringClose)
+        } catch {
+          case _: Throwable => // Ignore
+        }
+    }
+    throw t
   }
 
   override def close() {
     close(success = true)
   }
 
-  private def close(success: Boolean) = decoratedCypherException({
-    closer.close(success)
-  })
-
-  private def failIfThrows[U](f: => U): U = decoratedCypherException({
+  private def close(success: Boolean) = {
     try {
-      f
+      closer.close(success)
     } catch {
-      case t: Throwable =>
-        try {
-          close(success = false)
-        } catch {
-          case thrownDuringClose: Throwable =>
-            try {
-              t.addSuppressed(thrownDuringClose)
-            } catch {
-              case _: Throwable => // Ignore
-            }
-        }
-        throw t
+      case e: CypherException =>
+        throw exceptionDecorator(e)
     }
-  })
-
-  private def decoratedCypherException[U](f: => U): U = try {
-    f
-  } catch {
-    case e: CypherException =>
-      throw exceptionDecorator(e)
   }
 }


### PR DESCRIPTION
We recently added an extra [check](https://github.com/neo4j/neo4j/pull/11036) in the result iterator in order to close procedure streams. The extra check affects the inlining of the `next` method and shows up as a regression in benchmarks. This PR fixes the regression by removing a layer of indirection and makes the methods smaller.