### PR TITLE
Native string index migration

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceIntegrationTest.java
@@ -247,12 +247,12 @@ public class ConsistencyCheckServiceIntegrationTest
     public void oldLuceneSchemaIndexShouldBeConsideredConsistentWithFusionProvider() throws Exception
     {
         File storeDir = testDirectory.graphDbDir();
-        String defaultSchemaIndex = GraphDatabaseSettings.default_schema_index.name();
+        String defaultSchemaProvider = GraphDatabaseSettings.default_schema_provider.name();
         Label label = Label.label( "label" );
         String propKey = "propKey";
 
         // Given a lucene index
-        GraphDatabaseService db = getGraphDatabaseService( storeDir, defaultSchemaIndex, LUCENE10.param() );
+        GraphDatabaseService db = getGraphDatabaseService( storeDir, defaultSchemaProvider, LUCENE10.param() );
         createIndex( db, label, propKey );
         try ( Transaction tx = db.beginTx() )
         {
@@ -264,7 +264,7 @@ public class ConsistencyCheckServiceIntegrationTest
 
         ConsistencyCheckService service = new ConsistencyCheckService();
         Config configuration =
-                Config.defaults( settings( defaultSchemaIndex, NATIVE20.param() ) );
+                Config.defaults( settings( defaultSchemaProvider, NATIVE20.param() ) );
         Result result = runFullConsistencyCheck( service, configuration, storeDir );
         assertTrue( result.isSuccessful() );
     }

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceIntegrationTest.java
@@ -67,6 +67,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.SchemaIndex.LUCENE10;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.SchemaIndex.NATIVE20;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.test.Property.property;
 import static org.neo4j.test.Property.set;
@@ -245,12 +247,12 @@ public class ConsistencyCheckServiceIntegrationTest
     public void oldLuceneSchemaIndexShouldBeConsideredConsistentWithFusionProvider() throws Exception
     {
         File storeDir = testDirectory.graphDbDir();
-        String enableNativeIndex = GraphDatabaseSettings.enable_native_schema_index.name();
+        String defaultSchemaIndex = GraphDatabaseSettings.default_schema_index.name();
         Label label = Label.label( "label" );
         String propKey = "propKey";
 
         // Given a lucene index
-        GraphDatabaseService db = getGraphDatabaseService( storeDir, enableNativeIndex, Settings.FALSE );
+        GraphDatabaseService db = getGraphDatabaseService( storeDir, defaultSchemaIndex, LUCENE10.param() );
         createIndex( db, label, propKey );
         try ( Transaction tx = db.beginTx() )
         {
@@ -262,7 +264,7 @@ public class ConsistencyCheckServiceIntegrationTest
 
         ConsistencyCheckService service = new ConsistencyCheckService();
         Config configuration =
-                Config.defaults( settings( enableNativeIndex, Settings.TRUE ) );
+                Config.defaults( settings( defaultSchemaIndex, NATIVE20.param() ) );
         Result result = runFullConsistencyCheck( service, configuration, storeDir );
         assertTrue( result.isSuccessful() );
     }

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/IndexConsistencyIT.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/IndexConsistencyIT.java
@@ -39,9 +39,9 @@ import org.neo4j.helpers.collection.Pair;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.index.schema.fusion.FusionIndexProvider;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
+import org.neo4j.kernel.impl.transaction.state.DefaultIndexProviderMap;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.test.rule.DatabaseRule;
 import org.neo4j.test.rule.EmbeddedDatabaseRule;
@@ -81,7 +81,7 @@ public class IndexConsistencyIT
         someData();
         resolveComponent( CheckPointer.class ).forceCheckPoint( new SimpleTriggerInfo( "forcedCheckpoint" ) );
         File indexesCopy = new File( storeDir, "indexesCopy" );
-        File indexSources = resolveComponent( FusionIndexProvider.class ).directoryStructure().rootDirectory();
+        File indexSources = resolveComponent( DefaultIndexProviderMap.class ).getDefaultProvider().directoryStructure().rootDirectory();
         copyRecursively( indexSources, indexesCopy, SOURCE_COPY_FILE_FILTER );
 
         try ( Transaction tx = db.beginTx() )
@@ -107,7 +107,7 @@ public class IndexConsistencyIT
         someData();
         resolveComponent( CheckPointer.class ).forceCheckPoint( new SimpleTriggerInfo( "forcedCheckpoint" ) );
         File indexesCopy = new File( storeDir, "indexesCopy" );
-        File indexSources = resolveComponent( FusionIndexProvider.class ).directoryStructure().rootDirectory();
+        File indexSources = resolveComponent( DefaultIndexProviderMap.class ).getDefaultProvider().directoryStructure().rootDirectory();
         copyRecursively( indexSources, indexesCopy, SOURCE_COPY_FILE_FILTER );
 
         db.shutdownAndKeepStore();

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/IndexOpAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/IndexOpAcceptanceTest.scala
@@ -26,8 +26,8 @@ import org.neo4j.cypher.ExecutionEngineHelper.createEngine
 import org.neo4j.cypher.internal.javacompat.GraphDatabaseCypherService
 import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.kernel.api.exceptions.schema.{DropIndexFailureException, NoSuchIndexException}
+import org.neo4j.kernel.api.impl.schema.{LuceneIndexProviderFactory, NativeLuceneFusionIndexProviderFactory20}
 import org.neo4j.test.TestGraphDatabaseFactory
-import org.neo4j.kernel.api.impl.schema.{LuceneIndexProviderFactory, NativeLuceneFusionIndexProviderFactory}
 
 class IndexOpAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport {
 
@@ -112,7 +112,7 @@ class IndexOpAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistics
       tx.close()
     }
 
-    val indexDirectory = NativeLuceneFusionIndexProviderFactory.subProviderDirectoryStructure( storeDir )
+    val indexDirectory = NativeLuceneFusionIndexProviderFactory20.subProviderDirectoryStructure( storeDir )
         .forProvider( LuceneIndexProviderFactory.PROVIDER_DESCRIPTOR ).directoryForIndex( 1 )
     graph.shutdown()
 

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeValueIndexCursorTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeValueIndexCursorTestBase.java
@@ -333,7 +333,6 @@ public abstract class NodeValueIndexCursorTestBase<G extends KernelAPIReadTestSu
             read.nodeIndexSeek( index, node, IndexOrder.NONE, IndexQuery.range( prop, 5, true, 12, false ) );
 
             // then
-
             assertFoundNodesAndValue( node, uniqueIds, numberCapability, num5, num6 );
 
             // when

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -504,9 +504,41 @@ public class GraphDatabaseSettings implements LoadableConfig
     public static final Setting<Boolean> multi_threaded_schema_index_population_enabled =
             setting( "unsupported.dbms.multi_threaded_schema_index_population_enabled", BOOLEAN, TRUE );
 
+    // todo update ReplacedBy
+    @Deprecated
+    @ReplacedBy( "dbms.default_schema_index" )
     @Internal
     public static final Setting<Boolean> enable_native_schema_index =
             setting( "unsupported.dbms.enable_native_schema_index", BOOLEAN, TRUE );
+
+    // todo optionNames
+    public enum SchemaIndex
+    {
+        NATIVE20( "native" ),
+        NATIVE10( "native_no_strings" ),
+        LUCENE10( "no_native" );
+
+        private final String param;
+
+        SchemaIndex( String param )
+        {
+            this.param = param;
+        }
+
+        public String param()
+        {
+            return param;
+        }
+    }
+
+    // todo name
+    // todo unsupported.?
+    // todo @Internal ?
+    @Description( "Index provider to use when creating new indexes." )
+    public static final Setting<String> default_schema_index =
+            setting( "dbms.default_schema_index",
+                    optionsIgnoreCase( SchemaIndex.NATIVE20.param(), SchemaIndex.NATIVE10.param(), SchemaIndex.LUCENE10.param() ),
+                    null );
 
     @Description( "Location where Neo4j keeps the logical transaction logs." )
     public static final Setting<File> logical_logs_location =

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -504,19 +504,17 @@ public class GraphDatabaseSettings implements LoadableConfig
     public static final Setting<Boolean> multi_threaded_schema_index_population_enabled =
             setting( "unsupported.dbms.multi_threaded_schema_index_population_enabled", BOOLEAN, TRUE );
 
-    // todo update ReplacedBy
     @Deprecated
-    @ReplacedBy( "dbms.default_schema_index" )
+    @ReplacedBy( "dbms.index.default_schema_provider" )
     @Internal
     public static final Setting<Boolean> enable_native_schema_index =
             setting( "unsupported.dbms.enable_native_schema_index", BOOLEAN, TRUE );
 
-    // todo optionNames
     public enum SchemaIndex
     {
-        NATIVE20( "native" ),
-        NATIVE10( "native_no_strings" ),
-        LUCENE10( "no_native" );
+        NATIVE20( "lucene+native-2.0" ),
+        NATIVE10( "lucene+native-1.0" ),
+        LUCENE10( "lucene-1.0" );
 
         private final String param;
 
@@ -531,12 +529,9 @@ public class GraphDatabaseSettings implements LoadableConfig
         }
     }
 
-    // todo name
-    // todo unsupported.?
-    // todo @Internal ?
     @Description( "Index provider to use when creating new indexes." )
-    public static final Setting<String> default_schema_index =
-            setting( "dbms.default_schema_index",
+    public static final Setting<String> default_schema_provider =
+            setting( "dbms.index.default_schema_provider",
                     optionsIgnoreCase( SchemaIndex.NATIVE20.param(), SchemaIndex.NATIVE10.param(), SchemaIndex.LUCENE10.param() ),
                     null );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexAccessor.java
@@ -118,6 +118,8 @@ public interface IndexAccessor extends Closeable
      */
     boolean isDirty();
 
+    IndexAccessor EMPTY = new Adapter();
+
     class Adapter implements IndexAccessor
     {
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexAccessor.java
@@ -40,6 +40,8 @@ import static org.neo4j.helpers.collection.Iterators.emptyResourceIterator;
  */
 public interface IndexAccessor extends Closeable
 {
+    IndexAccessor EMPTY = new Adapter();
+
     /**
      * Deletes this index as well as closes all used external resources.
      * There will not be any interactions after this call.
@@ -117,8 +119,6 @@ public interface IndexAccessor extends Closeable
      * @return true if index was not shutdown properly and its internal state is dirty, false otherwise
      */
     boolean isDirty();
-
-    IndexAccessor EMPTY = new Adapter();
 
     class Adapter implements IndexAccessor
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexPopulator.java
@@ -142,6 +142,8 @@ public interface IndexPopulator
      */
     IndexSample sampleResult();
 
+    IndexPopulator EMPTY = new Adapter();
+
     class Adapter implements IndexPopulator
     {
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexProvider.java
@@ -114,11 +114,11 @@ public abstract class IndexProvider extends LifecycleAdapter implements Comparab
         void recoveryCompleted( long indexId, SchemaIndexDescriptor schemaIndexDescriptor, Map<String,Object> data );
     }
 
-    public static final IndexProvider NO_INDEX_PROVIDER =
+    public static final IndexProvider EMPTY =
             new IndexProvider( new Descriptor( "no-index-provider", "1.0" ), -1, IndexDirectoryStructure.NONE )
             {
-                private final IndexAccessor singleWriter = new IndexAccessor.Adapter();
-                private final IndexPopulator singlePopulator = new IndexPopulator.Adapter();
+                private final IndexAccessor singleWriter = IndexAccessor.EMPTY;
+                private final IndexPopulator singlePopulator = IndexPopulator.EMPTY;
 
                 @Override
                 public IndexAccessor getOnlineAccessor( long indexId, SchemaIndexDescriptor descriptor,
@@ -137,7 +137,7 @@ public abstract class IndexProvider extends LifecycleAdapter implements Comparab
                 @Override
                 public InternalIndexState getInitialState( long indexId, SchemaIndexDescriptor descriptor )
                 {
-                    return InternalIndexState.POPULATING;
+                    return InternalIndexState.ONLINE;
                 }
 
                 @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/GraphDatabaseConfigurationMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/GraphDatabaseConfigurationMigrator.java
@@ -119,14 +119,14 @@ public class GraphDatabaseConfigurationMigrator extends BaseConfigurationMigrato
             }
         } );
         add( new SpecificPropertyMigration( "unsupported.dbms.enable_native_schema_index",
-                "unsupported.dbms.enable_native_schema_index has been replaced with dbms.default_schema_index." )
+                "unsupported.dbms.enable_native_schema_index has been replaced with dbms.index.default_schema_provider." )
         {
             @Override
             public void setValueWithOldSetting( String value, Map<String,String> rawConfiguration )
             {
                 if ( value.equals( Settings.FALSE ) )
                 {
-                    rawConfiguration.putIfAbsent( GraphDatabaseSettings.default_schema_index.name(), GraphDatabaseSettings.SchemaIndex.LUCENE10.param() );
+                    rawConfiguration.putIfAbsent( GraphDatabaseSettings.default_schema_provider.name(), GraphDatabaseSettings.SchemaIndex.LUCENE10.param() );
                 }
             }
         } );

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/GraphDatabaseConfigurationMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/GraphDatabaseConfigurationMigrator.java
@@ -118,5 +118,17 @@ public class GraphDatabaseConfigurationMigrator extends BaseConfigurationMigrato
                 rawConfiguration.put( GraphDatabaseSettings.db_timezone.name(), value );
             }
         } );
+        add( new SpecificPropertyMigration( "unsupported.dbms.enable_native_schema_index",
+                "unsupported.dbms.enable_native_schema_index has been replaced with dbms.default_schema_index." )
+        {
+            @Override
+            public void setValueWithOldSetting( String value, Map<String,String> rawConfiguration )
+            {
+                if ( value.equals( Settings.FALSE ) )
+                {
+                    rawConfiguration.putIfAbsent( GraphDatabaseSettings.default_schema_index.name(), GraphDatabaseSettings.SchemaIndex.LUCENE10.param() );
+                }
+            }
+        } );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexReader.java
@@ -47,7 +47,7 @@ abstract class NativeSchemaIndexReader<KEY extends NativeSchemaKey, VALUE extend
     final Layout<KEY,VALUE> layout;
     private final IndexSamplingConfig samplingConfig;
 
