### PR TITLE
Update Cypher compiler dependencies to 3.2.10

### DIFF
--- a/community/cypher/cypher/pom.xml
+++ b/community/cypher/cypher/pom.xml
@@ -246,7 +246,7 @@
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-cypher-compiler-3.2</artifactId>
-      <version>3.2.9</version>
+      <version>3.2.10</version>
       <exclusions>
         <exclusion>
           <groupId>org.neo4j</groupId>

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
@@ -2778,8 +2778,7 @@ class EagerizationAcceptanceTest
         |RETURN size(tags) as nbrTags
       """.stripMargin
 
-    // Fixed in 3.2.10
-    val nonBugFixedConfig = Configs.Cost3_2 + Configs.Cost3_1
+    val nonBugFixedConfig = Configs.Cost3_1
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3 - Configs.AllRulePlanners, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, nonBugFixedConfig),
@@ -2801,8 +2800,7 @@ class EagerizationAcceptanceTest
         |RETURN COUNT(t.value) as nbrTags
       """.stripMargin
 
-    // Fixed in 3.2.10
-    val nonBugFixedConfig = Configs.Cost3_2 + Configs.Cost3_1 + Configs.AllRulePlanners
+    val nonBugFixedConfig = Configs.Cost3_1 + Configs.AllRulePlanners
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, nonBugFixedConfig),

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/HintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/HintAcceptanceTest.scala
@@ -46,11 +46,10 @@ class HintAcceptanceTest
                   |USING JOIN ON a
                   |RETURN a.name, b.name""".stripMargin
 
-    // Fixed in 3.2.10
-    executeWith(Configs.CommunityInterpreted - Configs.Cost2_3 - Configs.Cost3_1 - Configs.Cost3_2, query,
+    executeWith(Configs.CommunityInterpreted - Configs.Cost2_3 - Configs.Cost3_1, query,
       planComparisonStrategy = ComparePlansWithAssertion((p) => {
         p should useOperators("NodeOuterHashJoin")
         p should not(useOperators("NodeHashJoin"))
-      }, expectPlansToFail = Configs.AllRulePlanners + Configs.BackwardsCompatibility))
+      }, expectPlansToFail = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1))
   }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeAcceptanceTest.scala
@@ -64,7 +64,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
   // TODO: Change this setting when slotted supports the queries
   private val supportMerge = Configs.CommunityInterpreted - Configs.Cost2_3
   // TODO: Change this setting when the bugfix #10771 merged to earlier 3.x versions is included as a dependency
-  private val doNotYetHaveBugFix = Configs.Cost3_1 + Configs.Cost3_2
+  private val doNotYetHaveBugFix = Configs.Cost3_1
 
   test("Merging with self loop and relationship uniqueness") {
     graph.execute("CREATE (a) CREATE (a)-[:X]->(a)")

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/RemoveAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/RemoveAcceptanceTest.scala
@@ -34,16 +34,15 @@ class RemoveAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
         |REMOVE CASE WHEN a.age>b.age THEN a ELSE b END.age
         |RETURN a.age, b.age""".stripMargin
 
-    // Fixed in 3.2.10
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost3_2 - Configs.Cost3_1 - Configs.Cost2_3, query)
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost3_1 - Configs.Cost2_3, query)
 
     // then
     result.toList should equal(List(Map("a.age" -> 23, "b.age" -> null)))
   }
 
-  // Fixed in 3.1.8 and 3.2.10
+  // Fixed in 3.1.8
   test("remove property from null literal") {
-    executeWith(Configs.CommunityInterpreted - Configs.Cost3_1 - Configs.Cost3_2 - Configs.Cost2_3, "REMOVE null.p") should have size 0
+    executeWith(Configs.CommunityInterpreted - Configs.Cost3_1 - Configs.Cost2_3, "REMOVE null.p") should have size 0
   }
 
 }


### PR DESCRIPTION
Should probably be null-forward-merged, since 3.2 is not tested from 3.4.