### PR TITLE
Test East-Saskatchewan

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
@@ -115,8 +115,9 @@ public abstract class IndexProviderCompatibilityTestSuite
                             DateTimeValue.datetime( 2014, 3, 25, 12, 46, 13, 7474, "+05:00" ),
                             DateTimeValue.datetime( 2014, 3, 25, 12, 45, 14, 7474, "+05:00" ),
                             DateTimeValue.datetime( 2014, 3, 25, 12, 45, 14, 7475, "+05:00" ),
-                            // only runnable it JVM supports East-Saskatchewan
-                            // DateTimeValue.datetime( 2001, 1, 25, 11, 11, 30, 0, "Canada/East-Saskatchewan" ),
+                            DateTimeValue.parse( "2001-01-25T11:11:30[Canada/East-Saskatchewan]", null ),
+                                                // we cannot use regular construction for East-Saskatchewan,
+                                                // as all JVMs do not support it
                             DateTimeValue.datetime( 2038, 1, 18, 9, 14, 7, 0, "-18:00" ),
                             DateTimeValue.datetime( 10000, 100, ZoneOffset.ofTotalSeconds( 3 ) ),
                             DateTimeValue.datetime( 10000, 101, ZoneOffset.ofTotalSeconds( -3 ) ),

--- a/community/values/src/test/java/org/neo4j/values/storable/DateTimeValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DateTimeValueTest.java
@@ -454,11 +454,11 @@ public class DateTimeValueTest
         assertEqual( datetime( 10000, 100, UTC ), datetime( 10000, 100, UTC ) );
     }
 
-    @Ignore // only runnable it JVM supports East-Saskatchewan
+    @Test
     public void shouldEqualRenamedTimeZone()
     {
-        assertEqual( datetime( 10000, 100, ZoneId.of( "Canada/Saskatchewan" ) ),
-                     datetime( 10000, 100, ZoneId.of( "Canada/East-Saskatchewan" ) ) );
+        assertEqual( DateTimeValue.parse( Values.stringValue( "2018-02-11T11:23:34[Canada/Saskatchewan]" ), null ),
+                     DateTimeValue.parse( Values.stringValue( "2018-02-11T11:23:34[Canada/East-Saskatchewan]" ), null ) );
     }
 
     @Test

--- a/community/values/src/test/java/org/neo4j/values/storable/ValueComparisonTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/ValueComparisonTest.java
@@ -29,10 +29,12 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
@@ -265,11 +267,14 @@ public class ValueComparisonTest
         }
     }
 
-    @Ignore // only runnable it JVM supports East-Saskatchewan
+    @Test
     public void shouldCompareRenamedTimeZonesByZoneNumber()
     {
-        int cmp = Values.COMPARATOR.compare( datetime( 10000, 100, ZoneId.of( "Canada/Saskatchewan" ) ),
-                                             datetime( 10000, 100, ZoneId.of( "Canada/East-Saskatchewan" ) ) );
+        Supplier<ZoneId> utc = () -> ZoneOffset.UTC;
+        TextValue old = Values.stringValue( "2018-02-11T11:23:34[Canada/East-Saskatchewan]" );
+        TextValue renamed = Values.stringValue( "2018-02-11T11:23:34[Canada/Saskatchewan]" );
+        int cmp = Values.COMPARATOR.compare( DateTimeValue.parse( renamed, utc ),
+                                             DateTimeValue.parse( old, utc ) );
         assertEquals( "East-Saskatchewan and Saskatchewan are the same place", 0, cmp );
     }
 


### PR DESCRIPTION
Re-enable tests of East-Saskatchewan by creating the objects using parsing. This should work on all JVMs