-    protected final Set<RawCursor<Hit<KEY,VALUE>,IOException>> openSeekers;
+    final Set<RawCursor<Hit<KEY,VALUE>,IOException>> openSeekers;
     protected final SchemaIndexDescriptor descriptor;
 
     NativeSchemaIndexReader( GBPTree<KEY,VALUE> tree, Layout<KEY,VALUE> layout,
@@ -133,8 +133,8 @@ abstract class NativeSchemaIndexReader<KEY extends NativeSchemaKey, VALUE extend
 
     private PrimitiveLongResourceIterator getHitIterator( RawCursor<Hit<KEY,VALUE>,IOException> seeker, boolean needFilter, IndexQuery[] predicates )
     {
-        return needFilter ? new FilteringNativeHitIterator<KEY,VALUE>( seeker, openSeekers, predicates )
-                          : new NativeHitIterator<KEY,VALUE>( seeker, openSeekers );
+        return needFilter ? new FilteringNativeHitIterator<>( seeker, openSeekers, predicates )
+                          : new NativeHitIterator<>( seeker, openSeekers );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexReader.java
@@ -43,12 +43,11 @@ import org.neo4j.values.storable.Value;
 abstract class NativeSchemaIndexReader<KEY extends NativeSchemaKey, VALUE extends NativeSchemaValue>
         implements IndexReader
 {
-    private final GBPTree<KEY,VALUE> tree;
-    final Layout<KEY,VALUE> layout;
-    private final IndexSamplingConfig samplingConfig;
-
-    final Set<RawCursor<Hit<KEY,VALUE>,IOException>> openSeekers;
     protected final SchemaIndexDescriptor descriptor;
+    final Layout<KEY,VALUE> layout;
+    final Set<RawCursor<Hit<KEY,VALUE>,IOException>> openSeekers;
+    private final GBPTree<KEY,VALUE> tree;
+    private final IndexSamplingConfig samplingConfig;
 
     NativeSchemaIndexReader( GBPTree<KEY,VALUE> tree, Layout<KEY,VALUE> layout,
             IndexSamplingConfig samplingConfig,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringSchemaIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringSchemaIndexReader.java
@@ -117,7 +117,6 @@ class StringSchemaIndexReader extends NativeSchemaIndexReader<StringSchemaKey,Na
     @Override
     public boolean hasFullValuePrecision( IndexQuery... predicates )
     {
-        return false;
+        return true;
     }
-    // todo implement
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexAccessor.java
@@ -147,10 +147,7 @@ class FusionIndexAccessor extends FusionIndexBase<IndexAccessor> implements Inde
     public ResourceIterator<File> snapshotFiles() throws IOException
     {
         List<ResourceIterator<File>> snapshots = new ArrayList<>();
-        for ( IndexAccessor accessor : instances )
-        {
-            snapshots.add( accessor.snapshotFiles() );
-        }
+        forAll( accessor -> snapshots.add( accessor.snapshotFiles() ), instances );
         return concatResourceIterators( snapshots.iterator() );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexBase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexBase.java
@@ -167,17 +167,17 @@ public abstract class FusionIndexBase<T>
         }
     }
 
-    static void validateSelectorInstances( Object[] instances, int... notNullIndex )
+    static void validateSelectorInstances( Object[] instances, int... aliveIndex )
     {
         for ( int i = 0; i < instances.length; i++ )
         {
-            boolean expected = PrimitiveIntCollections.contains( notNullIndex, i );
+            boolean expected = PrimitiveIntCollections.contains( aliveIndex, i );
             boolean actual = instances[i] != IndexProvider.EMPTY;
             if ( expected != actual )
             {
                 throw new IllegalArgumentException(
                         String.format( "Only indexes expected to be separated from IndexProvider.EMPTY are %s but was %s",
-                                Arrays.toString( notNullIndex ), Arrays.toString( instances ) ) );
+                                Arrays.toString( aliveIndex ), Arrays.toString( instances ) ) );
             }
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexBase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexBase.java
@@ -20,9 +20,12 @@
 package org.neo4j.kernel.impl.index.schema.fusion;
 
 import java.lang.reflect.Array;
+import java.util.Arrays;
 
+import org.neo4j.collection.primitive.PrimitiveIntCollections;
 import org.neo4j.function.ThrowingConsumer;
 import org.neo4j.function.ThrowingFunction;
+import org.neo4j.kernel.api.index.IndexProvider;
 
 /**
  * Acting as a simplifier for the multiplexing that is going in inside a fusion index. A fusion index consists of multiple parts,
@@ -33,7 +36,7 @@ import org.neo4j.function.ThrowingFunction;
  */
 public abstract class FusionIndexBase<T>
 {
-    private static final int INSTANCE_COUNT = 5;
+    static final int INSTANCE_COUNT = 5;
 
     static final int STRING = 0;
     static final int NUMBER = 1;
@@ -161,6 +164,21 @@ public abstract class FusionIndexBase<T>
         if ( exception != null )
         {
             throw exception;
+        }
+    }
+
+    static void validateSelectorInstances( Object[] instances, int... notNullIndex )
+    {
+        for ( int i = 0; i < instances.length; i++ )
+        {
+            boolean expected = PrimitiveIntCollections.contains( notNullIndex, i );
+            boolean actual = instances[i] != IndexProvider.EMPTY;
+            if ( expected != actual )
+            {
+                throw new IllegalArgumentException(
+                        String.format( "Only indexes expected to be separated from IndexProvider.EMPTY are %s but was %s",
+                                Arrays.toString( notNullIndex ), Arrays.toString( instances ) ) );
+            }
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexBase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexBase.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import org.neo4j.collection.primitive.PrimitiveIntCollections;
 import org.neo4j.function.ThrowingConsumer;
 import org.neo4j.function.ThrowingFunction;
+import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.api.index.IndexProvider;
 
 /**
@@ -125,17 +126,9 @@ public abstract class FusionIndexBase<T>
             {
                 consumer.accept( subject );
             }
-            catch ( Exception caught )
+            catch ( Exception e )
             {
-                E castedException = (E) caught;
-                if ( exception == null )
-                {
-                    exception = castedException;
-                }
-                else
-                {
-                    exception.addSuppressed( castedException );
-                }
+                exception = Exceptions.chain( exception, (E) e );
             }
         }
         if ( exception != null )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexBase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexBase.java
@@ -92,30 +92,7 @@ public abstract class FusionIndexBase<T>
     @SafeVarargs
     public static <T, E extends Exception> void forAll( ThrowingConsumer<T,E> consumer, T... subjects ) throws E
     {
-        E exception = null;
-        for ( T subject : subjects )
-        {
-            try
-            {
-                consumer.accept( subject );
-            }
-            catch ( Throwable t )
-            {
-                E e = (E) t;
-                if ( exception == null )
-                {
-                    exception = e;
-                }
-                else
-                {
-                    exception.addSuppressed( e );
-                }
-            }
-        }
-        if ( exception != null )
-        {
-            throw exception;
-        }
+        forAll( consumer, Arrays.asList( subjects ) );
     }
 
     /**
@@ -148,16 +125,16 @@ public abstract class FusionIndexBase<T>
             {
                 consumer.accept( subject );
             }
-            catch ( Throwable t )
+            catch ( Exception caught )
             {
-                E e = (E) t;
+                E castedException = (E) caught;
                 if ( exception == null )
                 {
-                    exception = e;
+                    exception = castedException;
                 }
                 else
                 {
-                    exception.addSuppressed( e );
+                    exception.addSuppressed( castedException );
                 }
             }
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexProvider.java
@@ -68,6 +68,9 @@ public class FusionIndexProvider extends IndexProvider
             return instances[selectSlot( values )];
         }
 
+        /**
+         * @return Appropriate IndexReader for given predicate or null if predicate needs all readers.
+         */
         IndexReader select( IndexReader[] instances, IndexQuery... predicates );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexProvider.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 
 import org.neo4j.internal.kernel.api.IndexCapability;
 import org.neo4j.internal.kernel.api.IndexOrder;
+import org.neo4j.internal.kernel.api.IndexQuery;
 import org.neo4j.internal.kernel.api.InternalIndexState;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
@@ -33,18 +34,21 @@ import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.index.IndexProvider;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
-import org.neo4j.kernel.impl.index.schema.NumberIndexProvider;
-import org.neo4j.kernel.impl.index.schema.SpatialIndexProvider;
-import org.neo4j.kernel.impl.index.schema.StringIndexProvider;
-import org.neo4j.kernel.impl.index.schema.TemporalIndexProvider;
 import org.neo4j.kernel.impl.newapi.UnionIndexCapability;
 import org.neo4j.kernel.impl.storemigration.StoreMigrationParticipant;
+import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.ValueGroup;
 
-import static org.neo4j.helpers.collection.Iterators.array;
 import static org.neo4j.internal.kernel.api.InternalIndexState.FAILED;
 import static org.neo4j.internal.kernel.api.InternalIndexState.POPULATING;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.INSTANCE_COUNT;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.LUCENE;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.NUMBER;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.SPATIAL;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.STRING;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.TEMPORAL;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.forAll;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.instancesAs;
 
 /**
@@ -55,24 +59,28 @@ public class FusionIndexProvider extends IndexProvider
 {
     interface Selector
     {
+        void validateSatisfied( Object[] instances );
+
         int selectSlot( Value... values );
 
         default <T> T select( T[] instances, Value... values )
         {
             return instances[selectSlot( values )];
         }
+
+        IndexReader select( IndexReader[] instances, IndexQuery... predicates );
     }
 
-    private final IndexProvider[] providers;
+    private final IndexProvider[] providers = new IndexProvider[INSTANCE_COUNT];
     private final Selector selector;
     private final DropAction dropAction;
 
     public FusionIndexProvider(
             // good to be strict with specific providers here since this is dev facing
-            StringIndexProvider stringProvider,
-            NumberIndexProvider numberProvider,
-            SpatialIndexProvider spatialProvider,
-            TemporalIndexProvider temporalProvider,
+            IndexProvider stringProvider,
+            IndexProvider numberProvider,
+            IndexProvider spatialProvider,
+            IndexProvider temporalProvider,
             IndexProvider luceneProvider,
             Selector selector,
             Descriptor descriptor,
@@ -81,9 +89,20 @@ public class FusionIndexProvider extends IndexProvider
             FileSystemAbstraction fs )
     {
         super( descriptor, priority, directoryStructure );
-        this.providers = array( stringProvider, numberProvider, spatialProvider, temporalProvider, luceneProvider );
+        fillProvidersArray( stringProvider, numberProvider, spatialProvider, temporalProvider, luceneProvider );
+        selector.validateSatisfied( providers );
         this.selector = selector;
         this.dropAction = new FileSystemDropAction( fs, directoryStructure() );
+    }
+
+    private void fillProvidersArray( IndexProvider stringProvider, IndexProvider numberProvider, IndexProvider spatialProvider, IndexProvider temporalProvider,
+            IndexProvider luceneProvider )
+    {
+        providers[STRING] = stringProvider;
+        providers[NUMBER] = numberProvider;
+        providers[SPATIAL] = spatialProvider;
+        providers[TEMPORAL] = temporalProvider;
+        providers[LUCENE] = luceneProvider;
     }
 
     @Override
@@ -106,25 +125,13 @@ public class FusionIndexProvider extends IndexProvider
     public String getPopulationFailure( long indexId, SchemaIndexDescriptor descriptor ) throws IllegalStateException
     {
         StringBuilder builder = new StringBuilder();
-        for ( int i = 0; i < providers.length; i++ )
-        {
-            writeFailure( nameOf( i ), builder, providers[i], indexId, descriptor );
-        }
+        forAll( p -> writeFailure( p.getClass().getSimpleName(), builder, p, indexId, descriptor ), providers );
         String failure = builder.toString();
         if ( !failure.isEmpty() )
         {
             return failure;
         }
         throw new IllegalStateException( "None of the indexes were in a failed state" );
-    }
-
-    /**
-     * @param subProviderIndex the index into the providers array to get the name of.
-     * @return some name distinguishing the provider of this subProviderIndex from other providers.
-     */
-    private String nameOf( int subProviderIndex )
-    {
-        return providers[subProviderIndex].getClass().getSimpleName();
     }
 
     private void writeFailure( String indexName, StringBuilder builder, IndexProvider provider, long indexId, SchemaIndexDescriptor descriptor )
@@ -145,8 +152,7 @@ public class FusionIndexProvider extends IndexProvider
     @Override
     public InternalIndexState getInitialState( long indexId, SchemaIndexDescriptor descriptor )
     {
-        InternalIndexState[] states =
-                Arrays.stream( providers ).map( provider -> provider.getInitialState( indexId, descriptor ) ).toArray( InternalIndexState[]::new );
+        InternalIndexState[] states = FusionIndexBase.instancesAs( providers, InternalIndexState.class, p -> p.getInitialState( indexId, descriptor ) );
         if ( Arrays.stream( states ).anyMatch( state -> state == FAILED ) )
         {
             // One of the state is FAILED, the whole state must be considered FAILED

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexReader.java
@@ -27,13 +27,11 @@ import org.neo4j.graphdb.Resource;
 import org.neo4j.internal.kernel.api.IndexOrder;
 import org.neo4j.internal.kernel.api.IndexQuery;
 import org.neo4j.internal.kernel.api.IndexQuery.ExactPredicate;
-import org.neo4j.internal.kernel.api.IndexQuery.ExistsPredicate;
 import org.neo4j.internal.kernel.api.IndexQuery.RangePredicate;
 import org.neo4j.kernel.api.exceptions.index.IndexNotApplicableKernelException;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
 import org.neo4j.kernel.impl.api.schema.BridgingIndexProgressor;
 import org.neo4j.kernel.impl.index.schema.fusion.FusionIndexProvider.Selector;
-
 import org.neo4j.storageengine.api.schema.IndexProgressor;
 import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.storageengine.api.schema.IndexSampler;
@@ -41,9 +39,6 @@ import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.ValueGroup;
 
 import static java.lang.String.format;
-import static org.neo4j.internal.kernel.api.IndexQuery.StringContainsPredicate;
-import static org.neo4j.internal.kernel.api.IndexQuery.StringPrefixPredicate;
-import static org.neo4j.internal.kernel.api.IndexQuery.StringSuffixPredicate;
 
 class FusionIndexReader extends FusionIndexBase<IndexReader> implements IndexReader
 {
@@ -76,109 +71,28 @@ class FusionIndexReader extends FusionIndexBase<IndexReader> implements IndexRea
     @Override
     public PrimitiveLongResourceIterator query( IndexQuery... predicates ) throws IndexNotApplicableKernelException
     {
-        if ( predicates.length > 1 )
+        IndexReader instance = selector.select( instances, predicates );
+        if ( instance != null )
         {
-            return instances[LUCENE].query( predicates );
+            return instance.query( predicates );
         }
-        IndexQuery predicate = predicates[0];
-
-        if ( predicate instanceof ExactPredicate )
-        {
-            ExactPredicate exactPredicate = (ExactPredicate) predicate;
-            return selector.select( instances, exactPredicate.value() ).query( predicates );
-        }
-
-        if ( predicate instanceof StringPrefixPredicate ||
-             predicate instanceof StringSuffixPredicate ||
-             predicate instanceof StringContainsPredicate )
-        {
-            return instances[STRING].query( predicate );
-        }
-
-        if ( predicate instanceof RangePredicate )
-        {
-            switch ( predicate.valueGroup() )
-            {
-            case NUMBER:
-                return instances[NUMBER].query( predicates );
-            case GEOMETRY:
-                return instances[SPATIAL].query( predicates );
-            case TEXT:
-                return instances[STRING].query( predicates );
-            case DATE:
-            case LOCAL_DATE_TIME:
-            case ZONED_DATE_TIME:
-            case LOCAL_TIME:
-            case ZONED_TIME:
-            case DURATION:
-                return instances[TEMPORAL].query( predicates );
-            default: // fall through
-            }
-        }
-
-        // todo: There will be no ordering of the node ids here. Is this a problem?
-        if ( predicate instanceof ExistsPredicate )
+        else
         {
             PrimitiveLongResourceIterator[] converted = instancesAs( PrimitiveLongResourceIterator.class, reader -> reader.query( predicates ) );
             return PrimitiveLongResourceCollections.concat( converted );
         }
-
-        return instances[LUCENE].query( predicates );
     }
 
     @Override
     public void query( IndexProgressor.NodeValueClient cursor, IndexOrder indexOrder, IndexQuery... predicates )
             throws IndexNotApplicableKernelException
     {
-        if ( predicates.length > 1 )
+        IndexReader instance = selector.select( instances, predicates );
+        if ( instance != null )
         {
-            instances[LUCENE].query( cursor, indexOrder, predicates );
-            return;
+            instance.query( cursor, indexOrder, predicates );
         }
-        IndexQuery predicate = predicates[0];
-
-        if ( predicate instanceof ExactPredicate )
-        {
-            ExactPredicate exactPredicate = (ExactPredicate) predicate;
-            selector.select( instances, exactPredicate.value() ).query( cursor, indexOrder, predicate );
-            return;
-        }
-
-        if ( predicate instanceof StringPrefixPredicate ||
-             predicate instanceof StringSuffixPredicate ||
-             predicate instanceof StringContainsPredicate )
-        {
-            instances[STRING].query( cursor, indexOrder, predicate );
-            return;
-        }
-
-        if ( predicate instanceof RangePredicate )
-        {
-            switch ( predicate.valueGroup() )
-            {
-            case NUMBER:
-                instances[NUMBER].query( cursor, indexOrder, predicates );
-                return;
-            case GEOMETRY:
-                instances[SPATIAL].query( cursor, indexOrder, predicates );
-                return;
-            case TEXT:
-                instances[STRING].query( cursor, indexOrder, predicates );
-                return;
-            case DATE:
-            case LOCAL_DATE_TIME:
-            case ZONED_DATE_TIME:
-            case LOCAL_TIME:
-            case ZONED_TIME:
-            case DURATION:
-                instances[TEMPORAL].query( cursor, indexOrder, predicates );
-                return;
-            default: // fall through
-            }
-        }
-
-        // todo: There will be no ordering of the node ids here. Is this a problem?
-        if ( predicate instanceof ExistsPredicate )
+        else
         {
             if ( indexOrder != IndexOrder.NONE )
             {
@@ -191,12 +105,9 @@ class FusionIndexReader extends FusionIndexBase<IndexReader> implements IndexRea
             cursor.initialize( descriptor, multiProgressor, predicates );
             for ( IndexReader reader : instances )
             {
-                reader.query( multiProgressor, indexOrder, predicate );
+                reader.query( multiProgressor, indexOrder, predicates );
             }
-            return;
         }
-
-        instances[LUCENE].query( cursor, indexOrder, predicates );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexReader.java
@@ -113,6 +113,8 @@ class FusionIndexReader extends FusionIndexBase<IndexReader> implements IndexRea
         IndexReader instance = selector.select( instances, predicates );
         if ( instance == null )
         {
+            assert predicates.length == 1 && predicates[0] instanceof IndexQuery.ExistsPredicate :
+                    "Unexpected selector result for predicates " + Arrays.toString( predicates );
             // null means ExistsPredicate and we don't care about
             // full value precision for that, therefor true.
             return true;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexReader.java
@@ -26,6 +26,7 @@ import org.neo4j.collection.primitive.PrimitiveLongResourceIterator;
 import org.neo4j.graphdb.Resource;
 import org.neo4j.internal.kernel.api.IndexOrder;
 import org.neo4j.internal.kernel.api.IndexQuery;
+import org.neo4j.internal.kernel.api.IndexQuery.ExistsPredicate;
 import org.neo4j.kernel.api.exceptions.index.IndexNotApplicableKernelException;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
 import org.neo4j.kernel.impl.api.schema.BridgingIndexProgressor;
@@ -113,8 +114,10 @@ class FusionIndexReader extends FusionIndexBase<IndexReader> implements IndexRea
         IndexReader instance = selector.select( instances, predicates );
         if ( instance == null )
         {
-            assert predicates.length == 1 && predicates[0] instanceof IndexQuery.ExistsPredicate :
-                    "Unexpected selector result for predicates " + Arrays.toString( predicates );
+            if ( !(predicates.length == 1 && predicates[0] instanceof ExistsPredicate) )
+            {
+                throw new IllegalStateException( "Selected IndexReader null for predicates " + Arrays.toString( predicates ) );
+            }
             // null means ExistsPredicate and we don't care about
             // full value precision for that, therefor true.
             return true;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSelector00.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSelector00.java
@@ -28,7 +28,6 @@ import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.LUCENE;
 /**
  * Selector for index provider "lucene-1.x".
  * The version name "00" comes from lucene-1.x originally not being a fusion index.
- * todo If spatial and temporal will live together with lucene-1.x, update this selector. Otherwise, remove it.
  */
 public class FusionSelector00 implements FusionIndexProvider.Selector
 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSelector00.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSelector00.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema.fusion;
+
+import org.neo4j.internal.kernel.api.IndexQuery;
+import org.neo4j.storageengine.api.schema.IndexReader;
+import org.neo4j.values.storable.Value;
+
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.LUCENE;
+
+/**
+ * Selector for index provider "lucene-1.x".
+ * The version name "00" comes from lucene-1.x originally not being a fusion index.
+ * todo If spatial and temporal will live together with lucene-1.x, update this selector. Otherwise, remove it.
+ */
+public class FusionSelector00 implements FusionIndexProvider.Selector
+{
+    @Override
+    public void validateSatisfied( Object[] instances )
+    {
+        FusionIndexBase.validateSelectorInstances( instances, LUCENE );
+    }
+
+    @Override
+    public int selectSlot( Value... values )
+    {
+        return LUCENE;
+    }
+
+    @Override
+    public IndexReader select( IndexReader[] instances, IndexQuery... predicates )
+    {
+        return instances[LUCENE];
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSelector00.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSelector00.java
@@ -20,10 +20,12 @@
 package org.neo4j.kernel.impl.index.schema.fusion;
 
 import org.neo4j.internal.kernel.api.IndexQuery;
+import org.neo4j.internal.kernel.api.IndexQuery.RangePredicate;
 import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
 
+import static org.neo4j.internal.kernel.api.IndexQuery.*;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.LUCENE;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.SPATIAL;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.TEMPORAL;
@@ -73,13 +75,13 @@ public class FusionSelector00 implements FusionIndexProvider.Selector
         }
         IndexQuery predicate = predicates[0];
 
-        if ( predicate instanceof IndexQuery.ExactPredicate )
+        if ( predicate instanceof ExactPredicate )
         {
-            IndexQuery.ExactPredicate exactPredicate = (IndexQuery.ExactPredicate) predicate;
+            ExactPredicate exactPredicate = (ExactPredicate) predicate;
             return select( instances, exactPredicate.value() );
         }
 
-        if ( predicate instanceof IndexQuery.RangePredicate )
+        if ( predicate instanceof RangePredicate )
         {
             switch ( predicate.valueGroup() )
             {
@@ -95,7 +97,7 @@ public class FusionSelector00 implements FusionIndexProvider.Selector
             default: // fall through
             }
         }
-        if ( predicate instanceof IndexQuery.ExistsPredicate )
+        if ( predicate instanceof ExistsPredicate )
         {
             return null;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSelector10.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSelector10.java
@@ -26,6 +26,7 @@ import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.ValueGroup;
 import org.neo4j.values.storable.Values;
 
+import static org.neo4j.internal.kernel.api.IndexQuery.*;
 import static org.neo4j.internal.kernel.api.IndexQuery.ExactPredicate;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.LUCENE;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.NUMBER;
@@ -89,7 +90,7 @@ public class FusionSelector10 implements FusionIndexProvider.Selector
             return select( instances, exactPredicate.value() );
         }
 
-        if ( predicate instanceof IndexQuery.RangePredicate )
+        if ( predicate instanceof RangePredicate )
         {
             switch ( predicate.valueGroup() )
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSelector10.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSelector10.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema.fusion;
+
+import org.neo4j.internal.kernel.api.IndexQuery;
+import org.neo4j.internal.kernel.api.IndexQuery.ExistsPredicate;
+import org.neo4j.storageengine.api.schema.IndexReader;
+import org.neo4j.values.storable.Value;
+import org.neo4j.values.storable.ValueGroup;
+
+import static org.neo4j.internal.kernel.api.IndexQuery.ExactPredicate;
+import static org.neo4j.internal.kernel.api.IndexQuery.NumberRangePredicate;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.LUCENE;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.NUMBER;
+
+
+/**
+ * Selector for "lucene+native-1.x".
+ * Separates numbers into native index.
+ */
+public class FusionSelector10 implements FusionIndexProvider.Selector
+{
+    @Override
+    public void validateSatisfied( Object[] instances )
+    {
+        FusionIndexBase.validateSelectorInstances( instances, NUMBER, LUCENE );
+    }
+
+    @Override
+    public int selectSlot( Value... values )
+    {
+        if ( values.length > 1 )
+        {
+            // Multiple values must be handled by lucene
+            return LUCENE;
+        }
+
+        Value singleValue = values[0];
+
+        if ( singleValue.valueGroup() == ValueGroup.NUMBER )
+        {
+            return NUMBER;
+        }
+
+        return LUCENE;
+    }
+
+    @Override
+    public IndexReader select( IndexReader[] instances, IndexQuery... predicates )
+    {
+        if ( predicates.length > 1 )
+        {
+            return instances[LUCENE];
+        }
+        IndexQuery predicate = predicates[0];
+
+        if ( predicate instanceof ExactPredicate )
+        {
+            ExactPredicate exactPredicate = (ExactPredicate) predicate;
+            return select( instances, exactPredicate.value() );
+        }
+
+        if ( predicate instanceof NumberRangePredicate )
+        {
+            return instances[NUMBER];
+        }
+
+        if ( predicate instanceof ExistsPredicate )
+        {
+            return null;
+        }
+
+        return instances[LUCENE];
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSelector20.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSelector20.java
@@ -25,6 +25,7 @@ import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.ValueGroup;
 import org.neo4j.values.storable.Values;
 
+import static org.neo4j.internal.kernel.api.IndexQuery.*;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.LUCENE;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.NUMBER;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.SPATIAL;
@@ -85,18 +86,18 @@ public class FusionSelector20 implements FusionIndexProvider.Selector
         }
         IndexQuery predicate = predicates[0];
 
-        if ( predicate instanceof IndexQuery.ExactPredicate )
+        if ( predicate instanceof ExactPredicate )
         {
-            IndexQuery.ExactPredicate exactPredicate = (IndexQuery.ExactPredicate) predicate;
+            ExactPredicate exactPredicate = (ExactPredicate) predicate;
             return select( instances, exactPredicate.value() );
         }
 
-        if ( predicate instanceof IndexQuery.StringPredicate )
+        if ( predicate instanceof StringPredicate )
         {
             return instances[STRING];
         }
 
-        if ( predicate instanceof IndexQuery.RangePredicate )
+        if ( predicate instanceof RangePredicate )
         {
             switch ( predicate.valueGroup() )
             {
@@ -116,7 +117,7 @@ public class FusionSelector20 implements FusionIndexProvider.Selector
             default: // fall through
             }
         }
-        if ( predicate instanceof IndexQuery.ExistsPredicate )
+        if ( predicate instanceof ExistsPredicate )
         {
             return null;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSelector20.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSelector20.java
@@ -33,7 +33,7 @@ import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.TEMPORAL
 
 /**
  * Selector for "lucene+native-2.x".
- * Separates strings, numbers, temoporal and spatial into native index.
+ * Separates strings, numbers, temporal and spatial into native index.
  */
 public class FusionSelector20 implements FusionIndexProvider.Selector
 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/TestGraphDatabaseConfigurationMigrator.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/TestGraphDatabaseConfigurationMigrator.java
@@ -172,16 +172,16 @@ public class TestGraphDatabaseConfigurationMigrator
     {
         Map<String,String> migratedProperties = migrator.apply( stringMap( "unsupported.dbms.enable_native_schema_index", "false" ), getLog() );
         assertEquals( "Old property should be migrated to new",
-                migratedProperties, stringMap( "dbms.default_schema_index", LUCENE10.param() ));
+                migratedProperties, stringMap( "dbms.index.default_schema_provider", LUCENE10.param() ));
 
-        assertContainsWarningMessage("unsupported.dbms.enable_native_schema_index has been replaced with dbms.default_schema_index.");
+        assertContainsWarningMessage("unsupported.dbms.enable_native_schema_index has been replaced with dbms.index.default_schema_provider.");
     }
 
     @Test
     public void skipMigrationOfEnableNativeSchemaIndexIfNotPresent()
     {
-        Map<String,String> migratedProperties = migrator.apply( stringMap( "dbms.default_schema_index", NATIVE10.param() ), getLog() );
-        assertEquals( "Nothing to migrate", migratedProperties, stringMap( "dbms.default_schema_index", NATIVE10.param() ) );
+        Map<String,String> migratedProperties = migrator.apply( stringMap( "dbms.index.default_schema_provider", NATIVE10.param() ), getLog() );
+        assertEquals( "Nothing to migrate", migratedProperties, stringMap( "dbms.index.default_schema_provider", NATIVE10.param() ) );
         logProvider.assertNoLoggingOccurred();
     }
 
@@ -189,11 +189,11 @@ public class TestGraphDatabaseConfigurationMigrator
     public void skipMigrationOfEnableNativeSchemaIndexIfDefaultSchemaIndexConfigured()
     {
         Map<String,String> migratedProperties = migrator.apply( stringMap(
-                "dbms.default_schema_index", NATIVE10.param(),
+                "dbms.index.default_schema_provider", NATIVE10.param(),
                 "unsupported.dbms.enable_native_schema_index", "false"
                 ), getLog() );
         assertEquals( "Should keep pre configured default schema index.",
-                migratedProperties, stringMap( "dbms.default_schema_index", NATIVE10.param() ) );
+                migratedProperties, stringMap( "dbms.index.default_schema_provider", NATIVE10.param() ) );
         assertContainsWarningMessage();
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/TestGraphDatabaseConfigurationMigrator.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/TestGraphDatabaseConfigurationMigrator.java
@@ -33,6 +33,8 @@ import org.neo4j.logging.NullLog;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.SchemaIndex.LUCENE10;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.SchemaIndex.NATIVE10;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 /**
@@ -163,6 +165,36 @@ public class TestGraphDatabaseConfigurationMigrator
                 migratedProperties, stringMap( "dbms.allow_upgrade", "true" ));
 
         assertContainsWarningMessage("dbms.allow_format_migration has been replaced with dbms.allow_upgrade.");
+    }
+
+    @Test
+    public void migrateEnableNativeSchemaIndex()
+    {
+        Map<String,String> migratedProperties = migrator.apply( stringMap( "unsupported.dbms.enable_native_schema_index", "false" ), getLog() );
+        assertEquals( "Old property should be migrated to new",
+                migratedProperties, stringMap( "dbms.default_schema_index", LUCENE10.param() ));
+
+        assertContainsWarningMessage("unsupported.dbms.enable_native_schema_index has been replaced with dbms.default_schema_index.");
+    }
+
+    @Test
+    public void skipMigrationOfEnableNativeSchemaIndexIfNotPresent()
+    {
+        Map<String,String> migratedProperties = migrator.apply( stringMap( "dbms.default_schema_index", NATIVE10.param() ), getLog() );
+        assertEquals( "Nothing to migrate", migratedProperties, stringMap( "dbms.default_schema_index", NATIVE10.param() ) );
+        logProvider.assertNoLoggingOccurred();
+    }
+
+    @Test
+    public void skipMigrationOfEnableNativeSchemaIndexIfDefaultSchemaIndexConfigured()
+    {
+        Map<String,String> migratedProperties = migrator.apply( stringMap(
+                "dbms.default_schema_index", NATIVE10.param(),
+                "unsupported.dbms.enable_native_schema_index", "false"
+                ), getLog() );
+        assertEquals( "Should keep pre configured default schema index.",
+                migratedProperties, stringMap( "dbms.default_schema_index", NATIVE10.param() ) );
+        assertContainsWarningMessage();
     }
 
     private Log getLog()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulatorTest.java
@@ -21,11 +21,15 @@ package org.neo4j.kernel.impl.index.schema.fusion;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
@@ -45,30 +49,85 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.neo4j.helpers.ArrayUtil.contains;
-import static org.neo4j.helpers.ArrayUtil.without;
-import static org.neo4j.helpers.collection.Iterators.array;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.INSTANCE_COUNT;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.LUCENE;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.NUMBER;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.SPATIAL;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.STRING;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.TEMPORAL;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexTestHelp.add;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexTestHelp.verifyCallFail;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionVersion.v00;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionVersion.v10;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionVersion.v20;
 
+@RunWith( Parameterized.class )
 public class FusionIndexPopulatorTest
 {
-    private IndexPopulator lucenePopulator;
-    private IndexPopulator[] allPopulators;
+    private IndexPopulator[] alivePopulators;
+    private IndexPopulator[] populators;
     private FusionIndexPopulator fusionIndexPopulator;
     private final long indexId = 8;
     private final DropAction dropAction = mock( DropAction.class );
 
-    @Before
-    public void mockComponents()
+    @Parameterized.Parameters( name = "{0}" )
+    public static FusionVersion[] versions()
     {
-        IndexPopulator stringPopulator = mock( IndexPopulator.class );
-        IndexPopulator numberPopulator = mock( IndexPopulator.class );
-        IndexPopulator spatialPopulator = mock( IndexPopulator.class );
-        IndexPopulator temporalPopulator = mock( IndexPopulator.class );
-        lucenePopulator = mock( IndexPopulator.class );
-        allPopulators = array( stringPopulator, numberPopulator, spatialPopulator, temporalPopulator, lucenePopulator );
-        fusionIndexPopulator = new FusionIndexPopulator( allPopulators, new FusionSelector(), indexId, dropAction );
+        return new FusionVersion[]
+                {
+                        v00, v10, v20
+                };
+    }
+
+    @Parameterized.Parameter
+    public static FusionVersion fusionVersion;
+
+    @Before
+    public void setup()
+    {
+        initiateMocks();
+    }
+
+    private void initiateMocks()
+    {
+        int[] aliveSlots = fusionVersion.aliveSlots();
+        populators = new IndexPopulator[INSTANCE_COUNT];
+        Arrays.fill( populators, IndexPopulator.EMPTY );
+        alivePopulators = new IndexPopulator[aliveSlots.length];
+        for ( int i = 0; i < aliveSlots.length; i++ )
+        {
+            IndexPopulator mock = mock( IndexPopulator.class );
+            alivePopulators[i] = mock;
+            switch ( aliveSlots[i] )
+            {
+            case STRING:
+                populators[STRING] = mock;
+                break;
+            case NUMBER:
+                populators[NUMBER] = mock;
+                break;
+            case SPATIAL:
+                populators[SPATIAL] = mock;
+                break;
+            case TEMPORAL:
+                populators[TEMPORAL] = mock;
+                break;
+            case LUCENE:
+                populators[LUCENE] = mock;
+                break;
+            default:
+                throw new RuntimeException();
+            }
+        }
+        fusionIndexPopulator = new FusionIndexPopulator( populators, fusionVersion.selector(), indexId, dropAction );
+    }
+
+    private void resetMocks()
+    {
+        for ( IndexPopulator alivePopulator : alivePopulators )
+        {
+            reset( alivePopulator );
+        }
     }
 
     /* create */
@@ -80,20 +139,20 @@ public class FusionIndexPopulatorTest
         fusionIndexPopulator.create();
 
         // then
-        for ( IndexPopulator populator : allPopulators )
+        for ( IndexPopulator alivePopulator : alivePopulators )
         {
-            verify( populator, times( 1 ) ).create();
+            verify( alivePopulator, times( 1 ) ).create();
         }
     }
 
     @Test
     public void createMustThrowIfAnyThrow() throws Exception
     {
-        for ( IndexPopulator populator : allPopulators )
+        for ( IndexPopulator alivePopulator : alivePopulators )
         {
             // given
             IOException failure = new IOException( "fail" );
-            doThrow( failure ).when( populator ).create();
+            doThrow( failure ).when( alivePopulator ).create();
 
             verifyCallFail( failure, () ->
             {
@@ -102,7 +161,7 @@ public class FusionIndexPopulatorTest
             } );
 
             // reset throw for testing of next populator
-            doAnswer( invocation -> null ).when( populator ).create();
+            doAnswer( invocation -> null ).when( alivePopulator ).create();
         }
     }
 
@@ -115,9 +174,9 @@ public class FusionIndexPopulatorTest
         fusionIndexPopulator.drop();
 
         // then
-        for ( IndexPopulator populator : allPopulators )
+        for ( IndexPopulator alivePopulator : alivePopulators )
         {
-            verify( populator, times( 1 ) ).drop();
+            verify( alivePopulator, times( 1 ) ).drop();
         }
         verify( dropAction ).drop( indexId );
     }
@@ -125,11 +184,11 @@ public class FusionIndexPopulatorTest
     @Test
     public void dropMustThrowIfAnyDropThrow() throws Exception
     {
-        for ( IndexPopulator populator : allPopulators )
+        for ( IndexPopulator alivePopulator : alivePopulators )
         {
             // given
             IOException failure = new IOException( "fail" );
-            doThrow( failure ).when( populator ).drop();
+            doThrow( failure ).when( alivePopulator ).drop();
 
             verifyCallFail( failure, () ->
             {
@@ -138,7 +197,7 @@ public class FusionIndexPopulatorTest
             } );
 
             // reset throw for testing of next populator
-            doAnswer( invocation -> null ).when( populator ).drop();
+            doAnswer( invocation -> null ).when( alivePopulator ).drop();
         }
     }
 
@@ -151,11 +210,11 @@ public class FusionIndexPopulatorTest
         Value[][] values = FusionIndexTestHelp.valuesByGroup();
         Value[] allValues = FusionIndexTestHelp.allValues();
 
-        for ( int i = 0; i < allPopulators.length; i++ )
+        for ( int i = 0; i < populators.length; i++ )
         {
             for ( Value value : values[i] )
             {
-                verifyAddWithCorrectPopulator( allPopulators[i], value );
+                verifyAddWithCorrectPopulator( orLucene( populators[i] ), value );
             }
         }
 
@@ -164,7 +223,7 @@ public class FusionIndexPopulatorTest
         {
             for ( Value secondValue : allValues )
             {
-                verifyAddWithCorrectPopulator( lucenePopulator, firstValue, secondValue );
+                verifyAddWithCorrectPopulator( populators[FusionIndexBase.LUCENE], firstValue, secondValue );
             }
         }
     }
@@ -175,11 +234,11 @@ public class FusionIndexPopulatorTest
         Collection<IndexEntryUpdate<LabelSchemaDescriptor>> update = Collections.singletonList( add( numberValues ) );
         fusionIndexPopulator.add( update );
         verify( correctPopulator, times( 1 ) ).add( update );
-        for ( IndexPopulator populator : allPopulators )
+        for ( IndexPopulator alivePopulator : alivePopulators )
         {
-            if ( populator != correctPopulator )
+            if ( alivePopulator != correctPopulator )
             {
-                verify( populator, never() ).add( update );
+                verify( alivePopulator, never() ).add( update );
             }
         }
     }
@@ -188,11 +247,11 @@ public class FusionIndexPopulatorTest
     @Test
     public void verifyDeferredConstraintsMustThrowIfAnyThrow() throws Exception
     {
-        for ( IndexPopulator populator : allPopulators )
+        for ( IndexPopulator alivePopulator : alivePopulators )
         {
             // given
             IndexEntryConflictException failure = mock( IndexEntryConflictException.class );
-            doThrow( failure ).when( populator ).verifyDeferredConstraints( any() );
+            doThrow( failure ).when( alivePopulator ).verifyDeferredConstraints( any() );
 
             verifyCallFail( failure, () ->
             {
@@ -201,7 +260,7 @@ public class FusionIndexPopulatorTest
             } );
 
             // reset throw for testing of next populator
-            doAnswer( invocation -> null ).when( populator ).verifyDeferredConstraints( any() );
+            doAnswer( invocation -> null ).when( alivePopulator ).verifyDeferredConstraints( any() );
         }
     }
 
@@ -225,20 +284,20 @@ public class FusionIndexPopulatorTest
         fusionIndexPopulator.close( populationCompletedSuccessfully );
 
         // then
-        for ( IndexPopulator populator : allPopulators )
+        for ( IndexPopulator alivePopulator : alivePopulators )
         {
-            verify( populator, times( 1 ) ).close( populationCompletedSuccessfully );
+            verify( alivePopulator, times( 1 ) ).close( populationCompletedSuccessfully );
         }
     }
 
     @Test
     public void closeMustThrowIfCloseAnyThrow() throws Exception
     {
-        for ( IndexPopulator populator : allPopulators )
+        for ( IndexPopulator alivePopulator : alivePopulators )
         {
             // given
             IOException failure = new IOException( "fail" );
-            doThrow( failure ).when( populator ).close( anyBoolean() );
+            doThrow( failure ).when( alivePopulator ).close( anyBoolean() );
 
             verifyCallFail( failure, () ->
             {
@@ -247,12 +306,11 @@ public class FusionIndexPopulatorTest
             } );
 
             // reset throw for testing of next populator
-            doAnswer( invocation -> null ).when( populator ).close( anyBoolean() );
+            doAnswer( invocation -> null ).when( alivePopulator ).close( anyBoolean() );
         }
     }
 
-    private static void verifyOtherCloseOnThrow( IndexPopulator throwingPopulator, FusionIndexPopulator fusionPopulator, IndexPopulator... populators )
-            throws Exception
+    private void verifyOtherCloseOnThrow( IndexPopulator throwingPopulator ) throws Exception
     {
         // given
         IOException failure = new IOException( "fail" );
@@ -261,7 +319,7 @@ public class FusionIndexPopulatorTest
         // when
         try
         {
-            fusionPopulator.close( true );
+            fusionIndexPopulator.close( true );
             fail( "Should have failed" );
         }
         catch ( IOException ignore )
@@ -269,20 +327,19 @@ public class FusionIndexPopulatorTest
         }
 
         // then
-        for ( IndexPopulator populator : populators )
+        for ( IndexPopulator alivePopulator : alivePopulators )
         {
-            verify( populator, times( 1 ) ).close( true );
+            verify( alivePopulator, times( 1 ) ).close( true );
         }
     }
 
     @Test
     public void closeMustCloseOthersIfAnyThrow() throws Exception
     {
-        for ( int i = 0; i < allPopulators.length; i++ )
+        for ( IndexPopulator throwingPopulator : alivePopulators )
         {
-            IndexPopulator populator = allPopulators[i];
-            verifyOtherCloseOnThrow( populator, fusionIndexPopulator, without( allPopulators, populator ) );
-            mockComponents();
+            verifyOtherCloseOnThrow( throwingPopulator );
+            resetMocks();
         }
     }
 
@@ -290,11 +347,12 @@ public class FusionIndexPopulatorTest
     public void closeMustThrowIfAllThrow() throws Exception
     {
         // given
-        IOException[] failures = new IOException[allPopulators.length];
-        for ( int i = 0; i < allPopulators.length; i++ )
+        List<IOException> failures = new ArrayList<>();
+        for ( IndexPopulator alivePopulator : alivePopulators )
         {
-            failures[i] = new IOException( "FAILURE[" + i + "]" );
-            doThrow( failures[i] ).when( allPopulators[i] ).close( anyBoolean() );
+            IOException failure = new IOException( "FAILURE[" + alivePopulator + "]" );
+            failures.add( failure );
+            doThrow( failure ).when( alivePopulator ).close( anyBoolean() );
         }
 
         try
@@ -306,9 +364,9 @@ public class FusionIndexPopulatorTest
         catch ( IOException e )
         {
             // then
-            if ( !contains( failures, e ) )
+            if ( !failures.contains( e ) )
             {
-                fail( "Thrown exception didn't matchh any of the expected failures: " + Arrays.toString( failures ) );
+                fail( "Thrown exception didn't match any of the expected failures: " + failures );
             }
         }
     }
@@ -322,20 +380,20 @@ public class FusionIndexPopulatorTest
         fusionIndexPopulator.markAsFailed( failureMessage );
 
         // then
-        for ( IndexPopulator populator : allPopulators )
+        for ( IndexPopulator alivePopulator : alivePopulators )
         {
-            verify( populator, times( 1 ) ).markAsFailed( failureMessage );
+            verify( alivePopulator, times( 1 ) ).markAsFailed( failureMessage );
         }
     }
 
     @Test
     public void markAsFailedMustThrowIfAnyThrow() throws Exception
     {
-        for ( IndexPopulator populator : allPopulators )
+        for ( IndexPopulator alivePopulator : alivePopulators )
         {
             // given
             IOException failure = new IOException( "fail" );
-            doThrow( failure ).when( populator ).markAsFailed( anyString() );
+            doThrow( failure ).when( alivePopulator ).markAsFailed( anyString() );
 
             // then
             verifyCallFail( failure, () ->
@@ -345,7 +403,7 @@ public class FusionIndexPopulatorTest
             } );
 
             // reset throw for testing of next populator
-            doAnswer( invocation -> null ).when( populator ).markAsFailed( anyString() );
+            doAnswer( invocation -> null ).when( alivePopulator ).markAsFailed( anyString() );
         }
     }
 
@@ -355,9 +413,9 @@ public class FusionIndexPopulatorTest
         // given
         Value[][] values = FusionIndexTestHelp.valuesByGroup();
 
-        for ( int i = 0; i < allPopulators.length; i++ )
+        for ( int activeSlot : fusionVersion.aliveSlots() )
         {
-            verifySampleToCorrectPopulator( values[i], allPopulators[i] );
+            verifySampleToCorrectPopulator( values[activeSlot], populators[activeSlot] );
         }
     }
 
@@ -373,5 +431,10 @@ public class FusionIndexPopulatorTest
             verify( populator ).includeSample( update );
             reset( populator );
         }
+    }
+
+    private IndexPopulator orLucene( IndexPopulator populator )
+    {
+        return populator != IndexPopulator.EMPTY ? populator : populators[LUCENE];
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexProviderTest.java
@@ -22,6 +22,12 @@ package org.neo4j.kernel.impl.index.schema.fusion;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import org.neo4j.internal.kernel.api.InternalIndexState;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -49,32 +55,43 @@ import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.ArrayUtil.array;
 import static org.neo4j.kernel.api.index.IndexDirectoryStructure.NONE;
 import static org.neo4j.kernel.api.schema.index.SchemaIndexDescriptorFactory.forLabel;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.INSTANCE_COUNT;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.LUCENE;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.NUMBER;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.SPATIAL;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.STRING;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.TEMPORAL;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionVersion.v00;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionVersion.v10;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionVersion.v20;
 
+@RunWith( Parameterized.class )
 public class FusionIndexProviderTest
 {
     private static final IndexProvider.Descriptor DESCRIPTOR = new IndexProvider.Descriptor( "test-fusion", "1" );
 
-    private StringIndexProvider stringProvider;
-    private NumberIndexProvider numberProvider;
-    private SpatialIndexProvider spatialProvider;
-    private TemporalIndexProvider temporalProvider;
-    private IndexProvider luceneProvider;
     private IndexProvider[] providers;
+    private IndexProvider[] aliveProviders;
+    private IndexProvider fusionIndexProvider;
+    private Selector selector;
+
+    @Parameterized.Parameters( name = "{0}" )
+    public static FusionVersion[] versions()
+    {
+        return new FusionVersion[]
+                {
+                        v00, v10, v20
+                };
+    }
+
+    @Parameterized.Parameter
+    public static FusionVersion fusionVersion;
 
     @Before
     public void setup()
     {
-        stringProvider = mock( StringIndexProvider.class );
-        numberProvider = mock( NumberIndexProvider.class );
-        spatialProvider = mock( SpatialIndexProvider.class );
-        temporalProvider = mock( TemporalIndexProvider.class );
-        luceneProvider = mock( IndexProvider.class );
-        when( stringProvider.getProviderDescriptor() ).thenReturn( new IndexProvider.Descriptor( "string", "1" ) );
-        when( numberProvider.getProviderDescriptor() ).thenReturn( new IndexProvider.Descriptor( "number", "1" ) );
-        when( spatialProvider.getProviderDescriptor() ).thenReturn( new IndexProvider.Descriptor( "spatial", "1" ) );
-        when( temporalProvider.getProviderDescriptor() ).thenReturn( new IndexProvider.Descriptor( "temporal", "1" ) );
-        when( luceneProvider.getProviderDescriptor() ).thenReturn( new IndexProvider.Descriptor( "lucene", "1" ) );
-        providers = array( stringProvider, numberProvider, spatialProvider, temporalProvider, luceneProvider );
+        selector = fusionVersion.selector();
+        setupMocks();
     }
 
     @Rule
@@ -86,7 +103,6 @@ public class FusionIndexProviderTest
         // given
         Value[][] values = FusionIndexTestHelp.valuesByGroup();
         Value[] allValues = FusionIndexTestHelp.allValues();
-        Selector selector = new FusionSelector();
 
         for ( int i = 0; i < values.length; i++ )
         {
@@ -97,7 +113,7 @@ public class FusionIndexProviderTest
                 IndexProvider selected = selector.select( providers, value );
 
                 // then
-                assertSame( providers[i], selected );
+                assertSame( orLucene( providers[i] ), selected );
             }
         }
 
@@ -110,7 +126,7 @@ public class FusionIndexProviderTest
                 IndexProvider selected = selector.select( providers, firstValue, secondValue );
 
                 // then
-                assertSame( luceneProvider, selected );
+                assertSame( providers[LUCENE], selected );
             }
         }
     }
@@ -146,13 +162,10 @@ public class FusionIndexProviderTest
     @Test
     public void getPopulationFailureMustThrowIfNoFailure()
     {
-        // given
-        FusionIndexProvider fusionIndexProvider = fusionProvider();
-
         // when
         // ... no failure
         IllegalStateException failure = new IllegalStateException( "not failed" );
-        for ( IndexProvider provider : providers )
+        for ( IndexProvider provider : aliveProviders )
         {
             when( provider.getPopulationFailure( anyLong(), any( SchemaIndexDescriptor.class ) ) ).thenThrow( failure );
         }
@@ -171,48 +184,45 @@ public class FusionIndexProviderTest
     @Test
     public void getPopulationFailureMustReportFailureWhenAnyFailed()
     {
-        for ( int i = 0; i < providers.length; i++ )
+        for ( IndexProvider failingProvider : aliveProviders )
         {
-            FusionIndexProvider fusionSchemaIndexProvider = fusionProvider();
-
             // when
             String failure = "failure";
             IllegalStateException exception = new IllegalStateException( "not failed" );
-            for ( int j = 0; j < providers.length; j++ )
+            for ( IndexProvider provider : aliveProviders )
             {
-                if ( j == i )
+                if ( provider == failingProvider )
                 {
-                    when( providers[j].getPopulationFailure( anyLong(), any( SchemaIndexDescriptor.class ) ) ).thenReturn( failure );
+                    when( provider.getPopulationFailure( anyLong(), any( SchemaIndexDescriptor.class ) ) ).thenReturn( failure );
                 }
                 else
                 {
-                    when( providers[j].getPopulationFailure( anyLong(), any( SchemaIndexDescriptor.class ) ) ).thenThrow( exception );
+                    when( provider.getPopulationFailure( anyLong(), any( SchemaIndexDescriptor.class ) ) ).thenThrow( exception );
                 }
             }
 
             // then
-            assertThat( fusionSchemaIndexProvider.getPopulationFailure( 0, forLabel( 0, 0 ) ), containsString( failure ) );
+            assertThat( fusionIndexProvider.getPopulationFailure( 0, forLabel( 0, 0 ) ), containsString( failure ) );
         }
     }
 
     @Test
     public void getPopulationFailureMustReportFailureWhenMultipleFail()
     {
-        FusionIndexProvider fusionSchemaIndexProvider = fusionProvider();
-
         // when
-        String[] failures = new String[providers.length];
-        for ( int i = 0; i < providers.length; i++ )
+        List<String> failureMessages = new ArrayList<>();
+        for ( IndexProvider aliveProvider : aliveProviders )
         {
-            failures[i] = "FAILURE[" + i + "]";
-            when( providers[i].getPopulationFailure( anyLong(), any( SchemaIndexDescriptor.class ) ) ).thenReturn( failures[i] );
+            String failureMessage = "FAILURE[" + aliveProvider + "]";
+            failureMessages.add( failureMessage );
+            when( aliveProvider.getPopulationFailure( anyLong(), any( SchemaIndexDescriptor.class ) ) ).thenReturn( failureMessage );
         }
 
         // then
-        String populationFailure = fusionSchemaIndexProvider.getPopulationFailure( 0, forLabel( 0, 0 ) );
-        for ( String failure : failures )
+        String populationFailure = fusionIndexProvider.getPopulationFailure( 0, forLabel( 0, 0 ) );
+        for ( String failureMessage : failureMessages )
         {
-            assertThat( populationFailure, containsString( failure ) );
+            assertThat( populationFailure, containsString( failureMessage ) );
         }
     }
 
@@ -220,17 +230,17 @@ public class FusionIndexProviderTest
     public void shouldReportFailedIfAnyIsFailed()
     {
         // given
-        IndexProvider provider = fusionProvider();
+        IndexProvider provider = fusionIndexProvider;
         SchemaIndexDescriptor schemaIndexDescriptor = SchemaIndexDescriptorFactory.forLabel( 1, 1 );
 
         for ( InternalIndexState state : InternalIndexState.values() )
         {
-            for ( int i = 0; i < providers.length; i++ )
+            for ( IndexProvider failedProvider : aliveProviders )
             {
                 // when
-                for ( int j = 0; j < providers.length; j++ )
+                for ( IndexProvider aliveProvider : aliveProviders )
                 {
-                    setInitialState( providers[j], i == j ? InternalIndexState.FAILED : state );
+                    setInitialState( aliveProvider, failedProvider == aliveProvider ? InternalIndexState.FAILED : state );
                 }
                 InternalIndexState initialState = provider.getInitialState( 0, schemaIndexDescriptor );
 
@@ -244,19 +254,18 @@ public class FusionIndexProviderTest
     public void shouldReportPopulatingIfAnyIsPopulating()
     {
         // given
-        IndexProvider provider = fusionProvider();
         SchemaIndexDescriptor schemaIndexDescriptor = SchemaIndexDescriptorFactory.forLabel( 1, 1 );
 
         for ( InternalIndexState state : array( InternalIndexState.ONLINE, InternalIndexState.POPULATING ) )
         {
-            for ( int i = 0; i < providers.length; i++ )
+            for ( IndexProvider populatingProvider : aliveProviders )
             {
                 // when
-                for ( int j = 0; j < providers.length; j++ )
+                for ( IndexProvider aliveProvider : aliveProviders )
                 {
-                    setInitialState( providers[j], i == j ? InternalIndexState.POPULATING : state );
+                    setInitialState( aliveProvider, populatingProvider == aliveProvider ? InternalIndexState.POPULATING : state );
                 }
-                InternalIndexState initialState = provider.getInitialState( 0, schemaIndexDescriptor );
+                InternalIndexState initialState = fusionIndexProvider.getInitialState( 0, schemaIndexDescriptor );
 
                 // then
                 assertEquals( InternalIndexState.POPULATING, initialState );
@@ -264,14 +273,68 @@ public class FusionIndexProviderTest
         }
     }
 
-    private FusionIndexProvider fusionProvider()
+    private void setupMocks()
     {
-        return new FusionIndexProvider( stringProvider, numberProvider, spatialProvider, temporalProvider, luceneProvider, new FusionSelector(),
-                DESCRIPTOR, 10, NONE, mock( FileSystemAbstraction.class ) );
+        int[] aliveSlots = fusionVersion.aliveSlots();
+        aliveProviders = new IndexProvider[aliveSlots.length];
+        providers = new IndexProvider[INSTANCE_COUNT];
+        Arrays.fill( providers, IndexProvider.EMPTY );
+        for ( int i = 0; i < aliveSlots.length; i++ )
+        {
+            switch ( aliveSlots[i] )
+            {
+            case STRING:
+                IndexProvider string = mockProvider( StringIndexProvider.class, "string" );
+                providers[STRING] = string;
+                aliveProviders[i] = string;
+                break;
+            case NUMBER:
+                IndexProvider number = mockProvider( NumberIndexProvider.class, "number" );
+                providers[NUMBER] = number;
+                aliveProviders[i] = number;
+                break;
+            case SPATIAL:
+                IndexProvider spatial = mockProvider( SpatialIndexProvider.class, "spatial" );
+                providers[SPATIAL] = spatial;
+                aliveProviders[i] = spatial;
+                break;
+            case TEMPORAL:
+                IndexProvider temporal = mockProvider( TemporalIndexProvider.class, "temporal" );
+                providers[TEMPORAL] = temporal;
+                aliveProviders[i] = temporal;
+                break;
+            case LUCENE:
+                IndexProvider lucene = mockProvider( IndexProvider.class, "lucene" );
+                providers[LUCENE] = lucene;
+                aliveProviders[i] = lucene;
+                break;
+            default:
+                throw new RuntimeException();
+            }
+        }
+        fusionIndexProvider = new FusionIndexProvider(
+                providers[STRING],
+                providers[NUMBER],
+                providers[SPATIAL],
+                providers[TEMPORAL],
+                providers[LUCENE],
+                fusionVersion.selector(), DESCRIPTOR, 10, NONE, mock( FileSystemAbstraction.class ) );
+    }
+
+    private IndexProvider mockProvider( Class<? extends IndexProvider> providerClass, String name )
+    {
+        IndexProvider mock = mock( providerClass );
+        when( mock.getProviderDescriptor() ).thenReturn( new IndexProvider.Descriptor( name, "1" ) );
+        return mock;
     }
 
     private void setInitialState( IndexProvider mockedProvider, InternalIndexState state )
     {
         when( mockedProvider.getInitialState( anyLong(), any( SchemaIndexDescriptor.class ) ) ).thenReturn( state );
+    }
+
+    private IndexProvider orLucene( IndexProvider provider )
+    {
+        return provider != IndexProvider.EMPTY ? provider : providers[LUCENE];
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexReaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexReaderTest.java
@@ -21,6 +21,10 @@ package org.neo4j.kernel.impl.index.schema.fusion;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
 
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
@@ -41,6 +45,7 @@ import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -48,30 +53,75 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static org.neo4j.helpers.collection.Iterators.array;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.INSTANCE_COUNT;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.LUCENE;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.NUMBER;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.SPATIAL;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.STRING;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.TEMPORAL;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionVersion.v00;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionVersion.v10;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionVersion.v20;
 
+@RunWith( Parameterized.class )
 public class FusionIndexReaderTest
 {
-    private IndexReader stringReader;
-    private IndexReader numberReader;
-    private IndexReader spatialReader;
-    private IndexReader luceneReader;
-    private IndexReader temporalReader;
-    private IndexReader[] allReaders;
+    private IndexReader[] aliveReaders;
+    private IndexReader[] readers;
     private FusionIndexReader fusionIndexReader;
     private static final int PROP_KEY = 1;
     private static final int LABEL_KEY = 11;
 
+    @Parameterized.Parameters( name = "{0}" )
+    public static FusionVersion[] versions()
+    {
+        return new FusionVersion[]
+                {
+                        v00, v10, v20
+                };
+    }
+
+    @Parameterized.Parameter
+    public static FusionVersion fusionVersion;
+
     @Before
     public void setup()
     {
-        stringReader = mock( IndexReader.class );
-        numberReader = mock( IndexReader.class );
-        spatialReader = mock( IndexReader.class );
-        temporalReader = mock( IndexReader.class );
-        luceneReader = mock( IndexReader.class );
-        allReaders = array( stringReader, numberReader, spatialReader, temporalReader, luceneReader );
-        fusionIndexReader = new FusionIndexReader( allReaders, new FusionSelector(), SchemaIndexDescriptorFactory.forLabel( LABEL_KEY, PROP_KEY ) );
+        initiateMocks();
+    }
+
+    private void initiateMocks()
+    {
+        int[] activeSlots = fusionVersion.aliveSlots();
+        readers = new IndexReader[INSTANCE_COUNT];
+        Arrays.fill( readers, IndexReader.EMPTY );
+        aliveReaders = new IndexReader[activeSlots.length];
+        for ( int i = 0; i < activeSlots.length; i++ )
+        {
+            IndexReader mock = mock( IndexReader.class );
+            aliveReaders[i] = mock;
+            switch ( activeSlots[i] )
+            {
+            case STRING:
+                readers[STRING] = mock;
+                break;
+            case NUMBER:
+                readers[NUMBER] = mock;
+                break;
+            case SPATIAL:
+                readers[SPATIAL] = mock;
+                break;
+            case TEMPORAL:
+                readers[TEMPORAL] = mock;
+                break;
+            case LUCENE:
+                readers[LUCENE] = mock;
+                break;
+            default:
+                throw new RuntimeException();
+            }
+        }
+        fusionIndexReader = new FusionIndexReader( readers, fusionVersion.selector(), SchemaIndexDescriptorFactory.forLabel( LABEL_KEY, PROP_KEY ) );
     }
 
     /* close */
@@ -83,7 +133,7 @@ public class FusionIndexReaderTest
         fusionIndexReader.close();
 
         // then
-        for ( IndexReader reader : allReaders )
+        for ( IndexReader reader : aliveReaders )
         {
             verify( reader, times( 1 ) ).close();
         }
@@ -95,11 +145,11 @@ public class FusionIndexReaderTest
     public void closeIteratorMustCloseAll() throws Exception
     {
         // given
-        PrimitiveLongResourceIterator[] iterators = new PrimitiveLongResourceIterator[allReaders.length];
-        for ( int i = 0; i < allReaders.length; i++ )
+        PrimitiveLongResourceIterator[] iterators = new PrimitiveLongResourceIterator[aliveReaders.length];
+        for ( int i = 0; i < aliveReaders.length; i++ )
         {
             PrimitiveLongResourceIterator iterator = mock( PrimitiveLongResourceIterator.class );
-            when( allReaders[i].query( any( IndexQuery.class ) ) ).thenReturn( iterator );
+            when( aliveReaders[i].query( any( IndexQuery.class ) ) ).thenReturn( iterator );
             iterators[i] = iterator;
         }
 
@@ -122,11 +172,11 @@ public class FusionIndexReaderTest
         Value[][] values = FusionIndexTestHelp.valuesByGroup();
         Value[] allValues = FusionIndexTestHelp.allValues();
 
-        for ( int i = 0; i < allReaders.length; i++ )
+        for ( int i = 0; i < readers.length; i++ )
         {
             for ( Value value : values[i] )
             {
-                verifyCountIndexedNodesWithCorrectReader( allReaders[i], value );
+                verifyCountIndexedNodesWithCorrectReader( orLucene( readers[i] ), value );
             }
         }
 
@@ -135,7 +185,7 @@ public class FusionIndexReaderTest
         {
             for ( Value secondValue : allValues )
             {
-                verifyCountIndexedNodesWithCorrectReader( luceneReader, firstValue, secondValue );
+                verifyCountIndexedNodesWithCorrectReader( readers[LUCENE], firstValue, secondValue );
             }
         }
     }
@@ -144,7 +194,7 @@ public class FusionIndexReaderTest
     {
         fusionIndexReader.countIndexedNodes( 0, nativeValue );
         verify( correct, times( 1 ) ).countIndexedNodes( 0, nativeValue );
-        for ( IndexReader reader : allReaders )
+        for ( IndexReader reader : aliveReaders )
         {
             if ( reader != correct )
             {
@@ -159,7 +209,7 @@ public class FusionIndexReaderTest
     public void mustSelectLuceneForCompositePredicate() throws Exception
     {
         // then
-        verifyQueryWithCorrectReader( luceneReader, any( IndexQuery.class ), any( IndexQuery.class ) );
+        verifyQueryWithCorrectReader( readers[LUCENE], any( IndexQuery.class ), any( IndexQuery.class ) );
     }
 
     @Test
@@ -171,7 +221,7 @@ public class FusionIndexReaderTest
             IndexQuery indexQuery = IndexQuery.exact( PROP_KEY, value );
 
             // then
-            verifyQueryWithCorrectReader( stringReader, indexQuery );
+            verifyQueryWithCorrectReader( expectedForStrings(), indexQuery );
         }
     }
 
@@ -184,7 +234,7 @@ public class FusionIndexReaderTest
             IndexQuery indexQuery = IndexQuery.exact( PROP_KEY, value );
 
             // then
-            verifyQueryWithCorrectReader( numberReader, indexQuery );
+            verifyQueryWithCorrectReader( expectedForNumbers(), indexQuery );
         }
     }
 
@@ -192,12 +242,13 @@ public class FusionIndexReaderTest
     public void mustSelectSpatialForExactPredicateWithSpatialValue() throws Exception
     {
         // given
+        assumeTrue( hasSpatialSupport() );
         for ( Object value : FusionIndexTestHelp.valuesSupportedBySpatial() )
         {
             IndexQuery indexQuery = IndexQuery.exact( PROP_KEY, value );
 
             // then
-            verifyQueryWithCorrectReader( spatialReader, indexQuery );
+            verifyQueryWithCorrectReader( readers[SPATIAL], indexQuery );
         }
     }
 
@@ -205,12 +256,13 @@ public class FusionIndexReaderTest
     public void mustSelectTemporalForExactPredicateWithTemporalValue() throws Exception
     {
         // given
+        assumeTrue( hasTemporalSupport() );
         for ( Object temporalValue : FusionIndexTestHelp.valuesSupportedByTemporal() )
         {
             IndexQuery indexQuery = IndexQuery.exact( PROP_KEY, temporalValue );
 
             // then
-            verifyQueryWithCorrectReader( temporalReader, indexQuery );
+            verifyQueryWithCorrectReader( readers[TEMPORAL], indexQuery );
         }
     }
 
@@ -223,7 +275,7 @@ public class FusionIndexReaderTest
             IndexQuery indexQuery = IndexQuery.exact( PROP_KEY, value );
 
             // then
-            verifyQueryWithCorrectReader( luceneReader, indexQuery );
+            verifyQueryWithCorrectReader( readers[LUCENE], indexQuery );
         }
     }
 
@@ -234,7 +286,7 @@ public class FusionIndexReaderTest
         RangePredicate stringRange = IndexQuery.range( PROP_KEY, "abc", true, "def", false );
 
         // then
-        verifyQueryWithCorrectReader( stringReader, stringRange );
+        verifyQueryWithCorrectReader( expectedForStrings(), stringRange );
     }
 
     @Test
@@ -244,19 +296,20 @@ public class FusionIndexReaderTest
         RangePredicate numberRange = IndexQuery.range( PROP_KEY, 0, true, 1, false );
 
         // then
-        verifyQueryWithCorrectReader( numberReader, numberRange );
+        verifyQueryWithCorrectReader( expectedForNumbers(), numberRange );
     }
 
     @Test
     public void mustSelectSpatialForRangeGeometricPredicate() throws Exception
     {
         // given
+        assumeTrue( hasSpatialSupport() );
         PointValue from = Values.pointValue( CoordinateReferenceSystem.Cartesian, 1.0, 1.0);
         PointValue to = Values.pointValue( CoordinateReferenceSystem.Cartesian, 2.0, 2.0);
         RangePredicate geometryRange = IndexQuery.range( PROP_KEY, from, true, to, false );
 
         // then
-        verifyQueryWithCorrectReader( spatialReader, geometryRange );
+        verifyQueryWithCorrectReader( readers[SPATIAL], geometryRange );
     }
 
     @Test
@@ -266,7 +319,7 @@ public class FusionIndexReaderTest
         StringPrefixPredicate stringPrefix = IndexQuery.stringPrefix( PROP_KEY, "abc" );
 
         // then
-        verifyQueryWithCorrectReader( stringReader, stringPrefix );
+        verifyQueryWithCorrectReader( expectedForStrings(), stringPrefix );
     }
 
     @Test
@@ -276,7 +329,7 @@ public class FusionIndexReaderTest
         StringSuffixPredicate stringPrefix = IndexQuery.stringSuffix( PROP_KEY, "abc" );
 
         // then
-        verifyQueryWithCorrectReader( stringReader, stringPrefix );
+        verifyQueryWithCorrectReader( expectedForStrings(), stringPrefix );
     }
 
     @Test
@@ -286,7 +339,7 @@ public class FusionIndexReaderTest
         StringContainsPredicate stringContains = IndexQuery.stringContains( PROP_KEY, "abc" );
 
         // then
-        verifyQueryWithCorrectReader( stringReader, stringContains );
+        verifyQueryWithCorrectReader( expectedForStrings(), stringContains );
     }
 
     @Test
@@ -295,9 +348,9 @@ public class FusionIndexReaderTest
         // given
         IndexQuery.ExistsPredicate exists = IndexQuery.exists( PROP_KEY );
         long lastId = 0;
-        for ( int i = 0; i < allReaders.length; i++ )
+        for ( IndexReader aliveReader : aliveReaders )
         {
-            when( allReaders[i].query( exists ) ).thenReturn( PrimitiveLongResourceCollections.iterator( null, lastId++, lastId++ ) );
+            when( aliveReader.query( exists ) ).thenReturn( PrimitiveLongResourceCollections.iterator( null, lastId++, lastId++ ) );
         }
 
         // when
@@ -319,12 +372,37 @@ public class FusionIndexReaderTest
 
         // then
         verify( expectedReader, times( 1 ) ).query( indexQuery );
-        for ( IndexReader reader : allReaders )
+        for ( IndexReader reader : aliveReaders )
         {
             if ( reader != expectedReader )
             {
                 verifyNoMoreInteractions( reader );
             }
         }
+    }
+
+    private IndexReader expectedForStrings()
+    {
+        return orLucene( readers[STRING] );
+    }
+
+    private IndexReader expectedForNumbers()
+    {
+        return orLucene( readers[NUMBER] );
+    }
+
+    private boolean hasSpatialSupport()
+    {
+        return readers[SPATIAL] != IndexReader.EMPTY;
+    }
+
+    private boolean hasTemporalSupport()
+    {
+        return readers[TEMPORAL] != IndexReader.EMPTY;
+    }
+
+    private IndexReader orLucene( IndexReader reader )
+    {
+        return reader != IndexReader.EMPTY ? reader : readers[LUCENE];
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionVersion.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionVersion.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema.fusion;
+
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.LUCENE;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.NUMBER;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.SPATIAL;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.STRING;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.TEMPORAL;
+
+enum FusionVersion
+{
+    v00
+            {
+                @Override
+                int[] aliveSlots()
+                {
+                    return new int[]{LUCENE};
+                }
+
+                @Override
+                FusionIndexProvider.Selector selector()
+                {
+                    return new FusionSelector00();
+                }
+            },
+    v10
+            {
+                @Override
+                int[] aliveSlots()
+                {
+                    return new int[]{NUMBER, LUCENE};
+                }
+
+                @Override
+                FusionIndexProvider.Selector selector()
+                {
+                    return new FusionSelector10();
+                }
+            },
+    v20
+            {
+                @Override
+                int[] aliveSlots()
+                {
+                    return new int[]{STRING, NUMBER, SPATIAL, TEMPORAL, LUCENE};
+                }
+
+                @Override
+                FusionIndexProvider.Selector selector()
+                {
+                    return new FusionSelector20();
+                }
+            };
+
+    abstract int[] aliveSlots();
+
+    abstract FusionIndexProvider.Selector selector();
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionVersion.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionVersion.java
@@ -46,7 +46,7 @@ enum FusionVersion
                 @Override
                 int[] aliveSlots()
                 {
-                    return new int[]{NUMBER, LUCENE};
+                    return new int[]{NUMBER, LUCENE, SPATIAL, TEMPORAL};
                 }
 
                 @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionVersion.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionVersion.java
@@ -32,7 +32,7 @@ enum FusionVersion
                 @Override
                 int[] aliveSlots()
                 {
-                    return new int[]{LUCENE};
+                    return new int[]{LUCENE, SPATIAL, TEMPORAL};
                 }
 
                 @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/HighIdTransactionApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/HighIdTransactionApplierTest.java
@@ -34,7 +34,7 @@ import org.neo4j.kernel.impl.transaction.command.Command.RelationshipGroupComman
 import org.neo4j.test.rule.NeoStoresRule;
 
 import static org.junit.Assert.assertEquals;
-import static org.neo4j.kernel.api.index.IndexProvider.NO_INDEX_PROVIDER;
+import static org.neo4j.kernel.api.index.IndexProvider.EMPTY;
 
 public class HighIdTransactionApplierTest
 {
@@ -75,9 +75,9 @@ public class HighIdTransactionApplierTest
 
         // Schema rules
         tracker.visitSchemaRuleCommand( Commands.createIndexRule(
-                NO_INDEX_PROVIDER.getProviderDescriptor(), 10, SchemaDescriptorFactory.forLabel( 0, 1 ) ) );
+                EMPTY.getProviderDescriptor(), 10, SchemaDescriptorFactory.forLabel( 0, 1 ) ) );
         tracker.visitSchemaRuleCommand( Commands.createIndexRule(
-                NO_INDEX_PROVIDER.getProviderDescriptor(), 20, SchemaDescriptorFactory.forLabel( 1, 2 ) ) );
+                EMPTY.getProviderDescriptor(), 20, SchemaDescriptorFactory.forLabel( 1, 2 ) ) );
 
         // Properties
         tracker.visitPropertyCommand( Commands.createProperty( 10, PropertyType.STRING, 0, 6, 7 ) );

