### PR TITLE
Redesign StoreFileStreams

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpClient.java
@@ -85,8 +85,7 @@ public class CatchUpClient extends LifecycleAdapter
         channel.setResponseHandler( responseHandler, future );
         channel.send( request );
 
-        String operation = format( "Timed out executing operation %s on %s ",
-                request, upstream );
+        String operation = format( "Completed exceptionally when executing operation %s on %s ", request, upstream );
 
         return waitForCompletion( future, operation, channel::millisSinceLastResponse, inactivityTimeoutMillis, log );
     }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpResponseAdaptor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpResponseAdaptor.java
@@ -40,7 +40,7 @@ public class CatchUpResponseAdaptor<T> implements CatchUpResponseCallback<T>
     }
 
     @Override
-    public boolean onFileContent( CompletableFuture<T> signal, FileChunk response ) throws IOException
+    public boolean onFileContent( CompletableFuture<T> signal, FileChunk response )
     {
         unimplementedMethod( signal, response );
         return false;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpResponseCallback.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpResponseCallback.java
@@ -35,7 +35,7 @@ public interface CatchUpResponseCallback<T>
 {
     void onFileHeader( CompletableFuture<T> signal, FileHeader fileHeader );
 
-    boolean onFileContent( CompletableFuture<T> signal, FileChunk fileChunk ) throws IOException;
+    boolean onFileContent( CompletableFuture<T> signal, FileChunk fileChunk );
 
     void onFileStreamingComplete( CompletableFuture<T> signal, StoreCopyFinishedResponse response );
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStore.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStore.java
@@ -124,10 +124,8 @@ public class RemoteStore
         try
         {
             long lastFlushedTxId;
-            try ( StreamToDisk storeFileStreams = new StreamToDisk( destDir, fs, pageCache, monitors ) )
-            {
-                lastFlushedTxId = storeCopyClient.copyStoreFiles( addressProvider, expectedStoreId, storeFileStreams, DEFAULT_TERMINATION_CONDITIONS );
-            }
+            StreamToDiskProvider streamToDiskProvider = new StreamToDiskProvider( destDir, fs, pageCache, monitors );
+            lastFlushedTxId = storeCopyClient.copyStoreFiles( addressProvider, expectedStoreId, streamToDiskProvider, DEFAULT_TERMINATION_CONDITIONS );
 
             log.info( "Store files need to be recovered starting from: %d", lastFlushedTxId );
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreFileReceiver.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreFileReceiver.java
@@ -21,6 +21,6 @@ package org.neo4j.causalclustering.catchup.storecopy;
 
 public interface StoreFileReceiver
 {
-    StoreFileStreams getStoreFileStreams();
+    StoreFileStream getStoreFileStreams();
 }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreFileStream.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreFileStream.java
@@ -20,38 +20,8 @@
 package org.neo4j.causalclustering.catchup.storecopy;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
-class InMemoryFileSystemStream implements StoreFileStreams
+public interface StoreFileStream extends AutoCloseable
 {
-    Map<String,StringBuffer> filesystem = new HashMap<>();
-
-    /**
-     *
-     * @param destination
-     * @param requiredAlignment
-     * @param data
-     * @throws IOException
-     */
-    public void write( String destination, int requiredAlignment, byte[] data ) throws IOException
-    {
-        StringBuffer buffer = filesystem.getOrDefault( destination, new StringBuffer() );
-        for ( byte b : data )
-        {
-            buffer.append( (char) b );
-        }
-        filesystem.put( destination, buffer );
-    }
-
-    @Override
-    public void close() throws Exception
-    {
-        throw new RuntimeException( "Unimplemented" );
-    }
-
-    public Map<String,StringBuffer> getFilesystem()
-    {
-        return filesystem;
-    }
+    void write( byte[] data ) throws IOException;
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreFileStreamProvider.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreFileStreamProvider.java
@@ -21,7 +21,7 @@ package org.neo4j.causalclustering.catchup.storecopy;
 
 import java.io.IOException;
 
-public interface StoreFileStreams extends AutoCloseable
+public interface StoreFileStreamProvider
 {
-    void write( String destination, int requiredAlignment, byte[] data ) throws IOException;
+    StoreFileStream acquire( String destination, int requiredAlignment ) throws IOException;
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDisk.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDisk.java
@@ -19,88 +19,41 @@
  */
 package org.neo4j.causalclustering.catchup.storecopy;
 
-import java.io.File;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
-import java.nio.file.StandardOpenOption;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
-import org.neo4j.causalclustering.catchup.tx.FileCopyMonitor;
-import org.neo4j.io.fs.FileSystemAbstraction;
-import org.neo4j.io.pagecache.PageCache;
-import org.neo4j.io.pagecache.PagedFile;
-import org.neo4j.kernel.impl.store.StoreType;
-import org.neo4j.kernel.monitoring.Monitors;
+import static org.neo4j.io.IOUtils.closeAll;
 
-public class StreamToDisk implements StoreFileStreams
+public class StreamToDisk implements StoreFileStream
 {
-    private final File storeDir;
-    private final FileSystemAbstraction fs;
-    private final PageCache pageCache;
-    private final FileCopyMonitor fileCopyMonitor;
-    private final Map<String,WritableByteChannel> channels;
-    private final Map<String,PagedFile> pagedFiles;
+    private WritableByteChannel writableByteChannel;
+    private List<AutoCloseable> closeables;
 
-    public StreamToDisk( File storeDir, FileSystemAbstraction fs, PageCache pageCache, Monitors monitors ) throws IOException
+    public StreamToDisk( WritableByteChannel writableByteChannel, AutoCloseable... closeables )
     {
-        this.storeDir = storeDir;
-        this.fs = fs;
-        this.pageCache = pageCache;
-        fs.mkdirs( storeDir );
-        this.fileCopyMonitor = monitors.newMonitor( FileCopyMonitor.class );
-        channels = new HashMap<>();
-        pagedFiles = new HashMap<>();
-
+        this.writableByteChannel = writableByteChannel;
+        this.closeables = new ArrayList<>();
+        this.closeables.add( writableByteChannel );
+        this.closeables.addAll( Arrays.asList( closeables ) );
     }
 
     @Override
-    public void write( String destination, int requiredAlignment, byte[] data ) throws IOException
+    public void write( byte[] data ) throws IOException
     {
-        File fileName = new File( storeDir, destination );
-        fs.mkdirs( fileName.getParentFile() );
-
-        fileCopyMonitor.copyFile( fileName );
-
-        if ( !pageCache.fileSystemSupportsFileOperations() && StoreType.canBeManagedByPageCache( destination ) )
+        ByteBuffer buffer = ByteBuffer.wrap( data );
+        while ( buffer.hasRemaining() )
         {
-            WritableByteChannel channel = channels.get( destination );
-            if ( channel == null )
-            {
-                int filePageSize = pageCache.pageSize() - pageCache.pageSize() % requiredAlignment;
-                PagedFile pagedFile = pageCache.map( fileName, filePageSize, StandardOpenOption.CREATE );
-                channel = pagedFile.openWritableByteChannel();
-                pagedFiles.put( destination, pagedFile );
-                channels.put( destination, channel );
-            }
-
-            ByteBuffer buffer = ByteBuffer.wrap( data );
-            while ( buffer.hasRemaining() )
-            {
-                channel.write( buffer );
-            }
-        }
-        else
-        {
-            try ( OutputStream outputStream = fs.openAsOutputStream( fileName, true ) )
-            {
-                outputStream.write( data );
-            }
+            writableByteChannel.write( buffer );
         }
     }
 
     @Override
     public void close() throws IOException
     {
-        for ( WritableByteChannel channel : channels.values() )
-        {
-            channel.close();
-        }
-        for ( PagedFile pagedFile : pagedFiles.values() )
-        {
-            pagedFile.close();
-        }
+        closeAll( closeables );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDisk.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDisk.java
@@ -19,12 +19,17 @@
  */
 package org.neo4j.causalclustering.catchup.storecopy;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.OpenMode;
+import org.neo4j.io.pagecache.PagedFile;
 
 import static org.neo4j.io.IOUtils.closeAll;
 
@@ -33,7 +38,17 @@ public class StreamToDisk implements StoreFileStream
     private WritableByteChannel writableByteChannel;
     private List<AutoCloseable> closeables;
 
-    public StreamToDisk( WritableByteChannel writableByteChannel, AutoCloseable... closeables )
+    static StreamToDisk fromPagedFile( PagedFile pagedFile ) throws IOException
+    {
+        return new StreamToDisk( pagedFile.openWritableByteChannel(), pagedFile );
+    }
+
+    static StreamToDisk fromFile( FileSystemAbstraction fsa, File file ) throws IOException
+    {
+        return new StreamToDisk( fsa.open( file, OpenMode.READ_WRITE ) );
+    }
+
+    private StreamToDisk( WritableByteChannel writableByteChannel, AutoCloseable... closeables )
     {
         this.writableByteChannel = writableByteChannel;
         this.closeables = new ArrayList<>();

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDiskProvider.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDiskProvider.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.catchup.storecopy;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.StandardOpenOption;
+
+import org.neo4j.causalclustering.catchup.tx.FileCopyMonitor;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.OpenMode;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.kernel.impl.store.StoreType;
+import org.neo4j.kernel.monitoring.Monitors;
+
+public class StreamToDiskProvider implements StoreFileStreamProvider
+{
+    private final File storeDir;
+    private final FileSystemAbstraction fs;
+    private final PageCache pageCache;
+    private final FileCopyMonitor fileCopyMonitor;
+
+    StreamToDiskProvider( File storeDir, FileSystemAbstraction fs, PageCache pageCache, Monitors monitors )
+    {
+        this.storeDir = storeDir;
+        this.fs = fs;
+        this.pageCache = pageCache;
+        this.fileCopyMonitor = monitors.newMonitor( FileCopyMonitor.class );
+    }
+
+    @Override
+    public StoreFileStream acquire( String destination, int requiredAlignment ) throws IOException
+    {
+        File fileName = new File( storeDir, destination );
+        fs.mkdirs( fileName.getParentFile() );
+        fileCopyMonitor.copyFile( fileName );
+        if ( !pageCache.fileSystemSupportsFileOperations() && StoreType.canBeManagedByPageCache( destination ) )
+        {
+            int filePageSize = pageCache.pageSize() - pageCache.pageSize() % requiredAlignment;
+            PagedFile pagedFile = pageCache.map( fileName, filePageSize, StandardOpenOption.CREATE );
+            return new StreamToDisk( pagedFile.openWritableByteChannel(), pagedFile );
+        }
+        else
+        {
+            return new StreamToDisk( fs.open( fileName, OpenMode.READ_WRITE ) );
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDiskProvider.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDiskProvider.java
@@ -25,7 +25,6 @@ import java.nio.file.StandardOpenOption;
 
 import org.neo4j.causalclustering.catchup.tx.FileCopyMonitor;
 import org.neo4j.io.fs.FileSystemAbstraction;
-import org.neo4j.io.fs.OpenMode;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.impl.store.StoreType;
@@ -56,11 +55,11 @@ public class StreamToDiskProvider implements StoreFileStreamProvider
         {
             int filePageSize = pageCache.pageSize() - pageCache.pageSize() % requiredAlignment;
             PagedFile pagedFile = pageCache.map( fileName, filePageSize, StandardOpenOption.CREATE );
-            return new StreamToDisk( pagedFile.openWritableByteChannel(), pagedFile );
+            return StreamToDisk.fromPagedFile( pagedFile );
         }
         else
         {
-            return new StreamToDisk( fs.open( fileName, OpenMode.READ_WRITE ) );
+            return StreamToDisk.fromFile( fs, fileName );
         }
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/FakeCatchupServer.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/FakeCatchupServer.java
@@ -53,7 +53,7 @@ class TestCatchupServerHandler implements CatchupServerHandler
     private final Set<FakeFile> indexFiles = new HashSet<>();
     private final Map<String,Integer> pathToRequestCountMapping = new HashMap<>();
     private final Log log;
-    private final CatchupServerProtocol protocol;
+    final CatchupServerProtocol protocol;
     private TestDirectory testDirectory;
     private FileSystemAbstraction fileSystemAbstraction;
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/InMemoryStoreStreamProvider.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/InMemoryStoreStreamProvider.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.catchup.storecopy;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class InMemoryStoreStreamProvider implements StoreFileStreamProvider
+{
+    private Map<String,StringBuffer> fileStreams = new HashMap<>();
+
+    @Override
+    public StoreFileStream acquire( String destination, int requiredAlignment )
+    {
+        fileStreams.putIfAbsent( destination, new StringBuffer() );
+        return new InMemoryStoreStream( fileStreams.get( destination ) );
+    }
+
+    public Map<String,StringBuffer> fileStreams()
+    {
+        return fileStreams;
+    }
+
+    class InMemoryStoreStream implements StoreFileStream
+    {
+        private StringBuffer stringBuffer;
+
+        InMemoryStoreStream( StringBuffer stringBuffer )
+        {
+            this.stringBuffer = stringBuffer;
+        }
+
+        public void write( byte[] data )
+        {
+            for ( byte b : data )
+            {
+                stringBuffer.append( (char) b );
+            }
+        }
+
+        @Override
+        public void close()
+        {
+            // do nothing
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStoreTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStoreTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.function.Supplier;
 
 import org.neo4j.causalclustering.catchup.CatchUpClientException;
 import org.neo4j.causalclustering.catchup.CatchupAddressProvider;
@@ -72,7 +71,7 @@ public class RemoteStoreTest
         remoteStore.copy( catchupAddressProvider, storeId, new File( "destination" ) );
 
         // then
-        verify( storeCopyClient ).copyStoreFiles( eq( catchupAddressProvider ), eq( storeId ), any( StoreFileStreams.class ), any() );
+        verify( storeCopyClient ).copyStoreFiles( eq( catchupAddressProvider ), eq( storeId ), any( StoreFileStreamProvider.class ), any() );
         verify( txPullClient ).pullTransactions( eq( localhost ), eq( storeId ), anyLong(), isNull() );
     }
 
@@ -86,7 +85,7 @@ public class RemoteStoreTest
         CatchupAddressProvider catchupAddressProvider = CatchupAddressProvider.fromSingleAddress( localhost );
 
         StoreCopyClient storeCopyClient = mock( StoreCopyClient.class );
-        when( storeCopyClient.copyStoreFiles( eq( catchupAddressProvider ), eq( wantedStoreId ), any( StoreFileStreams.class ), any() ) )
+        when( storeCopyClient.copyStoreFiles( eq( catchupAddressProvider ), eq( wantedStoreId ), any( StoreFileStreamProvider.class ), any() ) )
                 .thenReturn( lastFlushedTxId );
 
         TxPullClient txPullClient = mock( TxPullClient.class );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/SimpleCatchupClient.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/SimpleCatchupClient.java
@@ -78,7 +78,7 @@ class SimpleCatchupClient implements AutoCloseable
     PrepareStoreCopyResponse requestListOfFilesFromServer( StoreId expectedStoreId ) throws CatchUpClientException
     {
         return catchUpClient.makeBlockingRequest( from, new PrepareStoreCopyRequest( expectedStoreId ),
-                new PrepareStoreCopyResponseAdaptor( streamToDiskProvider, logProvider ) );
+                StoreCopyResponseAdaptors.prepareStoreCopyAdaptor( streamToDiskProvider, logProvider.getLog( SimpleCatchupClient.class ) ) );
     }
 
     StoreCopyFinishedResponse requestIndividualFile( File file ) throws CatchUpClientException
@@ -90,7 +90,7 @@ class SimpleCatchupClient implements AutoCloseable
     {
         long lastTransactionId = getCheckPointer( graphDb ).lastCheckPointedTransactionId();
         GetStoreFileRequest storeFileRequest = new GetStoreFileRequest( expectedStoreId, file, lastTransactionId );
-        return catchUpClient.makeBlockingRequest( from, storeFileRequest, new StoreCopyClient.StoreFileCopyResponseAdaptor( streamToDiskProvider, log ) );
+        return catchUpClient.makeBlockingRequest( from, storeFileRequest, StoreCopyResponseAdaptors.filesCopyAdaptor( streamToDiskProvider, log ) );
     }
 
     private StoreId getStoreIdFromKernelStoreId( GraphDatabaseAPI graphDb )
@@ -109,7 +109,7 @@ class SimpleCatchupClient implements AutoCloseable
         long lastCheckPointedTransactionId = getCheckPointer( graphDb ).lastCheckPointedTransactionId();
         StoreId storeId = getStoreIdFromKernelStoreId( graphDb );
         GetIndexFilesRequest request = new GetIndexFilesRequest( storeId, indexId, lastCheckPointedTransactionId );
-        return catchUpClient.makeBlockingRequest( from, request, new StoreCopyClient.StoreFileCopyResponseAdaptor( streamToDiskProvider, log ) );
+        return catchUpClient.makeBlockingRequest( from, request, StoreCopyResponseAdaptors.filesCopyAdaptor( streamToDiskProvider, log ) );
     }
 
     @Override

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClientIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClientIT.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.causalclustering.catchup.storecopy;
 
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
 import org.apache.commons.compress.utils.Charsets;
 import org.junit.After;
 import org.junit.Before;
@@ -27,24 +30,38 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.Reader;
 import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import org.neo4j.causalclustering.catchup.CatchUpClient;
 import org.neo4j.causalclustering.catchup.CatchupAddressProvider;
 import org.neo4j.causalclustering.catchup.CatchupClientBuilder;
 import org.neo4j.causalclustering.catchup.CatchupServerBuilder;
 import org.neo4j.causalclustering.catchup.CatchupServerProtocol;
+import org.neo4j.causalclustering.catchup.ResponseMessageType;
+import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.causalclustering.net.Server;
+import org.neo4j.collection.primitive.base.Empty;
+import org.neo4j.function.ThrowingSupplier;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.helpers.ListenSocketAddress;
+import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.OpenMode;
 import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.io.pagecache.impl.muninn.StandalonePageCacheFactory;
+import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.FormattedLogProvider;
 import org.neo4j.logging.Level;
 import org.neo4j.logging.LogProvider;
@@ -112,11 +129,10 @@ public class StoreCopyClientIT
     }
 
     @Test
-    public void canPerformCatchup() throws StoreCopyFailedException, IOException
+    public void canPerformCatchup() throws StoreCopyFailedException
     {
-        // given remote node has a store
-        // and local client has a store
-        InMemoryFileSystemStream storeFileStream = new InMemoryFileSystemStream();
+        // given local client has a store
+        InMemoryStoreStreamProvider storeFileStream = new InMemoryStoreStreamProvider();
 
         // when catchup is performed for valid transactionId and StoreId
         CatchupAddressProvider catchupAddressProvider = CatchupAddressProvider.fromSingleAddress( from( catchupServer.address().getPort() ) );
@@ -124,20 +140,20 @@ public class StoreCopyClientIT
 
         // then the catchup is successful
         Set<String> expectedFiles = new HashSet<>( Arrays.asList( fileA.getFilename(), fileB.getFilename(), indexFileA.getFilename() ) );
-        assertEquals( expectedFiles, storeFileStream.filesystem.keySet() );
+        assertEquals( expectedFiles, storeFileStream.fileStreams().keySet() );
         assertEquals( fileContent( relative( fileA.getFilename() ) ), clientFileContents( storeFileStream, fileA.getFilename() ) );
         assertEquals( fileContent( relative( fileB.getFilename() ) ), clientFileContents( storeFileStream, fileB.getFilename() ) );
     }
 
     @Test
-    public void failedFileCopyShouldRetry() throws StoreCopyFailedException, IOException
+    public void failedFileCopyShouldRetry() throws StoreCopyFailedException
     {
         // given a file will fail twice before succeeding
         fileB.setRemainingFailed( 2 );
 
         // and remote node has a store
         // and local client has a store
-        InMemoryFileSystemStream clientStoreFileStream = new InMemoryFileSystemStream();
+        InMemoryStoreStreamProvider clientStoreFileStream = new InMemoryStoreStreamProvider();
 
         // when catchup is performed for valid transactionId and StoreId
         CatchupAddressProvider catchupAddressProvider = CatchupAddressProvider.fromSingleAddress( from( catchupServer.address().getPort() ) );
@@ -145,7 +161,7 @@ public class StoreCopyClientIT
 
         // then the catchup is successful
         Set<String> expectedFiles = new HashSet<>( Arrays.asList( fileA.getFilename(), fileB.getFilename(), indexFileA.getFilename() ) );
-        assertEquals( expectedFiles, clientStoreFileStream.filesystem.keySet() );
+        assertEquals( expectedFiles, clientStoreFileStream.fileStreams().keySet() );
 
         // and
         assertEquals( fileContent( relative( fileA.getFilename() ) ), clientFileContents( clientStoreFileStream, fileA.getFilename() ) );
@@ -159,14 +175,13 @@ public class StoreCopyClientIT
     }
 
     @Test
-    public void reconnectingWorks() throws StoreCopyFailedException, IOException
+    public void reconnectingWorks() throws StoreCopyFailedException
     {
-        // given a remote catchup will fail midway
-        // and local client has a store
-        InMemoryFileSystemStream storeFileStream = new InMemoryFileSystemStream();
+        // given local client has a store
+        InMemoryStoreStreamProvider storeFileStream = new InMemoryStoreStreamProvider(
 
-        // and file B is broken once (after retry it works)
-        fileB.setRemainingNoResponse( 1 );
+                // and file B is broken once (after retry it works)
+                fileB.setRemainingNoResponse( 1 );
 
         // when catchup is performed for valid transactionId and StoreId
         CatchupAddressProvider catchupAddressProvider = CatchupAddressProvider.fromSingleAddress( from( catchupServer.address().getPort() ) );
@@ -180,6 +195,124 @@ public class StoreCopyClientIT
         assertThat( serverHandler.getRequestCount( fileB.getFilename() ), greaterThan( 1 ) );
     }
 
+    @Test
+    public void shouldNotAppendToFileWhenRetryingWithNewFile() throws Throwable
+    {
+        // given
+        String fileName = "foo";
+        String pageCacheFileName = "bar";
+        String unfinishedContent = "abcd";
+        String finishedContent = "abcdefgh";
+        Iterator<String> contents = Iterators.iterator( unfinishedContent, finishedContent );
+
+        // and
+        TestCatchupServerHandler halfWayFailingServerhandler = new TestCatchupServerHandler( logProvider, new CatchupServerProtocol(), testDirectory, fsa )
+        {
+            @Override
+            public ChannelHandler getStoreFileRequestHandler()
+            {
+                return new SimpleChannelInboundHandler<GetStoreFileRequest>()
+                {
+                    @Override
+                    protected void channelRead0( ChannelHandlerContext ctx, GetStoreFileRequest msg ) throws IOException
+                    {
+                        // create the files and write the given content
+                        File file = new File( fileName );
+                        String thisConent = contents.next();
+                        writeContents( fsa, file, thisConent );
+                        PageCache pageCache = StandalonePageCacheFactory.createPageCache( fsa );
+                        PagedFile pagedFile =
+                                pageCache.map( new File( pageCacheFileName ), pageCache.pageSize(), StandardOpenOption.CREATE, StandardOpenOption.WRITE );
+                        try ( WritableByteChannel writableByteChannel = pagedFile.openWritableByteChannel() )
+                        {
+                            writableByteChannel.write( ByteBuffer.wrap( thisConent.getBytes() ) );
+                        }
+
+                        sendFile( ctx, file, pageCache );
+                        sendFile( ctx, pagedFile.file(), pageCache );
+                        StoreCopyFinishedResponse.Status status =
+                                contents.hasNext() ? StoreCopyFinishedResponse.Status.E_UNKNOWN : StoreCopyFinishedResponse.Status.SUCCESS;
+                        new StoreFileStreamingProtocol().end( ctx, status );
+                        protocol.expect( CatchupServerProtocol.State.MESSAGE_TYPE );
+                    }
+
+                    private void sendFile( ChannelHandlerContext ctx, File file, PageCache pageCache )
+                    {
+                        ctx.write( ResponseMessageType.FILE );
+                        ctx.write( new FileHeader( file.getName() ) );
+                        ctx.writeAndFlush( new FileSender( new StoreResource( file, file.getName(), 16, pageCache, fsa ) ) ).addListener(
+                                future -> fsa.deleteFile( file ) );
+                    }
+                };
+            }
+
+            @Override
+            public ChannelHandler storeListingRequestHandler()
+            {
+                return new SimpleChannelInboundHandler<PrepareStoreCopyRequest>()
+                {
+                    @Override
+                    protected void channelRead0( ChannelHandlerContext ctx, PrepareStoreCopyRequest msg )
+                    {
+                        ctx.write( ResponseMessageType.PREPARE_STORE_COPY_RESPONSE );
+                        ctx.writeAndFlush( PrepareStoreCopyResponse.success( new File[]{new File( fileName )}, new Empty.EmptyPrimitiveLongSet(), 1 ) );
+                        protocol.expect( CatchupServerProtocol.State.MESSAGE_TYPE );
+                    }
+                };
+            }
+
+            @Override
+            public ChannelHandler getIndexSnapshotRequestHandler()
+            {
+                return new SimpleChannelInboundHandler<GetIndexFilesRequest>()
+                {
+                    @Override
+                    protected void channelRead0( ChannelHandlerContext ctx, GetIndexFilesRequest msg )
+                    {
+                        throw new IllegalStateException( "There should not be any index requests" );
+                    }
+                };
+            }
+        };
+
+        Server halfWayFailingServer = null;
+
+        try
+        {
+            // when
+            ListenSocketAddress listenAddress = new ListenSocketAddress( "localhost", PortAuthority.allocatePort() );
+            halfWayFailingServer = new CatchupServerBuilder( protocol -> serverHandler ).listenAddress( listenAddress ).build();
+            halfWayFailingServer.start();
+
+            CatchupAddressProvider addressProvider = CatchupAddressProvider.fromSingleAddress( ListenSocketAddress
+                    listenAddress = new ListenSocketAddress( "localhost", PortAuthority.allocatePort() );
+            StoreId storeId = halfWayFailingServerhandler.getStoreId();
+            File storeDir = testDirectory.makeGraphDbDir();
+            PageCache pageCache = StandalonePageCacheFactory.createPageCache( fsa );
+            StreamToDiskProvider streamToDiskProvider = new StreamToDiskProvider( storeDir, fsa, pageCache, new Monitors() );
+
+            // and
+            subject.copyStoreFiles( addressProvider, storeId, streamToDiskProvider, () -> defaultTerminationCondition );
+
+            // then
+            assertEquals( fileContent( new File( storeDir, fileName ) ), finishedContent );
+
+            // and
+            PagedFile pagedFile = pageCache.map( new File( storeDir, pageCacheFileName ), pageCache.pageSize(), StandardOpenOption.READ );
+            ByteBuffer buffer = ByteBuffer.wrap( new byte[finishedContent.length()] );
+            try ( ReadableByteChannel readableByteChannel = pagedFile.openReadableByteChannel() )
+            {
+                readableByteChannel.read( buffer );
+            }
+            assertEquals( finishedContent, new String( buffer.array(), Charsets.UTF_8 ) );
+        }
+        finally
+        {
+            halfWayFailingServer.stop();
+            halfWayFailingServer.shutdown();
+        }
+    }
+
     private static AdvertisedSocketAddress from( int port )
     {
         return new AdvertisedSocketAddress( "localhost", port );
@@ -190,30 +323,63 @@ public class StoreCopyClientIT
         return testDirectory.file( filename );
     }
 
-    private String fileContent( File file ) throws IOException
+    private String fileContent( File file )
     {
         return fileContent( file, fsa );
     }
 
-    static String fileContent( File file, FileSystemAbstraction fsa ) throws IOException
+    private static StringBuilder serverFileContentsStringBuilder( File file, FileSystemAbstraction fileSystemAbstraction )
     {
-        int chunkSize = 128;
-        StringBuilder stringBuilder = new StringBuilder();
-        try ( Reader reader = fsa.openAsReader( file, Charsets.UTF_8 ) )
+        try ( StoreChannel storeChannel = fileSystemAbstraction.open( file, OpenMode.READ ) )
         {
-            CharBuffer charBuffer = CharBuffer.wrap( new char[chunkSize] );
-            while ( reader.read( charBuffer ) != -1 )
+            final int MAX_BUFFER_SIZE = 100;
+            ByteBuffer byteBuffer = ByteBuffer.wrap( new byte[MAX_BUFFER_SIZE] );
+            StringBuilder stringBuilder = new StringBuilder();
+            Predicate<Integer> inRange = betweenZeroAndRange( MAX_BUFFER_SIZE );
+            Supplier<Integer> readNext = unchecked( () -> storeChannel.read( byteBuffer ) );
+            for ( int readBytes = readNext.get(); inRange.test( readBytes ); readBytes = readNext.get() )
             {
-                charBuffer.flip();
-                stringBuilder.append( charBuffer );
-                charBuffer.clear();
+                for ( byte index = 0; index < readBytes; index++ )
+                {
+                    char actual = (char) byteBuffer.get( index );
+                    stringBuilder.append( actual );
+                }
             }
+            return stringBuilder;
         }
-        return stringBuilder.toString();
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
     }
 
-    private String clientFileContents( InMemoryFileSystemStream storeFileStreams, String filename )
+    static String fileContent( File file, FileSystemAbstraction fileSystemAbstraction )
     {
-        return storeFileStreams.filesystem.get( filename ).toString();
+        return serverFileContentsStringBuilder( file, fileSystemAbstraction ).toString();
+    }
+
+    private static Supplier<Integer> unchecked( ThrowingSupplier<Integer,?> throwableSupplier )
+    {
+        return () ->
+        {
+            try
+            {
+                return throwableSupplier.get();
+            }
+            catch ( Throwable throwable )
+            {
+                throw new RuntimeException( throwable );
+            }
+        };
+    }
+
+    private static Predicate<Integer> betweenZeroAndRange( int range )
+    {
+        return bytes -> bytes > 0 && bytes <= range;
+    }
+
+    private String clientFileContents( InMemoryStoreStreamProvider storeFileStreamsProvider, String filename )
+    {
+        return storeFileStreamsProvider.fileStreams().get( filename ).toString();
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClientTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClientTest.java
@@ -68,7 +68,7 @@ public class StoreCopyClientTest
     private final AdvertisedSocketAddress expectedAdvertisedAddress = new AdvertisedSocketAddress( "host", 1234 );
     private final CatchupAddressProvider catchupAddressProvider = CatchupAddressProvider.fromSingleAddress( expectedAdvertisedAddress );
     private final StoreId expectedStoreId = new StoreId( 1, 2, 3, 4 );
-    private final StoreFileStreams expectedStoreFileStreams = mock( StoreFileStreams.class );
+    private final StoreFileStreamProvider expectedStoreFileStream = mock( StoreFileStreamProvider.class );
 
     // helpers
     private File[] serverFiles = new File[]{new File( "fileA.txt" ), new File( "fileB.bmp" )};
@@ -96,7 +96,7 @@ public class StoreCopyClientTest
         when( catchUpClient.makeBlockingRequest( any(), any( GetIndexFilesRequest.class ), any() ) ).thenReturn( success );
 
         // when client requests catchup
-        subject.copyStoreFiles( catchupAddressProvider, expectedStoreId, expectedStoreFileStreams, continueIndefinitely() );
+        subject.copyStoreFiles( catchupAddressProvider, expectedStoreId, expectedStoreFileStream, continueIndefinitely() );
 
         // then there are as many requests to the server for individual requests
         List<String> filteredRequests = filenamesFromIndividualFileRequests( getRequests() );
@@ -146,7 +146,7 @@ public class StoreCopyClientTest
         // when we perform catchup
         try
         {
-            subject.copyStoreFiles( catchupAddressProvider, expectedStoreId, expectedStoreFileStreams, () -> () ->
+            subject.copyStoreFiles( catchupAddressProvider, expectedStoreId, expectedStoreFileStream, () -> () ->
             {
                 throw new StoreCopyFailedException( "This can't go on" );
             } );
@@ -174,7 +174,7 @@ public class StoreCopyClientTest
         expectedException.expect( StoreCopyFailedException.class );
 
         // when
-        subject.copyStoreFiles( catchupAddressProvider, expectedStoreId, expectedStoreFileStreams, continueIndefinitely() );
+        subject.copyStoreFiles( catchupAddressProvider, expectedStoreId, expectedStoreFileStream, continueIndefinitely() );
     }
 
     @Test
@@ -190,26 +190,7 @@ public class StoreCopyClientTest
         expectedException.expect( StoreCopyFailedException.class );
 
         // when
-        subject.copyStoreFiles( catchupAddressProvider, expectedStoreId, expectedStoreFileStreams, continueIndefinitely() );
-    }
-
-    @Test
-    public void storeIdMismatchOnCopyIndividualFile() throws StoreCopyFailedException, CatchUpClientException
-    {
-        // given listing response will be successful
-        PrepareStoreCopyResponse prepareStoreCopyResponse = PrepareStoreCopyResponse.success( serverFiles, indexIds, -123L );
-        when( catchUpClient.makeBlockingRequest( any(), any(), any() ) ).thenReturn( prepareStoreCopyResponse );
-
-        // and individual file requests get store id mismatch
-        StoreCopyFinishedResponse individualFileStoreCopyResposne = new StoreCopyFinishedResponse( StoreCopyFinishedResponse.Status.E_STORE_ID_MISMATCH );
-        when( catchUpClient.makeBlockingRequest( any(), any(), any() ) ).thenReturn( prepareStoreCopyResponse, individualFileStoreCopyResposne );
-
-        // then exception denotes store id mismatch
-        expectedException.expect( StoreCopyFailedException.class );
-        expectedException.expectMessage( "Store id mismatch" );
-
-        // when copy is performed
-        subject.copyStoreFiles( catchupAddressProvider, expectedStoreId, expectedStoreFileStreams, continueIndefinitely() );
+        subject.copyStoreFiles( catchupAddressProvider, expectedStoreId, expectedStoreFileStream, continueIndefinitely() );
     }
 
     private List<CatchUpRequest> getRequests() throws CatchUpClientException


### PR DESCRIPTION
We want to avoid using append when writing to file. Since files can now retry, we would get a situation where files would append from the beginning to half finished files.
    
The StoreFileStream would previously use a kind of mixed design where page files would be stored in a map while normal files would just open new output stream and append.
    
This introduces a StoreFileStreamProvider for the catchup client. Each StoreFileStream need to be closed after use. Append has been disabled so that we always start over when retrying to download a file.
