### PR TITLE
Core API: findNodes for composite and string queries

### DIFF
--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/GraphDatabaseService.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/GraphDatabaseService.java
@@ -135,6 +135,92 @@ public interface GraphDatabaseService
     ResourceIterator<Node> findNodes( Label label, String key, Object value );
 
     /**
+     * Returns all nodes having the label, and the wanted property values.
+     * If an online index is found, it will be used to look up the requested
+     * nodes. The specified properties do not have to be provided in the same order
+     * as they were defined in the index.
+     * <p>
+     * If no indexes exist for the label with all provided properties, the database will
+     * scan all labeled nodes looking for matching nodes.
+     * <p>
+     * Note that equality for values do not follow the rules of Java. This means that the number 42 is equals to all
+     * other 42 numbers, indifferently of if they are encoded as Integer, Long, Float, Short, Byte or Double.
+     * <p>
+     * Same rules follow Character and String - the Character 'A' is equal to the String 'A'.
+     * <p>
+     * Finally - arrays also follow these rules. An int[] {1,2,3} is equal to a double[] {1.0, 2.0, 3.0}
+     * <p>
+     * Please ensure that the returned {@link ResourceIterator} is closed correctly and as soon as possible
+     * inside your transaction to avoid potential blocking of write operations.
+     *
+     * @param label  consider nodes with this label
+     * @param key1   required property key1
+     * @param value1 required property value of key1
+     * @param key2   required property key2
+     * @param value2 required property value of key2
+     * @return an iterator containing all matching nodes. See {@link ResourceIterator} for responsibilities.
+     */
+    ResourceIterator<Node> findNodes( Label label, String key1, Object value1, String key2, Object value2 );
+
+    /**
+     * Returns all nodes having the label, and the wanted property values.
+     * If an online index is found, it will be used to look up the requested
+     * nodes. The specified properties do not have to be provided in the same order
+     * as they were defined in the index.
+     * <p>
+     * If no indexes exist for the label with all provided properties, the database will
+     * scan all labeled nodes looking for matching nodes.
+     * <p>
+     * Note that equality for values do not follow the rules of Java. This means that the number 42 is equals to all
+     * other 42 numbers, indifferently of if they are encoded as Integer, Long, Float, Short, Byte or Double.
+     * <p>
+     * Same rules follow Character and String - the Character 'A' is equal to the String 'A'.
+     * <p>
+     * Finally - arrays also follow these rules. An int[] {1,2,3} is equal to a double[] {1.0, 2.0, 3.0}
+     * <p>
+     * Please ensure that the returned {@link ResourceIterator} is closed correctly and as soon as possible
+     * inside your transaction to avoid potential blocking of write operations.
+     *
+     * @param label  consider nodes with this label
+     * @param key1   required property key1
+     * @param value1 required property value of key1
+     * @param key2   required property key2
+     * @param value2 required property value of key2
+     * @param key3   required property key3
+     * @param value3 required property value of key3
+     * @return an iterator containing all matching nodes. See {@link ResourceIterator} for responsibilities.
+     */
+    ResourceIterator<Node> findNodes( Label label,
+                                      String key1, Object value1,
+                                      String key2, Object value2,
+                                      String key3, Object value3 );
+
+    /**
+     * Returns all nodes having the label, and the wanted property values.
+     * If an online index is found, it will be used to look up the requested
+     * nodes. The specified properties do not have to be provided in the same order
+     * as they were defined in the index.
+     * <p>
+     * If no indexes exist for the label with all provided properties, the database will
+     * scan all labeled nodes looking for matching nodes.
+     * <p>
+     * Note that equality for values do not follow the rules of Java. This means that the number 42 is equals to all
+     * other 42 numbers, indifferently of if they are encoded as Integer, Long, Float, Short, Byte or Double.
+     * <p>
+     * Same rules follow Character and String - the Character 'A' is equal to the String 'A'.
+     * <p>
+     * Finally - arrays also follow these rules. An int[] {1,2,3} is equal to a double[] {1.0, 2.0, 3.0}
+     * <p>
+     * Please ensure that the returned {@link ResourceIterator} is closed correctly and as soon as possible
+     * inside your transaction to avoid potential blocking of write operations.
+     *
+     * @param label          consider nodes with this label
+     * @param propertyValues required property key-value combinations
+     * @return an iterator containing all matching nodes. See {@link ResourceIterator} for responsibilities.
+     */
+    ResourceIterator<Node> findNodes( Label label, Map<String, Object> propertyValues );
+
+    /**
      * Returns all nodes having a given label, and a property value of type String or Character matching the
      * given value template and search mode.
      * <p>

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/GraphDatabaseService.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/GraphDatabaseService.java
@@ -135,6 +135,35 @@ public interface GraphDatabaseService
     ResourceIterator<Node> findNodes( Label label, String key, Object value );
 
     /**
+     * Returns all nodes having a given label, and a property value of type String or Character matching the
+     * given value template and search mode.
+     * <p>
+     * If an online index is found, it will be used to look up the requested nodes.
+     * If no indexes exist for the label/property combination, the database will
+     * scan all labeled nodes looking for matching property values.
+     * <p>
+     * The search mode and value template are used to select nodes of interest. The search mode can
+     * be one of
+     * <ul>
+     *   <li>EXACT: The value has to match the template exactly.</li>
+     *   <li>PREFIX: The value must have a prefix matching the template.</li>
+     *   <li>SUFFIX: The value must have a suffix matching the template.</li>
+     *   <li>CONTAINS: The value must contain the template. Only exact matches are supported.</li>
+     * </ul>
+     * Note that in Neo4j the Character 'A' will be treated the same way as the String 'A'.
+     * <p>
+     * Please ensure that the returned {@link ResourceIterator} is closed correctly and as soon as possible
+     * inside your transaction to avoid potential blocking of write operations.
+     *
+     * @param label      consider nodes with this label
+     * @param key        required property key
+     * @param template   required property value template
+     * @param searchMode required property value template
+     * @return an iterator containing all matching nodes. See {@link ResourceIterator} for responsibilities.
+     */
+    ResourceIterator<Node> findNodes( Label label, String key, String template, StringSearchMode searchMode );
+
+    /**
      * Equivalent to {@link #findNodes(Label, String, Object)}, however it must find no more than one
      * {@link Node node} or it will throw an exception.
      *

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/GraphDatabaseService.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/GraphDatabaseService.java
@@ -160,7 +160,10 @@ public interface GraphDatabaseService
      * @param value2 required property value of key2
      * @return an iterator containing all matching nodes. See {@link ResourceIterator} for responsibilities.
      */
-    ResourceIterator<Node> findNodes( Label label, String key1, Object value1, String key2, Object value2 );
+    default ResourceIterator<Node> findNodes( Label label, String key1, Object value1, String key2, Object value2 )
+    {
+        throw new UnsupportedOperationException( "Composite findNodes is not supported by this GraphDatabaseService" );
+    }
 
     /**
      * Returns all nodes having the label, and the wanted property values.
@@ -190,10 +193,13 @@ public interface GraphDatabaseService
      * @param value3 required property value of key3
      * @return an iterator containing all matching nodes. See {@link ResourceIterator} for responsibilities.
      */
