### PR TITLE
Make sure we always read at least one line of data from the metric file

### DIFF
--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/MetricsTestHelper.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/MetricsTestHelper.java
@@ -135,7 +135,15 @@ public class MetricsTestHelper
 
             T currentValue = startValue;
             String line;
-            while ( (line = reader.readLine()) != null )
+
+            // Always read at least one line of data
+            do
+            {
+                line = reader.readLine();
+            }
+            while ( line == null );
+
+            do
             {
                 String[] fields = line.split( "," );
                 T newValue = parser.apply( fields[metricsValue.ordinal()] );
@@ -143,6 +151,7 @@ public class MetricsTestHelper
                         assumption.test( newValue, currentValue ) );
                 currentValue = newValue;
             }
+            while ( (line = reader.readLine()) != null );
             return currentValue;
         }
     }

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/output/RotatableCsvOutputIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/output/RotatableCsvOutputIT.java
@@ -39,6 +39,8 @@ import org.neo4j.test.rule.TestDirectory;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.neo4j.metrics.MetricsSettings.csvMaxArchives;
 import static org.neo4j.metrics.MetricsSettings.csvPath;
 import static org.neo4j.metrics.MetricsSettings.csvRotationThreshold;
 import static org.neo4j.metrics.MetricsTestHelper.readLongValueAndAssert;
@@ -52,6 +54,7 @@ public class RotatableCsvOutputIT
     private File outputPath;
     private GraphDatabaseService database;
     private static final BiPredicate<Long,Long> MONOTONIC = ( newValue, currentValue ) -> newValue >= currentValue;
+    private static final int MAX_ARCHIVES = 20;
 
     @Before
     public void setup()
@@ -60,6 +63,7 @@ public class RotatableCsvOutputIT
         database = new EnterpriseGraphDatabaseFactory().newEmbeddedDatabaseBuilder( testDirectory.graphDbDir() )
                 .setConfig( csvPath, outputPath.getAbsolutePath() )
                 .setConfig( csvRotationThreshold, "21" )
+                .setConfig( csvMaxArchives, String.valueOf( MAX_ARCHIVES ) )
                 .setConfig( OnlineBackupSettings.online_backup_enabled, Settings.FALSE )
                 .newGraphDatabase();
     }
@@ -73,23 +77,23 @@ public class RotatableCsvOutputIT
     @Test
     public void rotateMetricsFile() throws InterruptedException, IOException
     {
+        // Commit a transaction and wait for rotation to happen
         doTransaction();
+        waitForRotation( outputPath, TransactionMetrics.TX_COMMITTED );
 
-        // wait for rotation to happen
-        File metricsFile1 = metricsCsv( outputPath, TransactionMetrics.TX_COMMITTED, 1 );
-        long committedTransactions = readLongValueAndAssert( metricsFile1, MONOTONIC );
+        // Latest file should now have recorded the transaction
+        File metricsFile = metricsCsv( outputPath, TransactionMetrics.TX_COMMITTED );
+        long committedTransactions = readLongValueAndAssert( metricsFile, MONOTONIC );
         assertEquals( 1, committedTransactions );
 
+        // Commit yet another transaction and wait for rotation to happen again
         doTransaction();
+        waitForRotation( outputPath, TransactionMetrics.TX_COMMITTED );
 
-        // Wait for rotation, since we rotated twice, file 3 is actually the original file
-        File metricsFile2 = metricsCsv( outputPath, TransactionMetrics.TX_COMMITTED, 2 );
-        long oldCommittedTransactions = readLongValueAndAssert( metricsFile2, MONOTONIC );
-        assertEquals( 1, oldCommittedTransactions );
-
-        File metricsFile = metricsCsv( outputPath, TransactionMetrics.TX_COMMITTED );
-        long lastCommittedTransactions = readLongValueAndAssert( metricsFile, MONOTONIC );
-        assertEquals( 2, lastCommittedTransactions );
+        // Latest file should now have recorded the new transaction
+        File metricsFile2 = metricsCsv( outputPath, TransactionMetrics.TX_COMMITTED );
+        long committedTransactions2 = readLongValueAndAssert( metricsFile2, MONOTONIC );
+        assertEquals( 2, committedTransactions2 );
     }
 
     private void doTransaction()
@@ -101,6 +105,25 @@ public class RotatableCsvOutputIT
         }
     }
 
+    private static void waitForRotation( File dbDir, String metric ) throws InterruptedException
+    {
+        // Find highest missing file
+        int i = 0;
+        while ( getMetricFile( dbDir, metric, i ).exists() )
+        {
+            i++;
+        }
+
+        if ( i >= MAX_ARCHIVES )
+        {
+            fail( "Test did not finish before " + MAX_ARCHIVES + " rotations, which means we have rotated away from the " +
+                    "file we want to assert on." );
+        }
+
+        // wait for file to exists
+        metricsCsv( dbDir, metric, i );
+    }
+
     private static File metricsCsv( File dbDir, String metric ) throws InterruptedException
     {
         return metricsCsv( dbDir, metric, 0 );
@@ -108,8 +131,13 @@ public class RotatableCsvOutputIT
 
     private static File metricsCsv( File dbDir, String metric, long index ) throws InterruptedException
     {
-        File csvFile = new File( dbDir, index > 0 ? metric + ".csv." + index : metric + ".csv" );
+        File csvFile = getMetricFile( dbDir, metric, index );
         assertEventually( "Metrics file should exist", csvFile::exists, is( true ), 40, SECONDS );
         return csvFile;
+    }
+
+    private static File getMetricFile( File dbDir, String metric, long index )
+    {
+        return new File( dbDir, index > 0 ? metric + ".csv." + index : metric + ".csv" );
     }
 }


### PR DESCRIPTION
This is done to unflake the `RotatableCsvOutputIT`. The test is a bit reworked and now actually waits for a rotation to happen.

The test no longer tries to check that the rotation is done correctly in terms of renaming, since this cannot be reliably done at integration test level. This behavior is already validated by the `RotatingFileOutputStreamSupplier` tests.