--- a/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoreDataSourceRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoreDataSourceRule.java
@@ -180,7 +180,7 @@ public class NeoStoreDataSourceRule extends ExternalResource
             {
                 if ( IndexProvider.class.isAssignableFrom( type ) )
                 {
-                    return type.cast( IndexProvider.NO_INDEX_PROVIDER );
+                    return type.cast( IndexProvider.EMPTY );
                 }
                 throw new IllegalArgumentException( type.toString() );
             }

--- a/community/kernel/src/test/java/org/neo4j/test/rule/RecordStorageEngineRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/RecordStorageEngineRule.java
@@ -140,7 +140,7 @@ public class RecordStorageEngineRule extends ExternalResource
         private File storeDirectory = new File( "/graph.db" );
         private Function<BatchTransactionApplierFacade,BatchTransactionApplierFacade> transactionApplierTransformer =
                 applierFacade -> applierFacade;
-        private IndexProvider indexProvider = IndexProvider.NO_INDEX_PROVIDER;
+        private IndexProvider indexProvider = IndexProvider.EMPTY;
         private Monitors monitors = new Monitors();
 
         public Builder( FileSystemAbstraction fs, PageCache pageCache )

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/PartitionedIndexStorage.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/PartitionedIndexStorage.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.api.impl.index.storage;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
@@ -241,7 +242,7 @@ public class PartitionedIndexStorage
         File[] files = fileSystem.listFiles( rootFolder );
         return files == null ? Collections.emptyList()
                              : Stream.of( files )