-    ResourceIterator<Node> findNodes( Label label,
+    default ResourceIterator<Node> findNodes( Label label,
                                       String key1, Object value1,
                                       String key2, Object value2,
-                                      String key3, Object value3 );
+                                      String key3, Object value3 )
+    {
+        throw new UnsupportedOperationException( "Composite findNodes is not supported by this GraphDatabaseService" );
+    }
 
     /**
      * Returns all nodes having the label, and the wanted property values.
@@ -218,7 +224,10 @@ public interface GraphDatabaseService
      * @param propertyValues required property key-value combinations
      * @return an iterator containing all matching nodes. See {@link ResourceIterator} for responsibilities.
      */
-    ResourceIterator<Node> findNodes( Label label, Map<String, Object> propertyValues );
+    default ResourceIterator<Node> findNodes( Label label, Map<String, Object> propertyValues )
+    {
+        throw new UnsupportedOperationException( "Composite findNodes is not supported by this GraphDatabaseService" );
+    }
 
     /**
      * Returns all nodes having a given label, and a property value of type String or Character matching the
@@ -247,7 +256,10 @@ public interface GraphDatabaseService
      * @param searchMode required property value template
      * @return an iterator containing all matching nodes. See {@link ResourceIterator} for responsibilities.
      */
-    ResourceIterator<Node> findNodes( Label label, String key, String template, StringSearchMode searchMode );
+    default ResourceIterator<Node> findNodes( Label label, String key, String template, StringSearchMode searchMode )
+    {
+        throw new UnsupportedOperationException( "Specialized string queries are not supported by this GraphDatabaseService" );
+    }
 
     /**
      * Equivalent to {@link #findNodes(Label, String, Object)}, however it must find no more than one

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/GraphDatabaseService.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/GraphDatabaseService.java
@@ -118,7 +118,7 @@ public interface GraphDatabaseService
      * scan all labeled nodes looking for the property value.
      * <p>
      * Note that equality for values do not follow the rules of Java. This means that the number 42 is equals to all
-     * other 42 numbers, indifferently of if they are encoded as Integer, Long, Float, Short, Byte or Double.
+     * other 42 numbers, regardless of whether they are encoded as Integer, Long, Float, Short, Byte or Double.
      * <p>
      * Same rules follow Character and String - the Character 'A' is equal to the String 'A'.
      * <p>
@@ -143,7 +143,7 @@ public interface GraphDatabaseService
      * scan all labeled nodes looking for matching nodes.
      * <p>
      * Note that equality for values do not follow the rules of Java. This means that the number 42 is equals to all
-     * other 42 numbers, indifferently of if they are encoded as Integer, Long, Float, Short, Byte or Double.
+     * other 42 numbers, regardless of whether they are encoded as Integer, Long, Float, Short, Byte or Double.
      * <p>
      * Same rules follow Character and String - the Character 'A' is equal to the String 'A'.
      * <p>
@@ -173,7 +173,7 @@ public interface GraphDatabaseService
      * scan all labeled nodes looking for matching nodes.
      * <p>
      * Note that equality for values do not follow the rules of Java. This means that the number 42 is equals to all
-     * other 42 numbers, indifferently of if they are encoded as Integer, Long, Float, Short, Byte or Double.
+     * other 42 numbers, regardless of whether they are encoded as Integer, Long, Float, Short, Byte or Double.
      * <p>
      * Same rules follow Character and String - the Character 'A' is equal to the String 'A'.
      * <p>
@@ -208,7 +208,7 @@ public interface GraphDatabaseService
      * scan all labeled nodes looking for matching nodes.
      * <p>
      * Note that equality for values do not follow the rules of Java. This means that the number 42 is equals to all
-     * other 42 numbers, indifferently of if they are encoded as Integer, Long, Float, Short, Byte or Double.
+     * other 42 numbers, regardless of whether they are encoded as Integer, Long, Float, Short, Byte or Double.
      * <p>
      * Same rules follow Character and String - the Character 'A' is equal to the String 'A'.
      * <p>
@@ -237,7 +237,7 @@ public interface GraphDatabaseService
      * The search mode and value template are used to select nodes of interest. The search mode can
      * be one of
      * <ul>
-     *   <li>EXACT: The value has to match the template exactly.</li>
+     *   <li>EXACT: The value has to match the template exactly. This is the same behavior as {@link GraphDatabaseService#findNode(Label, String, Object)}.</li>
      *   <li>PREFIX: The value must have a prefix matching the template.</li>
      *   <li>SUFFIX: The value must have a suffix matching the template.</li>
      *   <li>CONTAINS: The value must contain the template. Only exact matches are supported.</li>

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/GraphDatabaseService.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/GraphDatabaseService.java
@@ -137,8 +137,7 @@ public interface GraphDatabaseService
     /**
      * Returns all nodes having the label, and the wanted property values.
      * If an online index is found, it will be used to look up the requested
-     * nodes. The specified properties do not have to be provided in the same order
-     * as they were defined in the index.
+     * nodes.
      * <p>
      * If no indexes exist for the label with all provided properties, the database will
      * scan all labeled nodes looking for matching nodes.
@@ -162,14 +161,13 @@ public interface GraphDatabaseService
      */
     default ResourceIterator<Node> findNodes( Label label, String key1, Object value1, String key2, Object value2 )
     {
-        throw new UnsupportedOperationException( "Composite findNodes is not supported by this GraphDatabaseService" );
+        throw new UnsupportedOperationException( "findNodes by multiple property names and values is not supported." );
     }
 
     /**
      * Returns all nodes having the label, and the wanted property values.
      * If an online index is found, it will be used to look up the requested
-     * nodes. The specified properties do not have to be provided in the same order
-     * as they were defined in the index.
+     * nodes.
      * <p>
      * If no indexes exist for the label with all provided properties, the database will
      * scan all labeled nodes looking for matching nodes.
@@ -198,14 +196,13 @@ public interface GraphDatabaseService
                                       String key2, Object value2,
                                       String key3, Object value3 )
     {
-        throw new UnsupportedOperationException( "Composite findNodes is not supported by this GraphDatabaseService" );
+        throw new UnsupportedOperationException( "findNodes by multiple property names and values is not supported." );
     }
 
     /**
      * Returns all nodes having the label, and the wanted property values.
      * If an online index is found, it will be used to look up the requested
-     * nodes. The specified properties do not have to be provided in the same order
-     * as they were defined in the index.
+     * nodes.
      * <p>
      * If no indexes exist for the label with all provided properties, the database will
      * scan all labeled nodes looking for matching nodes.
@@ -226,7 +223,7 @@ public interface GraphDatabaseService
      */
     default ResourceIterator<Node> findNodes( Label label, Map<String, Object> propertyValues )
     {
-        throw new UnsupportedOperationException( "Composite findNodes is not supported by this GraphDatabaseService" );
+        throw new UnsupportedOperationException( "findNodes by multiple property names and values is not supported." );
     }
 
     /**
@@ -258,7 +255,7 @@ public interface GraphDatabaseService
      */
     default ResourceIterator<Node> findNodes( Label label, String key, String template, StringSearchMode searchMode )
     {
-        throw new UnsupportedOperationException( "Specialized string queries are not supported by this GraphDatabaseService" );
+        throw new UnsupportedOperationException( "Specialized string queries are not supported" );
     }
 
     /**

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/StringSearchMode.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/StringSearchMode.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb;
+
+/**
+ * The string search mode is used together with a value template to find nodes of interest.
+ * The search mode can be one of:
+ * <ul>
+ *   <li>EXACT: The value has to match the template exactly.</li>
+ *   <li>PREFIX: The value must have a prefix matching the template.</li>
+ *   <li>SUFFIX: The value must have a suffix matching the template.</li>
+ *   <li>CONTAINS: The value must contain the template. Only exact matches are supported.</li>
+ * </ul>
+ */
+public enum StringSearchMode
+{
+    /**
+     * The value has to match the template exactly.
+     */
+    EXACT,
+    /**
+     * The value must have a prefix matching the template.
+     */
+    PREFIX,
+    /**
+     * The value must have a suffix matching the template.
+     */
+    SUFFIX,
+    /**
+     * The value must contain the template. Only exact matches are supported.
+     */
+    CONTAINS;
+}

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/StringSearchMode.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/StringSearchMode.java
@@ -44,7 +44,7 @@ public enum StringSearchMode
      */
     SUFFIX,
     /**
-     * The value must contain the template. Only exact matches are supported.
+     * The value must contain the template exactly. Regular expressions are not supported.
      */
     CONTAINS;
 }

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeIndexTransactionStateTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeIndexTransactionStateTestBase.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.kernel.api;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.collection.primitive.Primitive;
+import org.neo4j.collection.primitive.PrimitiveLongSet;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.values.storable.Values;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.graphdb.Label.label;
+
+public abstract class NodeIndexTransactionStateTestBase<G extends KernelAPIWriteTestSupport>
+        extends KernelAPIWriteTestBase<G>
+{
+    @Test
+    public void shouldPerformStringSuffixSearch() throws Exception
+    {
+        // given
+        PrimitiveLongSet expected = Primitive.longSet();
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            expected.add( nodeWithProp( tx, "1suff" ) );
+            nodeWithProp( tx, "pluff" );
+            tx.success();
+        }
+
+        createIndex();
+
+        // when
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            int label = tx.tokenRead().nodeLabel( "Node" );
+            int prop = tx.tokenRead().propertyKey( "prop" );
+            expected.add( nodeWithProp( tx, "2suff" ) );
+            nodeWithProp( tx, "skruff" );
+            CapableIndexReference index = tx.schemaRead().index( label, prop );
+            try ( NodeValueIndexCursor nodes = cursors.allocateNodeValueIndexCursor() )
+            {
+                tx.dataRead().nodeIndexSeek( index, nodes, IndexOrder.NONE, IndexQuery.stringSuffix( prop, "suff" ) );
+                PrimitiveLongSet found = Primitive.longSet();
+                while ( nodes.next() )
+                {
+                    found.add( nodes.nodeReference() );
+                }
+
+                assertThat( found, equalTo( expected ) );
+            }
+        }
+    }
+
+    @Test
+    public void shouldPerformStringContainsSearch() throws Exception
+    {
+        // given
+        PrimitiveLongSet expected = Primitive.longSet();
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            expected.add( nodeWithProp( tx, "gnomebat" ) );
+            nodeWithProp( tx, "fishwombat" );
+            tx.success();
+        }
+
+        createIndex();
+
+        // when
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            int label = tx.tokenRead().nodeLabel( "Node" );
+            int prop = tx.tokenRead().propertyKey( "prop" );
+            expected.add( nodeWithProp( tx, "homeopatic" ) );
+            nodeWithProp( tx, "telephonecompany" );
+            CapableIndexReference index = tx.schemaRead().index( label, prop );
+            try ( NodeValueIndexCursor nodes = cursors.allocateNodeValueIndexCursor() )
+            {
+                tx.dataRead().nodeIndexSeek( index, nodes, IndexOrder.NONE, IndexQuery.stringContains( prop, "me" ) );
+                PrimitiveLongSet found = Primitive.longSet();
+                while ( nodes.next() )
+                {
+                    found.add( nodes.nodeReference() );
+                }
+
+                assertThat( found, equalTo( expected ) );
+            }
+        }
+    }
+
+    private long nodeWithProp( Transaction tx, Object value ) throws Exception
+    {
+        Write write = tx.dataWrite();
+        long node = write.nodeCreate();
+        write.nodeAddLabel( node, tx.tokenWrite().labelGetOrCreateForName( "Node" ) );
+        write.nodeSetProperty( node, tx.tokenWrite().propertyKeyGetOrCreateForName( "prop" ), Values.of( value ) );
+        return node;
+    }
+
+    private void createIndex()
+    {
+        try ( org.neo4j.graphdb.Transaction tx = graphDb.beginTx() )
+        {
+            graphDb.schema().indexFor( Label.label( "Node" ) ).on( "prop" ).create();
+            tx.success();
+        }
+
+        try ( org.neo4j.graphdb.Transaction tx = graphDb.beginTx() )
+        {
+            graphDb.schema().awaitIndexesOnline( 1, TimeUnit.MINUTES );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema/LabelSchemaDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema/LabelSchemaDescriptor.java
@@ -88,7 +88,7 @@ public class LabelSchemaDescriptor implements org.neo4j.internal.kernel.api.sche
         if ( propertyIds.length != 1 )
         {
             throw new IllegalStateException(
-                    "Single property schema required one property but had " + propertyIds.length );
+                    "Single property schema requires one property but had " + propertyIds.length );
         }
         return propertyIds[0];
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema/LabelSchemaDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema/LabelSchemaDescriptor.java
@@ -88,7 +88,7 @@ public class LabelSchemaDescriptor implements org.neo4j.internal.kernel.api.sche
         if ( propertyIds.length != 1 )
         {
             throw new IllegalStateException(
-                    "Single property schema requires one property but had " + propertyIds.length );
+                    "Single property schema required one property but had " + propertyIds.length );
         }
         return propertyIds[0];
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
@@ -1018,7 +1018,8 @@ public class TxState implements TransactionState, RelationshipVisitor.Home
     @Override
     public PrimitiveLongReadableDiffSets indexUpdatesForSuffixOrContains( SchemaIndexDescriptor descriptor, IndexQuery query )
     {
-        descriptor.schema().getPropertyId(); // assert single property index
+        assert descriptor.schema().getPropertyIds().length == 0 :
+                "Suffix and contains queries are only supported for single property queries";
 
         if ( indexUpdates == null )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
@@ -1018,7 +1018,7 @@ public class TxState implements TransactionState, RelationshipVisitor.Home
     @Override
     public PrimitiveLongReadableDiffSets indexUpdatesForSuffixOrContains( SchemaIndexDescriptor descriptor, IndexQuery query )
     {
-        assert descriptor.schema().getPropertyIds().length == 0 :
+        assert descriptor.schema().getPropertyIds().length == 1 :
                 "Suffix and contains queries are only supported for single property queries";
 
         if ( indexUpdates == null )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -596,19 +596,18 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI, EmbeddedProxySPI
         IndexQuery query;
         switch ( searchMode )
         {
+        case EXACT:
+            query = IndexQuery.exact( propertyId, Values.stringValue( value ) );
+            break;
         case PREFIX:
             query = IndexQuery.stringPrefix( propertyId, value );
             break;
-// TODO: test the others
-//        case EXACT:
-//            query = IndexQuery.exact( propertyId, Values.stringValue( value ) );
-//            break;
-//        case SUFFIX:
-//            query = IndexQuery.stringPrefix( propertyId, value );
-//            break;
-//        case CONTAINS:
-//            query = IndexQuery.stringPrefix( propertyId, value );
-//            break;
+        case SUFFIX:
+            query = IndexQuery.stringSuffix( propertyId, value );
+            break;
+        case CONTAINS:
+            query = IndexQuery.stringContains( propertyId, value );
+            break;
         default:
             throw new IllegalStateException( "Unknown string search mode: " + searchMode );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeValueIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeValueIndexCursor.java
@@ -85,6 +85,7 @@ final class DefaultNodeValueIndexCursor extends IndexCursor<IndexProgressor>
             break;
 
         case stringPrefix:
+            assert query.length == 1;
             prefixQuery( descriptor, (IndexQuery.StringPrefixPredicate) firstPredicate );
             break;
 

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/ReadableTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/ReadableTransactionState.java
@@ -25,6 +25,7 @@ import org.neo4j.collection.primitive.PrimitiveIntSet;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.collection.primitive.PrimitiveLongResourceIterator;
 import org.neo4j.cursor.Cursor;
+import org.neo4j.internal.kernel.api.IndexQuery;
 import org.neo4j.internal.kernel.api.exceptions.schema.ConstraintValidationException;
 import org.neo4j.internal.kernel.api.schema.SchemaDescriptor;
 import org.neo4j.internal.kernel.api.schema.constraints.ConstraintDescriptor;
@@ -139,6 +140,8 @@ public interface ReadableTransactionState
     Long indexCreatedForConstraint( ConstraintDescriptor constraint );
 
     PrimitiveLongReadableDiffSets indexUpdatesForScan( SchemaIndexDescriptor index );
+
+    PrimitiveLongReadableDiffSets indexUpdatesForSuffixOrContains( SchemaIndexDescriptor index, IndexQuery query );
 
     PrimitiveLongReadableDiffSets indexUpdatesForSeek( SchemaIndexDescriptor index, ValueTuple values );
 

--- a/community/kernel/src/test/java/org/neo4j/graphdb/IndexingCompositeQueryAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/IndexingCompositeQueryAcceptanceTest.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.neo4j.collection.primitive.Primitive;
+import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.collection.primitive.PrimitiveLongSet;
+import org.neo4j.test.mockito.matcher.Neo4jMatchers;
+import org.neo4j.test.rule.ImpermanentDatabaseRule;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.helpers.collection.Iterators.array;
+
+@RunWith( Parameterized.class )
+public class IndexingCompositeQueryAcceptanceTest
+{
+    @ClassRule
+    public static ImpermanentDatabaseRule dbRule = new ImpermanentDatabaseRule();
+    @Rule
+    public final TestName testName = new TestName();
+
+    @Parameterized.Parameters
+    public static List<Object[]> data()
+    {
+        return Arrays.asList(
+                testCase( array( 2, 3 ), biIndexSeek, true ),
+                testCase( array( 2, 3 ), biIndexSeek, false ),
+                testCase( array( 2, 3, 4 ), triIndexSeek, true ),
+                testCase( array( 2, 3, 4 ), triIndexSeek, false ),
+                testCase( array( 2, 3, 4, 5, 6 ), mapIndexSeek, true ),
+                testCase( array( 2, 3, 4, 5, 6 ), mapIndexSeek, false )
+        );
+    }
+
+    @Parameterized.Parameter( 0 )
+    public String[] keys;
+    @Parameterized.Parameter( 1 )
+    public Object[] values;
+    @Parameterized.Parameter( 2 )
+    public Object[][] nonMatching;
+    @Parameterized.Parameter( 3 )
+    public IndexSeek indexSeek;
+    @Parameterized.Parameter( 4 )
+    public boolean withIndex;
+
+    private static Label LABEL = Label.label( "LABEL1" );;
+    private GraphDatabaseService db;
+
+    @Before
+    public void setup()
+    {
+        db = dbRule.getGraphDatabaseAPI();
+        if ( withIndex )
+        {
+            Neo4jMatchers.createIndex( db, LABEL, keys );
+            Neo4jMatchers.createIndex( db, LABEL, keys[0] );
+        }
+    }
+
+    @After
+    public void tearDown()
+    {
+        dbRule.shutdown();
+    }
+
+    @Test
+    public void shouldSupportIndexSeek()
+    {
+        // GIVEN
+        createNodes( db, LABEL, nonMatching );
+        PrimitiveLongSet expected = createNodes( db, LABEL, values );
+
+        // WHEN
+        PrimitiveLongSet found = Primitive.longSet();
+        try ( Transaction tx = db.beginTx() )
+        {
+            collectNodes( found, indexSeek.findNodes( keys, values, db ) );
+        }
+
+        // THEN
+        assertThat( found, equalTo( expected ) );
+    }
+
+    @Test
+    public void shouldSupportIndexSeekBackwardsOrder()
+    {
+        // GIVEN
+        createNodes( db, LABEL, nonMatching );
+        PrimitiveLongSet expected = createNodes( db, LABEL, values );
+
+        // WHEN
+        PrimitiveLongSet found = Primitive.longSet();
+        String[] reversedKeys = new String[keys.length];
+        Object[] reversedValues = new Object[keys.length];
+        for ( int i = 0; i < keys.length; i++ )
+        {
+            reversedValues[keys.length - 1 - i] = values[i];
+            reversedKeys[keys.length - 1 - i] = keys[i];
+        }
+        try ( Transaction tx = db.beginTx() )
+        {
+            collectNodes( found, indexSeek.findNodes( reversedKeys, reversedValues, db ) );
+        }
+
+        // THEN
+        assertThat( found, equalTo( expected ) );
+    }
+
+    @Test
+    public void shouldIncludeNodesCreatedInSameTxInIndexSeek()
+    {
+        // GIVEN
+        createNodes( db, LABEL, nonMatching[0], nonMatching[1] );
+        PrimitiveLongSet expected = createNodes( db, LABEL, values );
+        // WHEN
+        PrimitiveLongSet found = Primitive.longSet();
+        try ( Transaction tx = db.beginTx() )
+        {
+            expected.add( createNode( db, propertyMap( keys, values ), LABEL ).getId() );
+            createNode( db, propertyMap( keys, nonMatching[2] ), LABEL );
+
+            collectNodes( found, indexSeek.findNodes( keys, values, db ) );
+        }
+        // THEN
+        assertThat( found, equalTo( expected ) );
+    }
+
+    @Test
+    public void shouldNotIncludeNodesDeletedInSameTxInIndexSeek()
+    {
+        // GIVEN
+        createNodes( db, LABEL, nonMatching[0] );
+        PrimitiveLongSet toDelete = createNodes( db, LABEL, values, nonMatching[1], nonMatching[2] );
+        PrimitiveLongSet expected = createNodes( db, LABEL, values );
+        // WHEN
+        PrimitiveLongSet found = Primitive.longSet();
+        try ( Transaction tx = db.beginTx() )
+        {
+            PrimitiveLongIterator deleting = toDelete.iterator();
+            while ( deleting.hasNext() )
+            {
+                long id = deleting.next();
+                db.getNodeById( id ).delete();
+                expected.remove( id );
+            }
+
+            collectNodes( found, indexSeek.findNodes( keys, values, db ) );
+        }
+        // THEN
+        assertThat( found, equalTo( expected ) );
+    }
+
+    @Test
+    public void shouldConsiderNodesChangedInSameTxInIndexSeek()
+    {
+        // GIVEN
+        createNodes( db, LABEL, nonMatching[0] );
+        PrimitiveLongSet toChangeToMatch = createNodes( db, LABEL, nonMatching[1] );
+        PrimitiveLongSet toChangeToNotMatch = createNodes( db, LABEL, values );
+        PrimitiveLongSet expected = createNodes( db, LABEL, values );
+        // WHEN
+        PrimitiveLongSet found = Primitive.longSet();
+        try ( Transaction tx = db.beginTx() )
+        {
+            PrimitiveLongIterator toMatching = toChangeToMatch.iterator();
+            while ( toMatching.hasNext() )
+            {
+                long id = toMatching.next();
+                setProperties( id, values );
+                expected.add( id );
+            }
+            PrimitiveLongIterator toNotMatching = toChangeToNotMatch.iterator();
+            while ( toNotMatching.hasNext() )
+            {
+                long id = toNotMatching.next();
+                setProperties( id, nonMatching[2] );
+                expected.remove( id );
+            }
+
+            collectNodes( found, indexSeek.findNodes( keys, values, db ) );
+        }
+        // THEN
+        assertThat( found, equalTo( expected ) );
+    }
+
+    public PrimitiveLongSet createNodes( GraphDatabaseService db, Label label, Object[]... propertyValueTuples )
+    {
+        PrimitiveLongSet expected = Primitive.longSet();
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( Object[] valueTuple : propertyValueTuples )
+            {
+                expected.add( createNode( db, propertyMap( keys, valueTuple ), label ).getId() );
+            }
+            tx.success();
+        }
+        return expected;
+    }
+
+    public static Map<String,Object> propertyMap( String[] keys, Object[] valueTuple )
+    {
+        Map<String,Object> propertyValues = new HashMap<>();
+        for ( int i = 0; i < keys.length; i++ )
+        {
+            propertyValues.put( keys[i], valueTuple[i] );
+        }
+        return propertyValues;
+    }
+
+    public void collectNodes( PrimitiveLongSet bucket, ResourceIterator<Node> toCollect )
+    {
+        while ( toCollect.hasNext() )
+        {
+            bucket.add( toCollect.next().getId() );
+        }
+    }
+
+    public Node createNode( GraphDatabaseService beansAPI, Map<String, Object> properties, Label... labels )
+    {
+        try ( Transaction tx = beansAPI.beginTx() )
+        {
+            Node node = beansAPI.createNode( labels );
+            for ( Map.Entry<String,Object> property : properties.entrySet() )
+            {
+                node.setProperty( property.getKey(), property.getValue() );
+            }
+            tx.success();
+            return node;
+        }
+    }
+
+    public static Object[] testCase( Integer[] values, IndexSeek indexSeek, boolean withIndex )
+    {
+        Object[][] nonMatching = {plus( values, 1 ), plus( values, 2 ), plus( values, 3 )};
+        String[] keys = Arrays.stream( values ).map( v -> "key" + v ).toArray( String[]::new );
+        return new Object[]{keys, values, nonMatching, indexSeek, withIndex};
+    }
+
+    public static <T> Object[] plus( Integer[] values, int offset )
+    {
+        Object[] result = new Object[values.length];
+        for ( int i = 0; i < values.length; i++ )
+        {
+            result[i] = values[i] + offset;
+        }
+        return result;
+    }
+
+    private void setProperties( long id, Object[] values )
+    {
+        Node node = db.getNodeById( id );
+        for ( int i = 0; i < keys.length; i++ )
+        {
+            node.setProperty( keys[i], values[i] );
+        }
+    }
+
+    public interface IndexSeek {
+        ResourceIterator<Node> findNodes( String[] keys, Object[] values, GraphDatabaseService db );
+    }
+
+    public static IndexSeek biIndexSeek =
+            ( keys, values, db ) ->
+            {
+                assert keys.length == 2;
+                assert values.length == 2;
+                return db.findNodes( LABEL, keys[0], values[0], keys[1], values[1] );
+            };
+
+    public static IndexSeek triIndexSeek =
+            ( keys, values, db ) ->
+            {
+                assert keys.length == 3;
+                assert values.length == 3;
+                return db.findNodes( LABEL, keys[0], values[0], keys[1], values[1], keys[2], values[2] );
+            };
+
+    public static IndexSeek mapIndexSeek =
+            ( keys, values, db ) ->
+            {
+                return db.findNodes( LABEL, propertyMap( keys, values ) );
+            };
+}

--- a/community/kernel/src/test/java/org/neo4j/graphdb/IndexingCompositeQueryAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/IndexingCompositeQueryAcceptanceTest.java
@@ -75,7 +75,7 @@ public class IndexingCompositeQueryAcceptanceTest
     @Parameterized.Parameter( 4 )
     public boolean withIndex;
 
-    private static Label LABEL = Label.label( "LABEL1" );;
+    private static Label LABEL = Label.label( "LABEL1" );
     private GraphDatabaseService db;
 
     @Before
@@ -287,7 +287,8 @@ public class IndexingCompositeQueryAcceptanceTest
         }
     }
 
