### PR TITLE
Update Cypher compiler dependencies to 3.1.8

### DIFF
--- a/enterprise/cypher/cypher/pom.xml
+++ b/enterprise/cypher/cypher/pom.xml
@@ -209,7 +209,7 @@
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-cypher-compiler-3.1</artifactId>
-      <version>3.1.6</version>
+      <version>3.1.8</version>
       <exclusions>
         <exclusion>
           <groupId>org.neo4j</groupId>


### PR DESCRIPTION
Should be **null forward merged**, separate PRs for 3.3 and 3.4 to come (unlike this one they actually have changed test configs)