-                               .filter( fileSystem::isDirectory )
+                               .filter( f -> fileSystem.isDirectory( f ) && StringUtils.isNumeric( f.getName() ) )
                                .sorted( FILE_COMPARATOR )
                                .collect( toList() );
 

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/IndexProviderFactoryUtil.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/IndexProviderFactoryUtil.java
@@ -42,31 +42,29 @@ class IndexProviderFactoryUtil
         return config.get( GraphDatabaseSettings.read_only ) && (OperationalMode.single == operationalMode);
     }
 
-    static NumberIndexProvider numberProvider( PageCache pageCache, FileSystemAbstraction fs, IndexProvider.Monitor monitor,
-            RecoveryCleanupWorkCollector recoveryCleanupWorkCollector, IndexDirectoryStructure.Factory childDirectoryStructure, boolean readOnly )
+    static NumberIndexProvider numberProvider( PageCache pageCache, FileSystemAbstraction fs, IndexDirectoryStructure.Factory childDirectoryStructure,
+            IndexProvider.Monitor monitor, RecoveryCleanupWorkCollector recoveryCleanupWorkCollector, boolean readOnly )
     {
         return new NumberIndexProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
     }
 
-    static SpatialFusionIndexProvider spatialProvider( PageCache pageCache, FileSystemAbstraction fs, IndexProvider.Monitor monitor,
-            RecoveryCleanupWorkCollector recoveryCleanupWorkCollector, boolean readOnly, IndexDirectoryStructure.Factory directoryStructure,
-            Config config )
+    static SpatialFusionIndexProvider spatialProvider( PageCache pageCache, FileSystemAbstraction fs, IndexDirectoryStructure.Factory directoryStructure,
+            IndexProvider.Monitor monitor, RecoveryCleanupWorkCollector recoveryCleanupWorkCollector, boolean readOnly, Config config )
     {
         return new SpatialFusionIndexProvider( pageCache, fs, directoryStructure, monitor, recoveryCleanupWorkCollector, readOnly, config );
     }
 