-    public interface IndexSeek {
+    public interface IndexSeek
+    {
         ResourceIterator<Node> findNodes( String[] keys, Object[] values, GraphDatabaseService db );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/graphdb/IndexingCompositeQueryAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/IndexingCompositeQueryAcceptanceTest.java
@@ -32,11 +32,12 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
-import org.neo4j.test.mockito.matcher.Neo4jMatchers;
+import org.neo4j.graphdb.schema.IndexCreator;
 import org.neo4j.test.rule.ImpermanentDatabaseRule;
 
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -84,8 +85,24 @@ public class IndexingCompositeQueryAcceptanceTest
         db = dbRule.getGraphDatabaseAPI();
         if ( withIndex )
         {
-            Neo4jMatchers.createIndex( db, LABEL, keys );
-            Neo4jMatchers.createIndex( db, LABEL, keys[0] );
+            try ( org.neo4j.graphdb.Transaction tx = db.beginTx() )
+            {
+                db.schema().indexFor( LABEL ).on( keys[0] ).create();
+
+                IndexCreator indexCreator = db.schema().indexFor( LABEL );
+                for ( String key : keys )
+                {
+                    indexCreator = indexCreator.on( key );
+                }
+                indexCreator.create();
+                tx.success();
+            }
+
+            try ( org.neo4j.graphdb.Transaction tx = db.beginTx() )
+            {
+                db.schema().awaitIndexesOnline( 5, TimeUnit.MINUTES );
+                tx.success();
+            }
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/graphdb/IndexingStringQueryAcceptanceTestBase.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/IndexingStringQueryAcceptanceTestBase.java
@@ -170,7 +170,7 @@ public abstract class IndexingStringQueryAcceptanceTestBase
         assertThat( found, equalTo( expected ) );
     }
 
-    public static abstract class EXACT extends IndexingStringQueryAcceptanceTestBase
+    public abstract static class EXACT extends IndexingStringQueryAcceptanceTestBase
     {
         static String[] matching = {"Johan", "Johan", "Johan"};
         static String[] nonMatching = {"Johanna", "Olivia", "InteJohan"};
@@ -197,7 +197,7 @@ public abstract class IndexingStringQueryAcceptanceTestBase
         }
     }
 
-    public static abstract class PREFIX extends IndexingStringQueryAcceptanceTestBase
+    public abstract static class PREFIX extends IndexingStringQueryAcceptanceTestBase
     {
         static String[] matching = {"Olivia", "Olivia2", "OliviaYtterbrink"};
         static String[] nonMatching = {"Johan", "olivia", "InteOlivia"};
@@ -224,7 +224,7 @@ public abstract class IndexingStringQueryAcceptanceTestBase
         }
     }
 
