### PR TITLE
Support SRID in Point creation and accessors

### DIFF
--- a/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
@@ -361,28 +361,37 @@ public class PointValue extends ScalarValue implements Point, Comparable<PointVa
         return fromInputFields( fields );
     }
 
+    private static CoordinateReferenceSystem findSpecifiedCRS( AnyValue[] fields )
+    {
+        AnyValue crsValue = fields[PointValueField.CRS.ordinal()];
+        AnyValue sridValue = fields[PointValueField.SRID.ordinal()];
+        if ( crsValue != null && sridValue != null )
+        {
+            throw new IllegalArgumentException( "Cannot specify both CRS and SRID" );
+        }
+        else if ( crsValue != null )
+        {
+            TextValue crsName = (TextValue) crsValue;
+            return CoordinateReferenceSystem.byName( crsName.stringValue() );
+        }
+        else if ( sridValue != null )
+        {
+            NumberValue srid = (NumberValue) sridValue;
+            return CoordinateReferenceSystem.get( (int) srid.longValue() );
+        }
+        else
+        {
+            return null;
+        }
+    }
+
     /**
      * This contains the logic to decide the default coordinate reference system based on the input fields
      */
     private static PointValue fromInputFields( AnyValue[] fields )
     {
-        CoordinateReferenceSystem crs;
+        CoordinateReferenceSystem crs = findSpecifiedCRS( fields );
         double[] coordinates;
-
-        AnyValue crsValue = fields[PointValueField.CRS.ordinal()];
-        if ( crsValue != null )
-        {
-            TextValue crsName = (TextValue) crsValue;
-            crs = CoordinateReferenceSystem.byName( crsName.stringValue() );
-            if ( crs == null )
-            {
-                throw new IllegalArgumentException( "Unknown coordinate reference system: " + crsName.stringValue() );
-            }
-        }
-        else
-        {
-            crs = null;
-        }
 
         AnyValue xValue = fields[PointValueField.X.ordinal()];
         AnyValue yValue = fields[PointValueField.Y.ordinal()];
@@ -465,7 +474,8 @@ public class PointValue extends ScalarValue implements Point, Comparable<PointVa
         LATITUDE( NUMBER ),
         LONGITUDE( NUMBER ),
         HEIGHT( NUMBER ),
-        CRS( TEXT );
+        CRS( TEXT ),
+        SRID( NUMBER );
 
         PointValueField( ValueGroup valueType )
         {
@@ -501,6 +511,8 @@ public class PointValue extends ScalarValue implements Point, Comparable<PointVa
             return getNthCoordinate( 2, fieldName, true );
         case "crs":
             return Values.stringValue( crs.toString() );
+        case "srid":
+            return Values.intValue( crs.getCode() );
         default:
             throw new IllegalArgumentException( "No such field: " + fieldName );
         }

--- a/community/values/src/test/java/org/neo4j/values/storable/PointTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/PointTest.java
@@ -89,6 +89,8 @@ public class PointTest
                 PointValue.parse( "{latitude: 40.7128, longitude: -74.0060, crs: 'wgs-84'}" ) ); // - explicitly WGS84
         assertEqual( pointValue( Cartesian, -21, -45.3 ),
                 PointValue.parse( "{x: -21, y: -45.3}" ) ); // - default to cartesian 2D
+        assertEqual( pointValue( WGS84, -21, -45.3 ),
+                PointValue.parse( "{x: -21, y: -45.3, srid: 4326}" ) ); // - explicitly set WGS84 by SRID
         assertEqual( pointValue( Cartesian, 17, -52.8 ),
                 PointValue.parse( "{x: 17, y: -52.8, crs: 'cartesian'}" ) ); // - explicit cartesian 2D
         assertEqual( pointValue( WGS84_3D, 13.2, 56.7, 123.4 ),
@@ -146,6 +148,7 @@ public class PointTest
         assertCannotParse( "{a:a}" );
         assertCannotParse( "{ : 2.0, x : 1.0 }" );
         assertCannotParse( "x:1,y:2" );
+        assertCannotParse( "{x:1,y:2,srid:-9}" );
         assertCannotParse( "{x:1,y:'2'}" );
         assertCannotParse( "{crs:WGS-84 , lat:1, y:2}" );
     }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
@@ -56,6 +56,15 @@ class SpatialFunctionsAcceptanceTest extends ExecutionEngineFunSuite with Cypher
     result.toList should equal(List(Map("point" -> Values.pointValue(CoordinateReferenceSystem.Cartesian_3D, 2.3, 4.5, 6.7))))
   }
 