-    static TemporalIndexProvider temporalProvider( PageCache pageCache, FileSystemAbstraction fs, IndexProvider.Monitor monitor,
-            RecoveryCleanupWorkCollector recoveryCleanupWorkCollector, boolean readOnly, IndexDirectoryStructure.Factory directoryStructure )
+    static TemporalIndexProvider temporalProvider( PageCache pageCache, FileSystemAbstraction fs, IndexDirectoryStructure.Factory directoryStructure,
+            IndexProvider.Monitor monitor, RecoveryCleanupWorkCollector recoveryCleanupWorkCollector, boolean readOnly )
     {
         return new TemporalIndexProvider( pageCache, fs, directoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
     }
 
-    static LuceneIndexProvider luceneProvider( FileSystemAbstraction fileSystemAbstraction,
-            IndexDirectoryStructure.Factory directoryStructure, IndexProvider.Monitor monitor, Config config,
-            OperationalMode operationalMode )
+    static LuceneIndexProvider luceneProvider( FileSystemAbstraction fs, IndexDirectoryStructure.Factory directoryStructure, IndexProvider.Monitor monitor,
+            Config config, OperationalMode operationalMode )
     {
         boolean ephemeral = config.get( GraphDatabaseFacadeFactory.Configuration.ephemeral );
-        DirectoryFactory directoryFactory = directoryFactory( ephemeral, fileSystemAbstraction );
-        return new LuceneIndexProvider( fileSystemAbstraction, directoryFactory, directoryStructure, monitor, config, operationalMode );
+        DirectoryFactory directoryFactory = directoryFactory( ephemeral, fs );
+        return new LuceneIndexProvider( fs, directoryFactory, directoryStructure, monitor, config, operationalMode );
     }
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/IndexProviderFactoryUtil.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/IndexProviderFactoryUtil.java
@@ -30,9 +30,9 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.kernel.impl.factory.OperationalMode;
 import org.neo4j.kernel.impl.index.schema.NumberIndexProvider;
+import org.neo4j.kernel.impl.index.schema.SpatialIndexProvider;
 import org.neo4j.kernel.impl.index.schema.StringIndexProvider;
 import org.neo4j.kernel.impl.index.schema.TemporalIndexProvider;
-import org.neo4j.kernel.impl.index.schema.fusion.SpatialFusionIndexProvider;
 
 import static org.neo4j.kernel.api.impl.index.LuceneKernelExtensions.directoryFactory;
 
@@ -55,10 +55,10 @@ class IndexProviderFactoryUtil
         return new NumberIndexProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
     }
 
-    static SpatialFusionIndexProvider spatialProvider( PageCache pageCache, FileSystemAbstraction fs, IndexDirectoryStructure.Factory directoryStructure,
+    static SpatialIndexProvider spatialProvider( PageCache pageCache, FileSystemAbstraction fs, IndexDirectoryStructure.Factory directoryStructure,
             IndexProvider.Monitor monitor, RecoveryCleanupWorkCollector recoveryCleanupWorkCollector, boolean readOnly, Config config )
     {
-        return new SpatialFusionIndexProvider( pageCache, fs, directoryStructure, monitor, recoveryCleanupWorkCollector, readOnly, config );
+        return new SpatialIndexProvider( pageCache, fs, directoryStructure, monitor, recoveryCleanupWorkCollector, readOnly, config );
     }
 
     static TemporalIndexProvider temporalProvider( PageCache pageCache, FileSystemAbstraction fs, IndexDirectoryStructure.Factory directoryStructure,

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/IndexProviderFactoryUtil.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/IndexProviderFactoryUtil.java
@@ -30,6 +30,7 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.kernel.impl.factory.OperationalMode;
 import org.neo4j.kernel.impl.index.schema.NumberIndexProvider;
+import org.neo4j.kernel.impl.index.schema.StringIndexProvider;
 import org.neo4j.kernel.impl.index.schema.TemporalIndexProvider;
 import org.neo4j.kernel.impl.index.schema.fusion.SpatialFusionIndexProvider;
 
@@ -40,6 +41,12 @@ class IndexProviderFactoryUtil
     static boolean isReadOnly( Config config, OperationalMode operationalMode )
     {
         return config.get( GraphDatabaseSettings.read_only ) && (OperationalMode.single == operationalMode);
+    }
+
+    static StringIndexProvider stringProvider( PageCache pageCache, FileSystemAbstraction fs, IndexDirectoryStructure.Factory childDirectoryStructure,
+            IndexProvider.Monitor monitor, RecoveryCleanupWorkCollector recoveryCleanupWorkCollector, boolean readOnly )
+    {
+        return new StringIndexProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
     }
 
     static NumberIndexProvider numberProvider( PageCache pageCache, FileSystemAbstraction fs, IndexDirectoryStructure.Factory childDirectoryStructure,

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/IndexProviderFactoryUtil.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/IndexProviderFactoryUtil.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.schema;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.api.impl.index.storage.DirectoryFactory;
+import org.neo4j.kernel.api.index.IndexDirectoryStructure;
+import org.neo4j.kernel.api.index.IndexProvider;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+import org.neo4j.kernel.impl.factory.OperationalMode;
+import org.neo4j.kernel.impl.index.schema.NumberIndexProvider;
+import org.neo4j.kernel.impl.index.schema.TemporalIndexProvider;
+import org.neo4j.kernel.impl.index.schema.fusion.SpatialFusionIndexProvider;
+
+import static org.neo4j.kernel.api.impl.index.LuceneKernelExtensions.directoryFactory;
+
+class IndexProviderFactoryUtil
+{
+    static boolean isReadOnly( Config config, OperationalMode operationalMode )
+    {
+        return config.get( GraphDatabaseSettings.read_only ) && (OperationalMode.single == operationalMode);
+    }
+
+    static NumberIndexProvider numberProvider( PageCache pageCache, FileSystemAbstraction fs, IndexProvider.Monitor monitor,
+            RecoveryCleanupWorkCollector recoveryCleanupWorkCollector, IndexDirectoryStructure.Factory childDirectoryStructure, boolean readOnly )
+    {
+        return new NumberIndexProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
+    }
+
+    static SpatialFusionIndexProvider spatialProvider( PageCache pageCache, FileSystemAbstraction fs, IndexProvider.Monitor monitor,
+            RecoveryCleanupWorkCollector recoveryCleanupWorkCollector, boolean readOnly, IndexDirectoryStructure.Factory directoryStructure,
+            Config config )
+    {
+        return new SpatialFusionIndexProvider( pageCache, fs, directoryStructure, monitor, recoveryCleanupWorkCollector, readOnly, config );
+    }
+
+    static TemporalIndexProvider temporalProvider( PageCache pageCache, FileSystemAbstraction fs, IndexProvider.Monitor monitor,
+            RecoveryCleanupWorkCollector recoveryCleanupWorkCollector, boolean readOnly, IndexDirectoryStructure.Factory directoryStructure )
+    {
+        return new TemporalIndexProvider( pageCache, fs, directoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
+    }
+
+    static LuceneIndexProvider luceneProvider( FileSystemAbstraction fileSystemAbstraction,
+            IndexDirectoryStructure.Factory directoryStructure, IndexProvider.Monitor monitor, Config config,
+            OperationalMode operationalMode )
+    {
+        boolean ephemeral = config.get( GraphDatabaseFacadeFactory.Configuration.ephemeral );
+        DirectoryFactory directoryFactory = directoryFactory( ephemeral, fileSystemAbstraction );
+        return new LuceneIndexProvider( fileSystemAbstraction, directoryFactory, directoryStructure, monitor, config, operationalMode );
+    }
+}

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderFactory.java
@@ -32,10 +32,10 @@ import org.neo4j.kernel.api.index.LoggingMonitor;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.factory.OperationalMode;
+import org.neo4j.kernel.impl.index.schema.SpatialIndexProvider;
 import org.neo4j.kernel.impl.index.schema.TemporalIndexProvider;
 import org.neo4j.kernel.impl.index.schema.fusion.FusionIndexProvider;
 import org.neo4j.kernel.impl.index.schema.fusion.FusionSelector00;
-import org.neo4j.kernel.impl.index.schema.fusion.SpatialFusionIndexProvider;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.spi.KernelContext;
 import org.neo4j.kernel.monitoring.Monitors;
@@ -102,7 +102,7 @@ public class LuceneIndexProviderFactory extends
         LuceneIndexProvider lucene = IndexProviderFactoryUtil.luceneProvider( fs, baseDirStructure, monitor, config, operationalMode );
         TemporalIndexProvider temporal =
                 IndexProviderFactoryUtil.temporalProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
-        SpatialFusionIndexProvider spatial =
+        SpatialIndexProvider spatial =
                 IndexProviderFactoryUtil.spatialProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly, config );
 
         String defaultSchemaIndex = config.get( GraphDatabaseSettings.default_schema_index );

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderFactory.java
@@ -105,9 +105,9 @@ public class LuceneIndexProviderFactory extends
         SpatialIndexProvider spatial =
                 IndexProviderFactoryUtil.spatialProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly, config );
 
-        String defaultSchemaIndex = config.get( GraphDatabaseSettings.default_schema_index );
+        String defaultSchemaProvider = config.get( GraphDatabaseSettings.default_schema_provider );
         int priority = LuceneIndexProvider.PRIORITY;
-        if ( GraphDatabaseSettings.SchemaIndex.LUCENE10.param().equals( defaultSchemaIndex ) )
+        if ( GraphDatabaseSettings.SchemaIndex.LUCENE10.param().equals( defaultSchemaProvider ) )
         {
             priority = 100;
         }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderFactory.java
@@ -22,25 +22,27 @@ package org.neo4j.kernel.api.impl.schema;
 import java.io.File;
 
 import org.neo4j.helpers.Service;
+import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
 import org.neo4j.io.fs.FileSystemAbstraction;
-import org.neo4j.kernel.api.impl.index.storage.DirectoryFactory;
+import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexDirectoryStructure;
 import org.neo4j.kernel.api.index.IndexProvider;
 import org.neo4j.kernel.api.index.LoggingMonitor;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
-import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.kernel.impl.factory.OperationalMode;
+import org.neo4j.kernel.impl.index.schema.TemporalIndexProvider;
 import org.neo4j.kernel.impl.index.schema.fusion.FusionIndexProvider;
 import org.neo4j.kernel.impl.index.schema.fusion.FusionSelector00;
+import org.neo4j.kernel.impl.index.schema.fusion.SpatialFusionIndexProvider;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.spi.KernelContext;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.Log;
 
-import static org.neo4j.kernel.api.impl.index.LuceneKernelExtensions.directoryFactory;
 import static org.neo4j.kernel.api.index.IndexDirectoryStructure.directoriesByProvider;
 import static org.neo4j.kernel.api.index.IndexDirectoryStructure.directoriesByProviderKey;
+import static org.neo4j.kernel.api.index.IndexDirectoryStructure.directoriesBySubProvider;
 import static org.neo4j.kernel.api.index.IndexProvider.EMPTY;
 
 @Service.Implementation( KernelExtensionFactory.class )
@@ -54,6 +56,10 @@ public class LuceneIndexProviderFactory extends
 
     public interface Dependencies
     {
+        PageCache pageCache();
+
+        RecoveryCleanupWorkCollector recoveryCleanupWorkCollector();
+
         Config getConfig();
 
         Monitors monitors();
@@ -71,39 +77,35 @@ public class LuceneIndexProviderFactory extends
     @Override
     public IndexProvider newInstance( KernelContext context, Dependencies dependencies )
     {
-        FileSystemAbstraction fileSystemAbstraction = dependencies.fileSystem();
+        PageCache pageCache = dependencies.pageCache();
         File storeDir = context.storeDir();
-        Config config = dependencies.getConfig();
-        Log log = dependencies.getLogService().getInternalLogProvider().getLog( LuceneIndexProvider.class );
+        FileSystemAbstraction fs = dependencies.fileSystem();
         Monitors monitors = dependencies.monitors();
+        Log log = dependencies.getLogService().getInternalLogProvider().getLog( LuceneIndexProvider.class );
         monitors.addMonitorListener( new LoggingMonitor( log ), KEY );
         IndexProvider.Monitor monitor = monitors.newMonitor( IndexProvider.Monitor.class, KEY );
+        Config config = dependencies.getConfig();
         OperationalMode operationalMode = context.databaseInfo().operationalMode;
-
-        LuceneIndexProvider luceneProvider = createLuceneProvider( fileSystemAbstraction, storeDir, monitor, config, operationalMode );
-
-        return new FusionIndexProvider( EMPTY, EMPTY, EMPTY, EMPTY, luceneProvider, new FusionSelector00(),
-                PROVIDER_DESCRIPTOR, LuceneIndexProvider.PRIORITY, directoriesByProvider( storeDir ), fileSystemAbstraction );
+        RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = dependencies.recoveryCleanupWorkCollector();
+        return newInstance( pageCache, storeDir, fs, monitor, config, operationalMode, recoveryCleanupWorkCollector );
     }
 
-    public static LuceneIndexProvider createLuceneProvider( FileSystemAbstraction fileSystemAbstraction, File storeDir,
-                                              IndexProvider.Monitor monitor, Config config, OperationalMode operationalMode )
+    public static FusionIndexProvider newInstance( PageCache pageCache, File storeDir, FileSystemAbstraction fs,
+            IndexProvider.Monitor monitor, Config config, OperationalMode operationalMode,
+            RecoveryCleanupWorkCollector recoveryCleanupWorkCollector )
     {
-        return createLuceneProvider( fileSystemAbstraction, directoryStructureForLuceneProvider( storeDir ), monitor, config, operationalMode );
+        boolean readOnly = IndexProviderFactoryUtil.isReadOnly( config, operationalMode );
+        IndexDirectoryStructure.Factory baseDirStructure = directoriesByProviderKey( storeDir );
+        IndexDirectoryStructure.Factory childDirectoryStructure = directoriesBySubProvider( baseDirStructure.forProvider( PROVIDER_DESCRIPTOR ) );
+
+        LuceneIndexProvider lucene = IndexProviderFactoryUtil.luceneProvider( fs, baseDirStructure, monitor, config, operationalMode );
+        TemporalIndexProvider temporal =
+                IndexProviderFactoryUtil.temporalProvider( pageCache, fs, monitor, recoveryCleanupWorkCollector, readOnly, childDirectoryStructure );
+        SpatialFusionIndexProvider spatial =
+                IndexProviderFactoryUtil.spatialProvider( pageCache, fs, monitor, recoveryCleanupWorkCollector, readOnly, childDirectoryStructure, config );
+
+        return new FusionIndexProvider( EMPTY, EMPTY, spatial, temporal, lucene, new FusionSelector00(),
+                PROVIDER_DESCRIPTOR, LuceneIndexProvider.PRIORITY, directoriesByProvider( storeDir ), fs );
     }
 
-    static LuceneIndexProvider createLuceneProvider( FileSystemAbstraction fileSystemAbstraction,
-            IndexDirectoryStructure.Factory directoryStructure, IndexProvider.Monitor monitor, Config config,
-            OperationalMode operationalMode )
-    {
-        boolean ephemeral = config.get( GraphDatabaseFacadeFactory.Configuration.ephemeral );
-        DirectoryFactory directoryFactory = directoryFactory( ephemeral, fileSystemAbstraction );
-        return new LuceneIndexProvider( fileSystemAbstraction, directoryFactory, directoryStructure, monitor, config,
-                operationalMode );
-    }
-
-    private static IndexDirectoryStructure.Factory directoryStructureForLuceneProvider( File storeDir )
-    {
-        return directoriesByProviderKey( storeDir );
-    }
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderFactory.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.api.impl.schema;
 
 import java.io.File;
 
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Service;
 import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -104,8 +105,14 @@ public class LuceneIndexProviderFactory extends
         SpatialFusionIndexProvider spatial =
                 IndexProviderFactoryUtil.spatialProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly, config );
 
+        String defaultSchemaIndex = config.get( GraphDatabaseSettings.default_schema_index );
+        int priority = LuceneIndexProvider.PRIORITY;
+        if ( GraphDatabaseSettings.SchemaIndex.LUCENE10.param().equals( defaultSchemaIndex ) )
+        {
+            priority = 100;
+        }
         return new FusionIndexProvider( EMPTY, EMPTY, spatial, temporal, lucene, new FusionSelector00(),
-                PROVIDER_DESCRIPTOR, LuceneIndexProvider.PRIORITY, directoriesByProvider( storeDir ), fs );
+                PROVIDER_DESCRIPTOR, priority, directoriesByProvider( storeDir ), fs );
     }
 
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderFactory.java
@@ -100,9 +100,9 @@ public class LuceneIndexProviderFactory extends
 
         LuceneIndexProvider lucene = IndexProviderFactoryUtil.luceneProvider( fs, baseDirStructure, monitor, config, operationalMode );
         TemporalIndexProvider temporal =
