### PR TITLE
Fix NativeLabelScanStoreTest.shouldRestartPopulationIfIndexFileWasNeverFullyInitialized

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreTest.java
@@ -137,7 +137,7 @@ public class NativeLabelScanStoreTest extends LabelScanStoreTest
     {
         // given
         File labelScanStoreFile = NativeLabelScanStore.getLabelScanStoreFile( dir );
-        fileSystemRule.create( labelScanStoreFile );
+        fileSystemRule.create( labelScanStoreFile ).close();
         TrackingMonitor monitor = new TrackingMonitor();
         LifeSupport life = new LifeSupport();
 


### PR DESCRIPTION
By closing opened StoreChannel