### PR TITLE
More retry-resilient StringSchemaKey compare

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ConflictDetectingValueMerger.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ConflictDetectingValueMerger.java
@@ -30,7 +30,7 @@ import org.neo4j.values.storable.ValueTuple;
  * {@link ValueMerger} which will merely detect conflict, not change any value if conflict, i.e. if the
  * key already exists. After this merge has been used in a call to {@link Writer#merge(Object, Object, ValueMerger)}
  * {@link #checkConflict(Value[])} can be called to check whether or not that call conflicted with
- * an existing key. A call to {@link #checkConflict(Value[])} will also clear the conflict flag.
+ * an existing key. A call to {@link #checkConflict(Value[])} will also initialize the conflict flag.
  *
  * @param <VALUE> type of values being merged.
  */

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaKey.java
@@ -30,7 +30,7 @@ import org.neo4j.values.storable.ValueWriter;
  */
 abstract class NativeSchemaKey<SELF extends NativeSchemaKey> extends ValueWriter.Adapter<RuntimeException>
 {
-    static final boolean DEFAULT_COMPARE_ID = true;
+    private static final boolean DEFAULT_COMPARE_ID = true;
 
     private long entityId;
     private boolean compareId = DEFAULT_COMPARE_ID;
@@ -64,10 +64,21 @@ abstract class NativeSchemaKey<SELF extends NativeSchemaKey> extends ValueWriter
 
     final void from( long entityId, Value... values )
     {
-        compareId = DEFAULT_COMPARE_ID;
-        this.entityId = entityId;
+        initialize( entityId );
         // copy value state and store in this key instance
         assertValidValue( values ).writeTo( this );
+    }
+
+    /**
+     * Initializes this key with entity id and resets other flags to default values.
+     * Doesn't touch value data.
+     *
+     * @param entityId entity id to set for this key.
+     */
+    void initialize( long entityId )
+    {
+        this.compareId = DEFAULT_COMPARE_ID;
+        this.entityId = entityId;
     }
 
     private Value assertValidValue( Value... values )
@@ -94,8 +105,7 @@ abstract class NativeSchemaKey<SELF extends NativeSchemaKey> extends ValueWriter
 
     final void initAsLowest()
     {
-        compareId = DEFAULT_COMPARE_ID;
-        entityId = Long.MIN_VALUE;
+        initialize( Long.MIN_VALUE );
         initValueAsLowest();
     }
 
@@ -103,8 +113,7 @@ abstract class NativeSchemaKey<SELF extends NativeSchemaKey> extends ValueWriter
 
     final void initAsHighest()
     {
-        compareId = DEFAULT_COMPARE_ID;
-        entityId = Long.MAX_VALUE;
+        initialize( Long.MAX_VALUE );
         initValueAsHighest();
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialSchemaKey.java
@@ -81,8 +81,7 @@ class SpatialSchemaKey extends NativeSchemaKey<SpatialSchemaKey>
     public void fromDerivedValue( long entityId, long derivedValue )
     {
         rawValueBits = derivedValue;
-        setEntityId( entityId );
-        setCompareId( DEFAULT_COMPARE_ID );
+        initialize( entityId );
     }
 
     /**

--- a/community/values/src/main/java/org/neo4j/values/storable/UTF8StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/UTF8StringValue.java
@@ -342,24 +342,11 @@ public final class UTF8StringValue extends StringValue
 
     public static int codePointByteArrayCompare( byte[] value1, byte[] value2 )
     {
-        return codePointByteArrayCompare( value1, 0, value1.length,
-                value2, 0, value2.length, false );
+        return codePointByteArrayCompare( value1, 0, value1.length, value2, 0, value2.length );
     }
 
     public static int codePointByteArrayCompare( byte[] value1, int value1Offset, int value1Length,
             byte[] value2, int value2Offset, int value2Length )
-    {
-        return codePointByteArrayCompare( value1, value1Offset, value1Length,
-                value2, value2Offset, value2Length, false );
-    }
-
-    public static int codePointByteArrayCompare( byte[] value1, byte[] value2, boolean ignoreLength )
-    {
-        return codePointByteArrayCompare( value1, 0, value1.length, value2, 0, value2.length, ignoreLength );
-    }
-
-    public static int codePointByteArrayCompare( byte[] value1, int value1Offset, int value1Length,
-            byte[] value2, int value2Offset, int value2Length, boolean ignoreLength )
     {
         int len1 = value1.length;
         int len2 = value2.length;
@@ -391,11 +378,7 @@ public final class UTF8StringValue extends StringValue
                 return thisCodePoint - thatCodePoint;
             }
         }
-        if ( !ignoreLength )
-        {
-            return numberOfCodePoints( value1, value1Offset, value1Length ) - numberOfCodePoints( value2, value2Offset, value2Length );
-        }
-        return 0;
+        return numberOfCodePoints( value1, value1Offset, value1Length ) - numberOfCodePoints( value2, value2Offset, value2Length );
     }
 
     @Override


### PR DESCRIPTION
As well as deduplication of some common native schema key initialization
code reseting flags and entityId.