+  test("point function should work with literal map and srid") {
+    val result = executeWith(pointConfig, "RETURN point({x: 2.3, y: 4.5, srid: 4326}) as point",
+      expectedDifferentResults = Configs.Version3_1 + Configs.AllRulePlanners,
+      planComparisonStrategy = ComparePlansWithAssertion(_ should useOperatorWithText("Projection", "point"),
+        expectPlansToFail = Configs.AllRulePlanners))
+
+    result.toList should equal(List(Map("point" -> Values.pointValue(CoordinateReferenceSystem.WGS84, 2.3, 4.5))))
+  }
+
   test("point function should work with literal map and geographic coordinates") {
     val result = executeWith(pointConfig, "RETURN point({longitude: 2.3, latitude: 4.5, crs: 'WGS-84'}) as point",
       planComparisonStrategy = ComparePlansWithAssertion(_ should useOperatorWithText("Projection", "point"),
@@ -533,23 +542,23 @@ class SpatialFunctionsAcceptanceTest extends ExecutionEngineFunSuite with Cypher
   }
 
   test("accessors on 2D cartesian points") {
-    val result = executeWith(latestPointConfig, "WITH point({x: 1, y: 2}) AS p RETURN p.x, p.y, p.crs")
-    result.toList should be(List(Map("p.x" -> 1.0, "p.y" -> 2.0, "p.crs" -> "cartesian")))
+    val result = executeWith(latestPointConfig, "WITH point({x: 1, y: 2}) AS p RETURN p.x, p.y, p.crs, p.srid")
+    result.toList should be(List(Map("p.x" -> 1.0, "p.y" -> 2.0, "p.crs" -> "cartesian", "p.srid" -> 7203)))
 
     failWithError(latestPointConfig + Configs.Procs, "WITH point({x: 1, y: 2}) AS p RETURN p.latitude", Seq("Field: latitude is not available"))
     failWithError(latestPointConfig + Configs.Procs, "WITH point({x: 1, y: 2}) AS p RETURN p.z", Seq("Field: z is not available"))
   }
 
   test("accessors on 3D cartesian points") {
-    val result = executeWith(latestPointConfig, "WITH point({x: 1, y: 2, z:3}) AS p RETURN p.x, p.y, p.z, p.crs")
-    result.toList should be(List(Map("p.x" -> 1.0, "p.y" -> 2.0, "p.z" -> 3.0, "p.crs" -> "cartesian-3D")))
+    val result = executeWith(latestPointConfig, "WITH point({x: 1, y: 2, z:3}) AS p RETURN p.x, p.y, p.z, p.crs, p.srid")
+    result.toList should be(List(Map("p.x" -> 1.0, "p.y" -> 2.0, "p.z" -> 3.0, "p.crs" -> "cartesian-3D", "p.srid" -> 9157)))
 
     failWithError(latestPointConfig + Configs.Procs, "WITH point({x: 1, y: 2, z:3}) AS p RETURN p.latitude", Seq("Field: latitude is not available"))
   }
 
   test("accessors on 2D geographic points") {
-    val result = executeWith(latestPointConfig, "WITH point({longitude: 1, latitude: 2}) AS p RETURN p.longitude, p.latitude, p.crs, p.x, p.y")
-    result.toList should be(List(Map("p.longitude" -> 1.0, "p.latitude" -> 2.0, "p.crs" -> "WGS-84", "p.x" -> 1.0, "p.y" -> 2.0)))
+    val result = executeWith(latestPointConfig, "WITH point({longitude: 1, latitude: 2}) AS p RETURN p.longitude, p.latitude, p.crs, p.x, p.y, p.srid")
+    result.toList should be(List(Map("p.longitude" -> 1.0, "p.latitude" -> 2.0, "p.crs" -> "WGS-84", "p.x" -> 1.0, "p.y" -> 2.0, "p.srid" -> 4326)))
 
     failWithError(latestPointConfig + Configs.Procs, "WITH point({x: 1, y: 2}) AS p RETURN p.height", Seq("Field: height is not available"))
     failWithError(latestPointConfig + Configs.Procs, "WITH point({x: 1, y: 2}) AS p RETURN p.z", Seq("Field: z is not available"))
@@ -557,8 +566,8 @@ class SpatialFunctionsAcceptanceTest extends ExecutionEngineFunSuite with Cypher
 
   test("accessors on 3D geographic points") {
     val result = executeWith(latestPointConfig,
-      "WITH point({longitude: 1, latitude: 2, height:3}) AS p RETURN p.longitude, p.latitude, p.height, p.crs, p.x, p.y, p.z")
-    result.toList should be(List(Map("p.longitude" -> 1.0, "p.latitude" -> 2.0, "p.height" -> 3.0, "p.crs" -> "WGS-84-3D",
+      "WITH point({longitude: 1, latitude: 2, height:3}) AS p RETURN p.longitude, p.latitude, p.height, p.crs, p.x, p.y, p.z, p.srid")
+    result.toList should be(List(Map("p.longitude" -> 1.0, "p.latitude" -> 2.0, "p.height" -> 3.0, "p.crs" -> "WGS-84-3D", "p.srid" -> 4979,
                                      "p.x" -> 1.0, "p.y" -> 2.0, "p.z" -> 3.0)))
   }
 


### PR DESCRIPTION
The drivers work has argued for the exposure of the SRID in the surface for easier compatibility with external data sources. This PR adds support for SRID in the creation of points in Cypher and CVS import, as well as in accessors.