### PR TITLE
Don't make auth file globally readable

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/fs/DefaultFileSystemAbstraction.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/DefaultFileSystemAbstraction.java
@@ -37,9 +37,13 @@ import java.nio.file.CopyOption;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.WatchService;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.neo4j.io.IOUtils;
@@ -128,6 +132,23 @@ public class DefaultFileSystemAbstraction implements FileSystemAbstraction
     public boolean fileExists( File fileName )
     {
         return fileName.exists();
+    }
+
+    @Override
+    public void setPermissions( File fileName, FilePermission... permissions ) throws IOException
+    {
+        Set<PosixFilePermission> posixPerms = Arrays.stream( permissions )
+                .map( p -> PosixFilePermission.valueOf( p.name() ) )
+                .collect( Collectors.toSet() );
+        Files.setPosixFilePermissions( fileName.toPath(), posixPerms );
+    }
+
+    @Override
+    public Set<FilePermission> getPermissions( File fileName ) throws IOException
+    {
+        return Files.getPosixFilePermissions( fileName.toPath() ).stream()
+                .map( p -> FilePermission.valueOf( p.name() ) )
+                .collect( Collectors.toSet());
     }
 
     @Override

--- a/community/io/src/main/java/org/neo4j/io/fs/DelegateFileSystemAbstraction.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/DelegateFileSystemAbstraction.java
@@ -40,6 +40,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -113,6 +114,18 @@ public class DelegateFileSystemAbstraction implements FileSystemAbstraction
     public StoreChannel create( File fileName ) throws IOException
     {
         return open( fileName, OpenMode.READ_WRITE );
+    }
+
+    @Override
+    public void setPermissions( File fileName, FilePermission... permissions ) throws IOException
+    {
+        throw new UnsupportedOperationException( "This file system does not support file permissions." );
+    }
+
+    @Override
+    public Set<FilePermission> getPermissions( File fileName ) throws IOException
+    {
+        throw new UnsupportedOperationException( "This file system does not support file permissions." );
     }
 
     @Override

--- a/community/io/src/main/java/org/neo4j/io/fs/FilePermission.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/FilePermission.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.fs;
+
+public enum FilePermission
+{
+    OWNER_READ,
+    OWNER_WRITE,
+    OWNER_EXECUTE,
+    GROUP_READ,
+    GROUP_WRITE,
+    GROUP_EXECUTE,
+    OTHERS_READ,
+    OTHERS_WRITE,
+    OTHERS_EXECUTE
+}

--- a/community/io/src/main/java/org/neo4j/io/fs/FileSystemAbstraction.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/FileSystemAbstraction.java
@@ -30,6 +30,7 @@ import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.file.CopyOption;
 import java.nio.file.NoSuchFileException;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.zip.ZipOutputStream;
@@ -38,7 +39,6 @@ import org.neo4j.io.fs.watcher.FileWatcher;
 
 public interface FileSystemAbstraction extends Closeable
 {
-
     /**
      * Create file watcher that provides possibilities to monitor directories on underlying file system
      * abstraction
@@ -59,6 +59,18 @@ public interface FileSystemAbstraction extends Closeable
     Writer openAsWriter( File fileName, Charset charset, boolean append ) throws IOException;
 
     StoreChannel create( File fileName ) throws IOException;
+
+    /**
+     * If the filesystem supports it, sets the specified file permissions, otherwise throw.
+     * @throws UnsupportedOperationException if the underlying system does not support POSIX-style permissions
+     */
+    void setPermissions( File fileName, FilePermission ... permissions ) throws IOException;
+
+    /**
+     * If the underlying system supports it, return file permissions
+     * @throws UnsupportedOperationException if the underlying system does not support POSIX-style permissions
+     */
+    Set<FilePermission> getPermissions( File fileName ) throws IOException;
 
     boolean fileExists( File fileName );
 

--- a/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialFileSystemAbstraction.java
@@ -35,6 +35,7 @@ import java.nio.file.CopyOption;
 import java.nio.file.NoSuchFileException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -42,6 +43,7 @@ import org.neo4j.adversaries.Adversary;
 import org.neo4j.adversaries.watcher.AdversarialFileWatcher;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileHandle;
+import org.neo4j.io.fs.FilePermission;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.OpenMode;
 import org.neo4j.io.fs.StoreChannel;
@@ -206,6 +208,20 @@ public class AdversarialFileSystemAbstraction implements FileSystemAbstraction
     {
         adversary.injectFailure( SecurityException.class );
         return delegate.fileExists( fileName );
+    }
+
+    @Override
+    public void setPermissions( File fileName, FilePermission ... permissions ) throws IOException
+    {
+        adversary.injectFailure( SecurityException.class, IOException.class );
+        delegate.setPermissions( fileName, permissions );
+    }
+
+    @Override
+    public Set<FilePermission> getPermissions( File fileName ) throws IOException
+    {
+        adversary.injectFailure( SecurityException.class, IOException.class );
+        return delegate.getPermissions( fileName );
     }
 
     @Override

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/DelegatingFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/DelegatingFileSystemAbstraction.java
@@ -28,10 +28,12 @@ import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.file.CopyOption;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.neo4j.io.fs.FileHandle;
+import org.neo4j.io.fs.FilePermission;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.OpenMode;
 import org.neo4j.io.fs.StoreChannel;
@@ -88,6 +90,18 @@ public class DelegatingFileSystemAbstraction implements FileSystemAbstraction
             Function<Class<K>,K> creator )
     {
         return delegate.getOrCreateThirdPartyFileSystem( clazz, creator );
+    }
+
+    @Override
+    public void setPermissions( File fileName, FilePermission ... permissions ) throws IOException
+    {
+        delegate.setPermissions( fileName, permissions );
+    }
+
+    @Override
+    public Set<FilePermission> getPermissions( File fileName ) throws IOException
+    {
+        return delegate.getPermissions( fileName );
     }
 
     @Override

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
@@ -68,6 +68,7 @@ import java.util.zip.ZipOutputStream;
 import org.neo4j.io.ByteUnit;
 import org.neo4j.io.IOUtils;
 import org.neo4j.io.fs.FileHandle;
