### PR TITLE
Close transaction in kill query test

### DIFF
--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/KillQueryTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/KillQueryTest.scala
@@ -120,9 +120,10 @@ class KillQueryTest extends ExecutionEngineFunSuite {
             case _: TransientTransactionFailureException =>
 
             case e: Throwable =>
-              tx.close()
               continue.set(false)
               exLogger(e)
+          } finally {
+            tx.close()
           }
         }
       }


### PR DESCRIPTION
Close transaction and as result remove exceptions that was thrown during
test execution about attempt to start nested transaction in
already terminated parent transaction