### PR TITLE
Skip HA tests in normal builds, run them only when requested

### DIFF
--- a/enterprise/ha/pom.xml
+++ b/enterprise/ha/pom.xml
@@ -50,6 +50,55 @@
     </license>
   </licenses>
 
+  <profiles>
+    <profile>
+      <id>test-ha</id>
+      <activation>
+        <property>
+          <name>test-ha</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>false</skipTests>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <skipTests>false</skipTests>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.neo4j</groupId>


### PR DESCRIPTION
Forward port of 66a77bd346061a1461e1c4cc602eca77ba32bf1d and
 4b580ce4d5db18b0d04ff1ca832a5907e7c42c8b that were null
 forward merged.