### PR TITLE
Port almost all integration tests to use Kernel API

### DIFF
--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
@@ -799,62 +799,62 @@ sealed class TransactionBoundQueryContext(val transactionalContext: Transactiona
     transactionalContext.statement.readOperations().schemaStateGetOrCreate(key, javaCreator)
   }
 
-  override def addIndexRule(descriptor: IndexDescriptor): IdempotentResult[IndexDescriptor] = {
+  override def addIndexRule(descriptor: IndexDescriptor): IdempotentResult[CapableIndexReference] = {
     val kernelDescriptor = cypherToKernelSchema(descriptor)
     try {
-      IdempotentResult(
-        kernelToCypher(transactionalContext.statement.schemaWriteOperations().indexCreate(kernelDescriptor)))
+      IdempotentResult(transactionalContext.kernelTransaction.schemaWrite().indexCreate(kernelDescriptor))
     } catch {
       case _: AlreadyIndexedException =>
-        val indexDescriptor = transactionalContext.statement.readOperations().indexGetForSchema(
-          SchemaDescriptorFactory.forLabel(kernelDescriptor.getLabelId, kernelDescriptor.getPropertyIds: _*))
-        if (transactionalContext.statement.readOperations().indexGetState(indexDescriptor) == InternalIndexState.FAILED)
-          throw new FailedIndexException(indexDescriptor.userDescription(tokenNameLookup))
-       IdempotentResult(kernelToCypher(indexDescriptor), wasCreated = false)
+        val indexReference = transactionalContext.kernelTransaction.schemaRead().index(kernelDescriptor.getLabelId, kernelDescriptor.getPropertyIds: _*)
+        if (transactionalContext.kernelTransaction.schemaRead().indexGetState(indexReference) == InternalIndexState.FAILED)
+          throw new FailedIndexException(indexReference.userDescription(tokenNameLookup))
+       IdempotentResult(indexReference, wasCreated = false)
     }
   }
 
-  override def dropIndexRule(descriptor: IndexDescriptor) =
-    transactionalContext.statement.schemaWriteOperations().indexDrop(cypherToKernel(descriptor))
+  override def dropIndexRule(descriptor: IndexDescriptor): Unit =
+    transactionalContext.kernelTransaction.schemaWrite().indexDrop(
+      transactionalContext.kernelTransaction.schemaRead().index(descriptor.label, descriptor.properties.map(_.id):_*)
+    )
 
   override def createNodeKeyConstraint(descriptor: IndexDescriptor): Boolean = try {
-    transactionalContext.statement.schemaWriteOperations().nodeKeyConstraintCreate(cypherToKernelSchema(descriptor))
+    transactionalContext.kernelTransaction.schemaWrite().nodeKeyConstraintCreate(cypherToKernelSchema(descriptor))
     true
   } catch {
-    case existing: AlreadyConstrainedException => false
+    case _: AlreadyConstrainedException => false
   }
 
-  override def dropNodeKeyConstraint(descriptor: IndexDescriptor) =
-    transactionalContext.statement.schemaWriteOperations()
+  override def dropNodeKeyConstraint(descriptor: IndexDescriptor): Unit =
+    transactionalContext.kernelTransaction.schemaWrite()
       .constraintDrop(ConstraintDescriptorFactory.nodeKeyForSchema(cypherToKernelSchema(descriptor)))
 
   override def createUniqueConstraint(descriptor: IndexDescriptor): Boolean = try {
-    transactionalContext.statement.schemaWriteOperations().uniquePropertyConstraintCreate(cypherToKernelSchema(descriptor))
+    transactionalContext.kernelTransaction.schemaWrite().uniquePropertyConstraintCreate(cypherToKernelSchema(descriptor))
     true
   } catch {
-    case existing: AlreadyConstrainedException => false
+    case _: AlreadyConstrainedException => false
   }
 
-  override def dropUniqueConstraint(descriptor: IndexDescriptor) =
-    transactionalContext.statement.schemaWriteOperations()
+  override def dropUniqueConstraint(descriptor: IndexDescriptor): Unit =
+    transactionalContext.kernelTransaction.schemaWrite()
       .constraintDrop(ConstraintDescriptorFactory.uniqueForSchema(cypherToKernelSchema(descriptor)))
 
   override def createNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int): Boolean =
     try {
-      transactionalContext.statement.schemaWriteOperations().nodePropertyExistenceConstraintCreate(
+      transactionalContext.kernelTransaction.schemaWrite().nodePropertyExistenceConstraintCreate(
         SchemaDescriptorFactory.forLabel(labelId, propertyKeyId))
       true
     } catch {
       case existing: AlreadyConstrainedException => false
     }
 
-  override def dropNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int) =
-    transactionalContext.statement.schemaWriteOperations()
+  override def dropNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int): Unit =
+    transactionalContext.kernelTransaction.schemaWrite()
       .constraintDrop(ConstraintDescriptorFactory.existsForLabel(labelId, propertyKeyId))
 
   override def createRelationshipPropertyExistenceConstraint(relTypeId: Int, propertyKeyId: Int): Boolean =
     try {
-      transactionalContext.statement.schemaWriteOperations().relationshipPropertyExistenceConstraintCreate(
+      transactionalContext.kernelTransaction.schemaWrite().relationshipPropertyExistenceConstraintCreate(
         SchemaDescriptorFactory.forRelType(relTypeId, propertyKeyId))
       true
     } catch {
@@ -862,7 +862,7 @@ sealed class TransactionBoundQueryContext(val transactionalContext: Transactiona
     }
 
   override def dropRelationshipPropertyExistenceConstraint(relTypeId: Int, propertyKeyId: Int) =
-    transactionalContext.statement.schemaWriteOperations()
+    transactionalContext.kernelTransaction.schemaWrite()
       .constraintDrop(ConstraintDescriptorFactory.existsForRelType(relTypeId, propertyKeyId))
 
   override def getImportURL(url: URL): Either[String, URL] = transactionalContext.graph match {
@@ -1133,7 +1133,7 @@ sealed class TransactionBoundQueryContext(val transactionalContext: Transactiona
   }
 
   override def assertSchemaWritesAllowed(): Unit =
-    transactionalContext.statement.schemaWriteOperations()
+    transactionalContext.kernelTransaction.schemaWrite()
 
   private def allocateAndTraceNodeCursor() = {
     val cursor = transactionalContext.cursors.allocateNodeCursor()

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
@@ -56,7 +56,7 @@ import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptorFactory
 import org.neo4j.kernel.guard.TerminationGuard
 import org.neo4j.kernel.impl.api.RelationshipVisitor
 import org.neo4j.kernel.impl.api.operations.KeyReadOperations
-import org.neo4j.kernel.impl.api.store.RelationshipIterator
+import org.neo4j.kernel.impl.api.store.{DefaultCapableIndexReference, RelationshipIterator}
 import org.neo4j.kernel.impl.core.{EmbeddedProxySPI, ThreadToStatementContextBridge}
 import org.neo4j.kernel.impl.coreapi.PropertyContainerLocker
 import org.neo4j.kernel.impl.query.Neo4jTransactionalContext
@@ -814,7 +814,8 @@ sealed class TransactionBoundQueryContext(val transactionalContext: Transactiona
 
   override def dropIndexRule(descriptor: IndexDescriptor): Unit =
     transactionalContext.kernelTransaction.schemaWrite().indexDrop(
-      transactionalContext.kernelTransaction.schemaRead().index(descriptor.label, descriptor.properties.map(_.id):_*)
+      new DefaultCapableIndexReference(false, IndexCapability.NO_CAPABILITY, null, descriptor.label,
+                                       descriptor.properties.map(_.id):_*)
     )
 
   override def createNodeKeyConstraint(descriptor: IndexDescriptor): Boolean = try {

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/QueryContextAdaptation.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/QueryContextAdaptation.scala
@@ -27,8 +27,8 @@ import org.neo4j.cypher.internal.runtime._
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection
 import org.neo4j.cypher.internal.v3_4.logical.plans.QualifiedName
 import org.neo4j.graphdb.{Node, Path, PropertyContainer}
-import org.neo4j.internal.kernel.api.IndexReference
 import org.neo4j.internal.kernel.api.helpers.RelationshipSelectionCursor
+import org.neo4j.internal.kernel.api.{CapableIndexReference, IndexReference}
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
 import org.neo4j.kernel.impl.core.EmbeddedProxySPI
 import org.neo4j.values.AnyValue
@@ -181,7 +181,7 @@ trait QueryContextAdaptation {
 
   override def nodeCountByCountStore(labelId: Int): Long = ???
 
-  override def addIndexRule(descriptor: IndexDescriptor): IdempotentResult[IndexDescriptor] = ???
+  override def addIndexRule(descriptor: IndexDescriptor): IdempotentResult[CapableIndexReference] = ???
 
   override def getOptRelTypeId(relType: String): Option[Int] = ???
 

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/UpdateCountingQueryContextTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/UpdateCountingQueryContextTest.scala
@@ -27,8 +27,9 @@ import org.neo4j.cypher.internal.planner.v3_4.spi.{IdempotentResult, IndexDescri
 import org.neo4j.cypher.internal.runtime.{Operations, QueryContext, QueryStatistics}
 import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.graphdb.{Node, Relationship}
+import org.neo4j.internal.kernel.api.CapableIndexReference
 import org.neo4j.values.storable.Values
-import org.neo4j.values.virtual.{RelationshipValue, NodeValue}
+import org.neo4j.values.virtual.{NodeValue, RelationshipValue}
 
 class UpdateCountingQueryContextTest extends CypherFunSuite {
 
@@ -67,7 +68,7 @@ class UpdateCountingQueryContextTest extends CypherFunSuite {
   when( inner.createRelationshipPropertyExistenceConstraint(anyInt(), anyInt()) ).thenReturn(true)
 
   when(inner.addIndexRule(any()))
-    .thenReturn(IdempotentResult(mock[IndexDescriptor]))
+    .thenReturn(IdempotentResult(mock[CapableIndexReference]))
 
   var context: UpdateCountingQueryContext = null
 

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryContext.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryContext.scala
@@ -95,7 +95,7 @@ trait QueryContext extends TokenContext {
 
   def getOrCreatePropertyKeyId(propertyKey: String): Int
 
-  def addIndexRule(descriptor: IndexDescriptor): IdempotentResult[IndexDescriptor]
+  def addIndexRule(descriptor: IndexDescriptor): IdempotentResult[CapableIndexReference]
 
   def dropIndexRule(descriptor: IndexDescriptor)
 

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/IndexReference.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/IndexReference.java
@@ -19,6 +19,10 @@
  */
 package org.neo4j.internal.kernel.api;
 
+import org.neo4j.internal.kernel.api.schema.SchemaUtil;
+
+import static java.lang.String.format;
+
 /**
  * Reference to a specific index. This reference is valid until the schema of the database changes (that is a
  * create/drop of an index or constraint occurs).
@@ -30,4 +34,14 @@ public interface IndexReference
     int label();
 
     int[] properties();
+
+    /**
+     * @param tokenNameLookup used for looking up names for token ids.
+     * @return a user friendly description of what this index indexes.
+     */
+    default String userDescription( TokenNameLookup tokenNameLookup )
+    {
+        String type = isUnique() ? "UNIQUE" : "GENERAL";
+        return format( "Index( %s, %s )",  type, SchemaUtil.niceProperties( tokenNameLookup, properties() ) );
+    }
 }

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Procedures.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Procedures.java
@@ -19,9 +19,12 @@
  */
 package org.neo4j.internal.kernel.api;
 
+import java.util.Set;
+
 import org.neo4j.collection.RawIterator;
 import org.neo4j.internal.kernel.api.exceptions.ProcedureException;
 import org.neo4j.internal.kernel.api.procs.ProcedureHandle;
+import org.neo4j.internal.kernel.api.procs.ProcedureSignature;
 import org.neo4j.internal.kernel.api.procs.QualifiedName;
 import org.neo4j.internal.kernel.api.procs.UserAggregator;
 import org.neo4j.internal.kernel.api.procs.UserFunctionHandle;
@@ -51,6 +54,13 @@ public interface Procedures
      * @throws ProcedureException
      */
     ProcedureHandle procedureGet( QualifiedName name ) throws ProcedureException;
+
+    /**
+     * Fetch all procedures
+     * @return all procedures
+     * @throws ProcedureException
+     */
+    Set<ProcedureSignature> proceduresGetAll( ) throws ProcedureException;
 
     /**
      * Invoke a read-only procedure by id.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/SchemaRead.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/SchemaRead.java
@@ -20,6 +20,7 @@
 package org.neo4j.internal.kernel.api;
 
 import java.util.Iterator;
+import java.util.function.Function;
 
 import org.neo4j.internal.kernel.api.exceptions.schema.SchemaKernelException;
 import org.neo4j.internal.kernel.api.schema.SchemaDescriptor;
@@ -134,4 +135,28 @@ public interface SchemaRead
      * constraint.
      */
     Long indexGetOwningUniquenessConstraintId( CapableIndexReference index );
+
+    /**
+     * Returns schema state for the given key or create a new state if not there
+     * @param key The key to access
+     * @param creator function creating schema state
+     * @param <K> type of the key
+     * @param <V> type of the schema state value
+     * @return the state associated with the key or a new value if non-existing
+     */
+    <K, V> V schemaStateGetOrCreate( K key, Function<K, V> creator );
+
+    /**
+     * Returns the state associated with the key or <tt>null</tt> if nothing assocated with key
+     * @param key The key to access
+     * @param <K> The type of the key
+     * @param <V> The type of the assocated value
+     * @return The value associated with the given key or <tt>null</tt>
+     */
+    <K, V> V schemaStateGet( K key );
+
+    /**
+     * Flush the schema state
+     */
+    void schemaStateFlush();
 }

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Transaction.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Transaction.java
@@ -123,5 +123,8 @@ public interface Transaction extends AutoCloseable
      */
     CursorFactory cursors();
 
+    /**
+     * @return Returns procedure operations
+     */
     Procedures procedures();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -690,7 +690,8 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
                 transactionCommitProcess, indexConfigStore, explicitIndexProviderLookup, hooks, transactionMonitor,
                 availabilityGuard, tracers, storageEngine, procedures, transactionIdStore, clock,
                 cpuClockRef, heapAllocationRef, accessCapability, DefaultCursors::new, autoIndexing,
-                explicitIndexStore, versionContextSupplier, collectionsFactorySupplier, constraintSemantics ) );
+                explicitIndexStore, versionContextSupplier, collectionsFactorySupplier, constraintSemantics,
+                databaseSchemaState ) );
 
         buildTransactionMonitor( kernelTransactions, clock, config );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -190,7 +190,8 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
             TransactionTracer transactionTracer, LockTracer lockTracer, PageCursorTracerSupplier cursorTracerSupplier,
             StorageEngine storageEngine, AccessCapability accessCapability, DefaultCursors cursors, AutoIndexing autoIndexing,
             ExplicitIndexStore explicitIndexStore, VersionContextSupplier versionContextSupplier,
-            CollectionsFactorySupplier collectionsFactorySupplier, ConstraintSemantics constraintSemantics )
+            CollectionsFactorySupplier collectionsFactorySupplier, ConstraintSemantics constraintSemantics,
+            SchemaState schemaState )
     {
         this.statementOperations = statementOperations;
         this.schemaWriteGuard = schemaWriteGuard;
@@ -215,7 +216,8 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         this.statistics = new Statistics( this, cpuClockRef, heapAllocationRef );
         this.userMetaData = new HashMap<>();
         AllStoreHolder allStoreHolder =
-                new AllStoreHolder( storageEngine, storageStatement, this, cursors, explicitIndexStore, procedures );
+                new AllStoreHolder( storageEngine, storageStatement, this, cursors, explicitIndexStore,
+                        procedures, schemaState );
         this.operations =
                 new Operations(
                         allStoreHolder,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -101,6 +101,7 @@ public class KernelTransactions extends LifecycleAdapter implements Supplier<Ker
     private final AutoIndexing autoIndexing;
     private final ExplicitIndexStore explicitIndexStore;
     private final CollectionsFactorySupplier collectionsFactorySupplier;
+    private final SchemaState schemaState;
 
     /**
      * Used to enumerate all transactions in the system, active and idle ones.
@@ -145,7 +146,8 @@ public class KernelTransactions extends LifecycleAdapter implements Supplier<Ker
             ExplicitIndexStore explicitIndexStore,
             VersionContextSupplier versionContextSupplier,
             CollectionsFactorySupplier collectionsFactorySupplier,
-            ConstraintSemantics constraintSemantics )
+            ConstraintSemantics constraintSemantics,
+            SchemaState schemaState )
     {
         this.statementLocksFactory = statementLocksFactory;
         this.constraintIndexCreator = constraintIndexCreator;
@@ -174,6 +176,7 @@ public class KernelTransactions extends LifecycleAdapter implements Supplier<Ker
         this.cursorsSupplier = cursorsSupplier;
         this.collectionsFactorySupplier = collectionsFactorySupplier;
         this.constraintSemantics = constraintSemantics;
+        this.schemaState = schemaState;
     }
 
     public Supplier<ExplicitIndexTransactionState> explicitIndexTxStateSupplier()
@@ -371,7 +374,8 @@ public class KernelTransactions extends LifecycleAdapter implements Supplier<Ker
                             clock, cpuClockRef, heapAllocationRef, tracers.transactionTracer, tracers.lockTracer,
                             tracers.pageCursorTracerSupplier, storageEngine, accessCapability,
                             cursorsSupplier.get(), autoIndexing,
-                            explicitIndexStore, versionContextSupplier, collectionsFactorySupplier, constraintSemantics );
+                            explicitIndexStore, versionContextSupplier, collectionsFactorySupplier, constraintSemantics,
+                            schemaState );
             this.transactions.add( tx );
             return tx;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/ConstraintIndexCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/ConstraintIndexCreator.java
@@ -369,7 +369,7 @@ public class ConstraintIndexCreator
             TokenRead tokenRead, LabelSchemaDescriptor schema )
             throws SchemaKernelException, IndexNotFoundKernelException
     {
-        CapableIndexReference descriptor = schemaRead.index( schema.getLabelId(), schema.getPropertyId() );
+        CapableIndexReference descriptor = schemaRead.index( schema.getLabelId(), schema.getPropertyIds() );
         if ( descriptor != CapableIndexReference.NO_INDEX )
         {
             if ( descriptor.isUnique() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/constraints/StandardConstraintSemantics.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/constraints/StandardConstraintSemantics.java
@@ -59,7 +59,7 @@ public class StandardConstraintSemantics implements ConstraintSemantics
     public void validateNodeKeyConstraint( NodeLabelIndexCursor allNodes, NodeCursor nodeCursor,
             PropertyCursor propertyCursor, LabelSchemaDescriptor descriptor ) throws CreateConstraintFailureException
     {
-        throw propertyExistenceConstraintsNotAllowed( descriptor );
+        throw nodeKeyConstraintsNotAllowed( descriptor );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -541,11 +541,13 @@ public class NodeProxy implements Node, RelationshipFactory<Relationship>
         //{
         //    throw new IllegalArgumentException( "Nodes do not belong to same graph database." );
         //}
-        try ( Statement statement = spi.statement() )
+
+        KernelTransaction transaction = safeAcquireTransaction();
+        try ( Statement ignore = transaction.acquireStatement() )
         {
-            int relationshipTypeId = statement.tokenWriteOperations().relationshipTypeGetOrCreateForName( type.name() );
-            long relationshipId = statement.dataWriteOperations()
-                    .relationshipCreate( relationshipTypeId, nodeId, otherNode.getId() );
+            int relationshipTypeId = transaction.tokenWrite().relationshipTypeGetOrCreateForName( type.name() );
+            long relationshipId = transaction.dataWrite()
+                    .relationshipCreate( nodeId, relationshipTypeId, otherNode.getId() );
             return spi.newRelationshipProxy( relationshipId, nodeId, relationshipTypeId, otherNode.getId() );
         }
         catch ( IllegalTokenNameException e )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
@@ -119,7 +119,7 @@ public class AllStoreHolder extends Read
             DefaultCursors cursors,
             ExplicitIndexStore explicitIndexStore,
             Procedures procedures,
-            SchemaState schemaState)
+            SchemaState schemaState )
     {
         super( cursors, ktx );
         this.storeReadLayer = engine.storeReadLayer();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.newapi;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.neo4j.collection.RawIterator;
 import org.neo4j.function.Suppliers;
@@ -60,6 +61,7 @@ import org.neo4j.kernel.api.txstate.TransactionState;
 import org.neo4j.kernel.impl.api.ClockContext;
 import org.neo4j.kernel.impl.api.CountsRecordState;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
+import org.neo4j.kernel.impl.api.SchemaState;
 import org.neo4j.kernel.impl.api.security.OverriddenAccessMode;
 import org.neo4j.kernel.impl.api.security.RestrictedAccessMode;
 import org.neo4j.kernel.impl.api.store.DefaultCapableIndexReference;
@@ -107,12 +109,13 @@ public class AllStoreHolder extends Read
     private final ExplicitIndexStore explicitIndexStore;
     private final Lazy<ExplicitIndexTransactionState> explicitIndexes;
     private final Procedures procedures;
+    private final SchemaState schemaState;
 
     public AllStoreHolder( StorageEngine engine,
             StorageStatement statement,
             KernelTransactionImplementation ktx,
             DefaultCursors cursors,
-            ExplicitIndexStore explicitIndexStore, Procedures procedures )
+            ExplicitIndexStore explicitIndexStore, Procedures procedures  )
     {
         super( cursors, ktx );
         this.storeReadLayer = engine.storeReadLayer();
@@ -125,6 +128,7 @@ public class AllStoreHolder extends Read
         this.properties = statement.properties();
         this.explicitIndexStore = explicitIndexStore;
         this.procedures = procedures;
+        this.schemaState = engine.schemaState();
     }
 
     @Override
@@ -895,6 +899,24 @@ public class AllStoreHolder extends Read
     {
         return aggregationFunction( name,
                 new OverriddenAccessMode( ktx.securityContext().mode(), AccessMode.Static.READ ) );
+    }
+
+    @Override
+    public <K, V> V schemaStateGetOrCreate( K key, Function<K,V> creator )
+    {
+        return schemaState.getOrCreate( key, creator );
+    }
+
+    @Override
+    public <K, V> V schemaStateGet( K key )
+    {
+        return schemaState.get( key );
+    }
+
+    @Override
+    public void schemaStateFlush()
+    {
+        schemaState.clear();
     }
 
     private RawIterator<Object[],ProcedureException> callProcedure(

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
@@ -117,7 +117,9 @@ public class AllStoreHolder extends Read
             StorageStatement statement,
             KernelTransactionImplementation ktx,
             DefaultCursors cursors,
-            ExplicitIndexStore explicitIndexStore, Procedures procedures  )
+            ExplicitIndexStore explicitIndexStore,
+            Procedures procedures,
+            SchemaState schemaState)
     {
         super( cursors, ktx );
         this.storeReadLayer = engine.storeReadLayer();
@@ -130,7 +132,7 @@ public class AllStoreHolder extends Read
         this.properties = statement.properties();
         this.explicitIndexStore = explicitIndexStore;
         this.procedures = procedures;
-        this.schemaState = engine.schemaState();
+        this.schemaState = schemaState;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.newapi;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 import org.neo4j.collection.RawIterator;
@@ -35,6 +36,7 @@ import org.neo4j.internal.kernel.api.exceptions.ProcedureException;
 import org.neo4j.internal.kernel.api.exceptions.explicitindex.ExplicitIndexNotFoundKernelException;
 import org.neo4j.internal.kernel.api.exceptions.schema.ConstraintValidationException;
 import org.neo4j.internal.kernel.api.procs.ProcedureHandle;
+import org.neo4j.internal.kernel.api.procs.ProcedureSignature;
 import org.neo4j.internal.kernel.api.procs.QualifiedName;
 import org.neo4j.internal.kernel.api.procs.UserAggregator;
 import org.neo4j.internal.kernel.api.procs.UserFunctionHandle;
@@ -681,6 +683,13 @@ public class AllStoreHolder extends Read
     {
         ktx.assertOpen();
         return procedures.procedure( name );
+    }
+
+    @Override
+    public Set<ProcedureSignature> proceduresGetAll( ) throws ProcedureException
+    {
+        ktx.assertOpen();
+        return procedures.getAllProcedures();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
@@ -902,7 +902,7 @@ public class Operations implements Write, ExplicitIndexWrite, SchemaWrite
             throws SchemaKernelException
     {
         //Lock
-        acquireExclusiveRelationshipLock( descriptor.getRelTypeId() );
+        exclusiveRelationshipTypeLock( descriptor.getRelTypeId() );
         ktx.assertOpen();
 
         //verify data integrity
@@ -1002,6 +1002,11 @@ public class Operations implements Write, ExplicitIndexWrite, SchemaWrite
     private void sharedRelationshipTypeLock( long typeId )
     {
         ktx.statementLocks().optimistic().acquireShared( ktx.lockTracer(), ResourceTypes.RELATIONSHIP_TYPE, typeId );
+    }
+
+    private void exclusiveRelationshipTypeLock( long typeId )
+    {
+        ktx.statementLocks().optimistic().acquireExclusive( ktx.lockTracer(), ResourceTypes.RELATIONSHIP_TYPE, typeId );
     }
 
     private void lockRelationshipNodes( long startNodeId, long endNodeId )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
@@ -255,12 +255,6 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
     }
 
     @Override
-    public SchemaState schemaState()
-    {
-        return schemaState;
-    }
-
-    @Override
     public StoreReadLayer storeReadLayer()
     {
         return storeLayer;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
@@ -55,12 +55,12 @@ import org.neo4j.kernel.impl.api.IndexReaderFactory;
 import org.neo4j.kernel.impl.api.SchemaState;
 import org.neo4j.kernel.impl.api.TransactionApplier;
 import org.neo4j.kernel.impl.api.TransactionApplierFacade;
+import org.neo4j.kernel.impl.api.index.IndexProviderMap;
 import org.neo4j.kernel.impl.api.index.IndexStoreView;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.index.IndexingServiceFactory;
 import org.neo4j.kernel.impl.api.index.IndexingUpdateService;
 import org.neo4j.kernel.impl.api.index.PropertyPhysicalToLogicalConverter;
-import org.neo4j.kernel.impl.api.index.IndexProviderMap;
 import org.neo4j.kernel.impl.api.scan.FullLabelStream;
 import org.neo4j.kernel.impl.api.store.SchemaCache;
 import org.neo4j.kernel.impl.api.store.StorageLayer;
@@ -252,6 +252,12 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
 
         return () -> new StoreStatement( neoStores, indexReaderFactory, labelScanStore::newReader, lockService,
                 allocateCommandCreationContext() );
+    }
+
+    @Override
+    public SchemaState schemaState()
+    {
+        return schemaState;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageEngine.java
@@ -26,6 +26,7 @@ import org.neo4j.internal.kernel.api.exceptions.schema.ConstraintValidationExcep
 import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
+import org.neo4j.kernel.impl.api.SchemaState;
 import org.neo4j.kernel.info.DiagnosticsManager;
 import org.neo4j.storageengine.api.lock.ResourceLocker;
 import org.neo4j.storageengine.api.txstate.ReadableTransactionState;
@@ -40,6 +41,12 @@ public interface StorageEngine
      * {@link #apply(CommandsToApply, TransactionApplicationMode) applied} to this storage.
      */
     StoreReadLayer storeReadLayer();
+
+    /**
+     * Return access to the schema state
+     * @return an interface for accessing schema state
+     */
+    SchemaState schemaState();
 
     /**
      * @return a new {@link CommandCreationContext} meant to be kept for multiple calls to

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageEngine.java
@@ -26,7 +26,6 @@ import org.neo4j.internal.kernel.api.exceptions.schema.ConstraintValidationExcep
 import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
-import org.neo4j.kernel.impl.api.SchemaState;
 import org.neo4j.kernel.info.DiagnosticsManager;
 import org.neo4j.storageengine.api.lock.ResourceLocker;
 import org.neo4j.storageengine.api.txstate.ReadableTransactionState;
@@ -41,12 +40,6 @@ public interface StorageEngine
      * {@link #apply(CommandsToApply, TransactionApplicationMode) applied} to this storage.
      */
     StoreReadLayer storeReadLayer();
-
-    /**
-     * Return access to the schema state
-     * @return an interface for accessing schema state
-     */
-    SchemaState schemaState();
 
     /**
      * @return a new {@link CommandCreationContext} meant to be kept for multiple calls to

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
@@ -28,6 +28,7 @@ import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier;
 import org.neo4j.io.pagecache.tracing.cursor.context.EmptyVersionContextSupplier;
 import org.neo4j.kernel.api.explicitindex.AutoIndexing;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
+import org.neo4j.kernel.impl.api.SchemaState;
 import org.neo4j.kernel.impl.api.SchemaWriteGuard;
 import org.neo4j.kernel.impl.api.StatementOperationParts;
 import org.neo4j.kernel.impl.api.TransactionHeaderInformation;
@@ -104,7 +105,8 @@ public class KernelTransactionFactory
                 LockTracer.NONE,
                 PageCursorTracerSupplier.NULL,
                 storageEngine, new CanWrite(), new DefaultCursors(), AutoIndexing.UNSUPPORTED,
-                mock( ExplicitIndexStore.class ), EmptyVersionContextSupplier.EMPTY, ON_HEAP, new StandardConstraintSemantics() );
+                mock( ExplicitIndexStore.class ), EmptyVersionContextSupplier.EMPTY, ON_HEAP, new StandardConstraintSemantics(),
+                mock( SchemaState.class) );
 
         StatementLocks statementLocks = new SimpleStatementLocks( new NoOpClient() );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/SchemaProcedureIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/SchemaProcedureIT.java
@@ -32,8 +32,8 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.internal.kernel.api.Procedures;
+import org.neo4j.internal.kernel.api.SchemaWrite;
 import org.neo4j.internal.kernel.api.exceptions.ProcedureException;
-import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.security.AnonymousContext;
@@ -83,7 +83,7 @@ public class SchemaProcedureIT extends KernelIntegrationTest
                 .nodeSetProperty( nodeId, propertyIdName, Values.of( "Emil" ) );
         commit();
 
-        SchemaWriteOperations schemaOps = schemaWriteOperationsInNewTransaction();
+        SchemaWrite schemaOps = schemaWriteInNewTransaction();
         schemaOps.indexCreate( SchemaDescriptorFactory.forLabel( labelId, propertyIdName ) );
         schemaOps.uniquePropertyConstraintCreate( SchemaDescriptorFactory.forLabel( labelId, propertyIdAge ) );
         commit();

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/SchemaProcedureIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/SchemaProcedureIT.java
@@ -34,7 +34,7 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.internal.kernel.api.Procedures;
 import org.neo4j.internal.kernel.api.SchemaWrite;
 import org.neo4j.internal.kernel.api.exceptions.ProcedureException;
-import org.neo4j.kernel.api.Statement;
+import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.security.AnonymousContext;
 import org.neo4j.kernel.impl.api.integrationtest.KernelIntegrationTest;
@@ -73,13 +73,13 @@ public class SchemaProcedureIT extends KernelIntegrationTest
     public void testLabelIndex() throws Throwable
     {
         // Given there is label with index and a constraint
-        Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
-        long nodeId = statement.dataWriteOperations().nodeCreate();
-        int labelId = statement.tokenWriteOperations().labelGetOrCreateForName( "Person" );
-        statement.dataWriteOperations().nodeAddLabel( nodeId, labelId );
-        int propertyIdName = statement.tokenWriteOperations().propertyKeyGetOrCreateForName( "name" );
-        int propertyIdAge = statement.tokenWriteOperations().propertyKeyGetOrCreateForName( "age" );
-        statement.dataWriteOperations()
+        KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
+        long nodeId = transaction.dataWrite().nodeCreate();
+        int labelId = transaction.tokenWrite().labelGetOrCreateForName( "Person" );
+        transaction.dataWrite().nodeAddLabel( nodeId, labelId );
+        int propertyIdName = transaction.tokenWrite().propertyKeyGetOrCreateForName( "name" );
+        int propertyIdAge = transaction.tokenWrite().propertyKeyGetOrCreateForName( "age" );
+        transaction.dataWrite()
                 .nodeSetProperty( nodeId, propertyIdName, Values.of( "Emil" ) );
         commit();
 
@@ -113,15 +113,15 @@ public class SchemaProcedureIT extends KernelIntegrationTest
     public void testRelationShip() throws Throwable
     {
         // Given there ar
-        Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
-        long nodeIdPerson = statement.dataWriteOperations().nodeCreate();
-        int labelIdPerson = statement.tokenWriteOperations().labelGetOrCreateForName( "Person" );
-        statement.dataWriteOperations().nodeAddLabel( nodeIdPerson, labelIdPerson );
-        long nodeIdLocation = statement.dataWriteOperations().nodeCreate();
-        int labelIdLocation = statement.tokenWriteOperations().labelGetOrCreateForName( "Location" );
-        statement.dataWriteOperations().nodeAddLabel( nodeIdLocation, labelIdLocation );
-        int relationshipTypeId = statement.tokenWriteOperations().relationshipTypeGetOrCreateForName( "LIVES_IN" );
-        statement.dataWriteOperations().relationshipCreate( relationshipTypeId, nodeIdPerson, nodeIdLocation );
+        KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
+        long nodeIdPerson = transaction.dataWrite().nodeCreate();
+        int labelIdPerson = transaction.tokenWrite().labelGetOrCreateForName( "Person" );
+        transaction.dataWrite().nodeAddLabel( nodeIdPerson, labelIdPerson );
+        long nodeIdLocation = transaction.dataWrite().nodeCreate();
+        int labelIdLocation = transaction.tokenWrite().labelGetOrCreateForName( "Location" );
+        transaction.dataWrite().nodeAddLabel( nodeIdLocation, labelIdLocation );
+        int relationshipTypeId = transaction.tokenWrite().relationshipTypeGetOrCreateForName( "LIVES_IN" );
+        transaction.dataWrite().relationshipCreate(  nodeIdPerson, relationshipTypeId, nodeIdLocation );
         commit();
 
         // When

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTerminationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTerminationTest.java
@@ -349,7 +349,7 @@ public class KernelTransactionTerminationTest
                     LockTracer.NONE, PageCursorTracerSupplier.NULL,
                     mock( StorageEngine.class, RETURNS_MOCKS ), new CanWrite(),
                     mock( DefaultCursors.class ), AutoIndexing.UNSUPPORTED, mock( ExplicitIndexStore.class ),
-                    EmptyVersionContextSupplier.EMPTY, ON_HEAP, new StandardConstraintSemantics() );
+                    EmptyVersionContextSupplier.EMPTY, ON_HEAP, new StandardConstraintSemantics(), mock( SchemaState.class) );
 
             this.monitor = monitor;
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTestBase.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTestBase.java
@@ -166,7 +166,7 @@ public class KernelTransactionTestBase
                 new AtomicReference<>( HeapAllocation.NOT_AVAILABLE ), TransactionTracer.NULL, LockTracer.NONE, PageCursorTracerSupplier.NULL, storageEngine,
                 new CanWrite(), new DefaultCursors(), AutoIndexing.UNSUPPORTED,
                 mock( ExplicitIndexStore.class ), EmptyVersionContextSupplier.EMPTY, () -> collectionsFactory,
-                new StandardConstraintSemantics() );
+                new StandardConstraintSemantics(), mock( SchemaState.class) );
     }
 
     public class CapturingCommitProcess implements TransactionCommitProcess

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
@@ -47,6 +47,7 @@ import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.explicitindex.AutoIndexing;
 import org.neo4j.kernel.api.security.AnonymousContext;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
+import org.neo4j.kernel.impl.constraints.ConstraintSemantics;
 import org.neo4j.kernel.impl.constraints.StandardConstraintSemantics;
 import org.neo4j.kernel.impl.factory.AccessCapability;
 import org.neo4j.kernel.impl.factory.CanWrite;
@@ -590,9 +591,11 @@ public class KernelTransactionsTest
         return new KernelTransactions( statementLocksFactory, null, statementOperations,
                 null, DEFAULT, commitProcess, null, null, new TransactionHooks(),
                 mock( TransactionMonitor.class ), availabilityGuard, tracers, storageEngine, new Procedures(), transactionIdStore, clock,
-                new AtomicReference<>( CpuClock.NOT_AVAILABLE ), new AtomicReference<>( HeapAllocation.NOT_AVAILABLE ), new CanWrite(),
+                new AtomicReference<>( CpuClock.NOT_AVAILABLE ), new AtomicReference<>( HeapAllocation.NOT_AVAILABLE ),
+                new CanWrite(),
                 DefaultCursors::new, AutoIndexing.UNSUPPORTED,
-                mock( ExplicitIndexStore.class ), EmptyVersionContextSupplier.EMPTY, ON_HEAP, null );
+                mock( ExplicitIndexStore.class ), EmptyVersionContextSupplier.EMPTY, ON_HEAP,
+                mock( ConstraintSemantics.class ), mock( SchemaState.class ) );
     }
 
     private static TestKernelTransactions createTestTransactions( StorageEngine storageEngine,
@@ -661,7 +664,7 @@ public class KernelTransactionsTest
                     indexConfigStore, explicitIndexProviderLookup, hooks, transactionMonitor, availabilityGuard, tracers, storageEngine, procedures,
                     transactionIdStore, clock, new AtomicReference<>( CpuClock.NOT_AVAILABLE ), new AtomicReference<>( HeapAllocation.NOT_AVAILABLE ),
                     accessCapability, cursors, autoIndexing, mock( ExplicitIndexStore.class ), versionContextSupplier,
-                    ON_HEAP, new StandardConstraintSemantics() );
+                    ON_HEAP, new StandardConstraintSemantics(), mock( SchemaState.class ) );
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
@@ -35,6 +35,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.Iterators;
+import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.exceptions.schema.SchemaKernelException;
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
@@ -42,7 +43,6 @@ import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.Statement;
-import org.neo4j.kernel.api.TokenWriteOperations;
 import org.neo4j.kernel.api.index.PropertyAccessor;
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
@@ -75,7 +75,7 @@ public class IndexIT extends KernelIntegrationTest
     @Before
     public void createLabelAndProperty() throws Exception
     {
-        TokenWriteOperations tokenWrites = tokenWriteOperationsInNewTransaction();
+        TokenWrite tokenWrites = tokenWriteInNewTransaction();
         labelId = tokenWrites.labelGetOrCreateForName( LABEL );
         propertyKeyId = tokenWrites.propertyKeyGetOrCreateForName( PROPERTY_KEY );
         int propertyKeyId2 = tokenWrites.propertyKeyGetOrCreateForName( PROPERTY_KEY2 );
@@ -94,8 +94,8 @@ public class IndexIT extends KernelIntegrationTest
     @Test
     public void createIndexForAnotherLabelWhileHoldingSharedLockOnOtherLabel() throws KernelException
     {
-        TokenWriteOperations tokenWriteOperations = tokenWriteOperationsInNewTransaction();
-        int label2 = tokenWriteOperations.labelGetOrCreateForName( "Label2" );
+        TokenWrite tokenWrite = tokenWriteInNewTransaction();
+        int label2 = tokenWrite.labelGetOrCreateForName( "Label2" );
 
         DataWriteOperations dataWriteOperations = dataWriteOperationsInNewTransaction();
         long nodeId = dataWriteOperations.nodeCreate();
@@ -108,8 +108,8 @@ public class IndexIT extends KernelIntegrationTest
     @Test( timeout = 10_000 )
     public void createIndexesForDifferentLabelsConcurrently() throws Throwable
     {
-        TokenWriteOperations tokenWriteOperations = tokenWriteOperationsInNewTransaction();
-        int label2 = tokenWriteOperations.labelGetOrCreateForName( "Label2" );
+        TokenWrite tokenWrite = tokenWriteInNewTransaction();
+        int label2 = tokenWrite.labelGetOrCreateForName( "Label2" );
 
         LabelSchemaDescriptor anotherLabelDescriptor = SchemaDescriptorFactory.forLabel( label2, propertyKeyId );
         schemaWriteOperationsInNewTransaction().indexCreate( anotherLabelDescriptor );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
@@ -44,7 +44,6 @@ import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.exceptions.schema.SchemaKernelException;
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.index.PropertyAccessor;
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
@@ -172,8 +171,8 @@ public class IndexIT extends KernelIntegrationTest
         rollback();
 
         // THEN
-        ReadOperations readOperations = readOperationsInNewTransaction();
-        assertEquals( emptySet(), asSet( readOperations.indexesGetForLabel( labelId ) ) );
+        KernelTransaction transaction = newTransaction();
+        assertEquals( emptySet(), asSet( transaction.schemaRead().indexesGetForLabel( labelId ) ) );
         commit();
     }
 
@@ -186,8 +185,8 @@ public class IndexIT extends KernelIntegrationTest
 
         SchemaIndexDescriptor constraintIndex = creator.createConstraintIndex( descriptor );
         // then
-        ReadOperations readOperations = readOperationsInNewTransaction();
-        assertEquals( emptySet(), asSet( readOperations.constraintsGetForLabel( labelId ) ) );
+        KernelTransaction transaction = newTransaction();
+        assertEquals( emptySet(), asSet( transaction.schemaRead().constraintsGetForLabel( labelId ) ) );
         commit();
 
         // when
@@ -196,8 +195,8 @@ public class IndexIT extends KernelIntegrationTest
         commit();
 
         // then
-        readOperations = readOperationsInNewTransaction();
-        assertEquals( emptySet(), asSet( readOperations.indexesGetForLabel( labelId ) ) );
+        transaction = newTransaction();
+        assertEquals( emptySet(), asSet( transaction.schemaRead().indexesGetForLabel( labelId ) ) );
         commit();
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
@@ -44,7 +44,6 @@ import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.exceptions.schema.SchemaKernelException;
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.index.PropertyAccessor;
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema.constaints.IndexBackedConstraintDescriptor;
@@ -264,11 +263,11 @@ public class IndexIT extends KernelIntegrationTest
     public void shouldListConstraintIndexesInTheBeansAPI() throws Exception
     {
         // given
-        Statement statement = statementInNewTransaction( AUTH_DISABLED );
-        statement.schemaWriteOperations().uniquePropertyConstraintCreate(
+        KernelTransaction transaction = newTransaction( AUTH_DISABLED );
+        transaction.schemaWrite().uniquePropertyConstraintCreate(
                 SchemaDescriptorFactory.forLabel(
-                        statement.tokenWriteOperations().labelGetOrCreateForName( "Label1" ),
-                        statement.tokenWriteOperations().propertyKeyGetOrCreateForName( "property1" )
+                        transaction.tokenWrite().labelGetOrCreateForName( "Label1" ),
+                        transaction.tokenWrite().propertyKeyGetOrCreateForName( "property1" )
                 ) );
         commit();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
@@ -35,16 +35,20 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.Iterators;
+import org.neo4j.internal.kernel.api.CapableIndexReference;
+import org.neo4j.internal.kernel.api.SchemaRead;
+import org.neo4j.internal.kernel.api.SchemaWrite;
 import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.Write;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.exceptions.schema.SchemaKernelException;
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
+import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.ReadOperations;
-import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.index.PropertyAccessor;
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
+import org.neo4j.kernel.api.schema.constaints.IndexBackedConstraintDescriptor;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
 import org.neo4j.kernel.impl.api.integrationtest.KernelIntegrationTest;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
@@ -59,6 +63,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.neo4j.helpers.collection.Iterators.asSet;
 import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
+import static org.neo4j.kernel.impl.api.store.DefaultCapableIndexReference.fromDescriptor;
 
 public class IndexIT extends KernelIntegrationTest
 {
@@ -101,7 +106,7 @@ public class IndexIT extends KernelIntegrationTest
         long nodeId = write.nodeCreate();
         write.nodeAddLabel( nodeId, label2 );
 
-        schemaWriteOperationsInNewTransaction().indexCreate( descriptor );
+        schemaWriteInNewTransaction().indexCreate( descriptor );
         commit();
     }
 
@@ -112,7 +117,7 @@ public class IndexIT extends KernelIntegrationTest
         int label2 = tokenWrite.labelGetOrCreateForName( "Label2" );
 
         LabelSchemaDescriptor anotherLabelDescriptor = SchemaDescriptorFactory.forLabel( label2, propertyKeyId );
-        schemaWriteOperationsInNewTransaction().indexCreate( anotherLabelDescriptor );
+        schemaWriteInNewTransaction().indexCreate( anotherLabelDescriptor );
 
         Future<?> indexFuture = executorService.submit( createIndex( db, Label.label( LABEL ), PROPERTY_KEY ) );
         indexFuture.get();
@@ -123,16 +128,16 @@ public class IndexIT extends KernelIntegrationTest
     public void addIndexRuleInATransaction() throws Exception
     {
         // GIVEN
-        SchemaWriteOperations schemaWriteOperations = schemaWriteOperationsInNewTransaction();
+        SchemaWrite schemaWriteOperations = schemaWriteInNewTransaction();
 
         // WHEN
-        SchemaIndexDescriptor expectedRule = schemaWriteOperations.indexCreate( descriptor );
+        CapableIndexReference expectedRule = schemaWriteOperations.indexCreate( descriptor );
         commit();
 
         // THEN
-        ReadOperations readOperations = readOperationsInNewTransaction();
-        assertEquals( asSet( expectedRule ), asSet( readOperations.indexesGetForLabel( labelId ) ) );
-        assertEquals( expectedRule, readOperations.indexGetForSchema( descriptor ) );
+        SchemaRead schemaRead = newTransaction().schemaRead();
+        assertEquals( asSet( expectedRule ), asSet( schemaRead.indexesGetForLabel( labelId ) ) );
+        assertEquals( expectedRule, schemaRead.index( descriptor.getLabelId(), descriptor.getPropertyIds() ) );
         commit();
     }
 
@@ -140,15 +145,15 @@ public class IndexIT extends KernelIntegrationTest
     public void committedAndTransactionalIndexRulesShouldBeMerged() throws Exception
     {
         // GIVEN
-        SchemaWriteOperations schemaWriteOperations = schemaWriteOperationsInNewTransaction();
-        SchemaIndexDescriptor existingRule = schemaWriteOperations.indexCreate( descriptor );
+        SchemaWrite schemaWriteOperations = schemaWriteInNewTransaction();
+        CapableIndexReference existingRule = schemaWriteOperations.indexCreate( descriptor );
         commit();
 
         // WHEN
-        Statement statement = statementInNewTransaction( AUTH_DISABLED );
-        SchemaIndexDescriptor addedRule = statement.schemaWriteOperations()
+        KernelTransaction transaction = newTransaction( AUTH_DISABLED );
+        CapableIndexReference addedRule = transaction.schemaWrite()
                                                    .indexCreate( SchemaDescriptorFactory.forLabel( labelId, 10 ) );
-        Set<SchemaIndexDescriptor> indexRulesInTx = asSet( statement.readOperations().indexesGetForLabel( labelId ) );
+        Set<CapableIndexReference> indexRulesInTx = asSet( transaction.schemaRead().indexesGetForLabel( labelId ) );
         commit();
 
         // THEN
@@ -159,10 +164,10 @@ public class IndexIT extends KernelIntegrationTest
     public void rollBackIndexRuleShouldNotBeCommitted() throws Exception
     {
         // GIVEN
-        SchemaWriteOperations schemaWriteOperations = schemaWriteOperationsInNewTransaction();
+        SchemaWrite schemaWrite = schemaWriteInNewTransaction();
 
         // WHEN
-        schemaWriteOperations.indexCreate( descriptor );
+        schemaWrite.indexCreate( descriptor );
         // don't mark as success
         rollback();
 
@@ -186,8 +191,8 @@ public class IndexIT extends KernelIntegrationTest
         commit();
 
         // when
-        SchemaWriteOperations schemaWriteOperations = schemaWriteOperationsInNewTransaction();
-        schemaWriteOperations.indexDrop( constraintIndex );
+        SchemaWrite schemaWrite = schemaWriteInNewTransaction();
+        schemaWrite.indexDrop( fromDescriptor( constraintIndex ) );
         commit();
 
         // then
@@ -200,14 +205,14 @@ public class IndexIT extends KernelIntegrationTest
     public void shouldDisallowDroppingIndexThatDoesNotExist() throws Exception
     {
         // given
-        SchemaIndexDescriptor index;
+        CapableIndexReference index;
         {
-            SchemaWriteOperations statement = schemaWriteOperationsInNewTransaction();
+            SchemaWrite statement = schemaWriteInNewTransaction();
             index = statement.indexCreate( descriptor );
             commit();
         }
         {
-            SchemaWriteOperations statement = schemaWriteOperationsInNewTransaction();
+            SchemaWrite statement = schemaWriteInNewTransaction();
             statement.indexDrop( index );
             commit();
         }
@@ -215,7 +220,7 @@ public class IndexIT extends KernelIntegrationTest
         // when
         try
         {
-            SchemaWriteOperations statement = schemaWriteOperationsInNewTransaction();
+            SchemaWrite statement = schemaWriteInNewTransaction();
             statement.indexDrop( index );
             commit();
         }
@@ -233,7 +238,7 @@ public class IndexIT extends KernelIntegrationTest
     {
         // given
         {
-            SchemaWriteOperations statement = schemaWriteOperationsInNewTransaction();
+            SchemaWrite statement = schemaWriteInNewTransaction();
             statement.uniquePropertyConstraintCreate( descriptor );
             commit();
         }
@@ -241,7 +246,7 @@ public class IndexIT extends KernelIntegrationTest
         // when
         try
         {
-            SchemaWriteOperations statement = schemaWriteOperationsInNewTransaction();
+            SchemaWrite statement = schemaWriteInNewTransaction();
             statement.indexCreate( descriptor );
             commit();
 
@@ -302,15 +307,15 @@ public class IndexIT extends KernelIntegrationTest
     public void shouldListAll() throws Exception
     {
         // given
-        SchemaWriteOperations schemaWriteOperations = schemaWriteOperationsInNewTransaction();
-        SchemaIndexDescriptor index1 = schemaWriteOperations.indexCreate( descriptor );
-        SchemaIndexDescriptor index2 = schemaWriteOperations.uniquePropertyConstraintCreate( descriptor2 )
-                                                            .ownedIndexDescriptor();
+        SchemaWrite schemaWrite = schemaWriteInNewTransaction();
+        CapableIndexReference index1 = schemaWrite.indexCreate( descriptor );
+        CapableIndexReference index2 = fromDescriptor(
+                ((IndexBackedConstraintDescriptor) schemaWrite.uniquePropertyConstraintCreate( descriptor2 )).ownedIndexDescriptor()) ;
         commit();
 
         // then/when
-        ReadOperations readOperations = readOperationsInNewTransaction();
-        List<SchemaIndexDescriptor> indexes = Iterators.asList( readOperations.indexesGetAll() );
+        SchemaRead schemaRead = newTransaction().schemaRead();
+        List<CapableIndexReference> indexes = Iterators.asList( schemaRead.indexesGetAll() );
         assertThat( indexes, containsInAnyOrder( index1, index2 ) );
         commit();
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
@@ -36,10 +36,10 @@ import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.internal.kernel.api.TokenWrite;
+import org.neo4j.internal.kernel.api.Write;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.exceptions.schema.SchemaKernelException;
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
-import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.Statement;
@@ -97,9 +97,9 @@ public class IndexIT extends KernelIntegrationTest
         TokenWrite tokenWrite = tokenWriteInNewTransaction();
         int label2 = tokenWrite.labelGetOrCreateForName( "Label2" );
 
-        DataWriteOperations dataWriteOperations = dataWriteOperationsInNewTransaction();
-        long nodeId = dataWriteOperations.nodeCreate();
-        dataWriteOperations.nodeAddLabel( nodeId, label2 );
+        Write write = dataWriteInNewTransaction();
+        long nodeId = write.nodeCreate();
+        write.nodeAddLabel( nodeId, label2 );
 
         schemaWriteOperationsInNewTransaction().indexCreate( descriptor );
         commit();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
@@ -31,11 +31,11 @@ import java.util.Set;
 import org.neo4j.collection.RawIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.ResourceTracker;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.StubResourceManager;
-import org.neo4j.kernel.api.TokenWriteOperations;
 import org.neo4j.kernel.api.security.AnonymousContext;
 import org.neo4j.kernel.impl.api.index.inmemory.InMemoryIndexProviderFactory;
 import org.neo4j.kernel.internal.Version;
@@ -81,7 +81,7 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
     public void listPropertyKeys() throws Throwable
     {
         // Given
-        TokenWriteOperations ops = tokenWriteOperationsInNewTransaction();
+        TokenWrite ops = tokenWriteInNewTransaction();
         ops.propertyKeyGetOrCreateForName( "MyProp" );
         commit();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
@@ -33,8 +33,8 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.exceptions.ProcedureException;
+import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.ResourceTracker;
-import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.StubResourceManager;
 import org.neo4j.kernel.api.security.AnonymousContext;
 import org.neo4j.kernel.impl.api.index.inmemory.InMemoryIndexProviderFactory;
@@ -63,10 +63,10 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
     public void listAllLabels() throws Throwable
     {
         // Given
-        Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
-        long nodeId = statement.dataWriteOperations().nodeCreate();
-        int labelId = statement.tokenWriteOperations().labelGetOrCreateForName( "MyLabel" );
-        statement.dataWriteOperations().nodeAddLabel( nodeId, labelId );
+        KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
+        long nodeId = transaction.dataWrite().nodeCreate();
+        int labelId = transaction.tokenWrite().labelGetOrCreateForName( "MyLabel" );
+        transaction.dataWrite().nodeAddLabel( nodeId, labelId );
         commit();
 
         // When
@@ -98,11 +98,11 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
     public void listRelationshipTypes() throws Throwable
     {
         // Given
-        Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
-        int relType = statement.tokenWriteOperations().relationshipTypeGetOrCreateForName( "MyRelType" );
-        long startNodeId = statement.dataWriteOperations().nodeCreate();
-        long endNodeId = statement.dataWriteOperations().nodeCreate();
-        statement.dataWriteOperations().relationshipCreate( relType, startNodeId, endNodeId );
+        KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
+        int relType = transaction.tokenWrite().relationshipTypeGetOrCreateForName( "MyRelType" );
+        long startNodeId = transaction.dataWrite().nodeCreate();
+        long endNodeId = transaction.dataWrite().nodeCreate();
+        transaction.dataWrite().relationshipCreate(  startNodeId, relType, endNodeId );
         commit();
 
         // When
@@ -304,15 +304,15 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
     public void listAllIndexes() throws Throwable
     {
         // Given
-        Statement statement = statementInNewTransaction( AUTH_DISABLED );
-        int labelId1 = statement.tokenWriteOperations().labelGetOrCreateForName( "Person" );
-        int labelId2 = statement.tokenWriteOperations().labelGetOrCreateForName( "Age" );
-        int propertyKeyId1 = statement.tokenWriteOperations().propertyKeyGetOrCreateForName( "foo" );
-        int propertyKeyId2 = statement.tokenWriteOperations().propertyKeyGetOrCreateForName( "bar" );
+        KernelTransaction transaction = newTransaction( AUTH_DISABLED );
+        int labelId1 = transaction.tokenWrite().labelGetOrCreateForName( "Person" );
+        int labelId2 = transaction.tokenWrite().labelGetOrCreateForName( "Age" );
+        int propertyKeyId1 = transaction.tokenWrite().propertyKeyGetOrCreateForName( "foo" );
+        int propertyKeyId2 = transaction.tokenWrite().propertyKeyGetOrCreateForName( "bar" );
         //TODO: Add test support for composite indexes
-        statement.schemaWriteOperations().indexCreate( forLabel( labelId1, propertyKeyId1 ) );
-        statement.schemaWriteOperations().uniquePropertyConstraintCreate( forLabel( labelId2, propertyKeyId1 ) );
-        statement.schemaWriteOperations().indexCreate( forLabel( labelId1, propertyKeyId1, propertyKeyId2 ) );
+        transaction.schemaWrite().indexCreate( forLabel( labelId1, propertyKeyId1 ) );
+        transaction.schemaWrite().uniquePropertyConstraintCreate( forLabel( labelId2, propertyKeyId1 ) );
+        transaction.schemaWrite().indexCreate( forLabel( labelId1, propertyKeyId1, propertyKeyId2 ) );
         commit();
 
         //let indexes come online

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
@@ -37,16 +37,16 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionFailureException;
+import org.neo4j.internal.kernel.api.CapableIndexReference;
+import org.neo4j.internal.kernel.api.SchemaWrite;
+import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.internal.kernel.api.exceptions.InvalidTransactionTypeKernelException;
 import org.neo4j.internal.kernel.api.exceptions.schema.SchemaKernelException;
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.Statement;
-import org.neo4j.kernel.api.TokenWriteOperations;
 import org.neo4j.kernel.api.exceptions.Status;
-import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.storageengine.api.NodeItem;
@@ -495,12 +495,12 @@ public class KernelIT extends KernelIntegrationTest
     public void schemaStateShouldBeEvictedOnIndexComingOnline() throws Exception
     {
         // GIVEN
-        schemaWriteOperationsInNewTransaction();
+        schemaWriteInNewTransaction();
         getOrCreateSchemaState( "my key", "my state" );
         commit();
 
         // WHEN
-        createIndex( statementInNewTransaction( AUTH_DISABLED ) );
+        createIndex( newTransaction() );
         commit();
 
         try ( Transaction tx = db.beginTx() )
@@ -518,7 +518,7 @@ public class KernelIT extends KernelIntegrationTest
     public void schemaStateShouldBeEvictedOnIndexDropped() throws Exception
     {
         // GIVEN
-        SchemaIndexDescriptor idx = createIndex( statementInNewTransaction( AUTH_DISABLED ) );
+        CapableIndexReference idx = createIndex( newTransaction() );
         commit();
 
         try ( Transaction tx = db.beginTx() )
@@ -528,7 +528,7 @@ public class KernelIT extends KernelIntegrationTest
             tx.success();
         }
         // WHEN
-        schemaWriteOperationsInNewTransaction().indexDrop( idx );
+        schemaWriteInNewTransaction().indexDrop( idx );
         commit();
 
         // THEN schema state should be immediately updated (this works because the schema cache is updated during
@@ -637,14 +637,14 @@ public class KernelIT extends KernelIntegrationTest
         return txIdStore.getLastCommittedTransactionId();
     }
 
-    private SchemaIndexDescriptor createIndex( Statement statement )
+    private CapableIndexReference createIndex( KernelTransaction transaction )
             throws SchemaKernelException, InvalidTransactionTypeKernelException
     {
-        TokenWriteOperations tokenWriteOperations = statement.tokenWriteOperations();
-        SchemaWriteOperations schemaWriteOperations = statement.schemaWriteOperations();
-        LabelSchemaDescriptor schemaDescriptor = forLabel( tokenWriteOperations.labelGetOrCreateForName( "hello" ),
-                        tokenWriteOperations.propertyKeyGetOrCreateForName( "hepp" ) );
-        return schemaWriteOperations.indexCreate( schemaDescriptor );
+        TokenWrite tokenWrite = transaction.tokenWrite();
+        SchemaWrite schemaWrite = transaction.schemaWrite();
+        LabelSchemaDescriptor schemaDescriptor = forLabel( tokenWrite.labelGetOrCreateForName( "hello" ),
+                        tokenWrite.propertyKeyGetOrCreateForName( "hepp" ) );
+        return schemaWrite.indexCreate( schemaDescriptor );
     }
 
     private String getOrCreateSchemaState( String key, final String maybeSetThisState )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
@@ -47,6 +47,7 @@ import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.api.security.AnonymousContext;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.storageengine.api.NodeItem;
@@ -500,7 +501,7 @@ public class KernelIT extends KernelIntegrationTest
         commit();
 
         // WHEN
-        createIndex( newTransaction() );
+        createIndex( newTransaction( AUTH_DISABLED ) );
         commit();
 
         try ( Transaction tx = db.beginTx() )
@@ -518,7 +519,7 @@ public class KernelIT extends KernelIntegrationTest
     public void schemaStateShouldBeEvictedOnIndexDropped() throws Exception
     {
         // GIVEN
-        CapableIndexReference idx = createIndex( newTransaction() );
+        CapableIndexReference idx = createIndex( newTransaction( AUTH_DISABLED ) );
         commit();
 
         try ( Transaction tx = db.beginTx() )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
@@ -27,6 +27,7 @@ import org.junit.rules.RuleChain;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.internal.kernel.api.Procedures;
+import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.DataWriteOperations;
@@ -35,7 +36,6 @@ import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.Statement;
-import org.neo4j.kernel.api.TokenWriteOperations;
 import org.neo4j.kernel.api.dbms.DbmsOperations;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.security.AnonymousContext;
@@ -72,11 +72,10 @@ public abstract class KernelIntegrationTest
         return statement;
     }
 
-    protected TokenWriteOperations tokenWriteOperationsInNewTransaction() throws KernelException
+    protected TokenWrite tokenWriteInNewTransaction() throws KernelException
     {
         transaction = kernel.newTransaction( KernelTransaction.Type.implicit, AnonymousContext.writeToken() );
-        statement = transaction.acquireStatement();
-        return statement.tokenWriteOperations();
+        return transaction.tokenWrite();
     }
 
     protected DataWriteOperations dataWriteOperationsInNewTransaction() throws KernelException

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
@@ -212,7 +212,7 @@ public abstract class KernelIntegrationTest
 
     private void stopDb() throws TransactionFailureException
     {
-        if ( transaction != null )
+        if ( transaction != null  && transaction.isOpen())
         {
             transaction.close();
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
@@ -212,7 +212,7 @@ public abstract class KernelIntegrationTest
 
     private void stopDb() throws TransactionFailureException
     {
-        if ( transaction != null  && transaction.isOpen())
+        if ( transaction != null && transaction.isOpen() )
         {
             transaction.close();
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
@@ -358,12 +358,26 @@ public abstract class KernelIntegrationTest
         }
     }
 
-    int countNodes( KernelTransaction transaction )
+    protected int countNodes( KernelTransaction transaction )
     {
         int result = 0;
         try ( NodeCursor cursor = transaction.cursors().allocateNodeCursor() )
         {
             transaction.dataRead().allNodesScan( cursor );
+            while ( cursor.next() )
+            {
+                result++;
+            }
+        }
+        return result;
+    }
+
+    int countRelationships( KernelTransaction transaction )
+    {
+        int result = 0;
+        try ( RelationshipScanCursor cursor = transaction.cursors().allocateRelationshipScanCursor() )
+        {
+            transaction.dataRead().allRelationshipsScan( cursor );
             while ( cursor.next() )
             {
                 result++;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
@@ -28,9 +28,9 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.internal.kernel.api.Procedures;
 import org.neo4j.internal.kernel.api.TokenWrite;
+import org.neo4j.internal.kernel.api.Write;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.security.LoginContext;
-import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.InwardKernel;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.ReadOperations;
@@ -78,11 +78,10 @@ public abstract class KernelIntegrationTest
         return transaction.tokenWrite();
     }
 
-    protected DataWriteOperations dataWriteOperationsInNewTransaction() throws KernelException
+    protected Write dataWriteInNewTransaction() throws KernelException
     {
         transaction = kernel.newTransaction( KernelTransaction.Type.implicit, AnonymousContext.write() );
-        statement = transaction.acquireStatement();
-        return statement.dataWriteOperations();
+        return transaction.dataWrite();
     }
 
     protected SchemaWriteOperations schemaWriteOperationsInNewTransaction() throws KernelException

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
@@ -124,7 +124,7 @@ public abstract class KernelIntegrationTest
         return transaction;
     }
 
-    protected KernelTransaction newTransaction(LoginContext loginContext) throws TransactionFailureException
+    protected KernelTransaction newTransaction( LoginContext loginContext ) throws TransactionFailureException
     {
         transaction = kernel.newTransaction( KernelTransaction.Type.implicit, loginContext );
         return transaction;
@@ -227,7 +227,7 @@ public abstract class KernelIntegrationTest
 
     boolean nodeHasLabel( KernelTransaction transaction, long node, int label )
     {
-        try( NodeCursor cursor = transaction.cursors().allocateNodeCursor() )
+        try ( NodeCursor cursor = transaction.cursors().allocateNodeCursor() )
         {
             transaction.dataRead().singleNode( node, cursor );
             return cursor.next() && cursor.labels().contains( label );
@@ -356,5 +356,19 @@ public abstract class KernelIntegrationTest
         default:
             throw new IllegalStateException( direction + " is not a valid direction" );
         }
+    }
+
+    int countNodes( KernelTransaction transaction )
+    {
+        int result = 0;
+        try ( NodeCursor cursor = transaction.cursors().allocateNodeCursor() )
+        {
+            transaction.dataRead().allNodesScan( cursor );
+            while ( cursor.next() )
+            {
+                result++;
+            }
+        }
+        return result;
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/LabelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/LabelIT.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 import java.util.Iterator;
 
-import org.neo4j.kernel.api.DataWriteOperations;
+import org.neo4j.internal.kernel.api.Write;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.security.AnonymousContext;
@@ -74,9 +74,9 @@ public class LabelIT extends KernelIntegrationTest
         commit();
 
         // When I add and remove that label in the same tx
-        DataWriteOperations dataWriteOperations = dataWriteOperationsInNewTransaction();
-        dataWriteOperations.nodeRemoveLabel( node, label );
-        dataWriteOperations.nodeAddLabel( node, label );
+        Write write = dataWriteInNewTransaction();
+        write.nodeRemoveLabel( node, label );
+        write.nodeAddLabel( node, label );
 
         // Then commit should not throw exceptions
         commit();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/LabelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/LabelIT.java
@@ -23,8 +23,9 @@ import org.junit.Test;
 
 import java.util.Iterator;
 
+import org.neo4j.internal.kernel.api.NamedToken;
 import org.neo4j.internal.kernel.api.Write;
-import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.security.AnonymousContext;
 import org.neo4j.storageengine.api.Token;
@@ -54,12 +55,12 @@ public class LabelIT extends KernelIntegrationTest
         // when
         commit();
 
-        ReadOperations readOperations = readOperationsInNewTransaction();
-        Iterator<Token> labelIdsAfterCommit = readOperations.labelsGetAllTokens();
+        KernelTransaction transaction = newTransaction();
+        Iterator<NamedToken> labelIdsAfterCommit = transaction.tokenRead().labelsGetAllTokens();
 
         // then
         assertThat( asCollection( labelIdsAfterCommit ),
-                hasItems( new Token( "label1", label1Id ), new Token( "label2", label2Id ) ) );
+                hasItems( new NamedToken( "label1", label1Id ), new NamedToken( "label2", label2Id ) ) );
         commit();
     }
 
@@ -82,7 +83,8 @@ public class LabelIT extends KernelIntegrationTest
         commit();
 
         // And then the node should have the label
-        assertTrue( readOperationsInNewTransaction().nodeHasLabel( node, label ) );
+
+        assertTrue( nodeHasLabel( newTransaction(), node, label ) );
         commit();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/LabelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/LabelIT.java
@@ -26,9 +26,7 @@ import java.util.Iterator;
 import org.neo4j.internal.kernel.api.NamedToken;
 import org.neo4j.internal.kernel.api.Write;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.security.AnonymousContext;
-import org.neo4j.storageengine.api.Token;
 
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.junit.Assert.assertThat;
@@ -41,21 +39,21 @@ public class LabelIT extends KernelIntegrationTest
     public void shouldListAllLabels() throws Exception
     {
         // given
-        Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
-        int label1Id = statement.tokenWriteOperations().labelGetOrCreateForName( "label1" );
-        int label2Id = statement.tokenWriteOperations().labelGetOrCreateForName( "label2" );
+        KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
+        int label1Id = transaction.tokenWrite().labelGetOrCreateForName( "label1" );
+        int label2Id = transaction.tokenWrite().labelGetOrCreateForName( "label2" );
 
         // when
-        Iterator<Token> labelIdsBeforeCommit = statement.readOperations().labelsGetAllTokens();
+        Iterator<NamedToken> labelIdsBeforeCommit = transaction.tokenRead().labelsGetAllTokens();
 
         // then
         assertThat( asCollection( labelIdsBeforeCommit ),
-                hasItems( new Token( "label1", label1Id ), new Token( "label2", label2Id ) ) );
+                hasItems( new NamedToken( "label1", label1Id ), new NamedToken( "label2", label2Id ) ) );
 
         // when
         commit();
 
-        KernelTransaction transaction = newTransaction();
+        transaction = newTransaction();
         Iterator<NamedToken> labelIdsAfterCommit = transaction.tokenRead().labelsGetAllTokens();
 
         // then
@@ -68,10 +66,10 @@ public class LabelIT extends KernelIntegrationTest
     public void addingAndRemovingLabelInSameTxShouldHaveNoEffect() throws Exception
     {
         // Given a node with a label
-        Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
-        int label = statement.tokenWriteOperations().labelGetOrCreateForName( "Label 1" );
-        long node = statement.dataWriteOperations().nodeCreate();
-        statement.dataWriteOperations().nodeAddLabel( node, label );
+        KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
+        int label = transaction.tokenWrite().labelGetOrCreateForName( "Label 1" );
+        long node = transaction.dataWrite().nodeCreate();
+        transaction.dataWrite().nodeAddLabel( node, label );
         commit();
 
         // When I add and remove that label in the same tx

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodeGetUniqueFromIndexSeekIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodeGetUniqueFromIndexSeekIT.java
@@ -24,10 +24,10 @@ import org.junit.Test;
 
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.internal.kernel.api.TokenWrite;
+import org.neo4j.internal.kernel.api.Write;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.internal.kernel.api.security.LoginContext;
-import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.StatementConstants;
@@ -174,12 +174,12 @@ public class NodeGetUniqueFromIndexSeekIT extends KernelIntegrationTest
         final SchemaIndexDescriptor index = createUniquenessConstraint( labelId, propertyId1 );
         final Value value = Values.of( "value" );
 
-        DataWriteOperations dataStatement = dataWriteOperationsInNewTransaction();
-        long nodeId = dataStatement.nodeCreate();
-        dataStatement.nodeAddLabel( nodeId, labelId );
+        Write write = dataWriteInNewTransaction();
+        long nodeId = write.nodeCreate();
+        write.nodeAddLabel( nodeId, labelId );
 
         // This adds the node to the unique index and should take an index write lock
-        dataStatement.nodeSetProperty( nodeId, propertyId1, value );
+        write.nodeSetProperty( nodeId, propertyId1, value );
 
         Runnable runnableForThread2 = () ->
         {
@@ -227,21 +227,21 @@ public class NodeGetUniqueFromIndexSeekIT extends KernelIntegrationTest
 
     private long createNodeWithValue( Value value ) throws KernelException
     {
-        DataWriteOperations dataStatement = dataWriteOperationsInNewTransaction();
-        long nodeId = dataStatement.nodeCreate();
-        dataStatement.nodeAddLabel( nodeId, labelId );
-        dataStatement.nodeSetProperty( nodeId, propertyId1, value );
+        Write write = dataWriteInNewTransaction();
+        long nodeId = write.nodeCreate();
+        write.nodeAddLabel( nodeId, labelId );
+        write.nodeSetProperty( nodeId, propertyId1, value );
         commit();
         return nodeId;
     }
 
     private long createNodeWithValues( Value value1, Value value2 ) throws KernelException
     {
-        DataWriteOperations dataStatement = dataWriteOperationsInNewTransaction();
-        long nodeId = dataStatement.nodeCreate();
-        dataStatement.nodeAddLabel( nodeId, labelId );
-        dataStatement.nodeSetProperty( nodeId, propertyId1, value1 );
-        dataStatement.nodeSetProperty( nodeId, propertyId2, value2 );
+        Write write = dataWriteInNewTransaction();
+        long nodeId = write.nodeCreate();
+        write.nodeAddLabel( nodeId, labelId );
+        write.nodeSetProperty( nodeId, propertyId1, value1 );
+        write.nodeSetProperty( nodeId, propertyId2, value2 );
         commit();
         return nodeId;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodeGetUniqueFromIndexSeekIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodeGetUniqueFromIndexSeekIT.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.internal.kernel.api.security.LoginContext;
@@ -30,7 +31,6 @@ import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.StatementConstants;
-import org.neo4j.kernel.api.TokenWriteOperations;
 import org.neo4j.kernel.api.exceptions.index.IndexNotApplicableKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.schema.IndexBrokenKernelException;
@@ -52,10 +52,10 @@ public class NodeGetUniqueFromIndexSeekIT extends KernelIntegrationTest
     @Before
     public void createKeys() throws Exception
     {
-        TokenWriteOperations tokenWriteOperations = tokenWriteOperationsInNewTransaction();
-        this.labelId = tokenWriteOperations.labelGetOrCreateForName( "Person" );
-        this.propertyId1 = tokenWriteOperations.propertyKeyGetOrCreateForName( "foo" );
-        this.propertyId2 = tokenWriteOperations.propertyKeyGetOrCreateForName( "bar" );
+        TokenWrite tokenWrite = tokenWriteInNewTransaction();
+        this.labelId = tokenWrite.labelGetOrCreateForName( "Person" );
+        this.propertyId1 = tokenWrite.propertyKeyGetOrCreateForName( "foo" );
+        this.propertyId2 = tokenWrite.propertyKeyGetOrCreateForName( "bar" );
         commit();
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ProceduresKernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ProceduresKernelIT.java
@@ -95,7 +95,7 @@ public class ProceduresKernelIT extends KernelIntegrationTest
 
         // When
         List<ProcedureSignature> signatures =
-                Iterables.asList( readOperationsInNewTransaction().proceduresGetAll() );
+                Iterables.asList( newTransaction().procedures().proceduresGetAll() );
 
         // Then
         assertThat( signatures, hasItems(

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
@@ -24,8 +24,8 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.Iterator;
 
+import org.neo4j.internal.kernel.api.Write;
 import org.neo4j.internal.kernel.api.exceptions.EntityNotFoundException;
-import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.security.AnonymousContext;
@@ -206,7 +206,7 @@ public class PropertyIT extends KernelIntegrationTest
             commit();
         }
         {
-            DataWriteOperations statement = dataWriteOperationsInNewTransaction();
+            Write statement = dataWriteInNewTransaction();
 
             // WHEN
             Value result = statement.nodeRemoveProperty( nodeId, propertyId );
@@ -278,8 +278,8 @@ public class PropertyIT extends KernelIntegrationTest
         commit();
 
         // WHEN
-        DataWriteOperations dataWriteOperations = dataWriteOperationsInNewTransaction();
-        dataWriteOperations.nodeSetProperty( nodeId, propertyKeyId, Values.stringValue( "bozo" ) );
+        Write write = dataWriteInNewTransaction();
+        write.nodeSetProperty( nodeId, propertyKeyId, Values.stringValue( "bozo" ) );
         rollback();
 
         // THEN
@@ -300,8 +300,8 @@ public class PropertyIT extends KernelIntegrationTest
         commit();
 
         // WHEN
-        DataWriteOperations dataWriteOperations = dataWriteOperationsInNewTransaction();
-        dataWriteOperations.nodeSetProperty( nodeId, propertyId, Values.of( 42 ) );
+        Write write = dataWriteInNewTransaction();
+        write.nodeSetProperty( nodeId, propertyId, Values.of( 42 ) );
         commit();
 
         // THEN
@@ -402,11 +402,11 @@ public class PropertyIT extends KernelIntegrationTest
         commit();
 
         // when
-        DataWriteOperations dataWriteOperations = dataWriteOperationsInNewTransaction();
-        dataWriteOperations.nodeRemoveProperty( node, prop );
-        dataWriteOperations.nodeSetProperty( node, prop, Values.of( "bar" ) );
-        dataWriteOperations.nodeRemoveProperty( node, prop );
-        dataWriteOperations.nodeRemoveProperty( node, prop );
+        Write write = dataWriteInNewTransaction();
+        write.nodeRemoveProperty( node, prop );
+        write.nodeSetProperty( node, prop, Values.of( "bar" ) );
+        write.nodeRemoveProperty( node, prop );
+        write.nodeRemoveProperty( node, prop );
 
         commit();
 
@@ -432,11 +432,11 @@ public class PropertyIT extends KernelIntegrationTest
         commit();
 
         // when
-        DataWriteOperations dataWriteOperations = dataWriteOperationsInNewTransaction();
-        dataWriteOperations.relationshipRemoveProperty( rel, prop );
-        dataWriteOperations.relationshipSetProperty( rel, prop, Values.of( "bar" ) );
-        dataWriteOperations.relationshipRemoveProperty( rel, prop );
-        dataWriteOperations.relationshipRemoveProperty( rel, prop );
+        Write write = dataWriteInNewTransaction();
+        write.relationshipRemoveProperty( rel, prop );
+        write.relationshipSetProperty( rel, prop, Values.of( "bar" ) );
+        write.relationshipRemoveProperty( rel, prop );
+        write.relationshipRemoveProperty( rel, prop );
 
         commit();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipIT.java
@@ -34,7 +34,6 @@ import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.security.AnonymousContext;
 import org.neo4j.test.rule.concurrent.OtherThreadRule;
 
@@ -172,18 +171,18 @@ public class RelationshipIT extends KernelIntegrationTest
         int relTypeTheNodeDoesUse;
         int relTypeTheNodeDoesNotUse;
         {
-            Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
+            KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
 
-            relTypeTheNodeDoesUse = statement.tokenWriteOperations().relationshipTypeGetOrCreateForName( "Type1" );
-            relTypeTheNodeDoesNotUse = statement.tokenWriteOperations().relationshipTypeGetOrCreateForName( "Type2" );
+            relTypeTheNodeDoesUse = transaction.tokenWrite().relationshipTypeGetOrCreateForName( "Type1" );
+            relTypeTheNodeDoesNotUse = transaction.tokenWrite().relationshipTypeGetOrCreateForName( "Type2" );
 
-            refNode = statement.dataWriteOperations().nodeCreate();
-            long otherNode = statement.dataWriteOperations().nodeCreate();
+            refNode = transaction.dataWrite().nodeCreate();
+            long otherNode = transaction.dataWrite().nodeCreate();
 
             for ( int i = 0; i < rels.length; i++ )
             {
                 rels[i] =
-                        statement.dataWriteOperations().relationshipCreate( relTypeTheNodeDoesUse, refNode, otherNode );
+                        transaction.dataWrite().relationshipCreate( refNode, relTypeTheNodeDoesUse, otherNode );
             }
             commit();
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/TransactionHookIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/TransactionHookIT.java
@@ -21,7 +21,7 @@ package org.neo4j.kernel.impl.api.integrationtest;
 
 import org.junit.Test;
 
-import org.neo4j.kernel.api.DataWriteOperations;
+import org.neo4j.internal.kernel.api.Write;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.TransactionHook;
 import org.neo4j.kernel.api.exceptions.Status;
@@ -48,7 +48,7 @@ public class TransactionHookIT extends KernelIntegrationTest
         kernel.registerTransactionHook( hook );
 
         // When
-        DataWriteOperations ops = dataWriteOperationsInNewTransaction();
+        Write ops = dataWriteInNewTransaction();
         ops.nodeCreate();
         commit();
 
@@ -83,7 +83,7 @@ public class TransactionHookIT extends KernelIntegrationTest
         kernel.registerTransactionHook( hook );
 
         // When
-        DataWriteOperations ops = dataWriteOperationsInNewTransaction();
+        Write ops = dataWriteInNewTransaction();
         ops.nodeCreate();
 
         try

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationIT.java
@@ -21,11 +21,11 @@ package org.neo4j.kernel.impl.api.integrationtest;
 
 import org.junit.Test;
 
+import org.neo4j.internal.kernel.api.SchemaWrite;
 import org.neo4j.internal.kernel.api.TokenNameLookup;
 import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.ReadOperations;
-import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.StatementTokenNameLookup;
 import org.neo4j.kernel.api.exceptions.schema.UniquePropertyValueValidationException;
@@ -397,8 +397,8 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         propertyKeyId = tokenWrite.propertyKeyGetOrCreateForName( propertyKey );
         commit();
 
-        SchemaWriteOperations schemaWriteOperations = schemaWriteOperationsInNewTransaction();
-        schemaWriteOperations.uniquePropertyConstraintCreate( forLabel( labelId, propertyKeyId ) );
+        SchemaWrite schemaWrite = schemaWriteInNewTransaction();
+        schemaWrite.uniquePropertyConstraintCreate( forLabel( labelId, propertyKeyId ) );
         commit();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationIT.java
@@ -25,9 +25,10 @@ import org.neo4j.internal.kernel.api.SchemaWrite;
 import org.neo4j.internal.kernel.api.TokenNameLookup;
 import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.SilentTokenNameLookup;
 import org.neo4j.kernel.api.Statement;
-import org.neo4j.kernel.api.StatementTokenNameLookup;
 import org.neo4j.kernel.api.exceptions.schema.UniquePropertyValueValidationException;
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
@@ -40,7 +41,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.neo4j.collection.primitive.PrimitiveLongCollections.count;
 import static org.neo4j.internal.kernel.api.IndexQuery.exact;
 import static org.neo4j.kernel.api.schema.SchemaDescriptorFactory.forLabel;
 
@@ -52,21 +52,21 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         // given
         constrainedNode( "Label1", "key1", "value1" );
 
-        Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
+        KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
 
         // when
-        long node = createLabeledNode( statement, "Label1" );
+        long node = createLabeledNode( transaction, "Label1" );
         try
         {
-            int propertyKeyId = statement.tokenWriteOperations().propertyKeyGetOrCreateForName( "key1" );
-            statement.dataWriteOperations().nodeSetProperty( node, propertyKeyId, Values.of( "value1" ) );
+            int propertyKeyId = transaction.tokenWrite().propertyKeyGetOrCreateForName( "key1" );
+            transaction.dataWrite().nodeSetProperty( node, propertyKeyId, Values.of( "value1" ) );
 
             fail( "should have thrown exception" );
         }
         // then
         catch ( UniquePropertyValueValidationException e )
         {
-            assertThat( e.getUserMessage( tokenLookup( statement ) ), containsString( "`key1` = 'value1'" ) );
+            assertThat( e.getUserMessage( tokenLookup( transaction ) ), containsString( "`key1` = 'value1'" ) );
         }
         commit();
     }
@@ -79,9 +79,9 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         long propertyValue = 285414114323346805L;
         long firstNode = constrainedNode( "label1", "key1", propertyValue );
 
-        Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
+        KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
 
-        long node = createLabeledNode( statement, "label1" );
+        long node = createLabeledNode( transaction, "label1" );
 
         assertNotEquals( firstNode, node );
 
@@ -89,8 +89,8 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         // a new node with the same constraint is added, with a value not equal but which would be mapped to the same double
         propertyValue++;
         // note how propertyValue is definitely not equal to propertyValue++ but they do equal if they are cast to double
-        int propertyKeyId = statement.tokenWriteOperations().propertyKeyGetOrCreateForName( "key1" );
-        statement.dataWriteOperations().nodeSetProperty( node, propertyKeyId, Values.of( propertyValue ) );
+        int propertyKeyId = transaction.tokenWrite().propertyKeyGetOrCreateForName( "key1" );
+        transaction.dataWrite().nodeSetProperty( node, propertyKeyId, Values.of( propertyValue ) );
 
         // Then
         // the commit should still succeed
@@ -104,22 +104,22 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         constrainedNode( "Label1", "key1", 1 );
 
         // when
-        Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
-        long node = createNode( statement, "key1", 1 );
+        KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
+        long node = createNode( transaction, "key1", 1 );
         commit();
 
-        statement = statementInNewTransaction( AnonymousContext.writeToken() );
+        transaction = newTransaction( AnonymousContext.writeToken() );
         try
         {
-            int label = statement.tokenWriteOperations().labelGetOrCreateForName( "Label1" );
-            statement.dataWriteOperations().nodeAddLabel( node, label );
+            int label = transaction.tokenWrite().labelGetOrCreateForName( "Label1" );
+            transaction.dataWrite().nodeAddLabel( node, label );
 
             fail( "should have thrown exception" );
         }
         // then
         catch ( UniquePropertyValueValidationException e )
         {
-            assertThat( e.getUserMessage( tokenLookup( statement ) ), containsString( "`key1` = 1" ) );
+            assertThat( e.getUserMessage( tokenLookup( transaction ) ), containsString( "`key1` = 1" ) );
         }
         commit();
     }
@@ -130,21 +130,21 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         // given
         constrainedNode( "Label1", "key1", "value1" );
 
-        Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
+        KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
 
         // when
-        long node = createNode( statement, "key1", "value1" );
+        long node = createNode( transaction, "key1", "value1" );
         try
         {
-            int label = statement.tokenWriteOperations().labelGetOrCreateForName( "Label1" );
-            statement.dataWriteOperations().nodeAddLabel( node, label );
+            int label = transaction.tokenWrite().labelGetOrCreateForName( "Label1" );
+            transaction.dataWrite().nodeAddLabel( node, label );
 
             fail( "should have thrown exception" );
         }
         // then
         catch ( UniquePropertyValueValidationException e )
         {
-            assertThat( e.getUserMessage( tokenLookup( statement ) ), containsString( "`key1` = 'value1'" ) );
+            assertThat( e.getUserMessage( tokenLookup( transaction ) ), containsString( "`key1` = 'value1'" ) );
         }
         commit();
     }
@@ -155,11 +155,11 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         // given
         long node = constrainedNode( "Label1", "key1", "value1" );
 
-        Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
+        KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
 
         // when
-        statement.dataWriteOperations().nodeDelete( node );
-        createLabeledNode( statement, "Label1", "key1", "value1" );
+        transaction.dataWrite().nodeDelete( node );
+        createLabeledNode( transaction, "Label1", "key1", "value1" );
         commit();
     }
 
@@ -169,12 +169,12 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         // given
         long node = constrainedNode( "Label1", "key1", "value1" );
 
-        Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
+        KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
 
         // when
-        int label = statement.tokenWriteOperations().labelGetOrCreateForName( "Label1" );
-        statement.dataWriteOperations().nodeRemoveLabel( node, label );
-        createLabeledNode( statement, "Label1", "key1", "value1" );
+        int label = transaction.tokenWrite().labelGetOrCreateForName( "Label1" );
+        transaction.dataWrite().nodeRemoveLabel( node, label );
+        createLabeledNode( transaction, "Label1", "key1", "value1" );
         commit();
     }
 
@@ -184,12 +184,12 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         // given
         long node = constrainedNode( "Label1", "key1", "value1" );
 
-        Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
+        KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
 
         // when
-        int key = statement.readOperations().propertyKeyGetForName( "key1" );
-        statement.dataWriteOperations().nodeRemoveProperty( node, key );
-        createLabeledNode( statement, "Label1", "key1", "value1" );
+        int key = transaction.tokenRead().propertyKey( "key1" );
+        transaction.dataWrite().nodeRemoveProperty( node, key );
+        createLabeledNode( transaction, "Label1", "key1", "value1" );
         commit();
     }
 
@@ -199,12 +199,12 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         // given
         long node = constrainedNode( "Label1", "key1", "value1" );
 
-        Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
+        KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
 
         // when
-        int propertyKeyId = statement.tokenWriteOperations().propertyKeyGetOrCreateForName( "key1" );
-        statement.dataWriteOperations().nodeSetProperty( node, propertyKeyId, Values.of( "value2" ) );
-        createLabeledNode( statement, "Label1", "key1", "value1" );
+        int propertyKeyId = transaction.tokenWrite().propertyKeyGetOrCreateForName( "key1" );
+        transaction.dataWrite().nodeSetProperty( node, propertyKeyId, Values.of( "value2" ) );
+        createLabeledNode( transaction, "Label1", "key1", "value1" );
         commit();
     }
 
@@ -214,20 +214,20 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         // given
         constrainedNode( "Label1", "key1", "value1" );
 
-        Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
+        KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
 
         // when
-        createLabeledNode( statement, "Label1", "key1", "value2" );
+        createLabeledNode( transaction, "Label1", "key1", "value2" );
         try
         {
-            createLabeledNode( statement, "Label1", "key1", "value2" );
+            createLabeledNode( transaction, "Label1", "key1", "value2" );
 
             fail( "expected exception" );
         }
         // then
         catch ( UniquePropertyValueValidationException e )
         {
-            assertThat( e.getUserMessage( tokenLookup( statement ) ), containsString( "`key1` = 'value2'" ) );
+            assertThat( e.getUserMessage( tokenLookup( transaction ) ), containsString( "`key1` = 'value2'" ) );
         }
         commit();
     }
@@ -238,11 +238,11 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         // given
         long node = constrainedNode( "Label1", "key1", "value1" );
 
-        Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
+        KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
 
         // when
-        int key = statement.tokenWriteOperations().propertyKeyGetOrCreateForName( "key1" );
-        statement.dataWriteOperations().nodeSetProperty( node, key, Values.of( "value1" ) );
+        int key = transaction.tokenWrite().propertyKeyGetOrCreateForName( "key1" );
+        transaction.dataWrite().nodeSetProperty( node, key, Values.of( "value1" ) );
 
         // then should not throw exception
         commit();
@@ -254,11 +254,11 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         // given
         long node = constrainedNode( "Label1", "key1", "value1" );
 
-        Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
+        KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
 
         // when
-        int label = statement.tokenWriteOperations().labelGetOrCreateForName( "Label1" );
-        statement.dataWriteOperations().nodeAddLabel( node, label );
+        int label = transaction.tokenWrite().labelGetOrCreateForName( "Label1" );
+        transaction.dataWrite().nodeAddLabel( node, label );
 
         // then should not throw exception
         commit();
@@ -270,19 +270,19 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         // given
         constrainedNode( "Label1", "key1", "value1" );
 
-        Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
+        KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
 
         // when
-        createNode( statement, "key1", "value1" );
-        createLabeledNode( statement, "Label2", "key1", "value1" );
-        createLabeledNode( statement, "Label1", "key1", "value2" );
-        createLabeledNode( statement, "Label1", "key2", "value1" );
+        createNode( transaction, "key1", "value1" );
+        createLabeledNode( transaction, "Label2", "key1", "value1" );
+        createLabeledNode( transaction, "Label1", "key1", "value2" );
+        createLabeledNode( transaction, "Label1", "key2", "value1" );
 
         commit();
 
         // then
-        statement = statementInNewTransaction( AnonymousContext.writeToken() );
-        assertEquals( "number of nodes", 5, count( statement.readOperations().nodesGetAll() ) );
+        transaction = newTransaction( AnonymousContext.writeToken() );
+        assertEquals( "number of nodes", 5, countNodes( transaction) );
         rollback();
     }
 
@@ -294,23 +294,27 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
 
         long ourNode;
         {
-            Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
-            ourNode = createLabeledNode( statement, "Person", "id", 1 );
-            createLabeledNode( statement, "Item", "id", 2 );
+            KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
+            ourNode = createLabeledNode( transaction, "Person", "id", 1 );
+            createLabeledNode( transaction, "Item", "id", 2 );
             commit();
         }
 
-        Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
-        ReadOperations readOps = statement.readOperations();
-        int person = readOps.labelGetForName( "Person" );
-        int propId = readOps.propertyKeyGetForName( "id" );
-        SchemaIndexDescriptor idx = readOps.indexGetForSchema( SchemaDescriptorFactory.forLabel( person, propId ) );
+        KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
+        try ( Statement statement = transaction.acquireStatement() )
+        {
+            ReadOperations readOps = statement.readOperations();
+            int person = readOps.labelGetForName( "Person" );
+            int propId = readOps.propertyKeyGetForName( "id" );
+            SchemaIndexDescriptor idx = readOps.indexGetForSchema( SchemaDescriptorFactory.forLabel( person, propId ) );
 
-        // when
-        createLabeledNode( statement, "Item", "id", 2 );
+            // when
+            createLabeledNode( transaction, "Item", "id", 2 );
 
-        // then I should find the original node
-        assertThat( readOps.nodeGetFromUniqueIndexSeek( idx, exact( propId, Values.of( 1 ) ) ), equalTo( ourNode ) );
+            // then I should find the original node
+            assertThat( readOps.nodeGetFromUniqueIndexSeek( idx, exact( propId, Values.of( 1 ) ) ),
+                    equalTo( ourNode ) );
+        }
         commit();
     }
 
@@ -322,52 +326,56 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
 
         long ourNode;
         {
-            Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
-            ourNode = createLabeledNode( statement, "Person", "id", 1 );
+            KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
+            ourNode = createLabeledNode( transaction, "Person", "id", 1 );
             commit();
         }
 
-        Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
-        ReadOperations readOps = statement.readOperations();
-        int person = readOps.labelGetForName( "Person" );
-        int propId = readOps.propertyKeyGetForName( "id" );
-        SchemaIndexDescriptor idx = readOps.indexGetForSchema( SchemaDescriptorFactory.forLabel( person, propId ) );
+        KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
+        try ( Statement statement = transaction.acquireStatement() )
+        {
+            ReadOperations readOps = statement.readOperations();
+            int person = readOps.labelGetForName( "Person" );
+            int propId = readOps.propertyKeyGetForName( "id" );
+            SchemaIndexDescriptor idx = readOps.indexGetForSchema( SchemaDescriptorFactory.forLabel( person, propId ) );
 
-        // when
-        createLabeledNode( statement, "Person", "id", 2 );
+            // when
+            createLabeledNode( transaction, "Person", "id", 2 );
 
-        // then I should find the original node
-        assertThat( readOps.nodeGetFromUniqueIndexSeek( idx, exact( propId, Values.of( 1 ) ) ), equalTo( ourNode ));
+            // then I should find the original node
+            assertThat( readOps.nodeGetFromUniqueIndexSeek( idx, exact( propId, Values.of( 1 ) ) ),
+                    equalTo( ourNode ) );
+        }
         commit();
     }
 
-    private TokenNameLookup tokenLookup( Statement statement )
+    private TokenNameLookup tokenLookup( KernelTransaction transaction )
     {
-        return new StatementTokenNameLookup( statement.readOperations() );
+        return new SilentTokenNameLookup( transaction.tokenRead() );
     }
 
-    private long createLabeledNode( Statement statement, String label ) throws KernelException
+    private long createLabeledNode( KernelTransaction transaction, String label ) throws KernelException
     {
-        long node = statement.dataWriteOperations().nodeCreate();
-        int labelId = statement.tokenWriteOperations().labelGetOrCreateForName( label );
-        statement.dataWriteOperations().nodeAddLabel( node, labelId );
+        long node = transaction.dataWrite().nodeCreate();
+        int labelId = transaction.tokenWrite().labelGetOrCreateForName( label );
+        transaction.dataWrite().nodeAddLabel( node, labelId );
         return node;
     }
 
-    private long createNode( Statement statement, String key, Object value ) throws KernelException
+    private long createNode( KernelTransaction transaction, String key, Object value ) throws KernelException
     {
-        long node = statement.dataWriteOperations().nodeCreate();
-        int propertyKeyId = statement.tokenWriteOperations().propertyKeyGetOrCreateForName( key );
-        statement.dataWriteOperations().nodeSetProperty( node, propertyKeyId, Values.of( value ) );
+        long node = transaction.dataWrite().nodeCreate();
+        int propertyKeyId = transaction.tokenWrite().propertyKeyGetOrCreateForName( key );
+        transaction.dataWrite().nodeSetProperty( node, propertyKeyId, Values.of( value ) );
         return node;
     }
 
-    private long createLabeledNode( Statement statement, String label, String key, Object value )
+    private long createLabeledNode( KernelTransaction transaction, String label, String key, Object value )
             throws KernelException
     {
-        long node = createLabeledNode( statement, label );
-        int propertyKeyId = statement.tokenWriteOperations().propertyKeyGetOrCreateForName( key );
-        statement.dataWriteOperations().nodeSetProperty( node, propertyKeyId, Values.of( value ) );
+        long node = createLabeledNode( transaction, label );
+        int propertyKeyId = transaction.tokenWrite().propertyKeyGetOrCreateForName( key );
+        transaction.dataWrite().nodeSetProperty( node, propertyKeyId, Values.of( value ) );
         return node;
     }
 
@@ -376,12 +384,12 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
     {
         long node;
         {
-            Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
-            int label = statement.tokenWriteOperations().labelGetOrCreateForName( labelName );
-            node = statement.dataWriteOperations().nodeCreate();
-            statement.dataWriteOperations().nodeAddLabel( node, label );
-            int key = statement.tokenWriteOperations().propertyKeyGetOrCreateForName( propertyKey );
-            statement.dataWriteOperations().nodeSetProperty( node, key, Values.of( propertyValue ) );
+            KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
+            int label = transaction.tokenWrite().labelGetOrCreateForName( labelName );
+            node = transaction.dataWrite().nodeCreate();
+            transaction.dataWrite().nodeAddLabel( node, label );
+            int key = transaction.tokenWrite().propertyKeyGetOrCreateForName( propertyKey );
+            transaction.dataWrite().nodeSetProperty( node, key, Values.of( propertyValue ) );
             commit();
         }
         createConstraint( labelName, propertyKey );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationIT.java
@@ -21,13 +21,13 @@ package org.neo4j.kernel.impl.api.integrationtest;
 
 import org.junit.Test;
 
+import org.neo4j.internal.kernel.api.TokenNameLookup;
+import org.neo4j.internal.kernel.api.TokenWrite;
+import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.StatementTokenNameLookup;
-import org.neo4j.internal.kernel.api.TokenNameLookup;
-import org.neo4j.kernel.api.TokenWriteOperations;
-import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.schema.UniquePropertyValueValidationException;
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
@@ -392,9 +392,9 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
     {
         int labelId;
         int propertyKeyId;
-        TokenWriteOperations tokenWriteOperations = tokenWriteOperationsInNewTransaction();
-        labelId = tokenWriteOperations.labelGetOrCreateForName( label );
-        propertyKeyId = tokenWriteOperations.propertyKeyGetOrCreateForName( propertyKey );
+        TokenWrite tokenWrite = tokenWriteInNewTransaction();
+        labelId = tokenWrite.labelGetOrCreateForName( label );
+        propertyKeyId = tokenWrite.propertyKeyGetOrCreateForName( propertyKey );
         commit();
 
         SchemaWriteOperations schemaWriteOperations = schemaWriteOperationsInNewTransaction();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/MockStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/MockStore.java
@@ -24,6 +24,8 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 import java.util.Iterator;
+import java.util.Set;
+import java.util.function.Function;
 
 import org.neo4j.collection.RawIterator;
 import org.neo4j.collection.primitive.Primitive;
@@ -33,6 +35,7 @@ import org.neo4j.internal.kernel.api.InternalIndexState;
 import org.neo4j.internal.kernel.api.exceptions.ProcedureException;
 import org.neo4j.internal.kernel.api.exceptions.schema.SchemaKernelException;
 import org.neo4j.internal.kernel.api.procs.ProcedureHandle;
+import org.neo4j.internal.kernel.api.procs.ProcedureSignature;
 import org.neo4j.internal.kernel.api.procs.QualifiedName;
 import org.neo4j.internal.kernel.api.procs.UserAggregator;
 import org.neo4j.internal.kernel.api.procs.UserFunctionHandle;
@@ -252,6 +255,13 @@ public class MockStore extends Read implements TestRule
 
     @Override
     public ProcedureHandle procedureGet( QualifiedName name ) throws ProcedureException
+    {
+        throw new UnsupportedOperationException( "not implemented" );
+
+    }
+
+    @Override
+    public Set<ProcedureSignature> proceduresGetAll(  ) throws ProcedureException
     {
         throw new UnsupportedOperationException( "not implemented" );
 
@@ -636,5 +646,23 @@ public class MockStore extends Read implements TestRule
     public Long indexGetOwningUniquenessConstraintId( CapableIndexReference index )
     {
         return null;
+    }
+
+    @Override
+    public <K, V> V schemaStateGetOrCreate( K key, Function<K,V> creator )
+    {
+        throw new UnsupportedOperationException( "not implemented" );
+    }
+
+    @Override
+    public <K, V> V schemaStateGet( K key )
+    {
+        throw new UnsupportedOperationException( "not implemented" );
+    }
+
+    @Override
+    public void schemaStateFlush()
+    {
+        throw new UnsupportedOperationException( "not implemented" );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/OperationsLockTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/OperationsLockTest.java
@@ -44,6 +44,7 @@ import org.neo4j.kernel.api.schema.constaints.RelExistenceConstraintDescriptor;
 import org.neo4j.kernel.api.schema.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.api.txstate.TransactionState;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
+import org.neo4j.kernel.impl.api.SchemaState;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
 import org.neo4j.kernel.impl.api.state.TxState;
 import org.neo4j.kernel.impl.constraints.ConstraintSemantics;
@@ -118,7 +119,7 @@ public class OperationsLockTest
         when( storeReadLayer.constraintsGetAll() ).thenReturn( Collections.emptyIterator() );
         when( engine.storeReadLayer() ).thenReturn( storeReadLayer );
         allStoreHolder = new AllStoreHolder( engine, store,  transaction, cursors, mock(
-                ExplicitIndexStore.class ), mock( Procedures.class ) );
+                ExplicitIndexStore.class ), mock( Procedures.class ), mock( SchemaState.class ) );
         operations = new Operations( allStoreHolder, mock( IndexTxStateUpdater.class ),
                 store, transaction, new KernelToken( storeReadLayer, transaction ), cursors, autoindexing,
                 mock( ConstraintIndexCreator.class ), mock( ConstraintSemantics.class ) );

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/AbstractConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/AbstractConstraintCreationIT.java
@@ -62,6 +62,7 @@ import static org.junit.Assert.fail;
 import static org.neo4j.helpers.collection.Iterators.asCollection;
 import static org.neo4j.helpers.collection.Iterators.asSet;
 import static org.neo4j.helpers.collection.Iterators.single;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 
 public abstract class AbstractConstraintCreationIT<Constraint extends ConstraintDescriptor, DESCRIPTOR extends SchemaDescriptor>
         extends KernelIntegrationTest
@@ -111,7 +112,7 @@ public abstract class AbstractConstraintCreationIT<Constraint extends Constraint
     public void shouldBeAbleToStoreAndRetrieveConstraint() throws Exception
     {
         // given
-        KernelTransaction transaction = newTransaction();
+        KernelTransaction transaction = newTransaction( AUTH_DISABLED );
 
         // when
         ConstraintDescriptor constraint = createConstraint( transaction.schemaWrite(), descriptor );
@@ -135,7 +136,7 @@ public abstract class AbstractConstraintCreationIT<Constraint extends Constraint
     public void shouldBeAbleToStoreAndRetrieveConstraintAfterRestart() throws Exception
     {
         // given
-        KernelTransaction transaction = newTransaction();
+        KernelTransaction transaction = newTransaction( AUTH_DISABLED );
 
         // when
         ConstraintDescriptor constraint = createConstraint( transaction.schemaWrite(), descriptor );
@@ -180,7 +181,7 @@ public abstract class AbstractConstraintCreationIT<Constraint extends Constraint
     public void shouldNotStoreConstraintThatIsRemovedInTheSameTransaction() throws Exception
     {
         // given
-        KernelTransaction transaction = newTransaction();
+        KernelTransaction transaction = newTransaction( AUTH_DISABLED );
 
         Constraint constraint = createConstraint( transaction.schemaWrite(), descriptor );
 

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/AbstractConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/AbstractConstraintCreationIT.java
@@ -137,7 +137,6 @@ public abstract class AbstractConstraintCreationIT<Constraint extends Constraint
         // given
         KernelTransaction transaction = newTransaction();
 
-
         // when
         ConstraintDescriptor constraint = createConstraint( transaction.schemaWrite(), descriptor );
 
@@ -183,7 +182,6 @@ public abstract class AbstractConstraintCreationIT<Constraint extends Constraint
         // given
         KernelTransaction transaction = newTransaction();
 
-
         Constraint constraint = createConstraint( transaction.schemaWrite(), descriptor );
 
         // when
@@ -191,7 +189,6 @@ public abstract class AbstractConstraintCreationIT<Constraint extends Constraint
 
         // then
         assertFalse( "should not have any constraints", transaction.schemaRead().constraintsGetAll().hasNext() );
-
 
         // when
         commit();

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/AbstractConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/AbstractConstraintCreationIT.java
@@ -38,13 +38,13 @@ import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.graphdb.schema.Schema;
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.schema.SchemaDescriptor;
 import org.neo4j.internal.kernel.api.schema.constraints.ConstraintDescriptor;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.Statement;
-import org.neo4j.kernel.api.TokenWriteOperations;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.exceptions.schema.AlreadyConstrainedException;
@@ -75,7 +75,7 @@ public abstract class AbstractConstraintCreationIT<Constraint extends Constraint
     int propertyKeyId;
     DESCRIPTOR descriptor;
 
-    abstract int initializeLabelOrRelType( TokenWriteOperations tokenWriteOperations, String name )
+    abstract int initializeLabelOrRelType( TokenWrite tokenWrite, String name )
             throws KernelException;
 
     abstract Constraint createConstraint( SchemaWriteOperations writeOps, DESCRIPTOR descriptor ) throws Exception;
@@ -95,9 +95,9 @@ public abstract class AbstractConstraintCreationIT<Constraint extends Constraint
     @Before
     public void createKeys() throws Exception
     {
-        TokenWriteOperations tokenWriteOperations = tokenWriteOperationsInNewTransaction();
-        this.typeId = initializeLabelOrRelType( tokenWriteOperations, KEY );
-        this.propertyKeyId = tokenWriteOperations.propertyKeyGetOrCreateForName( PROP );
+        TokenWrite tokenWrite = tokenWriteInNewTransaction();
+        this.typeId = initializeLabelOrRelType( tokenWrite, KEY );
+        this.propertyKeyId = tokenWrite.propertyKeyGetOrCreateForName( PROP );
         this.descriptor = makeDescriptor( typeId, propertyKeyId );
         commit();
     }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodeKeyConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodeKeyConstraintCreationIT.java
@@ -24,10 +24,10 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.SchemaWriteOperations;
-import org.neo4j.kernel.api.TokenWriteOperations;
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema.constaints.ConstraintDescriptorFactory;
 import org.neo4j.kernel.api.schema.constaints.NodeKeyConstraintDescriptor;
@@ -35,9 +35,9 @@ import org.neo4j.kernel.api.schema.constaints.NodeKeyConstraintDescriptor;
 public class NodeKeyConstraintCreationIT extends AbstractConstraintCreationIT<NodeKeyConstraintDescriptor,LabelSchemaDescriptor>
 {
     @Override
-    int initializeLabelOrRelType( TokenWriteOperations tokenWriteOperations, String name ) throws KernelException
+    int initializeLabelOrRelType( TokenWrite tokenWrite, String name ) throws KernelException
     {
-        return tokenWriteOperations.labelGetOrCreateForName( name );
+        return tokenWrite.labelGetOrCreateForName( name );
     }
 
     @Override

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodeKeyConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodeKeyConstraintCreationIT.java
@@ -24,15 +24,16 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.internal.kernel.api.SchemaWrite;
 import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
-import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
-import org.neo4j.kernel.api.SchemaWriteOperations;
+import org.neo4j.internal.kernel.api.schema.constraints.ConstraintDescriptor;
+import org.neo4j.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema.constaints.ConstraintDescriptorFactory;
 import org.neo4j.kernel.api.schema.constaints.NodeKeyConstraintDescriptor;
 
-public class NodeKeyConstraintCreationIT extends AbstractConstraintCreationIT<NodeKeyConstraintDescriptor,LabelSchemaDescriptor>
+public class NodeKeyConstraintCreationIT extends AbstractConstraintCreationIT<ConstraintDescriptor,LabelSchemaDescriptor>
 {
     @Override
     int initializeLabelOrRelType( TokenWrite tokenWrite, String name ) throws KernelException
@@ -41,7 +42,7 @@ public class NodeKeyConstraintCreationIT extends AbstractConstraintCreationIT<No
     }
 
     @Override
-    NodeKeyConstraintDescriptor createConstraint( SchemaWriteOperations writeOps, LabelSchemaDescriptor descriptor )
+    ConstraintDescriptor createConstraint( SchemaWrite writeOps, LabelSchemaDescriptor descriptor )
             throws Exception
     {
         return writeOps.nodeKeyConstraintCreate( descriptor );
@@ -60,7 +61,7 @@ public class NodeKeyConstraintCreationIT extends AbstractConstraintCreationIT<No
     }
 
     @Override
-    void dropConstraint( SchemaWriteOperations writeOps, NodeKeyConstraintDescriptor constraint )
+    void dropConstraint( SchemaWrite writeOps, ConstraintDescriptor constraint )
             throws Exception
     {
         writeOps.constraintDrop( constraint );

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodePropertyExistenceConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodePropertyExistenceConstraintCreationIT.java
@@ -27,18 +27,17 @@ import org.neo4j.SchemaHelper;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.internal.kernel.api.SchemaWrite;
 import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.internal.kernel.api.schema.constraints.ConstraintDescriptor;
 import org.neo4j.kernel.api.ReadOperations;
-import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.NoSuchConstraintException;
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema.constaints.ConstraintDescriptorFactory;
 import org.neo4j.kernel.api.schema.constaints.NodeExistenceConstraintDescriptor;
-import org.neo4j.kernel.api.schema.constaints.UniquenessConstraintDescriptor;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
@@ -48,7 +47,7 @@ import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.helpers.collection.Iterators.single;
 
 public class NodePropertyExistenceConstraintCreationIT
-        extends AbstractConstraintCreationIT<NodeExistenceConstraintDescriptor,LabelSchemaDescriptor>
+        extends AbstractConstraintCreationIT<ConstraintDescriptor,LabelSchemaDescriptor>
 {
     @Override
     int initializeLabelOrRelType( TokenWrite tokenWrite, String name ) throws KernelException
@@ -57,7 +56,7 @@ public class NodePropertyExistenceConstraintCreationIT
     }
 
     @Override
-    NodeExistenceConstraintDescriptor createConstraint( SchemaWriteOperations writeOps, LabelSchemaDescriptor descriptor )
+    ConstraintDescriptor createConstraint( SchemaWrite writeOps, LabelSchemaDescriptor descriptor )
             throws Exception
     {
         return writeOps.nodePropertyExistenceConstraintCreate( descriptor );
@@ -76,7 +75,7 @@ public class NodePropertyExistenceConstraintCreationIT
     }
 
     @Override
-    void dropConstraint( SchemaWriteOperations writeOps, NodeExistenceConstraintDescriptor constraint )
+    void dropConstraint( SchemaWrite writeOps, ConstraintDescriptor constraint )
             throws Exception
     {
         writeOps.constraintDrop( constraint );
@@ -111,9 +110,9 @@ public class NodePropertyExistenceConstraintCreationIT
             throws Exception
     {
         // given
-        UniquenessConstraintDescriptor constraint;
+        ConstraintDescriptor constraint;
         {
-            SchemaWriteOperations statement = schemaWriteOperationsInNewTransaction();
+            SchemaWrite statement = schemaWriteInNewTransaction();
             constraint = statement.uniquePropertyConstraintCreate( descriptor );
             commit();
         }
@@ -121,7 +120,7 @@ public class NodePropertyExistenceConstraintCreationIT
         // when
         try
         {
-            SchemaWriteOperations statement = schemaWriteOperationsInNewTransaction();
+            SchemaWrite statement = schemaWriteInNewTransaction();
             statement.constraintDrop( ConstraintDescriptorFactory.existsForSchema( constraint.schema() ) );
 
             fail( "expected exception" );

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodePropertyExistenceConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodePropertyExistenceConstraintCreationIT.java
@@ -27,12 +27,12 @@ import org.neo4j.SchemaHelper;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.internal.kernel.api.schema.constraints.ConstraintDescriptor;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
-import org.neo4j.kernel.api.TokenWriteOperations;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.NoSuchConstraintException;
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
@@ -51,9 +51,9 @@ public class NodePropertyExistenceConstraintCreationIT
         extends AbstractConstraintCreationIT<NodeExistenceConstraintDescriptor,LabelSchemaDescriptor>
 {
     @Override
-    int initializeLabelOrRelType( TokenWriteOperations tokenWriteOperations, String name ) throws KernelException
+    int initializeLabelOrRelType( TokenWrite tokenWrite, String name ) throws KernelException
     {
-        return tokenWriteOperations.labelGetOrCreateForName( name );
+        return tokenWrite.labelGetOrCreateForName( name );
     }
 
     @Override

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodePropertyExistenceConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodePropertyExistenceConstraintCreationIT.java
@@ -32,7 +32,7 @@ import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.internal.kernel.api.schema.constraints.ConstraintDescriptor;
-import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.NoSuchConstraintException;
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
@@ -137,9 +137,9 @@ public class NodePropertyExistenceConstraintCreationIT
 
         // then
         {
-            ReadOperations statement = readOperationsInNewTransaction();
+            KernelTransaction transaction = newTransaction();
 
-            Iterator<ConstraintDescriptor> constraints = statement.constraintsGetForSchema( descriptor );
+            Iterator<ConstraintDescriptor> constraints = transaction.schemaRead().constraintsGetForSchema( descriptor );
 
             assertEquals( constraint, single( constraints ) );
             commit();

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyConstraintValidationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyConstraintValidationIT.java
@@ -33,12 +33,12 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.Statement;
-import org.neo4j.kernel.api.TokenWriteOperations;
 import org.neo4j.kernel.api.exceptions.ConstraintViolationTransactionFailureException;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
@@ -55,8 +55,10 @@ import static org.junit.Assert.fail;
 import static org.neo4j.kernel.api.schema.SchemaDescriptorFactory.forLabel;
 import static org.neo4j.kernel.api.schema.SchemaDescriptorFactory.forRelType;
 import static org.neo4j.kernel.impl.api.integrationtest.PropertyConstraintValidationIT.NodeKeyConstraintValidationIT;
-import static org.neo4j.kernel.impl.api.integrationtest.PropertyConstraintValidationIT.NodePropertyExistenceConstraintValidationIT;
-import static org.neo4j.kernel.impl.api.integrationtest.PropertyConstraintValidationIT.RelationshipPropertyExistenceConstraintValidationIT;
+import static org.neo4j.kernel.impl.api.integrationtest.PropertyConstraintValidationIT
+        .NodePropertyExistenceConstraintValidationIT;
+import static org.neo4j.kernel.impl.api.integrationtest.PropertyConstraintValidationIT
+        .RelationshipPropertyExistenceConstraintValidationIT;
 
 @RunWith( Suite.class )
 @SuiteClasses( {
@@ -71,9 +73,9 @@ public class PropertyConstraintValidationIT
         @Override
         void createConstraint( String key, String property ) throws KernelException
         {
-            TokenWriteOperations tokenWriteOperations = tokenWriteOperationsInNewTransaction();
-            int label = tokenWriteOperations.labelGetOrCreateForName( key );
-            int propertyKey = tokenWriteOperations.propertyKeyGetOrCreateForName( property );
+            TokenWrite tokenWrite = tokenWriteInNewTransaction();
+            int label = tokenWrite.labelGetOrCreateForName( key );
+            int propertyKey = tokenWrite.propertyKeyGetOrCreateForName( property );
             commit();
 
             SchemaWriteOperations schemaWrite = schemaWriteOperationsInNewTransaction();
@@ -137,9 +139,9 @@ public class PropertyConstraintValidationIT
         @Override
         void createConstraint( String key, String property ) throws KernelException
         {
-            TokenWriteOperations tokenWriteOperations = tokenWriteOperationsInNewTransaction();
-            int label = tokenWriteOperations.labelGetOrCreateForName( key );
-            int propertyKey = tokenWriteOperations.propertyKeyGetOrCreateForName( property );
+            TokenWrite tokenWrite = tokenWriteInNewTransaction();
+            int label = tokenWrite.labelGetOrCreateForName( key );
+            int propertyKey = tokenWrite.propertyKeyGetOrCreateForName( property );
             commit();
 
             SchemaWriteOperations schemaWrite = schemaWriteOperationsInNewTransaction();
@@ -218,9 +220,9 @@ public class PropertyConstraintValidationIT
         @Override
         void createConstraint( String key, String property ) throws KernelException
         {
-            TokenWriteOperations tokenWriteOperations = tokenWriteOperationsInNewTransaction();
-            int relTypeId = tokenWriteOperations.relationshipTypeGetOrCreateForName( key );
-            int propertyKeyId = tokenWriteOperations.propertyKeyGetOrCreateForName( property );
+            TokenWrite tokenWrite = tokenWriteInNewTransaction();
+            int relTypeId = tokenWrite.relationshipTypeGetOrCreateForName( key );
+            int propertyKeyId = tokenWrite.propertyKeyGetOrCreateForName( property );
             commit();
 
             SchemaWriteOperations schemaWrite = schemaWriteOperationsInNewTransaction();

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyConstraintValidationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyConstraintValidationIT.java
@@ -33,11 +33,11 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.internal.kernel.api.SchemaWrite;
 import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.ReadOperations;
-import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.ConstraintViolationTransactionFailureException;
 import org.neo4j.kernel.api.exceptions.Status;
@@ -78,7 +78,7 @@ public class PropertyConstraintValidationIT
             int propertyKey = tokenWrite.propertyKeyGetOrCreateForName( property );
             commit();
 
-            SchemaWriteOperations schemaWrite = schemaWriteOperationsInNewTransaction();
+            SchemaWrite schemaWrite = schemaWriteInNewTransaction();
             schemaWrite.nodeKeyConstraintCreate( forLabel( label, propertyKey ) );
             commit();
         }
@@ -144,7 +144,7 @@ public class PropertyConstraintValidationIT
             int propertyKey = tokenWrite.propertyKeyGetOrCreateForName( property );
             commit();
 
-            SchemaWriteOperations schemaWrite = schemaWriteOperationsInNewTransaction();
+            SchemaWrite schemaWrite = schemaWriteInNewTransaction();
             schemaWrite.nodePropertyExistenceConstraintCreate( forLabel( label, propertyKey ) );
             commit();
         }
@@ -225,7 +225,7 @@ public class PropertyConstraintValidationIT
             int propertyKeyId = tokenWrite.propertyKeyGetOrCreateForName( property );
             commit();
 
-            SchemaWriteOperations schemaWrite = schemaWriteOperationsInNewTransaction();
+            SchemaWrite schemaWrite = schemaWriteInNewTransaction();
             schemaWrite.relationshipPropertyExistenceConstraintCreate( forRelType( relTypeId, propertyKeyId ) );
             commit();
         }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyConstraintValidationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyConstraintValidationIT.java
@@ -32,8 +32,6 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.internal.kernel.api.NodeCursor;
-import org.neo4j.internal.kernel.api.RelationshipScanCursor;
 import org.neo4j.internal.kernel.api.SchemaWrite;
 import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.Write;
@@ -424,34 +422,6 @@ public class PropertyConstraintValidationIT
 
             // then
             assertEquals( 5, entityCount() );
-        }
-
-        int countNodes( KernelTransaction transaction )
-        {
-            int result = 0;
-            try ( NodeCursor cursor = transaction.cursors().allocateNodeCursor() )
-            {
-                transaction.dataRead().allNodesScan( cursor );
-                while ( cursor.next() )
-                {
-                    result++;
-                }
-            }
-            return result;
-        }
-
-        int countRelationships( KernelTransaction transaction )
-        {
-            int result = 0;
-            try ( RelationshipScanCursor cursor = transaction.cursors().allocateRelationshipScanCursor() )
-            {
-                transaction.dataRead().allRelationshipsScan( cursor );
-                while ( cursor.next() )
-                {
-                    result++;
-                }
-            }
-            return result;
         }
     }
 }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyExistenceConstraintVerificationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyExistenceConstraintVerificationIT.java
@@ -36,7 +36,6 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.api.exceptions.ConstraintViolationTransactionFailureException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
-import org.neo4j.kernel.impl.api.OperationsFacade;
 import org.neo4j.kernel.impl.newapi.Operations;
 import org.neo4j.test.rule.DatabaseRule;
 import org.neo4j.test.rule.EnterpriseDatabaseRule;
@@ -50,8 +49,10 @@ import static org.junit.Assert.fail;
 import static org.junit.runners.Suite.SuiteClasses;
 import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.graphdb.RelationshipType.withName;
-import static org.neo4j.kernel.impl.api.integrationtest.PropertyExistenceConstraintVerificationIT.NodePropertyExistenceExistenceConstrainVerificationIT;
-import static org.neo4j.kernel.impl.api.integrationtest.PropertyExistenceConstraintVerificationIT.RelationshipPropertyExistenceExistenceConstrainVerificationIT;
+import static org.neo4j.kernel.impl.api.integrationtest.PropertyExistenceConstraintVerificationIT
+        .NodePropertyExistenceExistenceConstrainVerificationIT;
+import static org.neo4j.kernel.impl.api.integrationtest.PropertyExistenceConstraintVerificationIT
+        .RelationshipPropertyExistenceExistenceConstrainVerificationIT;
 import static org.neo4j.test.rule.concurrent.ThreadingRule.waitingWhileIn;
 
 @RunWith( Suite.class )
@@ -133,7 +134,7 @@ public class PropertyExistenceConstraintVerificationIT
         @Override
         Class<?> getOwner()
         {
-            return OperationsFacade.class;
+            return Operations.class;
         }
 
     }
@@ -231,7 +232,7 @@ public class PropertyExistenceConstraintVerificationIT
                     createOffender( db, KEY );
 
                     constraintCreation = thread.executeAndAwait( createConstraint(), null,
-                            waitingWhileIn( OperationsFacade.class, constraintCreationMethodName() ),
+                            waitingWhileIn( Operations.class, constraintCreationMethodName() ),
                             WAIT_TIMEOUT_SECONDS, SECONDS );
 
                     tx.success();

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipPropertyExistenceConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipPropertyExistenceConstraintCreationIT.java
@@ -23,10 +23,11 @@ import org.neo4j.SchemaHelper;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.internal.kernel.api.SchemaWrite;
 import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
-import org.neo4j.internal.kernel.api.schema.RelationTypeSchemaDescriptor;
-import org.neo4j.kernel.api.SchemaWriteOperations;
+import org.neo4j.internal.kernel.api.schema.constraints.ConstraintDescriptor;
+import org.neo4j.kernel.api.schema.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema.constaints.ConstraintDescriptorFactory;
 import org.neo4j.kernel.api.schema.constaints.RelExistenceConstraintDescriptor;
@@ -34,7 +35,7 @@ import org.neo4j.kernel.api.schema.constaints.RelExistenceConstraintDescriptor;
 import static org.neo4j.graphdb.RelationshipType.withName;
 
 public class RelationshipPropertyExistenceConstraintCreationIT
-        extends AbstractConstraintCreationIT<RelExistenceConstraintDescriptor,RelationTypeSchemaDescriptor>
+        extends AbstractConstraintCreationIT<ConstraintDescriptor,RelationTypeSchemaDescriptor>
 {
     @Override
     int initializeLabelOrRelType( TokenWrite tokenWrite, String name ) throws KernelException
@@ -43,7 +44,7 @@ public class RelationshipPropertyExistenceConstraintCreationIT
     }
 
     @Override
-    RelExistenceConstraintDescriptor createConstraint( SchemaWriteOperations writeOps,
+    ConstraintDescriptor createConstraint( SchemaWrite writeOps,
             RelationTypeSchemaDescriptor descriptor ) throws Exception
     {
         return writeOps.relationshipPropertyExistenceConstraintCreate( descriptor );
@@ -62,7 +63,7 @@ public class RelationshipPropertyExistenceConstraintCreationIT
     }
 
     @Override
-    void dropConstraint( SchemaWriteOperations writeOps, RelExistenceConstraintDescriptor constraint )
+    void dropConstraint( SchemaWrite writeOps, ConstraintDescriptor constraint )
             throws Exception
     {
         writeOps.constraintDrop( constraint );

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipPropertyExistenceConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipPropertyExistenceConstraintCreationIT.java
@@ -23,10 +23,10 @@ import org.neo4j.SchemaHelper;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.schema.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.SchemaWriteOperations;
-import org.neo4j.kernel.api.TokenWriteOperations;
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema.constaints.ConstraintDescriptorFactory;
 import org.neo4j.kernel.api.schema.constaints.RelExistenceConstraintDescriptor;
@@ -37,9 +37,9 @@ public class RelationshipPropertyExistenceConstraintCreationIT
         extends AbstractConstraintCreationIT<RelExistenceConstraintDescriptor,RelationTypeSchemaDescriptor>
 {
     @Override
-    int initializeLabelOrRelType( TokenWriteOperations tokenWriteOperations, String name ) throws KernelException
+    int initializeLabelOrRelType( TokenWrite tokenWrite, String name ) throws KernelException
     {
-        return tokenWriteOperations.relationshipTypeGetOrCreateForName( name );
+        return tokenWrite.relationshipTypeGetOrCreateForName( name );
     }
 
     @Override

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintCreationIT.java
@@ -36,7 +36,6 @@ import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.internal.kernel.api.schema.constraints.ConstraintDescriptor;
 import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SilentTokenNameLookup;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
@@ -181,8 +180,8 @@ public class UniquenessConstraintCreationIT
         commit();
 
         // then
-        ReadOperations readOperations = readOperationsInNewTransaction();
-        assertEquals( asSet( uniqueIndex ), asSet( readOperations.indexesGetAll() ) );
+        KernelTransaction transaction = newTransaction();
+        assertEquals( asSet( uniqueIndex ), asSet( transaction.schemaRead().indexesGetAll() ) );
         commit();
     }
 
@@ -198,8 +197,8 @@ public class UniquenessConstraintCreationIT
         rollback();
 
         // then
-        ReadOperations readOperations = readOperationsInNewTransaction();
-        assertEquals( emptySet(), asSet( readOperations.indexesGetAll() ) );
+        KernelTransaction transaction = newTransaction();
+        assertEquals( emptySet(), asSet( transaction.schemaRead().indexesGetAll() ) );
         commit();
     }
 
@@ -232,9 +231,9 @@ public class UniquenessConstraintCreationIT
 
         // then
         {
-            ReadOperations statement = readOperationsInNewTransaction();
+            KernelTransaction transaction = newTransaction();
 
-            Iterator<ConstraintDescriptor> constraints = statement.constraintsGetForSchema( descriptor );
+            Iterator<ConstraintDescriptor> constraints = transaction.schemaRead().constraintsGetForSchema( descriptor );
 
             assertEquals( ConstraintDescriptorFactory.existsForSchema( descriptor ), single( constraints ) );
             commit();
@@ -280,8 +279,8 @@ public class UniquenessConstraintCreationIT
         commit();
 
         // then
-        ReadOperations readOperations = readOperationsInNewTransaction();
-        assertEquals( emptySet(), asSet( readOperations.indexesGetAll() ) );
+        KernelTransaction transaction = newTransaction();
+        assertEquals( emptySet(), asSet( transaction.schemaRead().indexesGetAll() ) );
         commit();
     }
 

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintCreationIT.java
@@ -28,6 +28,7 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.internal.kernel.api.TokenNameLookup;
+import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.exceptions.schema.ConstraintValidationException;
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
@@ -38,7 +39,6 @@ import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.SilentTokenNameLookup;
 import org.neo4j.kernel.api.Statement;
-import org.neo4j.kernel.api.TokenWriteOperations;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
@@ -72,9 +72,9 @@ public class UniquenessConstraintCreationIT
     private SchemaIndexDescriptor uniqueIndex;
 
     @Override
-    int initializeLabelOrRelType( TokenWriteOperations tokenWriteOperations, String name ) throws KernelException
+    int initializeLabelOrRelType( TokenWrite tokenWrite, String name ) throws KernelException
     {
-        return tokenWriteOperations.labelGetOrCreateForName( KEY );
+        return tokenWrite.labelGetOrCreateForName( KEY );
     }
 
     @Override

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintCreationIT.java
@@ -62,6 +62,7 @@ import static org.junit.Assert.fail;
 import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.helpers.collection.Iterators.asSet;
 import static org.neo4j.helpers.collection.Iterators.single;
+import static org.neo4j.kernel.impl.api.store.DefaultCapableIndexReference.fromDescriptor;
 
 public class UniquenessConstraintCreationIT
         extends AbstractConstraintCreationIT<ConstraintDescriptor,LabelSchemaDescriptor>
@@ -180,7 +181,7 @@ public class UniquenessConstraintCreationIT
 
         // then
         KernelTransaction transaction = newTransaction();
-        assertEquals( asSet( uniqueIndex ), asSet( transaction.schemaRead().indexesGetAll() ) );
+        assertEquals( asSet( fromDescriptor( uniqueIndex ) ), asSet( transaction.schemaRead().indexesGetAll() ) );
         commit();
     }
 
@@ -190,7 +191,7 @@ public class UniquenessConstraintCreationIT
         // given
         KernelTransaction transaction = newTransaction( LoginContext.AUTH_DISABLED );
         transaction.schemaWrite().uniquePropertyConstraintCreate( descriptor );
-        assertEquals( asSet( uniqueIndex ), asSet( transaction.schemaRead().indexesGetAll() ) );
+        assertEquals( asSet( fromDescriptor( uniqueIndex ) ), asSet( transaction.schemaRead().indexesGetAll() ) );
 
         // when
         rollback();
@@ -269,7 +270,7 @@ public class UniquenessConstraintCreationIT
         KernelTransaction transaction = newTransaction( LoginContext.AUTH_DISABLED );
         ConstraintDescriptor constraint =
                 transaction.schemaWrite().uniquePropertyConstraintCreate( descriptor );
-        assertEquals( asSet( uniqueIndex ), asSet( transaction.schemaRead().indexesGetAll() ) );
+        assertEquals( asSet( fromDescriptor( uniqueIndex ) ), asSet( transaction.schemaRead().indexesGetAll() ) );
         commit();
 
         // when

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintCreationIT.java
@@ -27,6 +27,7 @@ import org.neo4j.SchemaHelper;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.internal.kernel.api.SchemaWrite;
 import org.neo4j.internal.kernel.api.TokenNameLookup;
 import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
@@ -36,7 +37,6 @@ import org.neo4j.internal.kernel.api.schema.constraints.ConstraintDescriptor;
 import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.ReadOperations;
-import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.SilentTokenNameLookup;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
@@ -66,7 +66,7 @@ import static org.neo4j.helpers.collection.Iterators.asSet;
 import static org.neo4j.helpers.collection.Iterators.single;
 
 public class UniquenessConstraintCreationIT
-        extends AbstractConstraintCreationIT<UniquenessConstraintDescriptor,LabelSchemaDescriptor>
+        extends AbstractConstraintCreationIT<ConstraintDescriptor,LabelSchemaDescriptor>
 {
     private static final String DUPLICATED_VALUE = "apa";
     private SchemaIndexDescriptor uniqueIndex;
@@ -78,7 +78,7 @@ public class UniquenessConstraintCreationIT
     }
 
     @Override
-    UniquenessConstraintDescriptor createConstraint( SchemaWriteOperations writeOps, LabelSchemaDescriptor descriptor )
+    ConstraintDescriptor createConstraint( SchemaWrite writeOps, LabelSchemaDescriptor descriptor )
             throws Exception
     {
         return writeOps.uniquePropertyConstraintCreate( descriptor );
@@ -97,7 +97,7 @@ public class UniquenessConstraintCreationIT
     }
 
     @Override
-    void dropConstraint( SchemaWriteOperations writeOps, UniquenessConstraintDescriptor constraint ) throws Exception
+    void dropConstraint( SchemaWrite writeOps, ConstraintDescriptor constraint ) throws Exception
     {
         writeOps.constraintDrop( constraint );
     }
@@ -153,7 +153,7 @@ public class UniquenessConstraintCreationIT
         LabelSchemaDescriptor descriptor = SchemaDescriptorFactory.forLabel( foo, name );
         try
         {
-            SchemaWriteOperations schemaWriteOperations = schemaWriteOperationsInNewTransaction();
+            SchemaWrite schemaWriteOperations = schemaWriteInNewTransaction();
             schemaWriteOperations.uniquePropertyConstraintCreate( descriptor );
 
             fail( "expected exception" );
@@ -176,7 +176,7 @@ public class UniquenessConstraintCreationIT
     public void shouldCreateAnIndexToGoAlongWithAUniquePropertyConstraint() throws Exception
     {
         // when
-        SchemaWriteOperations schemaWriteOperations = schemaWriteOperationsInNewTransaction();
+        SchemaWrite schemaWriteOperations = schemaWriteInNewTransaction();
         schemaWriteOperations.uniquePropertyConstraintCreate( descriptor );
         commit();
 
@@ -208,14 +208,14 @@ public class UniquenessConstraintCreationIT
             throws Exception
     {
         // given
-        SchemaWriteOperations schemaWriteOperations = schemaWriteOperationsInNewTransaction();
+        SchemaWrite schemaWriteOperations = schemaWriteInNewTransaction();
         schemaWriteOperations.nodePropertyExistenceConstraintCreate( descriptor );
         commit();
 
         // when
         try
         {
-            SchemaWriteOperations statement = schemaWriteOperationsInNewTransaction();
+            SchemaWrite statement = schemaWriteInNewTransaction();
             statement.constraintDrop( ConstraintDescriptorFactory.uniqueForSchema( descriptor ) );
 
             fail( "expected exception" );
@@ -245,7 +245,7 @@ public class UniquenessConstraintCreationIT
     public void committedConstraintRuleShouldCrossReferenceTheCorrespondingIndexRule() throws Exception
     {
         // when
-        SchemaWriteOperations statement = schemaWriteOperationsInNewTransaction();
+        SchemaWrite statement = schemaWriteInNewTransaction();
         statement.uniquePropertyConstraintCreate( descriptor );
         commit();
 
@@ -275,7 +275,7 @@ public class UniquenessConstraintCreationIT
         commit();
 
         // when
-        SchemaWriteOperations schemaWriteOperations = schemaWriteOperationsInNewTransaction();
+        SchemaWrite schemaWriteOperations = schemaWriteInNewTransaction();
         schemaWriteOperations.constraintDrop( constraint );
         commit();
 

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintCreationIT.java
@@ -37,7 +37,6 @@ import org.neo4j.internal.kernel.api.schema.constraints.ConstraintDescriptor;
 import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.SilentTokenNameLookup;
-import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
@@ -131,21 +130,21 @@ public class UniquenessConstraintCreationIT
     public void shouldAbortConstraintCreationWhenDuplicatesExist() throws Exception
     {
         // given
-        Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
+        KernelTransaction transaction = newTransaction( AnonymousContext.writeToken() );
         // name is not unique for Foo in the existing data
 
-        int foo = statement.tokenWriteOperations().labelGetOrCreateForName( "Foo" );
-        int name = statement.tokenWriteOperations().propertyKeyGetOrCreateForName( "name" );
+        int foo = transaction.tokenWrite().labelGetOrCreateForName( "Foo" );
+        int name = transaction.tokenWrite().propertyKeyGetOrCreateForName( "name" );
 
-        long node1 = statement.dataWriteOperations().nodeCreate();
+        long node1 = transaction.dataWrite().nodeCreate();
 
-        statement.dataWriteOperations().nodeAddLabel( node1, foo );
-        statement.dataWriteOperations().nodeSetProperty( node1, name, Values.of( "foo" ) );
+        transaction.dataWrite().nodeAddLabel( node1, foo );
+        transaction.dataWrite().nodeSetProperty( node1, name, Values.of( "foo" ) );
 
-        long node2 = statement.dataWriteOperations().nodeCreate();
-        statement.dataWriteOperations().nodeAddLabel( node2, foo );
+        long node2 = transaction.dataWrite().nodeCreate();
+        transaction.dataWrite().nodeAddLabel( node2, foo );
 
-        statement.dataWriteOperations().nodeSetProperty( node2, name, Values.of( "foo" ) );
+        transaction.dataWrite().nodeSetProperty( node2, name, Values.of( "foo" ) );
         commit();
 
         // when
@@ -189,15 +188,15 @@ public class UniquenessConstraintCreationIT
     public void shouldDropCreatedConstraintIndexWhenRollingBackConstraintCreation() throws Exception
     {
         // given
-        Statement statement = statementInNewTransaction( LoginContext.AUTH_DISABLED );
-        statement.schemaWriteOperations().uniquePropertyConstraintCreate( descriptor );
-        assertEquals( asSet( uniqueIndex ), asSet( statement.readOperations().indexesGetAll() ) );
+        KernelTransaction transaction = newTransaction( LoginContext.AUTH_DISABLED );
+        transaction.schemaWrite().uniquePropertyConstraintCreate( descriptor );
+        assertEquals( asSet( uniqueIndex ), asSet( transaction.schemaRead().indexesGetAll() ) );
 
         // when
         rollback();
 
         // then
-        KernelTransaction transaction = newTransaction();
+        transaction = newTransaction();
         assertEquals( emptySet(), asSet( transaction.schemaRead().indexesGetAll() ) );
         commit();
     }
@@ -267,10 +266,10 @@ public class UniquenessConstraintCreationIT
     public void shouldDropConstraintIndexWhenDroppingConstraint() throws Exception
     {
         // given
-        Statement statement = statementInNewTransaction( LoginContext.AUTH_DISABLED );
-        UniquenessConstraintDescriptor constraint =
-                statement.schemaWriteOperations().uniquePropertyConstraintCreate( descriptor );
-        assertEquals( asSet( uniqueIndex ), asSet( statement.readOperations().indexesGetAll() ) );
+        KernelTransaction transaction = newTransaction( LoginContext.AUTH_DISABLED );
+        ConstraintDescriptor constraint =
+                transaction.schemaWrite().uniquePropertyConstraintCreate( descriptor );
+        assertEquals( asSet( uniqueIndex ), asSet( transaction.schemaRead().indexesGetAll() ) );
         commit();
 
         // when
@@ -279,7 +278,7 @@ public class UniquenessConstraintCreationIT
         commit();
 
         // then
-        KernelTransaction transaction = newTransaction();
+        transaction = newTransaction();
         assertEquals( emptySet(), asSet( transaction.schemaRead().indexesGetAll() ) );
         commit();
     }


### PR DESCRIPTION
Update all of the integration tests that does not use `nodeUniqueIndexSeek` to use Kernel API.

Builds on and replaces https://github.com/neo4j/neo4j/pull/11243/commits/d4611966e5e6e2eaa5efe94da5b3b9b83a06aec4 