-    public static abstract class SUFFIX extends IndexingStringQueryAcceptanceTestBase
+    public abstract static class SUFFIX extends IndexingStringQueryAcceptanceTestBase
     {
         static String[] matching = {"Jansson", "Hansson", "Svensson"};
         static String[] nonMatching = {"Taverner", "Svensson-Averbuch", "Taylor"};
@@ -251,7 +251,7 @@ public abstract class IndexingStringQueryAcceptanceTestBase
         }
     }
 
-    public static abstract class CONTAINS extends IndexingStringQueryAcceptanceTestBase
+    public abstract static class CONTAINS extends IndexingStringQueryAcceptanceTestBase
     {
         static String[] matching = {"good", "fool", "fooooood"};
         static String[] nonMatching = {"evil", "genius", "hungry"};

--- a/community/kernel/src/test/java/org/neo4j/graphdb/IndexingStringQueryAcceptanceTestBase.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/IndexingStringQueryAcceptanceTestBase.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import java.util.Map;
+
+import org.neo4j.collection.primitive.Primitive;
+import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.collection.primitive.PrimitiveLongSet;
+import org.neo4j.test.mockito.matcher.Neo4jMatchers;
+import org.neo4j.test.rule.ImpermanentDatabaseRule;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.helpers.collection.MapUtil.map;
+
+public abstract class IndexingStringQueryAcceptanceTestBase
+{
+    @ClassRule
+    public static ImpermanentDatabaseRule dbRule = new ImpermanentDatabaseRule();
+    @Rule
+    public final TestName testName = new TestName();
+
+    final String template;
+    final String[] matching;
+    final String[] nonMatching;
+    final StringSearchMode searchMode;
+
+    private Label LABEL;
+    private String KEY = "name";
+    private GraphDatabaseService db;
+
+    protected IndexingStringQueryAcceptanceTestBase( String template, String[] matching,
+            String[] nonMatching, StringSearchMode searchMode )
+    {
+        this.template = template;
+        this.matching = matching;
+        this.nonMatching = nonMatching;
+        this.searchMode = searchMode;
+    }
+
+    @Before
+    public void setupLabels()
+    {
+        LABEL = Label.label( "LABEL1-" + testName.getMethodName() );
+        db = dbRule.getGraphDatabaseAPI();
+        Neo4jMatchers.createIndex( db, LABEL, KEY );
+    }
+
+    @Test
+    public void shouldSupportIndexSeek()
+    {
+        // GIVEN
+        createNodes( db, LABEL, nonMatching );
+        PrimitiveLongSet expected = createNodes( db, LABEL, matching );
+
+        // WHEN
+        PrimitiveLongSet found = Primitive.longSet();
+        try ( Transaction tx = db.beginTx() )
+        {
+            collectNodes( found, db.findNodes( LABEL, KEY, template, searchMode ) );
+        }
+
+        // THEN
+        assertThat( found, equalTo( expected ) );
+    }
+
+    @Test
+    public void shouldIncludeNodesCreatedInSameTxInIndexSeek()
+    {
+        // GIVEN
+        createNodes( db, LABEL, nonMatching[0], nonMatching[1] );
+        PrimitiveLongSet expected = createNodes( db, LABEL, matching[0], matching[1] );
+        // WHEN
+        PrimitiveLongSet found = Primitive.longSet();
+        try ( Transaction tx = db.beginTx() )
+        {
+            expected.add( createNode( db, map( KEY, matching[2] ), LABEL ).getId() );
+            createNode( db, map( KEY, nonMatching[2] ), LABEL );
+
+            collectNodes( found, db.findNodes( LABEL, KEY, template, searchMode ) );
+        }
+        // THEN
+        assertThat( found, equalTo( expected ) );
+    }
+
+    @Test
+    public void shouldNotIncludeNodesDeletedInSameTxInIndexSeek()
+    {
+        // GIVEN
+        createNodes( db, LABEL, nonMatching[0] );
+        PrimitiveLongSet toDelete = createNodes( db, LABEL, matching[0], nonMatching[1], matching[1], nonMatching[2] );
+        PrimitiveLongSet expected = createNodes( db, LABEL, matching[2] );
+        // WHEN
+        PrimitiveLongSet found = Primitive.longSet();
+        try ( Transaction tx = db.beginTx() )
+        {
+            PrimitiveLongIterator deleting = toDelete.iterator();
+            while ( deleting.hasNext() )
+            {
+                long id = deleting.next();
+                db.getNodeById( id ).delete();
+                expected.remove( id );
+            }
+
+            collectNodes( found, db.findNodes( LABEL, KEY, template, searchMode ) );
+        }
+        // THEN
+        assertThat( found, equalTo( expected ) );
+    }
+
+    @Test
+    public void shouldConsiderNodesChangedInSameTxInIndexSeek()
+    {
+        // GIVEN
+        createNodes( db, LABEL, nonMatching[0] );
+        PrimitiveLongSet toChangeToMatch = createNodes( db, LABEL, nonMatching[1] );
+        PrimitiveLongSet toChangeToNotMatch = createNodes( db, LABEL, matching[0] );
+        PrimitiveLongSet expected = createNodes( db, LABEL, matching[1] );
+        // WHEN
+        PrimitiveLongSet found = Primitive.longSet();
+        try ( Transaction tx = db.beginTx() )
+        {
+            PrimitiveLongIterator toMatching = toChangeToMatch.iterator();
+            while ( toMatching.hasNext() )
+            {
+                long id = toMatching.next();
+                db.getNodeById( id ).setProperty( KEY, matching[2] );
+                expected.add( id );
+            }
+            PrimitiveLongIterator toNotMatching = toChangeToNotMatch.iterator();
+            while ( toNotMatching.hasNext() )
+            {
+                long id = toNotMatching.next();
+                db.getNodeById( id ).setProperty( KEY, nonMatching[2] );
+                expected.remove( id );
+            }
+
+            collectNodes( found, db.findNodes( LABEL, KEY, template, searchMode ) );
+        }
+        // THEN
+        assertThat( found, equalTo( expected ) );
+    }
+
+    public static class EXACT extends IndexingStringQueryAcceptanceTestBase
+    {
+        static String[] matching = {"Johan", "Johan", "Johan"};
+        static String[] nonMatching = {"Johanna", "Olivia", "InteJohan"};
+
+        public EXACT()
+        {
+            super( "Johan", matching, nonMatching, StringSearchMode.EXACT );
+        }
+    }
+
+    public static class PREFIX extends IndexingStringQueryAcceptanceTestBase
+    {
+        static String[] matching = {"Olivia", "Olivia2", "OliviaYtterbrink"};
+        static String[] nonMatching = {"Johan", "olivia", "InteOlivia"};
+
+        public PREFIX()
+        {
+            super( "Olivia", matching, nonMatching, StringSearchMode.PREFIX );
+        }
+    }
+
+    public static class SUFFIX extends IndexingStringQueryAcceptanceTestBase
+    {
+        static String[] matching = {"Jansson", "Hansson", "Svensson"};
+        static String[] nonMatching = {"Taverner", "Svensson-Averbuch", "Taylor"};
+
+        public SUFFIX()
+        {
+            super( "sson", matching, nonMatching, StringSearchMode.SUFFIX );
+        }
+    }
+
+    public static class CONTAINS extends IndexingStringQueryAcceptanceTestBase
+    {
+        static String[] matching = {"good", "fool", "fooooood"};
+        static String[] nonMatching = {"evil", "genius", "hungry"};
+
+        public CONTAINS()
+        {
+            super( "oo", matching, nonMatching, StringSearchMode.CONTAINS );
+        }
+    }
+
+    private PrimitiveLongSet createNodes( GraphDatabaseService db, Label label, String... propertyValues )
+    {
+        PrimitiveLongSet expected = Primitive.longSet();
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( String value : propertyValues )
+            {
+                expected.add( createNode( db, map( KEY, value ), label ).getId() );
+            }
+            tx.success();
+        }
+        return expected;
+    }
+
+    private void collectNodes( PrimitiveLongSet bucket, ResourceIterator<Node> toCollect )
+    {
+        while ( toCollect.hasNext() )
+        {
+            bucket.add( toCollect.next().getId() );
+        }
+    }
+
+    private Node createNode( GraphDatabaseService beansAPI, Map<String, Object> properties, Label... labels )
+    {
+        try ( Transaction tx = beansAPI.beginTx() )
+        {
+            Node node = beansAPI.createNode( labels );
+            for ( Map.Entry<String,Object> property : properties.entrySet() )
+            {
+                node.setProperty( property.getKey(), property.getValue() );
+            }
+            tx.success();
+            return node;
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/graphdb/IndexingStringQueryAcceptanceTestBase.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/IndexingStringQueryAcceptanceTestBase.java
@@ -44,30 +44,35 @@ public abstract class IndexingStringQueryAcceptanceTestBase
     @Rule
     public final TestName testName = new TestName();
 
-    final String template;
-    final String[] matching;
-    final String[] nonMatching;
-    final StringSearchMode searchMode;
+    private final String template;
+    private final String[] matching;
+    private final String[] nonMatching;
+    private final StringSearchMode searchMode;
+    private final boolean withIndex;
 
     private Label LABEL;
     private String KEY = "name";
     private GraphDatabaseService db;
 
-    protected IndexingStringQueryAcceptanceTestBase( String template, String[] matching,
-            String[] nonMatching, StringSearchMode searchMode )
+    IndexingStringQueryAcceptanceTestBase( String template, String[] matching,
+            String[] nonMatching, StringSearchMode searchMode, boolean withIndex )
     {
         this.template = template;
         this.matching = matching;
         this.nonMatching = nonMatching;
         this.searchMode = searchMode;
+        this.withIndex = withIndex;
     }
 
     @Before
-    public void setupLabels()
+    public void setup()
     {
         LABEL = Label.label( "LABEL1-" + testName.getMethodName() );
         db = dbRule.getGraphDatabaseAPI();
-        Neo4jMatchers.createIndex( db, LABEL, KEY );
+        if ( withIndex )
+        {
+            Neo4jMatchers.createIndex( db, LABEL, KEY );
+        }
     }
 
     @Test
@@ -165,47 +170,111 @@ public abstract class IndexingStringQueryAcceptanceTestBase
         assertThat( found, equalTo( expected ) );
     }
 
-    public static class EXACT extends IndexingStringQueryAcceptanceTestBase
+    public static abstract class EXACT extends IndexingStringQueryAcceptanceTestBase
     {
         static String[] matching = {"Johan", "Johan", "Johan"};
         static String[] nonMatching = {"Johanna", "Olivia", "InteJohan"};
 
-        public EXACT()
+        EXACT( boolean withIndex )
         {
-            super( "Johan", matching, nonMatching, StringSearchMode.EXACT );
+            super( "Johan", matching, nonMatching, StringSearchMode.EXACT, withIndex );
         }
     }
 
-    public static class PREFIX extends IndexingStringQueryAcceptanceTestBase
+    public static class EXACT_WITH_INDEX extends EXACT
+    {
+        public EXACT_WITH_INDEX()
+        {
+            super( true );
+        }
+    }
+
+    public static class EXACT_WITHOUT_INDEX extends EXACT
+    {
+        public EXACT_WITHOUT_INDEX()
+        {
+            super( false );
+        }
+    }
+
+    public static abstract class PREFIX extends IndexingStringQueryAcceptanceTestBase
     {
         static String[] matching = {"Olivia", "Olivia2", "OliviaYtterbrink"};
         static String[] nonMatching = {"Johan", "olivia", "InteOlivia"};
 
-        public PREFIX()
+        PREFIX( boolean withIndex )
         {
-            super( "Olivia", matching, nonMatching, StringSearchMode.PREFIX );
+            super( "Olivia", matching, nonMatching, StringSearchMode.PREFIX, withIndex );
         }
     }
 
-    public static class SUFFIX extends IndexingStringQueryAcceptanceTestBase
+    public static class PREFIX_WITH_INDEX extends PREFIX
+    {
+        public PREFIX_WITH_INDEX()
+        {
+            super( true );
+        }
+    }
+
+    public static class PREFIX_WITHOUT_INDEX extends PREFIX
+    {
+        public PREFIX_WITHOUT_INDEX()
+        {
+            super( false );
+        }
+    }
+
+    public static abstract class SUFFIX extends IndexingStringQueryAcceptanceTestBase
     {
         static String[] matching = {"Jansson", "Hansson", "Svensson"};
         static String[] nonMatching = {"Taverner", "Svensson-Averbuch", "Taylor"};
 
-        public SUFFIX()
+        SUFFIX( boolean withIndex )
         {
-            super( "sson", matching, nonMatching, StringSearchMode.SUFFIX );
+            super( "sson", matching, nonMatching, StringSearchMode.SUFFIX, withIndex );
         }
     }
 
-    public static class CONTAINS extends IndexingStringQueryAcceptanceTestBase
+    public static class SUFFIX_WITH_INDEX extends SUFFIX
+    {
+        public SUFFIX_WITH_INDEX()
+        {
+            super( true );
+        }
+    }
+
+    public static class SUFFIX_WITHOUT_INDEX extends SUFFIX
+    {
+        public SUFFIX_WITHOUT_INDEX()
+        {
+            super( false );
+        }
+    }
+
+    public static abstract class CONTAINS extends IndexingStringQueryAcceptanceTestBase
     {
         static String[] matching = {"good", "fool", "fooooood"};
         static String[] nonMatching = {"evil", "genius", "hungry"};
 
-        public CONTAINS()
+        public CONTAINS( boolean withIndex )
         {
-            super( "oo", matching, nonMatching, StringSearchMode.CONTAINS );
+            super( "oo", matching, nonMatching, StringSearchMode.CONTAINS, withIndex );
+        }
+    }
+
+    public static class CONTAINS_WITH_INDEX extends CONTAINS
+    {
+        public CONTAINS_WITH_INDEX()
+        {
+            super( true );
+        }
+    }
+
+    public static class CONTAINS_WITHOUT_INDEX extends CONTAINS
+    {
+        public CONTAINS_WITHOUT_INDEX()
+        {
+            super( false );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeIndexTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeIndexTransactionStateTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.newapi;
+
+import org.neo4j.internal.kernel.api.NodeIndexTransactionStateTestBase;
+
+public class NodeIndexTransactionStateTest extends NodeIndexTransactionStateTestBase<WriteTestSupport>
+{
+    @Override
+    public WriteTestSupport newTestSupport()
+    {
+        return new WriteTestSupport();
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/WriteTestSupport.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/WriteTestSupport.java
@@ -23,14 +23,13 @@ import java.io.File;
 
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PropertyContainer;
-import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.internal.kernel.api.Kernel;
 import org.neo4j.internal.kernel.api.KernelAPIWriteTestSupport;
 import org.neo4j.kernel.impl.core.EmbeddedProxySPI;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.test.GraphDatabaseServiceCleaner;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 class WriteTestSupport implements KernelAPIWriteTestSupport
@@ -46,25 +45,14 @@ class WriteTestSupport implements KernelAPIWriteTestSupport
     @Override
     public void clearGraph()
     {
+        GraphDatabaseServiceCleaner.cleanDatabaseContent( db );
         try ( Transaction tx = db.beginTx() )
         {
-
-            for ( Relationship relationship : db.getAllRelationships() )
-            {
-                relationship.delete();
-            }
-
-            for ( Node node : db.getAllNodes() )
-            {
-                node.delete();
-            }
-
             PropertyContainer graphProperties = graphProperties();
             for ( String key : graphProperties.getPropertyKeys() )
             {
                 graphProperties.removeProperty( key );
             }
-
             tx.success();
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/test/rule/DatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/DatabaseRule.java
@@ -536,6 +536,25 @@ public abstract class DatabaseRule extends ExternalResource implements GraphData
     }
 
     @Override
+    public ResourceIterator<Node> findNodes( Label label, String key1, Object value1, String key2, Object value2 )
+    {
+        return database.findNodes( label, key1, value1, key2, value2 );
+    }
+
+    @Override
+    public ResourceIterator<Node> findNodes( Label label, String key1, Object value1, String key2, Object value2,
+            String key3, Object value3 )
+    {
+        return database.findNodes( label, key1, value1, key2, value2, key3, value3 );
+    }
+
+    @Override
+    public ResourceIterator<Node> findNodes( Label label, Map<String,Object> propertyValues )
+    {
+        return database.findNodes( label, propertyValues );
+    }
+
+    @Override
     public ResourceIterator<Node> findNodes( Label label, String key, String template, StringSearchMode searchMode )
     {
         return database.findNodes( label, key, template, searchMode );

--- a/community/kernel/src/test/java/org/neo4j/test/rule/DatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/DatabaseRule.java
@@ -39,6 +39,7 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.StringSearchMode;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.event.KernelEventHandler;
@@ -532,6 +533,12 @@ public abstract class DatabaseRule extends ExternalResource implements GraphData
     public ResourceIterator<Node> findNodes( Label label, String key, Object value )
     {
         return database.findNodes( label, key, value );
+    }
+
+    @Override
+    public ResourceIterator<Node> findNodes( Label label, String key, String template, StringSearchMode searchMode )
+    {
+        return database.findNodes( label, key, template, searchMode );
     }
 
     @Override

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/ReadOnlyGraphDatabaseProxy.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/ReadOnlyGraphDatabaseProxy.java
@@ -38,6 +38,7 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.StringSearchMode;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.event.KernelEventHandler;
 import org.neo4j.graphdb.event.TransactionEventHandler;
@@ -1082,6 +1083,12 @@ public class ReadOnlyGraphDatabaseProxy implements GraphDatabaseService, GraphDa
     public ResourceIterator<Node> findNodes( Label label, String key, Object value )
     {
         return actual.findNodes( label, key, value );
+    }
+
+    @Override
+    public ResourceIterator<Node> findNodes( Label label, String key, String template, StringSearchMode searchMode )
+    {
+        return actual.findNodes( label, key, template, searchMode );
     }
 
     @Override

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/ReadOnlyGraphDatabaseProxy.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/ReadOnlyGraphDatabaseProxy.java
@@ -1086,6 +1086,25 @@ public class ReadOnlyGraphDatabaseProxy implements GraphDatabaseService, GraphDa
     }
 
     @Override
+    public ResourceIterator<Node> findNodes( Label label, String key1, Object value1, String key2, Object value2 )
+    {
+        return actual.findNodes( label, key1, value1, key2, value2 );
+    }
+
+    @Override
+    public ResourceIterator<Node> findNodes( Label label, String key1, Object value1, String key2, Object value2,
+            String key3, Object value3 )
+    {
+        return actual.findNodes( label, key1, value1, key2, value2, key3, value3 );
+    }
+
+    @Override
+    public ResourceIterator<Node> findNodes( Label label, Map<String,Object> propertyValues )
+    {
+        return actual.findNodes( label, propertyValues );
+    }
+
+    @Override
     public ResourceIterator<Node> findNodes( Label label, String key, String template, StringSearchMode searchMode )
     {
         return actual.findNodes( label, key, template, searchMode );

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/StubGraphDatabaseService.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/StubGraphDatabaseService.java
@@ -31,6 +31,7 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.StringSearchMode;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.event.KernelEventHandler;
 import org.neo4j.graphdb.event.TransactionEventHandler;
@@ -85,6 +86,12 @@ public class StubGraphDatabaseService implements GraphDatabaseService
 
     @Override
     public ResourceIterator<Node> findNodes( Label label, String key, Object value )
+    {
+        return null;
+    }
+
+    @Override
+    public ResourceIterator<Node> findNodes( Label label, String key, String template, StringSearchMode searchMode )
     {
         return null;
     }

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/StubGraphDatabaseService.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/StubGraphDatabaseService.java
@@ -91,6 +91,25 @@ public class StubGraphDatabaseService implements GraphDatabaseService
     }
 
     @Override
+    public ResourceIterator<Node> findNodes( Label label, String key1, Object value1, String key2, Object value2 )
+    {
+        return null;
+    }
+
+    @Override
+    public ResourceIterator<Node> findNodes( Label label, String key1, Object value1, String key2, Object value2,
+            String key3, Object value3 )
+    {
+        return null;
+    }
+
+    @Override
+    public ResourceIterator<Node> findNodes( Label label, Map<String,Object> propertyValues )
+    {
+        return null;
+    }
+
+    @Override
     public ResourceIterator<Node> findNodes( Label label, String key, String template, StringSearchMode searchMode )
     {
         return null;


### PR DESCRIPTION
This PR bring Core API up to date with underlying index capabilities. The added methods only rely on functionality which is anyway required by Cypher, so it should not constrain future product development. 

changelog: Extended Core API with more variants of findNodes: String prefix, suffix and contains queries on single property indexes, and exact seeks in composite indexes. 