### PR TITLE
Do backup through FileSystemAbstraction if applicable 

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/fs/FileSystemAbstraction.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/FileSystemAbstraction.java
@@ -122,5 +122,4 @@ public interface FileSystemAbstraction extends Closeable
      * @throws IOException If an I/O error occurs, possibly with the canonicalisation of the paths.
      */
     Stream<FileHandle> streamFilesRecursive( File directory ) throws IOException;
-
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
@@ -131,4 +131,14 @@ public interface PageCache extends AutoCloseable
      * @return the filesystem that the page cache is using.
      */
     FileSystemAbstraction getCachedFileSystem();
+
+    /**
+     * Check if the backing {@link FileSystemAbstraction file system} supports regular file operations or not.
+     * <p>
+     * E.g. the file system for block device will not work with generic open and read/write calls and all operations
+     * needs to be done through the page cache.
+     *
+     * @return {@code true} if the backing file system supports regular file operations.
+     */
+    boolean fileSystemSupportsFileOperations();
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
 
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.io.pagecache.PageCache;
@@ -637,6 +638,13 @@ public class MuninnPageCache implements PageCache
     public FileSystemAbstraction getCachedFileSystem()
     {
         return swapperFactory.getFileSystemAbstraction();
+    }
+
+    @Override
+    public boolean fileSystemSupportsFileOperations()
+    {
+        // Default filesystem supports direct file access.
+        return getCachedFileSystem() instanceof DefaultFileSystemAbstraction;
     }
 
     int getPageCacheId()

--- a/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialPageCache.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialPageCache.java
@@ -75,11 +75,7 @@ public class AdversarialPageCache implements PageCache
     {
         adversary.injectFailure( IOException.class, SecurityException.class );
         final Optional<PagedFile> optional = delegate.getExistingMapping( file );
-        if ( optional.isPresent() )
-        {
-            return Optional.of( new AdversarialPagedFile( optional.get(), adversary ) );
-        }
-        return optional;
+        return optional.map( pagedFile -> new AdversarialPagedFile( pagedFile, adversary ) );
     }
 
     @Override
@@ -131,5 +127,11 @@ public class AdversarialPageCache implements PageCache
     public FileSystemAbstraction getCachedFileSystem()
     {
         return delegate.getCachedFileSystem();
+    }
+
+    @Override
+    public boolean fileSystemSupportsFileOperations()
+    {
+        return delegate.fileSystemSupportsFileOperations();
     }
 }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPageCache.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPageCache.java
@@ -24,9 +24,7 @@ import java.io.IOException;
 import java.nio.file.OpenOption;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 
-import org.neo4j.io.fs.FileHandle;
 import org.neo4j.io.fs.FileSystemAbstraction;
 
 public class DelegatingPageCache implements PageCache
@@ -38,6 +36,7 @@ public class DelegatingPageCache implements PageCache
         this.delegate = delegate;
     }
 
+    @Override
     public PagedFile map( File file, int pageSize, OpenOption... openOptions ) throws IOException
     {
         return delegate.map( file, pageSize, openOptions );
@@ -61,11 +60,13 @@ public class DelegatingPageCache implements PageCache
         return delegate.pageSize();
     }
 
+    @Override
     public void close()
     {
         delegate.close();
     }
 
+    @Override
     public long maxCachedPages()
     {
         return delegate.maxCachedPages();
@@ -77,13 +78,21 @@ public class DelegatingPageCache implements PageCache
         return delegate.getCachedFileSystem();
     }
 
+    @Override
     public void flushAndForce( IOLimiter limiter ) throws IOException
     {
         delegate.flushAndForce( limiter );
     }
 
