### PR TITLE
Use LocalSlotReferences to close all hanging transaction on pool close.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -172,11 +172,6 @@ public class KernelTransactions extends LifecycleAdapter implements Supplier<Ker
         this.collectionsFactorySupplier = collectionsFactorySupplier;
     }
 
-    public Supplier<ExplicitIndexTransactionState> explicitIndexTxStateSupplier()
-    {
-        return explicitIndexTxStateSupplier;
-    }
-
     public KernelTransaction newInstance( KernelTransaction.Type type, LoginContext loginContext, long timeout )
     {
         assertCurrentThreadIsNotBlockingNewTransactions();
@@ -232,8 +227,8 @@ public class KernelTransactions extends LifecycleAdapter implements Supplier<Ker
     public void disposeAll()
     {
         terminateTransactions();
-        localTxPool.disposeAll();
-        globalTxPool.disposeAll();
+        localTxPool.close();
+        globalTxPool.close();
     }
 
     public void terminateTransactions()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageCommandCreationContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageCommandCreationContext.java
@@ -81,7 +81,7 @@ public class RecordStorageCommandCreationContext implements CommandCreationConte
         this.idBatches.close();
     }
 
-    public TransactionRecordState createTransactionRecordState( IntegrityValidator integrityValidator, long lastTransactionIdWhenStarted,
+    TransactionRecordState createTransactionRecordState( IntegrityValidator integrityValidator, long lastTransactionIdWhenStarted,
             ResourceLocker locks )
     {
         RecordChangeSet recordChangeSet = new RecordChangeSet( loaders );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/RenewableBatchIdSequence.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/RenewableBatchIdSequence.java
@@ -37,7 +37,7 @@ public class RenewableBatchIdSequence implements IdSequence, Resource
     private IdSequence currentBatch;
     private boolean closed;
 
-    public RenewableBatchIdSequence( IdSequence source, int batchSize, LongConsumer excessIdConsumer )
+    RenewableBatchIdSequence( IdSequence source, int batchSize, LongConsumer excessIdConsumer )
     {
         this.source = source;
         this.batchSize = batchSize;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
@@ -166,7 +166,7 @@ public class KernelTransactionsTest
         assertThat( postDispose, not( equalTo( first ) ) );
         assertThat( postDispose, not( equalTo( second ) ) );
 
-        assertTrue( leftOpen.getReasonIfTerminated() != null );
+        assertNotNull( leftOpen.getReasonIfTerminated() );
     }
 
     @Test

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/pool/LinkedQueuePool.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/pool/LinkedQueuePool.java
@@ -189,7 +189,8 @@ public class LinkedQueuePool<R> implements Pool<R>
     /**
      * Dispose of all pooled objects.
      */
-    public void disposeAll()
+    @Override
+    public void close()
     {
         for ( R resource = unused.poll(); resource != null; resource = unused.poll() )
         {

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/pool/Pool.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/pool/Pool.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.collection.pool;
 
-public interface Pool<T>
+public interface Pool<T> extends AutoCloseable
 {
     T acquire();
 


### PR DESCRIPTION
Before we were using weak references and reference queue when the pool was
closed to clean up all of the objects that were allocated but not yet disposed.
From time to time that was not possible since we
were able to observe state where WeakReference was already cleaned
but not yet visible in reference queue. That would cause some of the
objects (in our case transactions) to not release their resources properly.
For example batch of allocated ids will never be returned and will be lost
until id generator file rebuild.
This PR changes that behavior and use map of slotReferences to reliably
close all entries that available in the pool.
PR also makes pools AutoClosable.