+import org.neo4j.io.fs.FilePermission;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.OpenMode;
 import org.neo4j.io.fs.StoreChannel;
@@ -318,6 +319,18 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
     {
         EphemeralFileData file = files.get( canonicalFile( fileName ) );
         return file == null ? 0 : file.size();
+    }
+
+    @Override
+    public void setPermissions( File fileName, FilePermission ... permissions )
+    {
+        throw new UnsupportedOperationException( "This file system does not support file permissions." );
+    }
+
+    @Override
+    public Set<FilePermission> getPermissions( File fileName )
+    {
+        throw new UnsupportedOperationException( "This file system does not support file permissions." );
     }
 
     @Override

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/SelectiveFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/SelectiveFileSystemAbstraction.java
@@ -28,11 +28,13 @@ import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.file.CopyOption;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.neo4j.io.IOUtils;
 import org.neo4j.io.fs.FileHandle;
+import org.neo4j.io.fs.FilePermission;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.OpenMode;
 import org.neo4j.io.fs.StoreChannel;
@@ -105,6 +107,18 @@ public class SelectiveFileSystemAbstraction implements FileSystemAbstraction
     public boolean fileExists( File fileName )
     {
         return chooseFileSystem( fileName ).fileExists( fileName );
+    }
+
+    @Override
+    public void setPermissions( File fileName, FilePermission ... permissions ) throws IOException
+    {
+        chooseFileSystem( fileName ).setPermissions( fileName, permissions );
+    }
+
+    @Override
+    public Set<FilePermission> getPermissions( File fileName ) throws IOException
+    {
+        return chooseFileSystem( fileName ).getPermissions( fileName );
     }
 
     @Override

--- a/community/io/src/test/java/org/neo4j/io/fs/DefaultFileSystemAbstractionTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/DefaultFileSystemAbstractionTest.java
@@ -19,19 +19,25 @@
  */
 package org.neo4j.io.fs;
 
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.UUID;
 
+import static java.lang.String.format;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-
-import static java.lang.String.format;
-
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 import static org.neo4j.io.fs.DefaultFileSystemAbstraction.UNABLE_TO_CREATE_DIRECTORY_FORMAT;
 
 public class DefaultFileSystemAbstractionTest extends FileSystemAbstractionTest
@@ -41,6 +47,9 @@ public class DefaultFileSystemAbstractionTest extends FileSystemAbstractionTest
     {
         return new DefaultFileSystemAbstraction();
     }
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
     @Test
     public void shouldFailGracefullyWhenPathCannotBeCreated()
@@ -66,5 +75,43 @@ public class DefaultFileSystemAbstractionTest extends FileSystemAbstractionTest
             String expectedMessage = format( UNABLE_TO_CREATE_DIRECTORY_FORMAT, path );
             assertThat( e.getMessage(), is( expectedMessage ) );
         }
