### PR TITLE
GBPTree.readHeader don't need layout

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/Layout.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/Layout.java
@@ -19,10 +19,8 @@
  */
 package org.neo4j.index.internal.gbptree;
 
-import java.io.File;
 import java.util.Comparator;
 
-import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
 
 import static java.lang.String.format;
@@ -187,10 +185,6 @@ public interface Layout<KEY, VALUE> extends Comparator<KEY>
      * <p>
      * When opening a {@link GBPTree tree} to 'use' it, read and write to it, providing a layout with the right compatibility is
      * important because it decides how to read and write entries in the tree.
-     * A layout also needs to be provided when only {@link GBPTree#readHeader(PageCache, File, Layout, Header.Reader)} reading header}
-     * of tree. In this case there is no intention of reading or writing entries in the tree. If multiple layout implementations share
-     * the same header layout (but have different structure for entries) then a layout that is compatible with either of those layouts
-     * can be provided for the read header operation.
      *
      * @param layoutIdentifier the stored layout identifier we want to check compatibility against.
      * @param majorVersion the stored major version we want to check compatibility against.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreePartialCreateFuzzIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreePartialCreateFuzzIT.java
@@ -75,9 +75,9 @@ public class GBPTreePartialCreateFuzzIT
             // check readHeader
             try
             {
-                GBPTree.readHeader( pageCache, file, layout, NO_HEADER_READER );
+                GBPTree.readHeader( pageCache, file, NO_HEADER_READER );
             }
-            catch ( IOException e )
+            catch ( MetadataMismatchException | IOException e )
             {
                 // It's OK if the process was destroyed
                 assertNotEquals( 0, exitCode );
@@ -88,7 +88,7 @@ public class GBPTreePartialCreateFuzzIT
             {
                 new GBPTreeBuilder<>( pageCache, file, layout ).build().close();
             }
-            catch ( IOException e )
+            catch ( MetadataMismatchException | IOException e )
             {
                 // It's OK if the process was destroyed
                 assertNotEquals( 0, exitCode );

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
@@ -641,7 +641,7 @@ public class GBPTreeTest
 
         // WHEN
         // Read separate
-        GBPTree.readHeader( pageCache, indexFile, layout, headerReader );
+        GBPTree.readHeader( pageCache, indexFile, headerReader );
 
         assertEquals( expectedHeader.length, length.get() );
         assertArrayEquals( expectedHeader, readHeader );
@@ -654,7 +654,7 @@ public class GBPTreeTest
         File doesNotExist = new File( "Does not exist" );
         try
         {
-            GBPTree.readHeader( createPageCache( DEFAULT_PAGE_SIZE ), doesNotExist, layout, NO_HEADER_READER );
+            GBPTree.readHeader( createPageCache( DEFAULT_PAGE_SIZE ), doesNotExist, NO_HEADER_READER );
             fail( "Should have failed" );
         }
         catch ( NoSuchFileException e )
@@ -666,7 +666,7 @@ public class GBPTreeTest
     @Test
     public void openWithReadHeaderMustThrowMetadataMismatchExceptionIfFileIsEmpty() throws Exception
     {
-        openMustThrowMetadataMismatchExceptionIfFileIsEmpty( pageCache -> GBPTree.readHeader( pageCache, indexFile, layout, NO_HEADER_READER ) );
+        openMustThrowMetadataMismatchExceptionIfFileIsEmpty( pageCache -> GBPTree.readHeader( pageCache, indexFile, NO_HEADER_READER ) );
     }
 
     @Test
@@ -694,19 +694,19 @@ public class GBPTreeTest
     }
 
     @Test
-    public void readHeaderMustThrowIOExceptionIfSomeMetaPageIsMissing() throws Exception
+    public void readHeaderMustThrowMetadataMismatchExceptionIfSomeMetaPageIsMissing() throws Exception
     {
-        openMustThrowIOExceptionIfSomeMetaPageIsMissing(
-                pageCache -> GBPTree.readHeader( pageCache, indexFile, layout, NO_HEADER_READER ) );
+        openMustThrowMetadataMismatchExceptionIfSomeMetaPageIsMissing(
+                pageCache -> GBPTree.readHeader( pageCache, indexFile, NO_HEADER_READER ) );
     }
 
     @Test
-    public void constructorMustThrowIOExceptionIfSomeMetaPageIsMissing() throws Exception
+    public void constructorMustThrowMetadataMismatchExceptionIfSomeMetaPageIsMissing() throws Exception
     {
-        openMustThrowIOExceptionIfSomeMetaPageIsMissing( pageCache -> index( pageCache ).build() );
+        openMustThrowMetadataMismatchExceptionIfSomeMetaPageIsMissing( pageCache -> index( pageCache ).build() );
     }
 
-    private void openMustThrowIOExceptionIfSomeMetaPageIsMissing( ThrowingConsumer<PageCache,IOException> opener ) throws Exception
+    private void openMustThrowMetadataMismatchExceptionIfSomeMetaPageIsMissing( ThrowingConsumer<PageCache,IOException> opener ) throws Exception
     {
         // given an existing index with only the first page in it
         PageCache pageCache = createPageCache( DEFAULT_PAGE_SIZE );
@@ -721,7 +721,7 @@ public class GBPTreeTest
             opener.accept( pageCache );
             fail( "Should've thrown IOException" );
         }
-        catch ( IOException e )
+        catch ( MetadataMismatchException e )
         {
             // then good
         }
@@ -730,17 +730,17 @@ public class GBPTreeTest
     @Test
     public void readHeaderMustThrowIOExceptionIfStatePagesAreAllZeros() throws Exception
     {
-        openMustThrowIOExceptionIfStatePagesAreAllZeros(
-                pageCache -> GBPTree.readHeader( pageCache, indexFile, layout, NO_HEADER_READER ) );
+        openMustThrowMetadataMismatchExceptionIfStatePagesAreAllZeros(
+                pageCache -> GBPTree.readHeader( pageCache, indexFile, NO_HEADER_READER ) );
     }
 
     @Test
-    public void constructorMustThrowIOExceptionIfStatePagesAreAllZeros() throws Exception
+    public void constructorMustThrowMetadataMismatchExceptionIfStatePagesAreAllZeros() throws Exception
     {
-        openMustThrowIOExceptionIfStatePagesAreAllZeros( pageCache -> index( pageCache ).build() );
+        openMustThrowMetadataMismatchExceptionIfStatePagesAreAllZeros( pageCache -> index( pageCache ).build() );
     }
 
-    private void openMustThrowIOExceptionIfStatePagesAreAllZeros( ThrowingConsumer<PageCache,IOException> opener ) throws Exception
+    private void openMustThrowMetadataMismatchExceptionIfStatePagesAreAllZeros( ThrowingConsumer<PageCache,IOException> opener ) throws Exception
     {
         // given an existing index with all-zero state pages
         PageCache pageCache = createPageCache( DEFAULT_PAGE_SIZE );
@@ -761,7 +761,7 @@ public class GBPTreeTest
             opener.accept( pageCache );
             fail( "Should've thrown IOException" );
         }
-        catch ( IOException e )
+        catch ( MetadataMismatchException e )
         {
             // then good
         }
@@ -786,7 +786,7 @@ public class GBPTreeTest
                 length.set( headerData.limit() );
                 headerData.get( readHeader );
             };
-            GBPTree.readHeader( pageCache, indexFile, layout, headerReader );
+            GBPTree.readHeader( pageCache, indexFile, headerReader );
 
             // THEN
             assertEquals( headerBytes.length, length.get() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeIndexProvider.java
@@ -94,7 +94,7 @@ abstract class NativeIndexProvider<KEY extends NativeSchemaKey,VALUE extends Nat
     {
         try
         {
-            String failureMessage = NativeSchemaIndexes.readFailureMessage( pageCache, nativeIndexFileFromIndexId( indexId ), layout( descriptor ) );
+            String failureMessage = NativeSchemaIndexes.readFailureMessage( pageCache, nativeIndexFileFromIndexId( indexId ) );
             if ( failureMessage == null )
             {
                 throw new IllegalStateException( "Index " + indexId + " isn't failed" );
@@ -112,7 +112,7 @@ abstract class NativeIndexProvider<KEY extends NativeSchemaKey,VALUE extends Nat
     {
         try
         {
-            return NativeSchemaIndexes.readState( pageCache, nativeIndexFileFromIndexId( indexId ), layout( descriptor ) );
+            return NativeSchemaIndexes.readState( pageCache, nativeIndexFileFromIndexId( indexId ) );
         }
         catch ( IOException e )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexes.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexes.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.neo4j.index.internal.gbptree.GBPTree;
-import org.neo4j.index.internal.gbptree.Layout;
 import org.neo4j.internal.kernel.api.InternalIndexState;
 import org.neo4j.io.pagecache.PageCache;
 
@@ -36,10 +35,10 @@ public class NativeSchemaIndexes
     private  NativeSchemaIndexes()
     {}
 
-    public static InternalIndexState readState( PageCache pageCache, File indexFile, Layout<?,?> layout ) throws IOException
+    public static InternalIndexState readState( PageCache pageCache, File indexFile ) throws IOException
     {
         NativeSchemaIndexHeaderReader headerReader = new NativeSchemaIndexHeaderReader();
-        GBPTree.readHeader( pageCache, indexFile, layout, headerReader );
+        GBPTree.readHeader( pageCache, indexFile, headerReader );
         switch ( headerReader.state )
         {
         case BYTE_FAILED:
@@ -53,11 +52,11 @@ public class NativeSchemaIndexes
         }
     }
 
-    public static String readFailureMessage( PageCache pageCache, File indexFile, Layout<?,?> layout )
+    static String readFailureMessage( PageCache pageCache, File indexFile )
             throws IOException
     {
         NativeSchemaIndexHeaderReader headerReader = new NativeSchemaIndexHeaderReader();
-        GBPTree.readHeader( pageCache, indexFile, layout, headerReader );
+        GBPTree.readHeader( pageCache, indexFile, headerReader );
         return headerReader.failureMessage;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialCRSSchemaIndex.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialCRSSchemaIndex.java
@@ -44,8 +44,8 @@ import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexDirectoryStructure;
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
-import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.IndexProvider;
+import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.kernel.impl.index.schema.NativeSchemaIndexPopulator.IndexUpdateApply;
@@ -327,12 +327,12 @@ public class SpatialCRSSchemaIndex
 
     public String readPopulationFailure() throws IOException
     {
-        return NativeSchemaIndexes.readFailureMessage( pageCache, indexFile, layout );
+        return NativeSchemaIndexes.readFailureMessage( pageCache, indexFile );
     }
 
     public InternalIndexState readState() throws IOException
     {
-        return NativeSchemaIndexes.readState( pageCache, indexFile, layout );
+        return NativeSchemaIndexes.readState( pageCache, indexFile );
     }
 
     private synchronized void create() throws IOException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexProvider.java
@@ -84,7 +84,7 @@ public class TemporalIndexProvider extends IndexProvider
         {
             for ( TemporalIndexFiles.FileLayout subIndex : temporalIndexFiles.existing() )
             {
-                String indexFailure = NativeSchemaIndexes.readFailureMessage( pageCache, subIndex.indexFile, subIndex.layout );
+                String indexFailure = NativeSchemaIndexes.readFailureMessage( pageCache, subIndex.indexFile );
                 if ( indexFailure != null )
                 {
                     return indexFailure;
@@ -108,7 +108,7 @@ public class TemporalIndexProvider extends IndexProvider
         {
             try
             {
-                switch ( NativeSchemaIndexes.readState( pageCache, subIndex.indexFile, subIndex.layout ) )
+                switch ( NativeSchemaIndexes.readState( pageCache, subIndex.indexFile ) )
                 {
                 case FAILED:
                     return InternalIndexState.FAILED;


### PR DESCRIPTION
Layout was just needed to read header as an extra safety net.
We verified that the index that you read the header from was actually
the index that you thought it was, by verifying the layout. This created
more problems than it solved and we can drive without this seat belt
holding us back.

Also aligning exception type on missing meta page and missing state page.
Use MetadataMismatchException in both cases.