-                IndexProviderFactoryUtil.temporalProvider( pageCache, fs, monitor, recoveryCleanupWorkCollector, readOnly, childDirectoryStructure );
+                IndexProviderFactoryUtil.temporalProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
         SpatialFusionIndexProvider spatial =
-                IndexProviderFactoryUtil.spatialProvider( pageCache, fs, monitor, recoveryCleanupWorkCollector, readOnly, childDirectoryStructure, config );
+                IndexProviderFactoryUtil.spatialProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly, config );
 
         return new FusionIndexProvider( EMPTY, EMPTY, spatial, temporal, lucene, new FusionSelector00(),
                 PROVIDER_DESCRIPTOR, LuceneIndexProvider.PRIORITY, directoriesByProvider( storeDir ), fs );

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory.java
@@ -90,8 +90,7 @@ public class NativeLuceneFusionIndexProviderFactory
         // This is the v1.0 of the lucene+native fusion setup where there's only number+lucene indexes
         NumberIndexProvider numberProvider =
                 new NumberIndexProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
-
-        LuceneIndexProvider luceneProvider = LuceneIndexProviderFactory.create( fs, childDirectoryStructure, monitor, config, operationalMode );
+        LuceneIndexProvider luceneProvider = LuceneIndexProviderFactory.createLuceneProvider( fs, childDirectoryStructure, monitor, config, operationalMode );
 
         boolean useNativeIndex = config.get( GraphDatabaseSettings.enable_native_schema_index );
         int priority = useNativeIndex ? PRIORITY : 0;
@@ -109,4 +108,5 @@ public class NativeLuceneFusionIndexProviderFactory
     {
         return config.get( GraphDatabaseSettings.read_only ) && (OperationalMode.single == operationalMode);
     }
+
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory10.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory10.java
@@ -33,10 +33,10 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.factory.OperationalMode;
 import org.neo4j.kernel.impl.index.schema.NumberIndexProvider;
+import org.neo4j.kernel.impl.index.schema.SpatialIndexProvider;
 import org.neo4j.kernel.impl.index.schema.TemporalIndexProvider;
 import org.neo4j.kernel.impl.index.schema.fusion.FusionIndexProvider;
 import org.neo4j.kernel.impl.index.schema.fusion.FusionSelector10;
-import org.neo4j.kernel.impl.index.schema.fusion.SpatialFusionIndexProvider;
 import org.neo4j.kernel.impl.spi.KernelContext;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.Log;
@@ -80,7 +80,7 @@ public class NativeLuceneFusionIndexProviderFactory10 extends
 
         NumberIndexProvider number =
                 IndexProviderFactoryUtil.numberProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
-        SpatialFusionIndexProvider spatial =
+        SpatialIndexProvider spatial =
                 IndexProviderFactoryUtil.spatialProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly, config );
         TemporalIndexProvider temporal =
                 IndexProviderFactoryUtil.temporalProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory10.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory10.java
@@ -86,13 +86,17 @@ public class NativeLuceneFusionIndexProviderFactory10 extends
                 IndexProviderFactoryUtil.temporalProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
         LuceneIndexProvider lucene = IndexProviderFactoryUtil.luceneProvider( fs, childDirectoryStructure, monitor, config, operationalMode );
 
-        boolean useNativeIndex = config.get( GraphDatabaseSettings.enable_native_schema_index );
-        int priority = useNativeIndex ? PRIORITY : 0;
+        String defaultSchemaIndex = config.get( GraphDatabaseSettings.default_schema_index );
+        int priority = PRIORITY;
+        if ( GraphDatabaseSettings.SchemaIndex.NATIVE10.param().equals( defaultSchemaIndex ) )
+        {
+            priority = 100;
+        }
         return new FusionIndexProvider( EMPTY, number, spatial, temporal, lucene, new FusionSelector10(),
                 DESCRIPTOR, priority, directoriesByProvider( storeDir ), fs );
     }
 
-    public static IndexDirectoryStructure.Factory subProviderDirectoryStructure( File storeDir )
+    private static IndexDirectoryStructure.Factory subProviderDirectoryStructure( File storeDir )
     {
         return NativeLuceneFusionIndexProviderFactory.subProviderDirectoryStructure( storeDir, DESCRIPTOR );
     }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory10.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory10.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.schema;
+
+import java.io.File;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.Service;
+import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.api.index.IndexDirectoryStructure;
+import org.neo4j.kernel.api.index.IndexProvider;
+import org.neo4j.kernel.api.index.LoggingMonitor;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.extension.KernelExtensionFactory;
+import org.neo4j.kernel.impl.factory.OperationalMode;
+import org.neo4j.kernel.impl.index.schema.NumberIndexProvider;
+import org.neo4j.kernel.impl.index.schema.TemporalIndexProvider;
+import org.neo4j.kernel.impl.index.schema.fusion.FusionIndexProvider;
+import org.neo4j.kernel.impl.index.schema.fusion.FusionSelector10;
+import org.neo4j.kernel.impl.index.schema.fusion.SpatialFusionIndexProvider;
+import org.neo4j.kernel.impl.spi.KernelContext;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.Log;
+
+import static org.neo4j.kernel.api.index.IndexDirectoryStructure.directoriesByProvider;
+import static org.neo4j.kernel.api.index.IndexProvider.EMPTY;
+
+@Service.Implementation( KernelExtensionFactory.class )
+public class NativeLuceneFusionIndexProviderFactory10 extends
+        NativeLuceneFusionIndexProviderFactory<NativeLuceneFusionIndexProviderFactory10.Dependencies>
+{
+    public static final IndexProvider.Descriptor DESCRIPTOR = new IndexProvider.Descriptor( KEY, "1.0" );
+    static final int PRIORITY = LuceneIndexProvider.PRIORITY + 1;
+
+    public interface Dependencies extends LuceneIndexProviderFactory.Dependencies
+    {
+    }
+
+    @Override
+    public FusionIndexProvider newInstance( KernelContext context, Dependencies dependencies )
+    {
+        PageCache pageCache = dependencies.pageCache();
+        File storeDir = context.storeDir();
+        FileSystemAbstraction fs = dependencies.fileSystem();
+        Log log = dependencies.getLogService().getInternalLogProvider().getLog( FusionIndexProvider.class );
+        Monitors monitors = dependencies.monitors();
+        monitors.addMonitorListener( new LoggingMonitor( log ), KEY );
+        IndexProvider.Monitor monitor = monitors.newMonitor( IndexProvider.Monitor.class, KEY );
+        Config config = dependencies.getConfig();
+        OperationalMode operationalMode = context.databaseInfo().operationalMode;
+        RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = dependencies.recoveryCleanupWorkCollector();
+        return create( pageCache, storeDir, fs, monitor, config, operationalMode, recoveryCleanupWorkCollector );
+    }
+
+    public static FusionIndexProvider create( PageCache pageCache, File storeDir, FileSystemAbstraction fs,
+                                                   IndexProvider.Monitor monitor, Config config, OperationalMode operationalMode,
+                                                   RecoveryCleanupWorkCollector recoveryCleanupWorkCollector )
+    {
+        IndexDirectoryStructure.Factory childDirectoryStructure = subProviderDirectoryStructure( storeDir );
+        boolean readOnly = IndexProviderFactoryUtil.isReadOnly( config, operationalMode );
+
+        NumberIndexProvider number =
+                IndexProviderFactoryUtil.numberProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
+        SpatialFusionIndexProvider spatial =
+                IndexProviderFactoryUtil.spatialProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly, config );
+        TemporalIndexProvider temporal =
+                IndexProviderFactoryUtil.temporalProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
+        LuceneIndexProvider lucene = IndexProviderFactoryUtil.luceneProvider( fs, childDirectoryStructure, monitor, config, operationalMode );
+
+        boolean useNativeIndex = config.get( GraphDatabaseSettings.enable_native_schema_index );
+        int priority = useNativeIndex ? PRIORITY : 0;
+        return new FusionIndexProvider( EMPTY, number, spatial, temporal, lucene, new FusionSelector10(),
+                DESCRIPTOR, priority, directoriesByProvider( storeDir ), fs );
+    }
+
+    public static IndexDirectoryStructure.Factory subProviderDirectoryStructure( File storeDir )
+    {
+        return NativeLuceneFusionIndexProviderFactory.subProviderDirectoryStructure( storeDir, DESCRIPTOR );
+    }
+}

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory10.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory10.java
@@ -86,9 +86,9 @@ public class NativeLuceneFusionIndexProviderFactory10 extends
                 IndexProviderFactoryUtil.temporalProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
         LuceneIndexProvider lucene = IndexProviderFactoryUtil.luceneProvider( fs, childDirectoryStructure, monitor, config, operationalMode );
 
-        String defaultSchemaIndex = config.get( GraphDatabaseSettings.default_schema_index );
+        String defaultSchemaProvider = config.get( GraphDatabaseSettings.default_schema_provider );
         int priority = PRIORITY;
-        if ( GraphDatabaseSettings.SchemaIndex.NATIVE10.param().equals( defaultSchemaIndex ) )
+        if ( GraphDatabaseSettings.SchemaIndex.NATIVE10.param().equals( defaultSchemaProvider ) )
         {
             priority = 100;
         }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory20.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory20.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.schema;
+
+import java.io.File;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.Service;
+import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.api.index.IndexDirectoryStructure;
+import org.neo4j.kernel.api.index.IndexProvider;
+import org.neo4j.kernel.api.index.LoggingMonitor;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.extension.KernelExtensionFactory;
+import org.neo4j.kernel.impl.factory.OperationalMode;
+import org.neo4j.kernel.impl.index.schema.NumberIndexProvider;
+import org.neo4j.kernel.impl.index.schema.StringIndexProvider;
+import org.neo4j.kernel.impl.index.schema.TemporalIndexProvider;
+import org.neo4j.kernel.impl.index.schema.fusion.FusionIndexProvider;
+import org.neo4j.kernel.impl.index.schema.fusion.FusionSelector20;
+import org.neo4j.kernel.impl.index.schema.fusion.SpatialFusionIndexProvider;
+import org.neo4j.kernel.impl.spi.KernelContext;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.Log;
+
+import static org.neo4j.kernel.api.index.IndexDirectoryStructure.directoriesByProvider;
+
+@Service.Implementation( KernelExtensionFactory.class )
+public class NativeLuceneFusionIndexProviderFactory20 extends
+        NativeLuceneFusionIndexProviderFactory<NativeLuceneFusionIndexProviderFactory20.Dependencies>
+{
+    public static final IndexProvider.Descriptor DESCRIPTOR = new IndexProvider.Descriptor( KEY, "2.0" );
+    private static final int PRIORITY = NativeLuceneFusionIndexProviderFactory10.PRIORITY + 1;
+
+    public interface Dependencies extends LuceneIndexProviderFactory.Dependencies
+    {
+    }
+
+    @Override
+    public FusionIndexProvider newInstance( KernelContext context, Dependencies dependencies )
+    {
+        PageCache pageCache = dependencies.pageCache();
+        File storeDir = context.storeDir();
+        FileSystemAbstraction fs = dependencies.fileSystem();
+        Log log = dependencies.getLogService().getInternalLogProvider().getLog( FusionIndexProvider.class );
+        Monitors monitors = dependencies.monitors();
+        monitors.addMonitorListener( new LoggingMonitor( log ), KEY );
+        IndexProvider.Monitor monitor = monitors.newMonitor( IndexProvider.Monitor.class, KEY );
+        Config config = dependencies.getConfig();
+        OperationalMode operationalMode = context.databaseInfo().operationalMode;
+        RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = dependencies.recoveryCleanupWorkCollector();
+        return create( pageCache, storeDir, fs, monitor, config, operationalMode, recoveryCleanupWorkCollector );
+    }
+
+    public static FusionIndexProvider create( PageCache pageCache, File storeDir, FileSystemAbstraction fs,
+            IndexProvider.Monitor monitor, Config config, OperationalMode operationalMode,
+            RecoveryCleanupWorkCollector recoveryCleanupWorkCollector )
+    {
+        IndexDirectoryStructure.Factory childDirectoryStructure = subProviderDirectoryStructure( storeDir );
+        boolean readOnly = IndexProviderFactoryUtil.isReadOnly( config, operationalMode );
+
+        StringIndexProvider string =
+                IndexProviderFactoryUtil.stringProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
+        NumberIndexProvider number =
+                IndexProviderFactoryUtil.numberProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
+        SpatialFusionIndexProvider spatial =
+                IndexProviderFactoryUtil.spatialProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly, config );
+        TemporalIndexProvider temporal =
+                IndexProviderFactoryUtil.temporalProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
+        LuceneIndexProvider lucene = IndexProviderFactoryUtil.luceneProvider( fs, childDirectoryStructure, monitor, config, operationalMode );
+
+        boolean useNativeIndex = config.get( GraphDatabaseSettings.enable_native_schema_index );
+        int priority = useNativeIndex ? PRIORITY : 0;
+        return new FusionIndexProvider( string, number, spatial, temporal, lucene, new FusionSelector20(),
+                DESCRIPTOR, priority, directoriesByProvider( storeDir ), fs );
+    }
+
+    public static IndexDirectoryStructure.Factory subProviderDirectoryStructure( File storeDir )
+    {
+        return NativeLuceneFusionIndexProviderFactory.subProviderDirectoryStructure( storeDir, DESCRIPTOR );
+    }
+}

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory20.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory20.java
@@ -88,8 +88,12 @@ public class NativeLuceneFusionIndexProviderFactory20 extends
                 IndexProviderFactoryUtil.temporalProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
         LuceneIndexProvider lucene = IndexProviderFactoryUtil.luceneProvider( fs, childDirectoryStructure, monitor, config, operationalMode );
 
-        boolean useNativeIndex = config.get( GraphDatabaseSettings.enable_native_schema_index );
-        int priority = useNativeIndex ? PRIORITY : 0;
+        String defaultSchemaIndex = config.get( GraphDatabaseSettings.default_schema_index );
+        int priority = PRIORITY;
+        if ( GraphDatabaseSettings.SchemaIndex.NATIVE20.param().equals( defaultSchemaIndex ) )
+        {
+            priority = 100;
+        }
         return new FusionIndexProvider( string, number, spatial, temporal, lucene, new FusionSelector20(),
                 DESCRIPTOR, priority, directoriesByProvider( storeDir ), fs );
     }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory20.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory20.java
@@ -33,11 +33,11 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.factory.OperationalMode;
 import org.neo4j.kernel.impl.index.schema.NumberIndexProvider;
+import org.neo4j.kernel.impl.index.schema.SpatialIndexProvider;
 import org.neo4j.kernel.impl.index.schema.StringIndexProvider;
 import org.neo4j.kernel.impl.index.schema.TemporalIndexProvider;
 import org.neo4j.kernel.impl.index.schema.fusion.FusionIndexProvider;
 import org.neo4j.kernel.impl.index.schema.fusion.FusionSelector20;
-import org.neo4j.kernel.impl.index.schema.fusion.SpatialFusionIndexProvider;
 import org.neo4j.kernel.impl.spi.KernelContext;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.Log;
@@ -82,7 +82,7 @@ public class NativeLuceneFusionIndexProviderFactory20 extends
                 IndexProviderFactoryUtil.stringProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
         NumberIndexProvider number =
                 IndexProviderFactoryUtil.numberProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
-        SpatialFusionIndexProvider spatial =
+        SpatialIndexProvider spatial =
                 IndexProviderFactoryUtil.spatialProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly, config );
         TemporalIndexProvider temporal =
                 IndexProviderFactoryUtil.temporalProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory20.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory20.java