+    }
+
+    @Test
+    public void shouldAllowSettingFilePermissionsIfRunningOnPOSIX() throws Exception
+    {
+        // Given
+        assumeTrue( SystemUtils.IS_OS_UNIX );
+
+        // Note that we re-use the file intentionally, to test that the method overwrites
+        // any existing permissions
+        File path = new File( testDirectory.directory(), String.valueOf( UUID.randomUUID() ) );
+        fsa.mkdirs( testDirectory.directory() );
+        fsa.create( path ).close();
+
+        for ( FilePermission permission : FilePermission.values() )
+        {
+            // When
+            fsa.setPermissions( path, permission );
+
+            // Then
+            assertEquals( fsa.getPermissions( path ), new HashSet<>( Collections.singletonList( permission ) ) );
+        }
+    }
+
+    @Test
+    public void shouldShoutAndScreamIfSettingPermissionsOnSystemWithoutSupportForIt() throws Exception
+    {
+        // Given
+        assumeFalse( SystemUtils.IS_OS_UNIX );
+        File path = new File( testDirectory.directory(), String.valueOf( UUID.randomUUID() ) );
+        fsa.mkdirs( testDirectory.directory() );
+        fsa.create( path ).close();
+
+        // Expect
+        exception.expect( IOException.class );
+
+        // When
+        fsa.setPermissions( path, FilePermission.GROUP_EXECUTE );
     }
 }

--- a/community/io/src/test/java/org/neo4j/test/rule/fs/FileSystemRule.java
+++ b/community/io/src/test/java/org/neo4j/test/rule/fs/FileSystemRule.java
@@ -31,11 +31,13 @@ import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.file.CopyOption;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.neo4j.io.fs.FileHandle;
+import org.neo4j.io.fs.FilePermission;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.OpenMode;
 import org.neo4j.io.fs.StoreChannel;
@@ -117,6 +119,18 @@ public abstract class FileSystemRule<FS extends FileSystemAbstraction> extends E
     public StoreChannel create( File fileName ) throws IOException
     {
         return fs.create( fileName );
+    }
+
+    @Override
+    public void setPermissions( File fileName, FilePermission... permissions ) throws IOException
+    {
+        fs.setPermissions( fileName, permissions );
+    }
+
+    @Override
+    public Set<FilePermission> getPermissions( File fileName ) throws IOException
+    {
+        return fs.getPermissions( fileName );
     }
 
     @Override

--- a/community/security/src/main/java/org/neo4j/server/security/auth/FileRepositorySerializer.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/FileRepositorySerializer.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Random;
 
+import org.neo4j.io.fs.FilePermission;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.server.security.auth.exception.FormatException;
 import org.neo4j.string.UTF8;
@@ -77,6 +78,15 @@ public abstract class FileRepositorySerializer<S>
 
         try
         {
+            fileSystem.create( tempFile ).close();
+            try
+            {
+                fileSystem.setPermissions( tempFile, FilePermission.OWNER_READ, FilePermission.OWNER_WRITE );
+            }
+            catch(UnsupportedOperationException e)
+            {
+                // Underlying file system does not support permissions, so leave as-is.
+            }
             writeToFile( fileSystem, tempFile, serialize( records ) );
             fileSystem.renameFile( tempFile, recordsFile, ATOMIC_MOVE, REPLACE_EXISTING );
         }
@@ -87,7 +97,7 @@ public abstract class FileRepositorySerializer<S>
         }
     }
 
-    protected File getTempFile( FileSystemAbstraction fileSystem, File recordsFile ) throws IOException
+    private File getTempFile( FileSystemAbstraction fileSystem, File recordsFile ) throws IOException
     {
         File directory = recordsFile.getParentFile();
         if ( !fileSystem.fileExists( directory ) )

--- a/community/security/src/test/java/org/neo4j/server/security/auth/FileRepositorySerializerTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/FileRepositorySerializerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.security.auth;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FilePermission;
+import org.neo4j.kernel.impl.security.User;
+import org.neo4j.test.rule.TestDirectory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
+
+public class FileRepositorySerializerTest
+{
+    @Rule
+    public TestDirectory dir = TestDirectory.testDirectory();
+
+    @Test
+    public void shouldDisallowGlobalReadsIfPossible() throws Exception
+    {
+        // Given
+        assumeTrue( SystemUtils.IS_OS_UNIX );
+
+        File authFile = dir.file( "auth" );
+        DefaultFileSystemAbstraction fs = new DefaultFileSystemAbstraction();
+        UserSerialization serialization = new UserSerialization();
+
+        // When
+        serialization.saveRecordsToFile( fs, authFile,
+                Collections.singletonList( new User.Builder().withName( "steve_brookreson" ).build() ) );
+
+        // Then
+        assertEquals( fs.getPermissions( authFile ),
+                new HashSet<>( Arrays.asList( FilePermission.OWNER_READ, FilePermission.OWNER_WRITE ) ) );
+    }
+}


### PR DESCRIPTION
On systems with POSIX-style file permissions,
restrict permissions on auth file to `500`.

This introduces, as a side effect, a proposed
addition to FSA to set file permissions.