### PR TITLE
3.4 write to beginning store copy

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDisk.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDisk.java
@@ -83,7 +83,7 @@ public class StreamToDisk implements StoreFileStreams
         }
         else
         {
-            try ( OutputStream outputStream = fs.openAsOutputStream( fileName, true ) )
+            try ( OutputStream outputStream = fs.openAsOutputStream( fileName, false ) )
             {
                 outputStream.write( data );
             }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClientTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClientTest.java
@@ -193,25 +193,6 @@ public class StoreCopyClientTest
         subject.copyStoreFiles( catchupAddressProvider, expectedStoreId, expectedStoreFileStreams, continueIndefinitely() );
     }
 
-    @Test
-    public void storeIdMismatchOnCopyIndividualFile() throws StoreCopyFailedException, CatchUpClientException
-    {
-        // given listing response will be successful
-        PrepareStoreCopyResponse prepareStoreCopyResponse = PrepareStoreCopyResponse.success( serverFiles, indexIds, -123L );
-        when( catchUpClient.makeBlockingRequest( any(), any(), any() ) ).thenReturn( prepareStoreCopyResponse );
-
-        // and individual file requests get store id mismatch
-        StoreCopyFinishedResponse individualFileStoreCopyResposne = new StoreCopyFinishedResponse( StoreCopyFinishedResponse.Status.E_STORE_ID_MISMATCH );
-        when( catchUpClient.makeBlockingRequest( any(), any(), any() ) ).thenReturn( prepareStoreCopyResponse, individualFileStoreCopyResposne );
-
-        // then exception denotes store id mismatch
-        expectedException.expect( StoreCopyFailedException.class );
-        expectedException.expectMessage( "Store id mismatch" );
-
-        // when copy is performed
-        subject.copyStoreFiles( catchupAddressProvider, expectedStoreId, expectedStoreFileStreams, continueIndefinitely() );
-    }
-
     private List<CatchUpRequest> getRequests() throws CatchUpClientException
     {
         ArgumentCaptor<CatchUpRequest> fileRequestArgumentCaptor = ArgumentCaptor.forClass( CatchUpRequest.class );


### PR DESCRIPTION
Make sure we always write to beginning during store copy
    
Now, when we can retry files during store copy, we must make sure that we do not append to files that have been partially copied.

Also made store copy failures more lenient by only throwing exception if the status in unrecognized.
