### PR TITLE
Restores number layout identifiers

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberLayout.java
@@ -27,9 +27,9 @@ import org.neo4j.io.pagecache.PageCursor;
  */
 abstract class NumberLayout extends SchemaLayout<NumberSchemaKey>
 {
-    NumberLayout( String identifierName, int majorVersion, int minorVersion )
+    NumberLayout( long identifier, int majorVersion, int minorVersion )
     {
-        super( identifierName, majorVersion, minorVersion );
+        super( identifier, majorVersion, minorVersion );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberLayoutNonUnique.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberLayoutNonUnique.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.index.schema;
 
+import org.neo4j.index.internal.gbptree.Layout;
+
 class NumberLayoutNonUnique extends NumberLayout
 {
     private static final String IDENTIFIER_NAME = "NUNI";
@@ -27,6 +29,6 @@ class NumberLayoutNonUnique extends NumberLayout
 
     NumberLayoutNonUnique()
     {
-        super( IDENTIFIER_NAME, MAJOR_VERSION, MINOR_VERSION );
+        super( Layout.namedIdentifier( IDENTIFIER_NAME, NativeSchemaValue.SIZE ), MAJOR_VERSION, MINOR_VERSION );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberLayoutUnique.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberLayoutUnique.java
@@ -32,6 +32,6 @@ class NumberLayoutUnique extends NumberLayout
 
     NumberLayoutUnique()
     {
-        super( IDENTIFIER_NAME, MAJOR_VERSION, MINOR_VERSION );
+        super( Layout.namedIdentifier( IDENTIFIER_NAME, NumberSchemaKey.SIZE ), MAJOR_VERSION, MINOR_VERSION );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SchemaLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SchemaLayout.java
@@ -28,11 +28,17 @@ abstract class SchemaLayout<KEY extends NativeSchemaKey> extends Layout.Adapter<
     private final int majorVersion;
     private final int minorVersion;
 
-    SchemaLayout( String layoutName, int majorVersion, int minorVersion )
+    // allows more control of the identifier, needed for legacy reasons for the two number layouts
+    SchemaLayout( long identifier, int majorVersion, int minorVersion )
     {
-        this.identifier = Layout.namedIdentifier( layoutName, NativeSchemaValue.SIZE );
+        this.identifier = identifier;
         this.majorVersion = majorVersion;
         this.minorVersion = minorVersion;
+    }
+
+    SchemaLayout( String layoutName, int majorVersion, int minorVersion )
+    {
+        this( Layout.namedIdentifier( layoutName, NativeSchemaValue.SIZE ), majorVersion, minorVersion );
     }
 
     @Override


### PR DESCRIPTION
They were apparently changed by mistake, making migration
from 3.3 difficult