@@ -88,9 +88,9 @@ public class NativeLuceneFusionIndexProviderFactory20 extends
                 IndexProviderFactoryUtil.temporalProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
         LuceneIndexProvider lucene = IndexProviderFactoryUtil.luceneProvider( fs, childDirectoryStructure, monitor, config, operationalMode );
 
-        String defaultSchemaIndex = config.get( GraphDatabaseSettings.default_schema_index );
+        String defaultSchemaProvider = config.get( GraphDatabaseSettings.default_schema_provider );
         int priority = PRIORITY;
-        if ( GraphDatabaseSettings.SchemaIndex.NATIVE20.param().equals( defaultSchemaIndex ) )
+        if ( GraphDatabaseSettings.SchemaIndex.NATIVE20.param().equals( defaultSchemaProvider ) )
         {
             priority = 100;
         }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/LuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/LuceneIndexPopulator.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.util.Collection;
 
 import org.neo4j.io.IOUtils;
-import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.impl.schema.LuceneDocumentStructure;
 import org.neo4j.kernel.api.impl.schema.SchemaIndex;
 import org.neo4j.kernel.api.impl.schema.writer.LuceneIndexWriter;

--- a/community/lucene-index/src/main/resources/META-INF/services/org.neo4j.kernel.extension.KernelExtensionFactory
+++ b/community/lucene-index/src/main/resources/META-INF/services/org.neo4j.kernel.extension.KernelExtensionFactory
@@ -1,3 +1,4 @@
 org.neo4j.kernel.api.impl.index.LuceneKernelExtensionFactory
 org.neo4j.kernel.api.impl.schema.LuceneIndexProviderFactory