+    @Override
     public void flushAndForce() throws IOException
     {
         delegate.flushAndForce();
+    }
+
+    @Override
+    public boolean fileSystemSupportsFileOperations()
+    {
+        return delegate.fileSystemSupportsFileOperations();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreType.java
@@ -260,7 +260,7 @@ public enum StoreType
      * @param storeFileName file name of the store file to check.
      * @return Returns whether or not store file by given file name should be managed by the page cache.
      */
-    public static boolean shouldBeManagedByPageCache( String storeFileName )
+    public static boolean canBeManagedByPageCache( String storeFileName )
     {
         boolean isLabelScanStore = NativeLabelScanStore.FILE_NAME.equals( storeFileName );
         return isLabelScanStore || StoreType.typeOf( storeFileName ).map( StoreType::isRecordStore ).orElse( false );

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/KernelDiagnostics.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/KernelDiagnostics.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
@@ -147,7 +146,7 @@ public abstract class KernelDiagnostics implements DiagnosticsProvider
 
             public void addFile( File file )
             {
-                if ( StoreType.shouldBeManagedByPageCache( file.getName() ) )
+                if ( StoreType.canBeManagedByPageCache( file.getName() ) )
                 {
                     size += file.length();
                 }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupClient.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupClient.java
@@ -80,12 +80,12 @@ class BackupClient extends Client<TheBackupInterface> implements TheBackupInterf
     }
 
     @Override
-    protected boolean shouldCheckStoreId( RequestType<TheBackupInterface> type )
+    protected boolean shouldCheckStoreId( RequestType type )
     {
         return type != BackupRequestType.FULL_BACKUP;
     }
 
-    public enum BackupRequestType implements RequestType<TheBackupInterface>
+    public enum BackupRequestType implements RequestType
     {
         FULL_BACKUP( (TargetCaller<TheBackupInterface, Void>) ( master, context, input, target ) ->
         {

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupServer.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupServer.java
@@ -103,13 +103,13 @@ class BackupServer extends Server<TheBackupInterface,Object>
     }
 
     @Override
-    protected void responseWritten( RequestType<TheBackupInterface> type, Channel channel,
+    protected void responseWritten( RequestType type, Channel channel,
                                     RequestContext context )
     {
     }
 
     @Override
-    protected RequestType<TheBackupInterface> getRequestContext( byte id )
+    protected RequestType getRequestContext( byte id )
     {
         return contexts[id];
     }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreResource.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreResource.java
@@ -26,7 +26,6 @@ import java.nio.channels.ReadableByteChannel;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PagedFile;
@@ -52,8 +51,7 @@ class StoreResource implements Closeable
 
     ReadableByteChannel open() throws IOException
     {
-        boolean isDefaultFileSystem = pageCache.getCachedFileSystem() instanceof DefaultFileSystemAbstraction;
-        if ( !isDefaultFileSystem )
+        if ( !pageCache.fileSystemSupportsFileOperations() )
         {
             Optional<PagedFile> existingMapping = pageCache.getExistingMapping( file );
             if ( existingMapping.isPresent() )
@@ -64,6 +62,7 @@ class StoreResource implements Closeable
                 }
             }
         }
+
         return fs.open( file, "r" );
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDisk.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDisk.java
@@ -64,7 +64,7 @@ class StreamToDisk implements StoreFileStreams
 
         fileCopyMonitor.copyFile( fileName );
 
-        if ( !pageCache.fileSystemSupportsFileOperations() && StoreType.shouldBeManagedByPageCache( destination ) )
+        if ( !pageCache.fileSystemSupportsFileOperations() && StoreType.canBeManagedByPageCache( destination ) )
         {
             WritableByteChannel channel = channels.get( destination );
             if ( channel == null )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDisk.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDisk.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.neo4j.causalclustering.catchup.tx.FileCopyMonitor;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PagedFile;
@@ -63,7 +64,11 @@ class StreamToDisk implements StoreFileStreams
         fs.mkdirs( fileName.getParentFile() );
 
         fileCopyMonitor.copyFile( fileName );
-        if ( StoreType.shouldBeManagedByPageCache( destination ) )
+
+        // Default filesystem supports writing of data through the file system directly
+        boolean isDefaultFileSystem = pageCache.getCachedFileSystem() instanceof DefaultFileSystemAbstraction;
+
+        if ( !isDefaultFileSystem && StoreType.shouldBeManagedByPageCache( destination ) )
         {
             WritableByteChannel channel = channels.get( destination );
             if ( channel == null )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDisk.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDisk.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.neo4j.causalclustering.catchup.tx.FileCopyMonitor;
-import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PagedFile;
@@ -65,10 +64,7 @@ class StreamToDisk implements StoreFileStreams
 
         fileCopyMonitor.copyFile( fileName );
 
-        // Default filesystem supports writing of data through the file system directly
-        boolean isDefaultFileSystem = pageCache.getCachedFileSystem() instanceof DefaultFileSystemAbstraction;
-
-        if ( !isDefaultFileSystem && StoreType.shouldBeManagedByPageCache( destination ) )
+        if ( !pageCache.fileSystemSupportsFileOperations() && StoreType.shouldBeManagedByPageCache( destination ) )
         {
             WritableByteChannel channel = channels.get( destination );
             if ( channel == null )

--- a/enterprise/com/src/main/java/org/neo4j/com/BlockLogBuffer.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/BlockLogBuffer.java
@@ -72,31 +72,25 @@ public class BlockLogBuffer implements Closeable
      * are moved over at the beginning of the cleared buffer.
      *
      * @return the buffer
-     * @throws IOException
      */
-    private BlockLogBuffer checkFlush() throws IOException
+    private BlockLogBuffer checkFlush()
     {
         if ( byteBuffer.position() > MAX_SIZE )
         {
-            flush( MAX_SIZE );
+            flush();
         }
         return this;
     }
 
-    private void flush( int howManyBytesToWrite ) throws IOException
+    private void flush()
     {
+        int howManyBytesToWrite = MAX_SIZE;
         target.writeBytes( byteArray, 0, howManyBytesToWrite );
         monitor.bytesWritten( howManyBytesToWrite );
         int pos = byteBuffer.position();
         clearInternalBuffer();
         byteBuffer.put( byteArray, howManyBytesToWrite, pos - howManyBytesToWrite );
     }
-
-//    @Override
-//    public void emptyBufferIntoChannelAndClearIt() throws IOException
-//    {
-//        flush( byteBuffer.position() );
-//    }
 
     public BlockLogBuffer put( byte b ) throws IOException
     {
@@ -167,7 +161,7 @@ public class BlockLogBuffer implements Closeable
     public int write( ReadableByteChannel data ) throws IOException
     {
         int result = 0;
-        int bytesRead = 0;
+        int bytesRead;
         while ( (bytesRead = data.read( byteBuffer )) >= 0 )
         {
             checkFlush();

--- a/enterprise/com/src/main/java/org/neo4j/com/Client.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Client.java
@@ -282,13 +282,13 @@ public abstract class Client<T> extends LifecycleAdapter implements ChannelPipel
         msgLog.info( toString() + " shutdown", true );
     }
 
-    protected <R> Response<R> sendRequest( RequestType<T> type, RequestContext context,
+    protected <R> Response<R> sendRequest( RequestType type, RequestContext context,
             Serializer serializer, Deserializer<R> deserializer )
     {
         return sendRequest( type, context, serializer, deserializer, null, NO_OP_TX_HANDLER );
     }
 
-    protected <R> Response<R> sendRequest( RequestType<T> type, RequestContext context,
+    protected <R> Response<R> sendRequest( RequestType type, RequestContext context,
             Serializer serializer, Deserializer<R> deserializer,
             StoreId specificStoreId, TxHandler txHandler )
     {
@@ -351,12 +351,12 @@ public abstract class Client<T> extends LifecycleAdapter implements ChannelPipel
         }
     }
 
-    protected long getReadTimeout( RequestType<T> type, long readTimeout )
+    protected long getReadTimeout( RequestType type, long readTimeout )
     {
         return readTimeout;
     }
 
-    protected boolean shouldCheckStoreId( RequestType<T> type )
+    protected boolean shouldCheckStoreId( RequestType type )
     {
         return true;
     }
@@ -374,7 +374,7 @@ public abstract class Client<T> extends LifecycleAdapter implements ChannelPipel
         }
     }
 
-    private ChannelContext acquireChannelContext( RequestType<T> type )
+    private ChannelContext acquireChannelContext( RequestType type )
     {
         try
         {

--- a/enterprise/com/src/main/java/org/neo4j/com/Protocol.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Protocol.java
@@ -175,7 +175,7 @@ public abstract class Protocol
         }
     }
 
-    public void serializeRequest( Channel channel, ChannelBuffer buffer, RequestType<?> type, RequestContext ctx,
+    public void serializeRequest( Channel channel, ChannelBuffer buffer, RequestType type, RequestContext ctx,
                                   Serializer payload ) throws IOException
     {
         buffer.clear();

--- a/enterprise/com/src/main/java/org/neo4j/com/RequestType.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/RequestType.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.com;
 
-public interface RequestType<M>
+public interface RequestType
 {
     TargetCaller getTargetCaller();
 

--- a/enterprise/com/src/main/java/org/neo4j/com/Server.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Server.java
@@ -411,7 +411,7 @@ public abstract class Server<T, R> extends SimpleChannelHandler implements Chann
             if ( partialRequest == null )
             {
                 // This is the first chunk in a multi-chunk request
-                RequestType<T> type = getRequestContext( buffer.readByte() );
+                RequestType type = getRequestContext( buffer.readByte() );
                 RequestContext context = readContext( buffer );
                 ChannelBuffer targetBuffer = mapSlave( channel, context );
                 partialRequest = new PartialRequest( type, context, targetBuffer );
@@ -422,7 +422,7 @@ public abstract class Server<T, R> extends SimpleChannelHandler implements Chann
         else
         {
             PartialRequest partialRequest = partialRequests.remove( channel );
-            RequestType<T> type;
+            RequestType type;
             RequestContext context;
             ChannelBuffer targetBuffer;
             ChannelBuffer bufferToReadFrom;
@@ -488,7 +488,7 @@ public abstract class Server<T, R> extends SimpleChannelHandler implements Chann
         }
     }
 
-    protected void responseWritten( RequestType<T> type, Channel channel, RequestContext context )
+    protected void responseWritten( RequestType type, Channel channel, RequestContext context )
     {
     }
 
@@ -511,7 +511,7 @@ public abstract class Server<T, R> extends SimpleChannelHandler implements Chann
         return readRequestContext;
     }
 
-    protected abstract RequestType<T> getRequestContext( byte id );
+    protected abstract RequestType getRequestContext( byte id );
 
     protected ChannelBuffer mapSlave( Channel channel, RequestContext slave )
     {
@@ -551,13 +551,13 @@ public abstract class Server<T, R> extends SimpleChannelHandler implements Chann
 
     private class TargetCaller implements Response.Handler, Runnable
     {
-        private final RequestType<T> type;
+        private final RequestType type;
         private final Channel channel;
         private final RequestContext context;
         private final ChunkingChannelBuffer targetBuffer;
         private final ChannelBuffer bufferToReadFrom;
 
-        TargetCaller( RequestType<T> type, Channel channel, RequestContext context,
+        TargetCaller( RequestType type, Channel channel, RequestContext context,
                       ChunkingChannelBuffer targetBuffer, ChannelBuffer bufferToReadFrom )
         {
             this.type = type;
@@ -621,9 +621,9 @@ public abstract class Server<T, R> extends SimpleChannelHandler implements Chann
     {
         final RequestContext context;
         final ChannelBuffer buffer;
-        final RequestType<T> type;
+        final RequestType type;
 
-        PartialRequest( RequestType<T> type, RequestContext context, ChannelBuffer buffer )
+        PartialRequest( RequestType type, RequestContext context, ChannelBuffer buffer )
         {
             this.type = type;
             this.context = context;

--- a/enterprise/com/src/main/java/org/neo4j/com/monitor/RequestMonitor.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/monitor/RequestMonitor.java
@@ -26,7 +26,7 @@ import org.neo4j.com.RequestType;
 
 public interface RequestMonitor
 {
-    void beginRequest( SocketAddress remoteAddress, RequestType<?> requestType, RequestContext requestContext );
+    void beginRequest( SocketAddress remoteAddress, RequestType requestType, RequestContext requestContext );
 
     void endRequest( Throwable t );
 }

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ExternallyManagedPageCache.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ExternallyManagedPageCache.java
@@ -111,6 +111,12 @@ public class ExternallyManagedPageCache implements PageCache
         return delegate.getCachedFileSystem();
     }
 
+    @Override
+    public boolean fileSystemSupportsFileOperations()
+    {
+        return delegate.fileSystemSupportsFileOperations();
+    }
+
     /**
      * Create a GraphDatabaseFactory that will build EmbeddedGraphDatabase instances that all use the given page cache.
      */

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyServer.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyServer.java
@@ -32,7 +32,6 @@ import org.neo4j.function.ThrowingAction;
 import org.neo4j.graphdb.Resource;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.io.ByteUnit;
-import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PagedFile;
@@ -176,8 +175,7 @@ public class StoreCopyServer
                     File file = meta.file();
                     int recordSize = meta.recordSize();
 
-                    boolean isDefaultFileSystem = pageCache.getCachedFileSystem() instanceof DefaultFileSystemAbstraction;
-                    if ( !isDefaultFileSystem )
+                    if ( !pageCache.fileSystemSupportsFileOperations() )
                     {
                         // Read from paged file if mapping exists. Otherwise read through file system.
                         // A file is mapped if it is a store, and we have a running database, which will be the case for
@@ -196,7 +194,7 @@ public class StoreCopyServer
                             }
                         }
                     }
-                    // in the case where isDefaultFileSystem == true we always read the file from disk
+
                     try ( ReadableByteChannel fileChannel = fileSystem.open( file, "r" ) )
                     {
                         long fileSize = fileSystem.getFileSize( file );

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToFileStoreWriter.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToFileStoreWriter.java
@@ -26,7 +26,6 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.util.List;
 
-import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.io.pagecache.PageCache;
@@ -70,12 +69,9 @@ public class ToFileStoreWriter implements StoreWriter
             monitor.startReceivingStoreFile( file );
             try
             {
-                // Default filesystem supports writing of data through the file system directly
-                boolean isDefaultFileSystem = pageCache.getCachedFileSystem() instanceof DefaultFileSystemAbstraction;
-
                 // Note that we don't bother checking if the page cache already has a mapping for the given file.
                 // The reason is that we are copying to a temporary store location, and then we'll move the files later.
-                if ( !isDefaultFileSystem && StoreType.shouldBeManagedByPageCache( filename ) )
+                if ( !pageCache.fileSystemSupportsFileOperations() && StoreType.shouldBeManagedByPageCache( filename ) )
                 {
                     int filePageSize = filePageSize( requiredElementAlignment );
                     try ( PagedFile pagedFile = pageCache.map( file, filePageSize, CREATE, WRITE ) )

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToFileStoreWriter.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToFileStoreWriter.java
@@ -26,6 +26,7 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.util.List;
 
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.io.pagecache.PageCache;
@@ -69,9 +70,12 @@ public class ToFileStoreWriter implements StoreWriter
             monitor.startReceivingStoreFile( file );
             try
             {
+                // Default filesystem supports writing of data through the file system directly
+                boolean isDefaultFileSystem = pageCache.getCachedFileSystem() instanceof DefaultFileSystemAbstraction;
+
                 // Note that we don't bother checking if the page cache already has a mapping for the given file.
                 // The reason is that we are copying to a temporary store location, and then we'll move the files later.
-                if ( StoreType.shouldBeManagedByPageCache( filename ) )
+                if ( !isDefaultFileSystem && StoreType.shouldBeManagedByPageCache( filename ) )
                 {
                     int filePageSize = filePageSize( requiredElementAlignment );
                     try ( PagedFile pagedFile = pageCache.map( file, filePageSize, CREATE, WRITE ) )

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToFileStoreWriter.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToFileStoreWriter.java
@@ -71,7 +71,7 @@ public class ToFileStoreWriter implements StoreWriter
             {
                 // Note that we don't bother checking if the page cache already has a mapping for the given file.
                 // The reason is that we are copying to a temporary store location, and then we'll move the files later.
-                if ( !pageCache.fileSystemSupportsFileOperations() && StoreType.shouldBeManagedByPageCache( filename ) )
+                if ( !pageCache.fileSystemSupportsFileOperations() && StoreType.canBeManagedByPageCache( filename ) )
                 {
                     int filePageSize = filePageSize( requiredElementAlignment );
                     try ( PagedFile pagedFile = pageCache.map( file, filePageSize, CREATE, WRITE ) )

--- a/enterprise/com/src/test/java/org/neo4j/com/MadeUpServer.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/MadeUpServer.java
@@ -76,7 +76,7 @@ public class MadeUpServer extends Server<MadeUpCommunicationInterface, Void>
     }
 
     @Override
-    protected void responseWritten( RequestType<MadeUpCommunicationInterface> type, Channel channel,
+    protected void responseWritten( RequestType type, Channel channel,
                                     RequestContext context )
     {
         responseWritten = true;
@@ -96,7 +96,7 @@ public class MadeUpServer extends Server<MadeUpCommunicationInterface, Void>
     }
 
     @Override
-    protected RequestType<MadeUpCommunicationInterface> getRequestContext( byte id )
+    protected RequestType getRequestContext( byte id )
     {
         return MadeUpRequestType.values()[id];
     }
@@ -116,7 +116,7 @@ public class MadeUpServer extends Server<MadeUpCommunicationInterface, Void>
         return responseFailureEncountered;
     }
 
-    enum MadeUpRequestType implements RequestType<MadeUpCommunicationInterface>
+    enum MadeUpRequestType implements RequestType
     {
         MULTIPLY( ( master, context, input, target ) ->
         {

--- a/enterprise/com/src/test/java/org/neo4j/com/ServerTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/ServerTest.java
@@ -138,7 +138,7 @@ public class ServerTest
                 mock( ByteCounterMonitor.class ), mock( RequestMonitor.class ) )
         {
             @Override
-            protected RequestType<Object> getRequestContext( byte id )
+            protected RequestType getRequestContext( byte id )
             {
                 return mock( RequestType.class );
             }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/AbstractHaRequestTypes.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/AbstractHaRequestTypes.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.ha;
 import org.neo4j.com.ObjectSerializer;
 import org.neo4j.com.RequestType;
 import org.neo4j.com.TargetCaller;
-import org.neo4j.kernel.ha.com.master.Master;
 
 abstract class AbstractHaRequestTypes implements HaRequestTypes
 {
@@ -40,13 +39,13 @@ abstract class AbstractHaRequestTypes implements HaRequestTypes
     }
 
     @Override
-    public RequestType<Master> type( Type type )
+    public RequestType type( Type type )
     {
         return type( (byte) type.ordinal() );
     }
 
     @Override
-    public RequestType<Master> type( byte id )
+    public RequestType type( byte id )
     {
         HaRequestType requestType = types[id];
         if ( requestType == null )

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRequestType.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRequestType.java
@@ -22,9 +22,8 @@ package org.neo4j.kernel.ha;
 import org.neo4j.com.ObjectSerializer;
 import org.neo4j.com.RequestType;
 import org.neo4j.com.TargetCaller;
-import org.neo4j.kernel.ha.com.master.Master;
 
-public class HaRequestType implements RequestType<Master>
+public class HaRequestType implements RequestType
 {
     private final TargetCaller targetCaller;
     private final ObjectSerializer objectSerializer;

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRequestTypes.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRequestTypes.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.ha;
 
 import org.neo4j.com.RequestType;
-import org.neo4j.kernel.ha.com.master.Master;
 
 public interface HaRequestTypes
 {
@@ -43,13 +42,13 @@ public interface HaRequestTypes
         CREATE_PROPERTY_KEY,
         CREATE_LABEL;
 
-        public boolean is( RequestType<?> type )
+        public boolean is( RequestType type )
         {
             return type.id() == ordinal();
         }
     }
 
-    RequestType<Master> type( Type type );
+    RequestType type( Type type );
 
-    RequestType<Master> type( byte id );
+    RequestType type( byte id );
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient214.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient214.java
@@ -151,7 +151,7 @@ public class MasterClient214 extends Client<Master> implements MasterClient
     }
 
     @Override
-    protected long getReadTimeout( RequestType<Master> type, long readTimeout )
+    protected long getReadTimeout( RequestType type, long readTimeout )
     {
         if ( HaRequestTypes.Type.ACQUIRE_EXCLUSIVE_LOCK.is( type ) ||
              HaRequestTypes.Type.ACQUIRE_SHARED_LOCK.is( type ) )
@@ -166,7 +166,7 @@ public class MasterClient214 extends Client<Master> implements MasterClient
     }
 
     @Override
-    protected boolean shouldCheckStoreId( RequestType<Master> type )
+    protected boolean shouldCheckStoreId( RequestType type )
     {
         return !HaRequestTypes.Type.COPY_STORE.is( type );
     }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterServer.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterServer.java
@@ -57,7 +57,7 @@ public class MasterServer extends Server<Master, Void>
     }
 
     @Override
-    protected RequestType<Master> getRequestContext( byte id )
+    protected RequestType getRequestContext( byte id )
     {
         return requestTypes.type( id );
     }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/SlaveClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/SlaveClient.java
@@ -75,7 +75,7 @@ public class SlaveClient extends Client<Slave> implements Slave
         return SlaveServer.SLAVE_PROTOCOL_VERSION;
     }
 
-    public enum SlaveRequestType implements RequestType<Slave>
+    public enum SlaveRequestType implements RequestType
     {
         PULL_UPDATES( (TargetCaller<Slave,Void>) ( master, context, input, target ) ->
         {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/SlaveServer.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/SlaveServer.java
@@ -48,7 +48,7 @@ public class SlaveServer extends Server<Slave, Void>
     }
 
     @Override
-    protected RequestType<Slave> getRequestContext( byte id )
+    protected RequestType getRequestContext( byte id )
     {
         return SlaveRequestType.values()[id];
     }


### PR DESCRIPTION
Doing backup through the page cache was a necessary change to support block devices, however, this introduced an overhead in cases where it wasn't necessary. This commit will revert the behavior to the old way of doing things unless the underlying filesystem is not the default one, i.e. block device file system.