### PR TITLE
Use existing hashCode logic instead of having two separate implementations

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/ResourceTypes.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/ResourceTypes.java
@@ -179,91 +179,9 @@ public enum ResourceTypes implements ResourceType
         {
             int propertyKeyId = predicate.propertyKeyId();
             Value v = predicate.value();
-            Object value = v.asObject();
-            Class<?> type = value.getClass();
 
             hash = indexEntryHash_4_x.update( hash, propertyKeyId );
-
-            if ( type == String.class )
-            {
-                String str = (String) value;
-                int length = str.length();
-
-                hash = indexEntryHash_4_x.update( hash, length );
-
-                for ( int i = 0; i < length; i++ )
-                {
-                    hash = indexEntryHash_4_x.update( hash, str.charAt( i ) );
-                }
-            }
-            else if ( type.isArray() )
-            {
-                int length = Array.getLength( value );
-                Class<?> componentType = type.getComponentType();
-
-                hash = indexEntryHash_4_x.update( hash, length );
-
-                if ( componentType == String.class )
-                {
-                    for ( int i = 0; i < length; i++ )
-                    {
-                        String str = (String) Array.get( value, i );
-                        int len = str.length();
-
-                        hash = indexEntryHash_4_x.update( hash, len );
-
-                        for ( int j = 0; j < len; j++ )
-                        {
-                            hash = indexEntryHash_4_x.update( hash, str.charAt( j ) );
-                        }
-                    }
-                }
-                else if ( componentType == Double.TYPE )
-                {
-                    for ( int i = 0; i < length; i++ )
-                    {
-                        hash = indexEntryHash_4_x.update(
-                                hash, Double.doubleToLongBits( Array.getDouble( value, i ) ) );
-                    }
-                }
-                else if ( componentType == Boolean.TYPE )
-                {
-                    for ( int i = 0; i < length; i++ )
-                    {
-                        hash = indexEntryHash_4_x.update( hash, Boolean.hashCode( Array.getBoolean( value, i ) ) );
-                    }
-                }
-                else if ( componentType == Character.TYPE )
-                {
-                    for ( int i = 0; i < length; i++ )
-                    {
-                        hash = indexEntryHash_4_x.update( hash, Array.getChar( value, i ) );
-                    }
-                }
-                else
-                {
-                    for ( int i = 0; i < length; i++ )
-                    {
-                        hash = indexEntryHash_4_x.update( hash, ((Number) Array.get( value, i )).longValue() );
-                    }
-                }
-            }
-            else if ( type == Double.class )
-            {
-                hash = indexEntryHash_4_x.update( hash, Double.doubleToLongBits( (Double) value ) );
-            }
-            else if ( type == Boolean.class )
-            {
-                hash = indexEntryHash_4_x.update( hash, value.hashCode() );
-            }
-            else if ( type == Character.class )
-            {
-                hash = indexEntryHash_4_x.update( hash, (char) value );
-            }
-            else
-            {
-                hash = indexEntryHash_4_x.update( hash, ((Number) value).longValue() );
-            }
+            hash = indexEntryHash_4_x.update( hash, v.hashCode() );
         }
 
         return indexEntryHash_4_x.finalise( hash );


### PR DESCRIPTION
If I understand the code correctly, the old code path simply ignored values of types that were not explicitly coded for. Since temporal and spatial types were not part of the code, this would have led to problems for these values.