-org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory
+org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory10
+org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory20

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/NonUniqueIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/NonUniqueIndexTest.java
@@ -176,14 +176,14 @@ public class NonUniqueIndexTest
     private IndexProvider selectIndexProvider( PageCache pageCache, File storeDir, FileSystemAbstraction fs, IndexProvider.Monitor monitor, Config config,
             OperationalMode operationalMode )
     {
-        String defaultSchemaIndex = config.get( GraphDatabaseSettings.default_schema_index );
+        String defaultSchemaProvider = config.get( GraphDatabaseSettings.default_schema_provider );
         RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = RecoveryCleanupWorkCollector.IMMEDIATE;
-        if ( LUCENE10.param().equals( defaultSchemaIndex ) )
+        if ( LUCENE10.param().equals( defaultSchemaProvider ) )
         {
             return LuceneIndexProviderFactory
                     .newInstance( pageCache, storeDir, fs, monitor, config, operationalMode, recoveryCleanupWorkCollector );
         }
-        else if ( NATIVE10.param().equals( defaultSchemaIndex ) )
+        else if ( NATIVE10.param().equals( defaultSchemaProvider ) )
         {
             return NativeLuceneFusionIndexProviderFactory10
                     .create( pageCache, storeDir, fs, monitor, config, operationalMode, recoveryCleanupWorkCollector );

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/NonUniqueIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/NonUniqueIndexTest.java
@@ -37,7 +37,7 @@ import org.neo4j.internal.kernel.api.IndexQuery;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.impl.schema.LuceneIndexProviderFactory;
-import org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory;
+import org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory20;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexProvider;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptorFactory;
@@ -165,8 +165,8 @@ public class NonUniqueIndexTest
         RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = RecoveryCleanupWorkCollector.IMMEDIATE;
         if ( useFusionIndex )
         {
-            indexProvider = NativeLuceneFusionIndexProviderFactory
-                    .newInstance( pageCache, storeDir, fs, monitor, config, operationalMode, recoveryCleanupWorkCollector );
+            indexProvider = NativeLuceneFusionIndexProviderFactory20
+                    .create( pageCache, storeDir, fs, monitor, config, operationalMode, recoveryCleanupWorkCollector );
         }
         else
         {

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/NonUniqueIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/NonUniqueIndexTest.java
@@ -162,14 +162,16 @@ public class NonUniqueIndexTest
         PageCache pageCache = resources.pageCache();
         Boolean useFusionIndex = config.get( GraphDatabaseSettings.enable_native_schema_index );
         IndexProvider indexProvider;
+        RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = RecoveryCleanupWorkCollector.IMMEDIATE;
         if ( useFusionIndex )
         {
             indexProvider = NativeLuceneFusionIndexProviderFactory
-                    .newInstance( pageCache, storeDir, fs, monitor, config, operationalMode, RecoveryCleanupWorkCollector.IMMEDIATE );
+                    .newInstance( pageCache, storeDir, fs, monitor, config, operationalMode, recoveryCleanupWorkCollector );
         }
         else
         {
-            indexProvider = LuceneIndexProviderFactory.createLuceneProvider( fs, storeDir, monitor, config, operationalMode );
+            indexProvider = LuceneIndexProviderFactory
+                    .newInstance( pageCache, storeDir, fs, monitor, config, operationalMode, recoveryCleanupWorkCollector );
         }
         IndexSamplingConfig samplingConfig = new IndexSamplingConfig( config );
         try ( IndexAccessor accessor = indexProvider.getOnlineAccessor( indexId,

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/NonUniqueIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/NonUniqueIndexTest.java
@@ -169,7 +169,7 @@ public class NonUniqueIndexTest
         }
         else
         {
-            indexProvider = LuceneIndexProviderFactory.create( fs, storeDir, monitor, config, operationalMode );
+            indexProvider = LuceneIndexProviderFactory.createLuceneProvider( fs, storeDir, monitor, config, operationalMode );
         }
         IndexSamplingConfig samplingConfig = new IndexSamplingConfig( config );
         try ( IndexAccessor accessor = indexProvider.getOnlineAccessor( indexId,

--- a/community/lucene-index/src/test/java/org/neo4j/index/lucene/ConstraintIndexFailureIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/lucene/ConstraintIndexFailureIT.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.kernel.api.impl.schema.LuceneIndexProviderFactory.PROVIDER_DESCRIPTOR;
-import static org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory.subProviderDirectoryStructure;
+import static org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory20.subProviderDirectoryStructure;
 
 public class ConstraintIndexFailureIT
 {

--- a/community/lucene-index/src/test/java/org/neo4j/index/recovery/UniqueIndexRecoveryTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/recovery/UniqueIndexRecoveryTest.java
@@ -40,7 +40,8 @@ import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.kernel.api.impl.schema.LuceneIndexProviderFactory;
-import org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory;
+import org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory10;
+import org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory20;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.api.index.inmemory.InMemoryIndexProviderFactory;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
@@ -75,7 +76,8 @@ public class UniqueIndexRecoveryTest
     {
         return asList(
                 new Object[]{new LuceneIndexProviderFactory()},
-                new Object[]{new NativeLuceneFusionIndexProviderFactory()},
+                new Object[]{new NativeLuceneFusionIndexProviderFactory10()},
+                new Object[]{new NativeLuceneFusionIndexProviderFactory20()},
                 new Object[]{new InMemoryIndexProviderFactory()} );
     }
 

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/storage/PartitionedIndexStorageTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/storage/PartitionedIndexStorageTest.java
@@ -237,7 +237,7 @@ public class PartitionedIndexStorageTest
 
     private void createRandomFile( File rootFolder ) throws IOException
     {
-        File file = new File( rootFolder, RandomStringUtils.randomAlphabetic( 5 ) );
+        File file = new File( rootFolder, RandomStringUtils.randomNumeric( 5 ) );
         try ( StoreChannel channel = fs.create( file ) )
         {
             channel.writeAll( ByteBuffer.allocate( 100 ) );
@@ -246,7 +246,7 @@ public class PartitionedIndexStorageTest
 
     private File createRandomFolder( File rootFolder ) throws IOException
     {
-        File folder = new File( rootFolder, RandomStringUtils.randomAlphabetic( 5 ) );
+        File folder = new File( rootFolder, RandomStringUtils.randomNumeric( 5 ) );
         fs.mkdirs( folder );
         return folder;
     }
@@ -254,7 +254,7 @@ public class PartitionedIndexStorageTest
     private static Document randomDocument()
     {
         Document doc = new Document();
-        doc.add( new StringField( "field", RandomStringUtils.randomAlphabetic( 5 ), Field.Store.YES ) );
+        doc.add( new StringField( "field", RandomStringUtils.randomNumeric( 5 ), Field.Store.YES ) );
         return doc;
     }
 

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DefaultSchemaIndexConfigTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DefaultSchemaIndexConfigTest.java
@@ -49,7 +49,7 @@ public class DefaultSchemaIndexConfigTest
     public void shouldUseConfiguredIndexProviderNull() throws IndexNotFoundKernelException
     {
         // given
-        GraphDatabaseService db = dbBuilder.setConfig( GraphDatabaseSettings.default_schema_index, null ).newGraphDatabase();
+        GraphDatabaseService db = dbBuilder.setConfig( GraphDatabaseSettings.default_schema_provider, null ).newGraphDatabase();
 
         // when
         createIndex( db );
@@ -63,7 +63,7 @@ public class DefaultSchemaIndexConfigTest
     {
         // given
         GraphDatabaseService db =
-                dbBuilder.setConfig( GraphDatabaseSettings.default_schema_index, GraphDatabaseSettings.SchemaIndex.LUCENE10.param() ).newGraphDatabase();
+                dbBuilder.setConfig( GraphDatabaseSettings.default_schema_provider, GraphDatabaseSettings.SchemaIndex.LUCENE10.param() ).newGraphDatabase();
 
         // when
         createIndex( db );
@@ -77,7 +77,7 @@ public class DefaultSchemaIndexConfigTest
     {
         // given
         GraphDatabaseService db =
-                dbBuilder.setConfig( GraphDatabaseSettings.default_schema_index, GraphDatabaseSettings.SchemaIndex.NATIVE10.param() ).newGraphDatabase();
+                dbBuilder.setConfig( GraphDatabaseSettings.default_schema_provider, GraphDatabaseSettings.SchemaIndex.NATIVE10.param() ).newGraphDatabase();
 
         // when
         createIndex( db );
@@ -91,7 +91,7 @@ public class DefaultSchemaIndexConfigTest
     {
         // given
         GraphDatabaseService db =
-                dbBuilder.setConfig( GraphDatabaseSettings.default_schema_index, GraphDatabaseSettings.SchemaIndex.NATIVE20.param() ).newGraphDatabase();
+                dbBuilder.setConfig( GraphDatabaseSettings.default_schema_provider, GraphDatabaseSettings.SchemaIndex.NATIVE20.param() ).newGraphDatabase();
 
         // when
         createIndex( db );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DefaultSchemaIndexConfigTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DefaultSchemaIndexConfigTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.schema;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.Statement;
+import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
+import org.neo4j.kernel.api.index.IndexProvider;
+import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptorFactory;
+import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.test.TestLabels;
+
+import static org.junit.Assert.assertEquals;
+
+public class DefaultSchemaIndexConfigTest
+{
+    private static final String KEY = "key";
+    private static final TestLabels LABEL = TestLabels.LABEL_ONE;
+    private static final GraphDatabaseBuilder dbBuilder = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder();
+
+    @Test
+    public void shouldUseConfiguredIndexProviderNull() throws IndexNotFoundKernelException
+    {
+        // given
+        GraphDatabaseService db = dbBuilder.setConfig( GraphDatabaseSettings.default_schema_index, null ).newGraphDatabase();
+
+        // when
+        createIndex( db );
+
+        // then
+        assertIndexProvider( db, NativeLuceneFusionIndexProviderFactory20.DESCRIPTOR );
+    }
+
+    @Test
+    public void shouldUseConfiguredIndexProviderLucene() throws IndexNotFoundKernelException
+    {
+        // given
+        GraphDatabaseService db =
+                dbBuilder.setConfig( GraphDatabaseSettings.default_schema_index, GraphDatabaseSettings.SchemaIndex.LUCENE10.param() ).newGraphDatabase();
+
+        // when
+        createIndex( db );
+
+        // then
+        assertIndexProvider( db, LuceneIndexProviderFactory.PROVIDER_DESCRIPTOR );
+    }
+
+    @Test
+    public void shouldUseConfiguredIndexProviderNative10() throws IndexNotFoundKernelException
+    {
+        // given
+        GraphDatabaseService db =
+                dbBuilder.setConfig( GraphDatabaseSettings.default_schema_index, GraphDatabaseSettings.SchemaIndex.NATIVE10.param() ).newGraphDatabase();
+
+        // when
+        createIndex( db );
+
+        // then
+        assertIndexProvider( db, NativeLuceneFusionIndexProviderFactory10.DESCRIPTOR );
+    }
+
+    @Test
+    public void shouldUseConfiguredIndexProviderNative20() throws IndexNotFoundKernelException
+    {
+        // given
+        GraphDatabaseService db =
+                dbBuilder.setConfig( GraphDatabaseSettings.default_schema_index, GraphDatabaseSettings.SchemaIndex.NATIVE20.param() ).newGraphDatabase();
+
+        // when
+        createIndex( db );
+
+        // then
+        assertIndexProvider( db, NativeLuceneFusionIndexProviderFactory20.DESCRIPTOR );
+    }
+
+    private void assertIndexProvider( GraphDatabaseService db, IndexProvider.Descriptor expected ) throws IndexNotFoundKernelException
+    {
+        GraphDatabaseAPI graphDatabaseAPI = (GraphDatabaseAPI) db;
+        try ( Transaction tx = graphDatabaseAPI.beginTx();
+              Statement statement = graphDatabaseAPI.getDependencyResolver().resolveDependency( ThreadToStatementContextBridge.class ).get() )
+        {
+            ReadOperations readOperations = statement.readOperations();
+            int labelId = readOperations.labelGetForName( LABEL.name() );
+            int propertyId = readOperations.propertyKeyGetForName( KEY );
+            IndexProvider.Descriptor descriptor = readOperations.indexGetProviderDescriptor( SchemaIndexDescriptorFactory.forLabel( labelId, propertyId ) );
+            assertEquals( "expected IndexProvider.Descriptor", expected, descriptor );
+            tx.success();
+        }
+    }
+
+    private void createIndex( GraphDatabaseService db )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.schema().indexFor( LABEL ).on( KEY ).create();
+            tx.success();
+        }
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.schema().awaitIndexesOnline( 1, TimeUnit.MINUTES );
+            tx.success();
+        }
+    }
+}

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexIT.java
@@ -33,7 +33,6 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.index.IndexProvider;
-import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.index.schema.NumberIndexProvider;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.rule.DatabaseRule;
@@ -51,7 +50,7 @@ public class FusionIndexIT
 {
     @Rule
     public DatabaseRule db = new EmbeddedDatabaseRule()
-            .withSetting( GraphDatabaseSettings.enable_native_schema_index, Settings.TRUE );
+            .withSetting( GraphDatabaseSettings.default_schema_index, GraphDatabaseSettings.SchemaIndex.NATIVE20.param() );
 
     private File storeDir;
     private final Label label = Label.label( "label" );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexIT.java
@@ -50,7 +50,7 @@ public class FusionIndexIT
 {
     @Rule
     public DatabaseRule db = new EmbeddedDatabaseRule()
-            .withSetting( GraphDatabaseSettings.default_schema_index, GraphDatabaseSettings.SchemaIndex.NATIVE20.param() );
+            .withSetting( GraphDatabaseSettings.default_schema_provider, GraphDatabaseSettings.SchemaIndex.NATIVE20.param() );
 
     private File storeDir;
     private final Label label = Label.label( "label" );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexProvider10CompatibilitySuiteTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexProvider10CompatibilitySuiteTest.java
@@ -30,7 +30,7 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.factory.OperationalMode;
 
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.SchemaIndex.NATIVE10;
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.default_schema_index;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.default_schema_provider;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class FusionIndexProvider10CompatibilitySuiteTest extends IndexProviderCompatibilityTestSuite
@@ -39,7 +39,7 @@ public class FusionIndexProvider10CompatibilitySuiteTest extends IndexProviderCo
     protected IndexProvider createIndexProvider( PageCache pageCache, FileSystemAbstraction fs, File graphDbDir )
     {
         IndexProvider.Monitor monitor = IndexProvider.Monitor.EMPTY;
-        Config config = Config.defaults( stringMap( default_schema_index.name(), NATIVE10.param() ) );
+        Config config = Config.defaults( stringMap( default_schema_provider.name(), NATIVE10.param() ) );
         OperationalMode mode = OperationalMode.single;
         RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = RecoveryCleanupWorkCollector.IMMEDIATE;
         return NativeLuceneFusionIndexProviderFactory10.create( pageCache, graphDbDir, fs, monitor, config, mode, recoveryCleanupWorkCollector );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexProvider10CompatibilitySuiteTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexProvider10CompatibilitySuiteTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.schema;
+
+import java.io.File;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.api.index.IndexProvider;
+import org.neo4j.kernel.api.index.IndexProviderCompatibilityTestSuite;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.configuration.Settings;
+import org.neo4j.kernel.impl.factory.OperationalMode;
+
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
+public class FusionIndexProvider10CompatibilitySuiteTest extends IndexProviderCompatibilityTestSuite
+{
+    @Override
+    protected IndexProvider createIndexProvider( PageCache pageCache, FileSystemAbstraction fs, File graphDbDir )
+    {
+        IndexProvider.Monitor monitor = IndexProvider.Monitor.EMPTY;
+        Config config = Config.defaults( stringMap( GraphDatabaseSettings.enable_native_schema_index.name(), Settings.TRUE ) );
+        OperationalMode mode = OperationalMode.single;
+        RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = RecoveryCleanupWorkCollector.IMMEDIATE;
+        return NativeLuceneFusionIndexProviderFactory10.create( pageCache, graphDbDir, fs, monitor, config, mode, recoveryCleanupWorkCollector );
+    }
+
+    @Override
+    public boolean supportsSpatial()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean supportsTemporal()
+    {
+        return true;
+    }
+}

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexProvider10CompatibilitySuiteTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexProvider10CompatibilitySuiteTest.java
@@ -21,16 +21,16 @@ package org.neo4j.kernel.api.impl.schema;
 
 import java.io.File;
 
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexProvider;
 import org.neo4j.kernel.api.index.IndexProviderCompatibilityTestSuite;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.factory.OperationalMode;
 
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.SchemaIndex.NATIVE10;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.default_schema_index;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class FusionIndexProvider10CompatibilitySuiteTest extends IndexProviderCompatibilityTestSuite
@@ -39,7 +39,7 @@ public class FusionIndexProvider10CompatibilitySuiteTest extends IndexProviderCo
     protected IndexProvider createIndexProvider( PageCache pageCache, FileSystemAbstraction fs, File graphDbDir )
     {
         IndexProvider.Monitor monitor = IndexProvider.Monitor.EMPTY;
-        Config config = Config.defaults( stringMap( GraphDatabaseSettings.enable_native_schema_index.name(), Settings.TRUE ) );
+        Config config = Config.defaults( stringMap( default_schema_index.name(), NATIVE10.param() ) );
         OperationalMode mode = OperationalMode.single;
         RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = RecoveryCleanupWorkCollector.IMMEDIATE;
         return NativeLuceneFusionIndexProviderFactory10.create( pageCache, graphDbDir, fs, monitor, config, mode, recoveryCleanupWorkCollector );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexProvider20CompatibilitySuiteTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexProvider20CompatibilitySuiteTest.java
@@ -33,7 +33,7 @@ import org.neo4j.kernel.impl.factory.OperationalMode;
 
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
-public class FusionIndexProviderCompatibilitySuiteTest extends IndexProviderCompatibilityTestSuite
+public class FusionIndexProvider20CompatibilitySuiteTest extends IndexProviderCompatibilityTestSuite
 {
     @Override
     protected IndexProvider createIndexProvider( PageCache pageCache, FileSystemAbstraction fs, File graphDbDir )
@@ -42,7 +42,7 @@ public class FusionIndexProviderCompatibilitySuiteTest extends IndexProviderComp
         Config config = Config.defaults( stringMap( GraphDatabaseSettings.enable_native_schema_index.name(), Settings.TRUE ) );
         OperationalMode mode = OperationalMode.single;
         RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = RecoveryCleanupWorkCollector.IMMEDIATE;
-        return NativeLuceneFusionIndexProviderFactory.newInstance( pageCache, graphDbDir, fs, monitor, config, mode, recoveryCleanupWorkCollector );
+        return NativeLuceneFusionIndexProviderFactory20.create( pageCache, graphDbDir, fs, monitor, config, mode, recoveryCleanupWorkCollector );
     }
 
     @Override

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexProvider20CompatibilitySuiteTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexProvider20CompatibilitySuiteTest.java
@@ -30,7 +30,7 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.factory.OperationalMode;
 
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.SchemaIndex.NATIVE20;
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.default_schema_index;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.default_schema_provider;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class FusionIndexProvider20CompatibilitySuiteTest extends IndexProviderCompatibilityTestSuite
@@ -39,7 +39,7 @@ public class FusionIndexProvider20CompatibilitySuiteTest extends IndexProviderCo
     protected IndexProvider createIndexProvider( PageCache pageCache, FileSystemAbstraction fs, File graphDbDir )
     {
         IndexProvider.Monitor monitor = IndexProvider.Monitor.EMPTY;
-        Config config = Config.defaults( stringMap( default_schema_index.name(), NATIVE20.param() ) );
+        Config config = Config.defaults( stringMap( default_schema_provider.name(), NATIVE20.param() ) );
         OperationalMode mode = OperationalMode.single;
         RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = RecoveryCleanupWorkCollector.IMMEDIATE;
         return NativeLuceneFusionIndexProviderFactory20.create( pageCache, graphDbDir, fs, monitor, config, mode, recoveryCleanupWorkCollector );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexProvider20CompatibilitySuiteTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexProvider20CompatibilitySuiteTest.java
@@ -21,16 +21,16 @@ package org.neo4j.kernel.api.impl.schema;
 
 import java.io.File;
 
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexProvider;
 import org.neo4j.kernel.api.index.IndexProviderCompatibilityTestSuite;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.factory.OperationalMode;
 
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.SchemaIndex.NATIVE20;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.default_schema_index;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class FusionIndexProvider20CompatibilitySuiteTest extends IndexProviderCompatibilityTestSuite
@@ -39,7 +39,7 @@ public class FusionIndexProvider20CompatibilitySuiteTest extends IndexProviderCo
     protected IndexProvider createIndexProvider( PageCache pageCache, FileSystemAbstraction fs, File graphDbDir )
     {
         IndexProvider.Monitor monitor = IndexProvider.Monitor.EMPTY;
-        Config config = Config.defaults( stringMap( GraphDatabaseSettings.enable_native_schema_index.name(), Settings.TRUE ) );
+        Config config = Config.defaults( stringMap( default_schema_index.name(), NATIVE20.param() ) );
         OperationalMode mode = OperationalMode.single;
         RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = RecoveryCleanupWorkCollector.IMMEDIATE;
         return NativeLuceneFusionIndexProviderFactory20.create( pageCache, graphDbDir, fs, monitor, config, mode, recoveryCleanupWorkCollector );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexProviderCompatibilitySuiteTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexProviderCompatibilitySuiteTest.java
@@ -25,8 +25,8 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
-import org.neo4j.kernel.api.index.IndexProviderCompatibilityTestSuite;
 import org.neo4j.kernel.api.index.IndexProvider;
+import org.neo4j.kernel.api.index.IndexProviderCompatibilityTestSuite;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.factory.OperationalMode;
@@ -40,9 +40,9 @@ public class FusionIndexProviderCompatibilitySuiteTest extends IndexProviderComp
     {
         IndexProvider.Monitor monitor = IndexProvider.Monitor.EMPTY;
         Config config = Config.defaults( stringMap( GraphDatabaseSettings.enable_native_schema_index.name(), Settings.TRUE ) );
-        return NativeLuceneFusionIndexProviderFactory
-                .newInstance( pageCache, graphDbDir, fs, monitor, config, OperationalMode.single,
-                        RecoveryCleanupWorkCollector.IMMEDIATE );
+        OperationalMode mode = OperationalMode.single;
+        RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = RecoveryCleanupWorkCollector.IMMEDIATE;
+        return NativeLuceneFusionIndexProviderFactory.newInstance( pageCache, graphDbDir, fs, monitor, config, mode, recoveryCleanupWorkCollector );
     }
 
     @Override

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderCompatibilitySuiteTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderCompatibilitySuiteTest.java
@@ -21,16 +21,16 @@ package org.neo4j.kernel.api.impl.schema;
 
 import java.io.File;
 
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexProvider;
 import org.neo4j.kernel.api.index.IndexProviderCompatibilityTestSuite;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.factory.OperationalMode;
 
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.SchemaIndex.LUCENE10;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.default_schema_index;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class LuceneIndexProviderCompatibilitySuiteTest extends IndexProviderCompatibilityTestSuite
@@ -39,7 +39,7 @@ public class LuceneIndexProviderCompatibilitySuiteTest extends IndexProviderComp
     protected IndexProvider createIndexProvider( PageCache pageCache, FileSystemAbstraction fs, File graphDbDir )
     {
         IndexProvider.Monitor monitor = IndexProvider.Monitor.EMPTY;
-        Config config = Config.defaults( stringMap( GraphDatabaseSettings.enable_native_schema_index.name(), Settings.FALSE ) );
+        Config config = Config.defaults( stringMap( default_schema_index.name(), LUCENE10.param() ) );
         OperationalMode mode = OperationalMode.single;
         RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = RecoveryCleanupWorkCollector.IMMEDIATE;
         return LuceneIndexProviderFactory.newInstance( pageCache, graphDbDir, fs, monitor, config, mode, recoveryCleanupWorkCollector );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderCompatibilitySuiteTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderCompatibilitySuiteTest.java
@@ -30,7 +30,7 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.factory.OperationalMode;
 
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.SchemaIndex.LUCENE10;
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.default_schema_index;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.default_schema_provider;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class LuceneIndexProviderCompatibilitySuiteTest extends IndexProviderCompatibilityTestSuite
@@ -39,7 +39,7 @@ public class LuceneIndexProviderCompatibilitySuiteTest extends IndexProviderComp
     protected IndexProvider createIndexProvider( PageCache pageCache, FileSystemAbstraction fs, File graphDbDir )
     {
         IndexProvider.Monitor monitor = IndexProvider.Monitor.EMPTY;
-        Config config = Config.defaults( stringMap( default_schema_index.name(), LUCENE10.param() ) );
+        Config config = Config.defaults( stringMap( default_schema_provider.name(), LUCENE10.param() ) );
         OperationalMode mode = OperationalMode.single;
         RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = RecoveryCleanupWorkCollector.IMMEDIATE;
         return LuceneIndexProviderFactory.newInstance( pageCache, graphDbDir, fs, monitor, config, mode, recoveryCleanupWorkCollector );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderCompatibilitySuiteTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderCompatibilitySuiteTest.java
@@ -22,11 +22,11 @@ package org.neo4j.kernel.api.impl.schema;
 import java.io.File;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
-import org.neo4j.kernel.api.impl.index.storage.DirectoryFactory;
-import org.neo4j.kernel.api.index.IndexProviderCompatibilityTestSuite;
 import org.neo4j.kernel.api.index.IndexProvider;
+import org.neo4j.kernel.api.index.IndexProviderCompatibilityTestSuite;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.factory.OperationalMode;
@@ -36,24 +36,24 @@ import static org.neo4j.helpers.collection.MapUtil.stringMap;
 public class LuceneIndexProviderCompatibilitySuiteTest extends IndexProviderCompatibilityTestSuite
 {
     @Override
-    protected LuceneIndexProvider createIndexProvider( PageCache pageCache, FileSystemAbstraction fs, File graphDbDir )
+    protected IndexProvider createIndexProvider( PageCache pageCache, FileSystemAbstraction fs, File graphDbDir )
     {
-        DirectoryFactory.InMemoryDirectoryFactory directoryFactory = new DirectoryFactory.InMemoryDirectoryFactory();
         IndexProvider.Monitor monitor = IndexProvider.Monitor.EMPTY;
         Config config = Config.defaults( stringMap( GraphDatabaseSettings.enable_native_schema_index.name(), Settings.FALSE ) );
         OperationalMode mode = OperationalMode.single;
-        return LuceneIndexProviderFactory.createLuceneProvider( fs, graphDbDir, monitor, config, mode );
+        RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = RecoveryCleanupWorkCollector.IMMEDIATE;
+        return LuceneIndexProviderFactory.newInstance( pageCache, graphDbDir, fs, monitor, config, mode, recoveryCleanupWorkCollector );
     }
 
     @Override
     public boolean supportsSpatial()
     {
-        return false;
+        return true;
     }
 
     @Override
     public boolean supportsTemporal()
     {
-        return false;
+        return true;
     }
 }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderCompatibilitySuiteTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderCompatibilitySuiteTest.java
@@ -42,7 +42,7 @@ public class LuceneIndexProviderCompatibilitySuiteTest extends IndexProviderComp
         IndexProvider.Monitor monitor = IndexProvider.Monitor.EMPTY;
         Config config = Config.defaults( stringMap( GraphDatabaseSettings.enable_native_schema_index.name(), Settings.FALSE ) );
         OperationalMode mode = OperationalMode.single;
-        return LuceneIndexProviderFactory.create( fs, graphDbDir, monitor, config, mode );
+        return LuceneIndexProviderFactory.createLuceneProvider( fs, graphDbDir, monitor, config, mode );
     }
 
     @Override

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceIntegrationTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceIntegrationTest.java
@@ -42,7 +42,8 @@ import org.neo4j.internal.kernel.api.InternalIndexState;
 import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.impl.schema.LuceneIndexProviderFactory;
-import org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory;
+import org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory10;
+import org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory20;
 import org.neo4j.kernel.api.index.IndexProvider;
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptorFactory;
@@ -82,7 +83,8 @@ public class IndexingServiceIntegrationTest
     {
         return asList(
                 new Object[]{new LuceneIndexProviderFactory(), LuceneIndexProviderFactory.PROVIDER_DESCRIPTOR},
-                new Object[]{new NativeLuceneFusionIndexProviderFactory(), NativeLuceneFusionIndexProviderFactory.DESCRIPTOR},
+                new Object[]{new NativeLuceneFusionIndexProviderFactory10(), NativeLuceneFusionIndexProviderFactory10.DESCRIPTOR},
+                new Object[]{new NativeLuceneFusionIndexProviderFactory20(), NativeLuceneFusionIndexProviderFactory20.DESCRIPTOR},
                 new Object[]{new InMemoryIndexProviderFactory(), InMemoryIndexProviderFactory.PROVIDER_DESCRIPTOR} );
     }
 

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorLuceneTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorLuceneTest.java
@@ -29,7 +29,7 @@ public class NodeValueIndexCursorLuceneTest extends AbstractNodeValueIndexCursor
     public ReadTestSupport newTestSupport()
     {
         ReadTestSupport readTestSupport = new ReadTestSupport();
-        readTestSupport.addSetting( GraphDatabaseSettings.default_schema_index, LUCENE10.param() );
+        readTestSupport.addSetting( GraphDatabaseSettings.default_schema_provider, LUCENE10.param() );
         return readTestSupport;
     }
 

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorNative10Test.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorNative10Test.java
@@ -27,7 +27,7 @@ public class NodeValueIndexCursorNative10Test extends AbstractNodeValueIndexCurs
     public ReadTestSupport newTestSupport()
     {
         ReadTestSupport readTestSupport = new ReadTestSupport();
-        readTestSupport.addSetting( GraphDatabaseSettings.default_schema_index, GraphDatabaseSettings.SchemaIndex.NATIVE10.param() );
+        readTestSupport.addSetting( GraphDatabaseSettings.default_schema_provider, GraphDatabaseSettings.SchemaIndex.NATIVE10.param() );
         return readTestSupport;
     }
 

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorNative10Test.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorNative10Test.java
@@ -21,22 +21,20 @@ package org.neo4j.kernel.impl.newapi;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.SchemaIndex.LUCENE10;
-
-public class NodeValueIndexCursorLuceneTest extends AbstractNodeValueIndexCursorTest
+public class NodeValueIndexCursorNative10Test extends AbstractNodeValueIndexCursorTest
 {
     @Override
     public ReadTestSupport newTestSupport()
     {
         ReadTestSupport readTestSupport = new ReadTestSupport();
-        readTestSupport.addSetting( GraphDatabaseSettings.default_schema_index, LUCENE10.param() );
+        readTestSupport.addSetting( GraphDatabaseSettings.default_schema_index, GraphDatabaseSettings.SchemaIndex.NATIVE10.param() );
         return readTestSupport;
     }
 
     @Override
     protected String providerKey()
     {
-        return "lucene";
+        return "lucene+native";
     }
 
     @Override

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorNative20Test.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorNative20Test.java
@@ -27,7 +27,7 @@ public class NodeValueIndexCursorNative20Test extends AbstractNodeValueIndexCurs
     public ReadTestSupport newTestSupport()
     {
         ReadTestSupport readTestSupport = new ReadTestSupport();
-        readTestSupport.addSetting( GraphDatabaseSettings.default_schema_index, GraphDatabaseSettings.SchemaIndex.NATIVE20.param() );
+        readTestSupport.addSetting( GraphDatabaseSettings.default_schema_provider, GraphDatabaseSettings.SchemaIndex.NATIVE20.param() );
         return readTestSupport;
     }
 

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorNative20Test.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorNative20Test.java
@@ -20,15 +20,14 @@
 package org.neo4j.kernel.impl.newapi;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.kernel.configuration.Settings;
 
-public class NodeValueIndexCursorNativeTest extends AbstractNodeValueIndexCursorTest
+public class NodeValueIndexCursorNative20Test extends AbstractNodeValueIndexCursorTest
 {
     @Override
     public ReadTestSupport newTestSupport()
     {
         ReadTestSupport readTestSupport = new ReadTestSupport();
-        readTestSupport.addSetting( GraphDatabaseSettings.enable_native_schema_index, Settings.TRUE );
+        readTestSupport.addSetting( GraphDatabaseSettings.default_schema_index, GraphDatabaseSettings.SchemaIndex.NATIVE20.param() );
         return readTestSupport;
     }
 

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorNativeTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorNativeTest.java
@@ -41,6 +41,6 @@ public class NodeValueIndexCursorNativeTest extends AbstractNodeValueIndexCursor
     @Override
     protected String providerVersion()
     {
-        return "1.0";
+        return "2.0";
     }
 }

--- a/community/neo4j/src/test/java/org/neo4j/index/IndexFailureOnStartupTest.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/IndexFailureOnStartupTest.java
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.neo4j.graphdb.schema.Schema.IndexState.ONLINE;
 import static org.neo4j.kernel.api.impl.schema.LuceneIndexProviderFactory.PROVIDER_DESCRIPTOR;
-import static org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory.subProviderDirectoryStructure;
+import static org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory20.subProviderDirectoryStructure;
 
 public class IndexFailureOnStartupTest
 {

--- a/community/neo4j/src/test/java/recovery/RecoveryCleanupIT.java
+++ b/community/neo4j/src/test/java/recovery/RecoveryCleanupIT.java
@@ -59,6 +59,7 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.rule.TestDirectory;
 
 import static org.junit.Assert.fail;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.SchemaIndex.NATIVE20;
 
 public class RecoveryCleanupIT
 {
@@ -141,7 +142,7 @@ public class RecoveryCleanupIT
     public void nativeIndexMustLogCrashPointerCleanupDuringRecovery() throws Exception
     {
         // given
-        setTestConfig( GraphDatabaseSettings.enable_native_schema_index, "true" );
+        setTestConfig( GraphDatabaseSettings.default_schema_index, NATIVE20.param() );
         dirtyDatabase();
 
         // when
@@ -172,7 +173,7 @@ public class RecoveryCleanupIT
         db = null;
     }
 
-    private void setTestConfig( Setting<Boolean> setting, String value )
+    private void setTestConfig( Setting<?> setting, String value )
     {
         testSpecificConfig.put( setting, value );
     }

--- a/community/neo4j/src/test/java/recovery/RecoveryCleanupIT.java
+++ b/community/neo4j/src/test/java/recovery/RecoveryCleanupIT.java
@@ -142,7 +142,7 @@ public class RecoveryCleanupIT
     public void nativeIndexMustLogCrashPointerCleanupDuringRecovery() throws Exception
     {
         // given
-        setTestConfig( GraphDatabaseSettings.default_schema_index, NATIVE20.param() );
+        setTestConfig( GraphDatabaseSettings.default_schema_provider, NATIVE20.param() );
         dirtyDatabase();
 
         // when

--- a/community/neo4j/src/test/java/schema/MultiIndexPopulationConcurrentUpdatesIT.java
+++ b/community/neo4j/src/test/java/schema/MultiIndexPopulationConcurrentUpdatesIT.java
@@ -55,7 +55,8 @@ import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexPopulationFailedKernelException;
 import org.neo4j.kernel.api.impl.schema.LuceneIndexProviderFactory;
-import org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory;
+import org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory10;
+import org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory20;
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexProvider;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
@@ -64,12 +65,12 @@ import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptorFactory;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.SchemaState;
+import org.neo4j.kernel.impl.api.index.IndexProviderMap;
 import org.neo4j.kernel.impl.api.index.IndexProxy;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.index.IndexingServiceFactory;
 import org.neo4j.kernel.impl.api.index.MultipleIndexPopulator;
 import org.neo4j.kernel.impl.api.index.NodeUpdates;
-import org.neo4j.kernel.impl.api.index.IndexProviderMap;
 import org.neo4j.kernel.impl.api.index.StoreScan;
 import org.neo4j.kernel.impl.api.index.inmemory.InMemoryIndexProviderFactory;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
@@ -119,7 +120,8 @@ public class MultiIndexPopulationConcurrentUpdatesIT
     public static Collection<IndexProvider.Descriptor> parameters()
     {
         return asList( LuceneIndexProviderFactory.PROVIDER_DESCRIPTOR,
-                NativeLuceneFusionIndexProviderFactory.DESCRIPTOR,
+                NativeLuceneFusionIndexProviderFactory10.DESCRIPTOR,
+                NativeLuceneFusionIndexProviderFactory20.DESCRIPTOR,
                 InMemoryIndexProviderFactory.PROVIDER_DESCRIPTOR );
     }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/BuiltInProcedureAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/BuiltInProcedureAcceptanceTest.scala
@@ -21,6 +21,7 @@ package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.graphdb.{Label, Node, Relationship}
 import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
+import org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory20
 
 import scala.collection.JavaConversions._
 
@@ -268,6 +269,7 @@ class BuiltInProcedureAcceptanceTest extends ProcedureCallAcceptanceTest with Cy
     //When
     val result = executeWith(Configs.Procs, "CALL db.indexes")
 
+
     // Then
     result.toList should equal(
       List(Map("description" -> "INDEX ON :A(prop)",
@@ -275,7 +277,9 @@ class BuiltInProcedureAcceptanceTest extends ProcedureCallAcceptanceTest with Cy
         "properties" -> List("prop"),
         "state" -> "ONLINE",
         "type" -> "node_label_property",
-        "provider" -> Map("version" -> "1.0", "key" -> "lucene+native"))))
+        "provider" -> Map(
+          "version" -> NativeLuceneFusionIndexProviderFactory20.DESCRIPTOR.getVersion,
+          "key" -> NativeLuceneFusionIndexProviderFactory20.DESCRIPTOR.getKey))))
   }
 
   test("yield from void procedure should return correct error msg") {

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
@@ -52,13 +52,13 @@ import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
-import org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory;
+import org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory20;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexPopulator;
+import org.neo4j.kernel.api.index.IndexProvider;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.PropertyAccessor;
-import org.neo4j.kernel.api.index.IndexProvider;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
@@ -572,8 +572,8 @@ public class SchemaIndexHaIT
             OperationalMode operationalMode = context.databaseInfo().operationalMode;
             RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = deps.recoveryCleanupWorkCollector();
 
-            FusionIndexProvider fusionIndexProvider = NativeLuceneFusionIndexProviderFactory
-                    .newInstance( pageCache, storeDir, fs, monitor, config, operationalMode, recoveryCleanupWorkCollector );
+            FusionIndexProvider fusionIndexProvider = NativeLuceneFusionIndexProviderFactory20
+                    .create( pageCache, storeDir, fs, monitor, config, operationalMode, recoveryCleanupWorkCollector );
 
             if ( injectLatchPredicate.test( deps.db() ) )
             {


### PR DESCRIPTION
## Include
* Divide FusionIndexProvider into Fusion-1.0 and Fusion-2.0.
* Turn old Lucene-1.0 provider into a fusion provider as well.
* Add support for Spatial and Temporal to all IndexProviders.
* Introduce new config setting to control default index provider and deprecate old `unsupported.enable_native_schema_index`.

## Old indexes
Indexes that already exist will _not_ be migrated to use native index for strings. Instead they will work just as before without any downtime. Manual migration of existing index can be done by dropping and then recreating it.
All new indexes will be using the latest index provider that use native storage for strings, unless configured otherwise.

cl: Strings are indexed with native implementation instead of in Lucene.