### PR TITLE
Remove Kernel.cursors()

### DIFF
--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Kernel.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Kernel.java
@@ -26,8 +26,6 @@ import org.neo4j.internal.kernel.api.security.LoginContext;
  */
 public interface Kernel
 {
-    CursorFactory cursors();
-
     Session beginSession( LoginContext loginContext );
 
     Modes modes();

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/ConstraintTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/ConstraintTestBase.java
@@ -190,7 +190,7 @@ public abstract class ConstraintTestBase<G extends KernelAPIWriteTestSupport> ex
 
         //Verify
         try ( Transaction tx = session.beginTransaction();
-              NodeCursor nodeCursor = cursors.allocateNodeCursor() )
+              NodeCursor nodeCursor = tx.cursors().allocateNodeCursor() )
         {
             //Node without conflict
             tx.dataRead().singleNode( nodeNotConflicting, nodeCursor );
@@ -248,8 +248,8 @@ public abstract class ConstraintTestBase<G extends KernelAPIWriteTestSupport> ex
 
         //Verify
         try ( Transaction tx = session.beginTransaction();
-              NodeCursor nodeCursor = cursors.allocateNodeCursor();
-              PropertyCursor propertyCursor = cursors.allocatePropertyCursor() )
+              NodeCursor nodeCursor = tx.cursors().allocateNodeCursor();
+              PropertyCursor propertyCursor = tx.cursors().allocatePropertyCursor() )
         {
             //Node without conflict
             tx.dataRead().singleNode( nodeNotConflicting, nodeCursor );

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/GraphPropertiesTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/GraphPropertiesTestBase.java
@@ -111,7 +111,7 @@ public abstract class GraphPropertiesTestBase<G extends KernelAPIWriteTestSuppor
         }
 
         try ( Transaction tx = session.beginTransaction();
-              PropertyCursor cursor = cursors.allocatePropertyCursor() )
+              PropertyCursor cursor = tx.cursors().allocatePropertyCursor() )
         {
             tx.dataRead().graphProperties( cursor );
 
@@ -135,7 +135,7 @@ public abstract class GraphPropertiesTestBase<G extends KernelAPIWriteTestSuppor
     public void shouldSeeNewGraphPropertyInTransaction() throws Exception
     {
         try ( Transaction tx = session.beginTransaction();
-              PropertyCursor cursor = cursors.allocatePropertyCursor() )
+              PropertyCursor cursor = tx.cursors().allocatePropertyCursor() )
         {
             int prop = tx.tokenWrite().propertyKeyGetOrCreateForName( "prop" );
             assertThat( tx.dataWrite().graphSetProperty( prop, stringValue( "hello" ) ), equalTo( NO_VALUE ) );
@@ -159,7 +159,7 @@ public abstract class GraphPropertiesTestBase<G extends KernelAPIWriteTestSuppor
         }
 
         try ( Transaction tx = session.beginTransaction();
-              PropertyCursor cursor = cursors.allocatePropertyCursor() )
+              PropertyCursor cursor = tx.cursors().allocatePropertyCursor() )
         {
             assertThat( tx.dataWrite().graphSetProperty( prop, stringValue( "good bye" ) ),
                     equalTo( stringValue( "hello" ) ) );
@@ -184,7 +184,7 @@ public abstract class GraphPropertiesTestBase<G extends KernelAPIWriteTestSuppor
         }
 
         try ( Transaction tx = session.beginTransaction();
-              PropertyCursor cursor = cursors.allocatePropertyCursor() )
+              PropertyCursor cursor = tx.cursors().allocatePropertyCursor() )
         {
             assertThat( tx.dataWrite().graphRemoveProperty( prop ), equalTo( stringValue( "hello" ) ) );
 

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/KernelAPIReadTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/KernelAPIReadTestBase.java
@@ -79,12 +79,12 @@ public abstract class KernelAPIReadTestBase<ReadSupport extends KernelAPIReadTes
         }
         Kernel kernel = testSupport.kernelToTest();
         session = kernel.beginSession( LoginContext.AUTH_DISABLED );
-        cursors = new ManagedTestCursors( kernel.cursors() );
         tx = session.beginTransaction( Transaction.Type.explicit );
         token = tx.token();
         read = tx.dataRead();
         indexRead = tx.indexRead();
         schemaRead = tx.schemaRead();
+        cursors = new ManagedTestCursors( tx.cursors() );
     }
 
     @Rule

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/KernelAPIWriteTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/KernelAPIWriteTestBase.java
@@ -48,11 +48,7 @@ public abstract class KernelAPIWriteTestBase<WriteSupport extends KernelAPIWrite
     protected static KernelAPIWriteTestSupport testSupport;
     protected Session session;
     protected Modes modes;
-    protected ManagedTestCursors cursors;
     protected static GraphDatabaseService graphDb;
-
-    @Rule
-    public CursorsClosedPostCondition conditionalTeardown = new CursorsClosedPostCondition( () -> cursors );
 
     /**
      * Creates a new instance of WriteSupport, which will be used to execute the concrete test
@@ -73,7 +69,6 @@ public abstract class KernelAPIWriteTestBase<WriteSupport extends KernelAPIWrite
         Kernel kernel = testSupport.kernelToTest();
         session = kernel.beginSession( LoginContext.AUTH_DISABLED );
         modes = kernel.modes();
-        cursors = new ManagedTestCursors( kernel.cursors() );
     }
 
     @After

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeTransactionStateTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeTransactionStateTestBase.java
@@ -46,7 +46,7 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
         try ( Transaction tx = session.beginTransaction() )
         {
             nodeId = tx.dataWrite().nodeCreate();
-            try ( NodeCursor node = cursors.allocateNodeCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor() )
             {
                 tx.dataRead().singleNode( nodeId, node );
                 assertTrue( "should access node", node.next() );
@@ -75,7 +75,7 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
             labelId = tx.token().labelGetOrCreateForName( labelName );
             tx.dataWrite().nodeAddLabel( nodeId, labelId );
 
-            try ( NodeCursor node = cursors.allocateNodeCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor() )
             {
                 tx.dataRead().singleNode( nodeId, node );
                 assertTrue( "should access node", node.next() );
@@ -128,7 +128,7 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
             tx.dataWrite().nodeAddLabel( nodeId, toAdd );
             tx.dataWrite().nodeRemoveLabel( nodeId, toDelete );
 
-            try ( NodeCursor node = cursors.allocateNodeCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor() )
             {
                 tx.dataRead().singleNode( nodeId, node );
                 assertTrue( "should access node", node.next() );
@@ -160,7 +160,7 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
         try ( Transaction tx = session.beginTransaction() )
         {
             assertTrue( tx.dataWrite().nodeDelete( nodeId ) );
-            try ( NodeCursor node = cursors.allocateNodeCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor() )
             {
                 tx.dataRead().singleNode( nodeId, node );
                 assertFalse( node.next() );
@@ -202,8 +202,8 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
             assertEquals( tx.dataWrite().nodeSetProperty( nodeId, prop1, stringValue( "hello" ) ), NO_VALUE );
             assertEquals( tx.dataWrite().nodeSetProperty( nodeId, prop2, stringValue( "world" ) ), NO_VALUE );
 
-            try ( NodeCursor node = cursors.allocateNodeCursor();
-                  PropertyCursor property = cursors.allocatePropertyCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor();
+                  PropertyCursor property = tx.cursors().allocatePropertyCursor() )
             {
                 tx.dataRead().singleNode( nodeId, node );
                 assertTrue( "should access node", node.next() );
@@ -243,8 +243,8 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
             int propToken = tx.token().propertyKeyGetOrCreateForName( propKey );
             assertEquals( tx.dataWrite().nodeSetProperty( nodeId, propToken, stringValue( "hello" ) ), NO_VALUE );
 
-            try ( NodeCursor node = cursors.allocateNodeCursor();
-                  PropertyCursor property = cursors.allocatePropertyCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor();
+                  PropertyCursor property = tx.cursors().allocatePropertyCursor() )
             {
                 tx.dataRead().singleNode( nodeId, node );
                 assertTrue( "should access node", node.next() );
@@ -291,8 +291,8 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
             propToken2 = tx.token().propertyKeyGetOrCreateForName( propKey2 );
             assertEquals( tx.dataWrite().nodeSetProperty( nodeId, propToken2, stringValue( "world" ) ), NO_VALUE );
 
-            try ( NodeCursor node = cursors.allocateNodeCursor();
-                  PropertyCursor property = cursors.allocatePropertyCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor();
+                  PropertyCursor property = tx.cursors().allocatePropertyCursor() )
             {
                 tx.dataRead().singleNode( nodeId, node );
                 assertTrue( "should access node", node.next() );
@@ -344,8 +344,8 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
         {
             assertEquals( tx.dataWrite().nodeSetProperty( nodeId, propToken, stringValue( "world" ) ),
                     stringValue( "hello" ) );
-            try ( NodeCursor node = cursors.allocateNodeCursor();
-                  PropertyCursor property = cursors.allocatePropertyCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor();
+                  PropertyCursor property = tx.cursors().allocatePropertyCursor() )
             {
                 tx.dataRead().singleNode( nodeId, node );
                 assertTrue( "should access node", node.next() );
@@ -389,8 +389,8 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
         try ( Transaction tx = session.beginTransaction() )
         {
             assertEquals( tx.dataWrite().nodeRemoveProperty( nodeId, propToken ), stringValue( "hello" ) );
-            try ( NodeCursor node = cursors.allocateNodeCursor();
-                  PropertyCursor property = cursors.allocatePropertyCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor();
+                  PropertyCursor property = tx.cursors().allocatePropertyCursor() )
             {
                 tx.dataRead().singleNode( nodeId, node );
                 assertTrue( "should access node", node.next() );
@@ -430,8 +430,8 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
         {
             assertEquals( tx.dataWrite().nodeRemoveProperty( nodeId, propToken ), stringValue( "hello" ) );
             assertEquals( tx.dataWrite().nodeSetProperty( nodeId, propToken, stringValue( "world" ) ), NO_VALUE );
-            try ( NodeCursor node = cursors.allocateNodeCursor();
-                  PropertyCursor property = cursors.allocatePropertyCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor();
+                  PropertyCursor property = tx.cursors().allocatePropertyCursor() )
             {
                 tx.dataRead().singleNode( nodeId, node );
                 assertTrue( "should access node", node.next() );
@@ -522,7 +522,7 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
         Node node = createNode( "label" );
 
         try ( org.neo4j.internal.kernel.api.Transaction tx = session.beginTransaction();
-              NodeLabelIndexCursor cursor = cursors.allocateNodeLabelIndexCursor() )
+              NodeLabelIndexCursor cursor = tx.cursors().allocateNodeLabelIndexCursor() )
         {
             // when
             tx.dataWrite().nodeDelete( node.node );
@@ -540,7 +540,7 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
         Node node = createNode( "label" );
 
         try ( org.neo4j.internal.kernel.api.Transaction tx = session.beginTransaction();
-              NodeLabelIndexCursor cursor = cursors.allocateNodeLabelIndexCursor() )
+              NodeLabelIndexCursor cursor = tx.cursors().allocateNodeLabelIndexCursor() )
         {
             // when
             tx.dataWrite().nodeRemoveLabel( node.node, node.labels[0] );
@@ -558,7 +558,7 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
         Node node = createNode(  );
 
         try ( org.neo4j.internal.kernel.api.Transaction tx = session.beginTransaction();
-              NodeLabelIndexCursor cursor = cursors.allocateNodeLabelIndexCursor() )
+              NodeLabelIndexCursor cursor = tx.cursors().allocateNodeLabelIndexCursor() )
         {
             // when
             int label = tx.tokenWrite().labelGetOrCreateForName( "label" );
@@ -579,7 +579,7 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
         Node node2 = createNode();
 
         try ( org.neo4j.internal.kernel.api.Transaction tx = session.beginTransaction();
-              NodeLabelIndexCursor cursor = cursors.allocateNodeLabelIndexCursor() )
+              NodeLabelIndexCursor cursor = tx.cursors().allocateNodeLabelIndexCursor() )
         {
             // when
             tx.dataWrite().nodeRemoveLabel( node1.node, node1.labels[0] );
@@ -599,7 +599,7 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
         Node node = createNode( "label1", "label2" );
 
         try ( org.neo4j.internal.kernel.api.Transaction tx = session.beginTransaction();
-              NodeLabelIndexCursor cursor = cursors.allocateNodeLabelIndexCursor() )
+              NodeLabelIndexCursor cursor = tx.cursors().allocateNodeLabelIndexCursor() )
         {
             // when
             tx.dataWrite().nodeDelete( node.node );
@@ -617,7 +617,7 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
         Node node = createNode( "label1", "label2" );
 
         try ( org.neo4j.internal.kernel.api.Transaction tx = session.beginTransaction();
-              NodeLabelIndexCursor cursor = cursors.allocateNodeLabelIndexCursor() )
+              NodeLabelIndexCursor cursor = tx.cursors().allocateNodeLabelIndexCursor() )
         {
             // when
             tx.dataWrite().nodeRemoveLabel( node.node, node.labels[1] );
@@ -636,7 +636,7 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
         Node node = createNode( "label1", "label2" );
 
         try ( org.neo4j.internal.kernel.api.Transaction tx = session.beginTransaction();
-              NodeLabelIndexCursor cursor = cursors.allocateNodeLabelIndexCursor() )
+              NodeLabelIndexCursor cursor = tx.cursors().allocateNodeLabelIndexCursor() )
         {
             // when
             tx.dataWrite().nodeRemoveLabel( node.node, node.labels[0] );
@@ -655,7 +655,7 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
         Node node = createNode( "label1");
 
         try ( org.neo4j.internal.kernel.api.Transaction tx = session.beginTransaction();
-              NodeLabelIndexCursor cursor = cursors.allocateNodeLabelIndexCursor() )
+              NodeLabelIndexCursor cursor = tx.cursors().allocateNodeLabelIndexCursor() )
         {
             // when
             int label1 = tx.tokenWrite().labelGetOrCreateForName( "label1" );
@@ -676,7 +676,7 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
         Node node = createNode( "label1" );
 
         try ( org.neo4j.internal.kernel.api.Transaction tx = session.beginTransaction();
-              NodeLabelIndexCursor cursor = cursors.allocateNodeLabelIndexCursor() )
+              NodeLabelIndexCursor cursor = tx.cursors().allocateNodeLabelIndexCursor() )
         {
             // when
             int label2 = tx.tokenWrite().labelGetOrCreateForName( "label2" );
@@ -696,7 +696,7 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
         Node node = createNode( "label1", "label2" );
 
         try ( org.neo4j.internal.kernel.api.Transaction tx = session.beginTransaction();
-              NodeLabelIndexCursor cursor = cursors.allocateNodeLabelIndexCursor() )
+              NodeLabelIndexCursor cursor = tx.cursors().allocateNodeLabelIndexCursor() )
         {
             // when
             tx.dataWrite().nodeDelete( node.node );
@@ -714,7 +714,7 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
         Node node = createNode( "label1", "label2" );
 
         try ( org.neo4j.internal.kernel.api.Transaction tx = session.beginTransaction();
-              NodeLabelIndexCursor cursor = cursors.allocateNodeLabelIndexCursor() )
+              NodeLabelIndexCursor cursor = tx.cursors().allocateNodeLabelIndexCursor() )
         {
             // when
             tx.dataWrite().nodeRemoveLabel( node.node, node.labels[1] );
@@ -732,7 +732,7 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
         Node node = createNode("label1");
 
         try ( org.neo4j.internal.kernel.api.Transaction tx = session.beginTransaction();
-              NodeLabelIndexCursor cursor = cursors.allocateNodeLabelIndexCursor() )
+              NodeLabelIndexCursor cursor = tx.cursors().allocateNodeLabelIndexCursor() )
         {
             // when
             int label2 = tx.tokenWrite().labelGetOrCreateForName( "label2" );
@@ -752,7 +752,7 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
         Node node = createNode();
 
         try ( org.neo4j.internal.kernel.api.Transaction tx = session.beginTransaction();
-              NodeLabelIndexCursor cursor = cursors.allocateNodeLabelIndexCursor() )
+              NodeLabelIndexCursor cursor = tx.cursors().allocateNodeLabelIndexCursor() )
         {
             // when
             int label1 = tx.tokenWrite().labelGetOrCreateForName( "labe1" );
@@ -772,8 +772,7 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
         Node node1 = createNode( "label" );
         Node node2 = createNode();
 
-        try ( org.neo4j.internal.kernel.api.Transaction tx = session.beginTransaction();
-              NodeLabelIndexCursor cursor = cursors.allocateNodeLabelIndexCursor() )
+        try ( org.neo4j.internal.kernel.api.Transaction tx = session.beginTransaction() )
         {
             // when
             tx.dataWrite().nodeAddLabel( node2.node, node1.labels[0] );
@@ -793,8 +792,7 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
         createNode();
         createNode();
 
-        try ( org.neo4j.internal.kernel.api.Transaction tx = session.beginTransaction();
-              NodeLabelIndexCursor cursor = cursors.allocateNodeLabelIndexCursor() )
+        try ( org.neo4j.internal.kernel.api.Transaction tx = session.beginTransaction() )
         {
             // when
             tx.dataWrite().nodeCreate();
@@ -814,8 +812,7 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
         Node node1 = createNode( "label" );
         Node node2 = createNode( "label" );
 
-        try ( org.neo4j.internal.kernel.api.Transaction tx = session.beginTransaction();
-              NodeLabelIndexCursor cursor = cursors.allocateNodeLabelIndexCursor() )
+        try ( org.neo4j.internal.kernel.api.Transaction tx = session.beginTransaction() )
         {
             // when
             tx.dataWrite().nodeRemoveLabel( node2.node, node2.labels[0] );
@@ -835,8 +832,7 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
         Node node1 = createNode( "label" );
         Node node2 = createNode( "label" );
 
-        try ( org.neo4j.internal.kernel.api.Transaction tx = session.beginTransaction();
-              NodeLabelIndexCursor cursor = cursors.allocateNodeLabelIndexCursor() )
+        try ( org.neo4j.internal.kernel.api.Transaction tx = session.beginTransaction() )
         {
             // when
             tx.dataWrite().nodeDelete( node2.node );

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTransactionStateTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTransactionStateTestBase.java
@@ -75,7 +75,7 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
         try ( Transaction tx = session.beginTransaction() )
         {
             long r = tx.dataWrite().relationshipCreate( n1, label, n2 );
-            try ( RelationshipScanCursor relationship = cursors.allocateRelationshipScanCursor() )
+            try ( RelationshipScanCursor relationship = tx.cursors().allocateRelationshipScanCursor() )
             {
                 tx.dataRead().singleRelationship( r, relationship );
                 assertTrue( "should find relationship", relationship.next() );
@@ -112,7 +112,7 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
         try ( Transaction tx = session.beginTransaction() )
         {
             assertTrue( "should delete relationship", tx.dataWrite().relationshipDelete( r ) );
-            try ( RelationshipScanCursor relationship = cursors.allocateRelationshipScanCursor() )
+            try ( RelationshipScanCursor relationship = tx.cursors().allocateRelationshipScanCursor() )
             {
                 tx.dataRead().singleRelationship( r, relationship );
                 assertFalse( "should not find relationship", relationship.next() );
@@ -143,7 +143,7 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
         try ( Transaction tx = session.beginTransaction() )
         {
             long r = tx.dataWrite().relationshipCreate( n1, type, n2 );
-            try ( RelationshipScanCursor relationship = cursors.allocateRelationshipScanCursor() )
+            try ( RelationshipScanCursor relationship = tx.cursors().allocateRelationshipScanCursor() )
             {
                 tx.dataRead().allRelationshipsScan( relationship );
                 assertCountRelationships( relationship, nRelationshipsInStore + 1, n1, type, n2 );
@@ -175,7 +175,7 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
         try ( Transaction tx = session.beginTransaction() )
         {
             assertTrue( "should delete relationship", tx.dataWrite().relationshipDelete( r ) );
-            try ( RelationshipScanCursor relationship = cursors.allocateRelationshipScanCursor() )
+            try ( RelationshipScanCursor relationship = tx.cursors().allocateRelationshipScanCursor() )
             {
                 tx.dataRead().allRelationshipsScan( relationship );
                 assertCountRelationships( relationship, nRelationshipsInStore - 1, n1, type, n2 );
@@ -199,8 +199,8 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
         {
             int label = tx.tokenWrite().relationshipTypeGetOrCreateForName( "R" );
             long r = tx.dataWrite().relationshipCreate( n1, label, n2 );
-            try ( NodeCursor node = cursors.allocateNodeCursor();
-                  RelationshipTraversalCursor relationship = cursors.allocateRelationshipTraversalCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor();
+                  RelationshipTraversalCursor relationship = tx.cursors().allocateRelationshipTraversalCursor() )
             {
                 tx.dataRead().singleNode( n1, node );
                 assertTrue( "should access node", node.next() );
@@ -233,8 +233,8 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
         try ( Transaction tx = session.beginTransaction() )
         {
             tx.dataWrite().relationshipDelete( r );
-            try ( NodeCursor node = cursors.allocateNodeCursor();
-                  RelationshipTraversalCursor relationship = cursors.allocateRelationshipTraversalCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor();
+                  RelationshipTraversalCursor relationship = tx.cursors().allocateRelationshipTraversalCursor() )
             {
                 tx.dataRead().singleNode( n1, node );
                 assertTrue( "should access node", node.next() );
@@ -261,8 +261,8 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
         {
             int label = tx.tokenWrite().relationshipTypeGetOrCreateForName( "R" );
             long r = tx.dataWrite().relationshipCreate( n1, label, n2 );
-            try ( NodeCursor node = cursors.allocateNodeCursor();
-                  RelationshipTraversalCursor relationship = cursors.allocateRelationshipTraversalCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor();
+                  RelationshipTraversalCursor relationship = tx.cursors().allocateRelationshipTraversalCursor() )
             {
                 tx.dataRead().singleNode( n1, node );
                 assertTrue( "should access node", node.next() );
@@ -342,9 +342,9 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
             assertEquals( tx.dataWrite().relationshipSetProperty( r, prop1, stringValue( "hello" ) ), NO_VALUE );
             assertEquals( tx.dataWrite().relationshipSetProperty( r, prop2, stringValue( "world" ) ), NO_VALUE );
 
-            try ( NodeCursor node = cursors.allocateNodeCursor();
-                  RelationshipTraversalCursor relationship = cursors.allocateRelationshipTraversalCursor();
-                  PropertyCursor property = cursors.allocatePropertyCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor();
+                  RelationshipTraversalCursor relationship = tx.cursors().allocateRelationshipTraversalCursor();
+                  PropertyCursor property = tx.cursors().allocatePropertyCursor() )
             {
                 tx.dataRead().singleNode( n1, node );
                 assertTrue( "should access node", node.next() );
@@ -397,8 +397,8 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
             assertEquals( tx.dataWrite().relationshipSetProperty( relationshipId, propToken, stringValue( "hello" ) ),
                     NO_VALUE );
 
-            try ( RelationshipScanCursor relationship = cursors.allocateRelationshipScanCursor();
-                  PropertyCursor property = cursors.allocatePropertyCursor() )
+            try ( RelationshipScanCursor relationship = tx.cursors().allocateRelationshipScanCursor();
+                  PropertyCursor property = tx.cursors().allocatePropertyCursor() )
             {
                 tx.dataRead().singleRelationship( relationshipId, relationship );
                 assertTrue( "should access relationship", relationship.next() );
@@ -449,8 +449,8 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
             assertEquals( tx.dataWrite().relationshipSetProperty( relationshipId, propToken2, stringValue( "world" ) ),
                     NO_VALUE );
 
-            try ( RelationshipScanCursor relationship = cursors.allocateRelationshipScanCursor();
-                  PropertyCursor property = cursors.allocatePropertyCursor() )
+            try ( RelationshipScanCursor relationship = tx.cursors().allocateRelationshipScanCursor();
+                  PropertyCursor property = tx.cursors().allocatePropertyCursor() )
             {
                 tx.dataRead().singleRelationship( relationshipId, relationship );
                 assertTrue( "should access relationship", relationship.next() );
@@ -510,8 +510,8 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
         {
             assertEquals( tx.dataWrite().relationshipSetProperty( relationshipId, propToken, stringValue( "world" ) ),
                     stringValue( "hello" ) );
-            try ( RelationshipScanCursor relationship = cursors.allocateRelationshipScanCursor();
-                  PropertyCursor property = cursors.allocatePropertyCursor() )
+            try ( RelationshipScanCursor relationship = tx.cursors().allocateRelationshipScanCursor();
+                  PropertyCursor property = tx.cursors().allocatePropertyCursor() )
             {
                 tx.dataRead().singleRelationship( relationshipId, relationship );
                 assertTrue( "should access relationship", relationship.next() );
@@ -559,8 +559,8 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
         {
             assertEquals( tx.dataWrite().relationshipRemoveProperty( relationshipId, propToken ),
                     stringValue( "hello" ) );
-            try ( RelationshipScanCursor relationship = cursors.allocateRelationshipScanCursor();
-                  PropertyCursor property = cursors.allocatePropertyCursor() )
+            try ( RelationshipScanCursor relationship = tx.cursors().allocateRelationshipScanCursor();
+                  PropertyCursor property = tx.cursors().allocatePropertyCursor() )
             {
                 tx.dataRead().singleRelationship( relationshipId, relationship );
                 assertTrue( "should access relationship", relationship.next() );
@@ -605,8 +605,8 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
                     stringValue( "hello" ) );
             assertEquals( tx.dataWrite().relationshipSetProperty( relationshipId, propToken, stringValue( "world" ) ),
                     NO_VALUE );
-            try ( RelationshipScanCursor relationship = cursors.allocateRelationshipScanCursor();
-                  PropertyCursor property = cursors.allocatePropertyCursor() )
+            try ( RelationshipScanCursor relationship = tx.cursors().allocateRelationshipScanCursor();
+                  PropertyCursor property = tx.cursors().allocatePropertyCursor() )
             {
                 tx.dataRead().singleRelationship( relationshipId, relationship );
                 assertTrue( "should access relationship", relationship.next() );
@@ -698,9 +698,9 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
             long in1 = write.relationshipCreate( write.nodeCreate(), incoming, start );
             long in2 = write.relationshipCreate( write.nodeCreate(), incoming, start );
             long loop = write.relationshipCreate( start, looping, start );
-            try ( NodeCursor node = cursors.allocateNodeCursor();
-                  RelationshipTraversalCursor traversal = cursors.allocateRelationshipTraversalCursor();
-                  RelationshipGroupCursor group = cursors.allocateRelationshipGroupCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor();
+                  RelationshipTraversalCursor traversal = tx.cursors().allocateRelationshipTraversalCursor();
+                  RelationshipGroupCursor group = tx.cursors().allocateRelationshipGroupCursor() )
             {
                 Read read = tx.dataRead();
                 read.singleNode( start, node );
@@ -766,9 +766,9 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
             Write write = tx.dataWrite();
             long newRelationship = write.relationshipCreate( start, type, write.nodeCreate() );
 
-            try ( NodeCursor node = cursors.allocateNodeCursor();
-                  RelationshipTraversalCursor traversal = cursors.allocateRelationshipTraversalCursor();
-                  RelationshipGroupCursor group = cursors.allocateRelationshipGroupCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor();
+                  RelationshipTraversalCursor traversal = tx.cursors().allocateRelationshipTraversalCursor();
+                  RelationshipGroupCursor group = tx.cursors().allocateRelationshipGroupCursor() )
             {
                 Read read = tx.dataRead();
                 read.singleNode( start, node );
@@ -808,9 +808,9 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
             int two = tx.tokenWrite().relationshipTypeGetOrCreateForName( "TWO" );
             long newRelationship = write.relationshipCreate( start, two, write.nodeCreate() );
 
-            try ( NodeCursor node = cursors.allocateNodeCursor();
-                  RelationshipTraversalCursor traversal = cursors.allocateRelationshipTraversalCursor();
-                  RelationshipGroupCursor group = cursors.allocateRelationshipGroupCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor();
+                  RelationshipTraversalCursor traversal = tx.cursors().allocateRelationshipTraversalCursor();
+                  RelationshipGroupCursor group = tx.cursors().allocateRelationshipGroupCursor() )
             {
                 Read read = tx.dataRead();
                 read.singleNode( start, node );
@@ -871,9 +871,9 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
             int two = tx.tokenWrite().relationshipTypeGetOrCreateForName( "TWO" );
             long newRelationship = write.relationshipCreate( start, two, write.nodeCreate() );
 
-            try ( NodeCursor node = cursors.allocateNodeCursor();
-                  RelationshipTraversalCursor traversal = cursors.allocateRelationshipTraversalCursor();
-                  RelationshipGroupCursor group = cursors.allocateRelationshipGroupCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor();
+                  RelationshipTraversalCursor traversal = tx.cursors().allocateRelationshipTraversalCursor();
+                  RelationshipGroupCursor group = tx.cursors().allocateRelationshipGroupCursor() )
             {
                 Read read = tx.dataRead();
                 read.singleNode( start, node );
@@ -936,9 +936,9 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
             Write write = tx.dataWrite();
             long newRelationship = write.relationshipCreate( start, type, write.nodeCreate() );
 
-            try ( NodeCursor node = cursors.allocateNodeCursor();
-                  RelationshipTraversalCursor traversal = cursors.allocateRelationshipTraversalCursor();
-                  RelationshipGroupCursor group = cursors.allocateRelationshipGroupCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor();
+                  RelationshipTraversalCursor traversal = tx.cursors().allocateRelationshipTraversalCursor();
+                  RelationshipGroupCursor group = tx.cursors().allocateRelationshipGroupCursor() )
             {
                 Read read = tx.dataRead();
                 read.singleNode( start, node );
@@ -985,9 +985,9 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
             Write write = tx.dataWrite();
             long newRelationship = write.relationshipCreate( start, type, write.nodeCreate() );
 
-            try ( NodeCursor node = cursors.allocateNodeCursor();
-                  RelationshipTraversalCursor traversal = cursors.allocateRelationshipTraversalCursor();
-                  RelationshipGroupCursor group = cursors.allocateRelationshipGroupCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor();
+                  RelationshipTraversalCursor traversal = tx.cursors().allocateRelationshipTraversalCursor();
+                  RelationshipGroupCursor group = tx.cursors().allocateRelationshipGroupCursor() )
             {
                 Read read = tx.dataRead();
                 read.singleNode( start, node );
@@ -1131,8 +1131,8 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
             Map<String,Integer> expectedCounts = modifyStartNodeRelationships( start, tx );
 
             // given
-            try ( NodeCursor node = cursors.allocateNodeCursor();
-                  RelationshipTraversalCursor relationship = cursors.allocateRelationshipTraversalCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor();
+                  RelationshipTraversalCursor relationship = tx.cursors().allocateRelationshipTraversalCursor() )
             {
                 // when
                 tx.dataRead().singleNode( start.id, node );
@@ -1165,9 +1165,9 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
             Map<String,Integer> expectedCounts = modifyStartNodeRelationships( start, tx );
 
             // given
-            try ( NodeCursor node = cursors.allocateNodeCursor();
-                  RelationshipGroupCursor group = cursors.allocateRelationshipGroupCursor();
-                  RelationshipTraversalCursor relationship = cursors.allocateRelationshipTraversalCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor();
+                  RelationshipGroupCursor group = tx.cursors().allocateRelationshipGroupCursor();
+                  RelationshipTraversalCursor relationship = tx.cursors().allocateRelationshipTraversalCursor() )
             {
                 // when
                 read.singleNode( start.id, node );
@@ -1320,8 +1320,8 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
         {
             Write write = tx.dataWrite();
             createRelationship( direction, start, type, write );
-            try ( NodeCursor node = cursors.allocateNodeCursor();
-                  RelationshipGroupCursor group = cursors.allocateRelationshipGroupCursor() )
+            try ( NodeCursor node = tx.cursors().allocateNodeCursor();
+                  RelationshipGroupCursor group = tx.cursors().allocateRelationshipGroupCursor() )
             {
                 Read read = tx.dataRead();
                 read.singleNode( start, node );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
@@ -144,12 +144,6 @@ public class Kernel extends LifecycleAdapter implements InwardKernel
     }
 
     @Override
-    public CursorFactory cursors()
-    {
-        return newKernel.cursors();
-    }
-
-    @Override
     public Session beginSession( LoginContext loginContext )
     {
         return newKernel.beginSession( loginContext );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NewKernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NewKernel.java
@@ -37,7 +37,6 @@ public class NewKernel implements Kernel, Modes
     private final InwardKernel kernel;
 
     private StorageStatement statement;
-    private DefaultCursors cursors;
 
     private volatile boolean isRunning;
 
@@ -46,13 +45,6 @@ public class NewKernel implements Kernel, Modes
         this.engine = engine;
         this.kernel = kernel;
         this.isRunning = false;
-    }
-
-    @Override
-    public CursorFactory cursors()
-    {
-        assert isRunning : "kernel is not running, so it is not possible to use it";
-        return cursors;
     }
 
     @Override
@@ -71,7 +63,6 @@ public class NewKernel implements Kernel, Modes
     public void start()
     {
         statement = engine.storeReadLayer().newStatement();
-        this.cursors = new DefaultCursors();
         isRunning = true;
     }
 
@@ -83,7 +74,6 @@ public class NewKernel implements Kernel, Modes
         }
         statement.close();
         isRunning = false;
-        this.cursors = null;
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
@@ -344,12 +344,6 @@ public class ConstraintIndexCreatorTest
         }
 
         @Override
-        public CursorFactory cursors()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
         public Session beginSession( LoginContext loginContext )
         {
             throw new UnsupportedOperationException();


### PR DESCRIPTION
This cannot be used since we introduced pooling of cursors, because that would lead to
all kinds of concurrency problems. Use `Transaction.cursors()` instead.