### PR TITLE
Change TimeValue back to nanosPerDayUTC

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPackV1.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPackV1.java
@@ -332,7 +332,7 @@ public class Neo4jPackV1 implements Neo4jPack
         }
 
         @Override
-        public void writeTime( long nanosOfDayLocal, int offsetSeconds ) throws IOException
+        public void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws IOException
         {
             error = new Error( Status.Request.Invalid,
                     "Time is not yet supported as a return type in Bolt" );

--- a/community/bolt/src/main/java/org/neo4j/bolt/v2/messaging/Neo4jPackV2.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v2/messaging/Neo4jPackV2.java
@@ -43,6 +43,7 @@ import static org.neo4j.values.storable.DateValue.epochDate;
 import static org.neo4j.values.storable.DurationValue.duration;
 import static org.neo4j.values.storable.LocalDateTimeValue.localDateTime;
 import static org.neo4j.values.storable.LocalTimeValue.localTime;
+import static org.neo4j.values.storable.TimeConstants.NANOS_PER_SECOND;
 import static org.neo4j.values.storable.TimeValue.time;
 import static org.neo4j.values.storable.Values.pointValue;
 
@@ -136,10 +137,10 @@ public class Neo4jPackV2 extends Neo4jPackV1
         }
 
         @Override
-        public void writeTime( long nanosOfDayLocal, int offsetSeconds ) throws IOException
+        public void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws IOException
         {
             packStructHeader( 2, TIME );
-            pack( nanosOfDayLocal );
+            pack( nanosOfDayUTC + offsetSeconds * NANOS_PER_SECOND );
             pack( offsetSeconds );
         }
 
@@ -246,7 +247,7 @@ public class Neo4jPackV2 extends Neo4jPackV1
         {
             long nanosOfDayUTC = unpackLong();
             int offsetSeconds = unpackInteger();
-            return time( nanosOfDayUTC, ZoneOffset.ofTotalSeconds( offsetSeconds ) );
+            return time( nanosOfDayUTC - offsetSeconds * NANOS_PER_SECOND, ZoneOffset.ofTotalSeconds( offsetSeconds ) );
         }
 
         private LocalDateTimeValue unpackLocalDateTime() throws IOException

--- a/community/bolt/src/main/java/org/neo4j/bolt/v2/messaging/Neo4jPackV2.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v2/messaging/Neo4jPackV2.java
@@ -36,6 +36,7 @@ import org.neo4j.values.storable.DurationValue;
 import org.neo4j.values.storable.LocalDateTimeValue;
 import org.neo4j.values.storable.LocalTimeValue;
 import org.neo4j.values.storable.PointValue;
+import org.neo4j.values.storable.TimeUtil;
 import org.neo4j.values.storable.TimeValue;
 
 import static org.neo4j.values.storable.DateTimeValue.datetime;
@@ -43,7 +44,6 @@ import static org.neo4j.values.storable.DateValue.epochDate;
 import static org.neo4j.values.storable.DurationValue.duration;
 import static org.neo4j.values.storable.LocalDateTimeValue.localDateTime;
 import static org.neo4j.values.storable.LocalTimeValue.localTime;
-import static org.neo4j.values.storable.TimeConstants.NANOS_PER_SECOND;
 import static org.neo4j.values.storable.TimeValue.time;
 import static org.neo4j.values.storable.Values.pointValue;
 
@@ -140,7 +140,7 @@ public class Neo4jPackV2 extends Neo4jPackV1
         public void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws IOException
         {
             packStructHeader( 2, TIME );
-            pack( nanosOfDayUTC + offsetSeconds * NANOS_PER_SECOND );
+            pack( TimeUtil.nanosOfDayToLocal( nanosOfDayUTC, offsetSeconds ) );
             pack( offsetSeconds );
         }
 
@@ -245,9 +245,9 @@ public class Neo4jPackV2 extends Neo4jPackV1
 
         private TimeValue unpackTime() throws IOException
         {
-            long nanosOfDayUTC = unpackLong();
+            long nanosOfDayLocal = unpackLong();
             int offsetSeconds = unpackInteger();
-            return time( nanosOfDayUTC - offsetSeconds * NANOS_PER_SECOND, ZoneOffset.ofTotalSeconds( offsetSeconds ) );
+            return time( TimeUtil.nanosOfDayToUTC( nanosOfDayLocal, offsetSeconds ), ZoneOffset.ofTotalSeconds( offsetSeconds ) );
         }
 
         private LocalDateTimeValue unpackLocalDateTime() throws IOException

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/ParameterConverter.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/ParameterConverter.java
@@ -54,6 +54,7 @@ import org.neo4j.values.virtual.RelationshipValue;
 
 import static java.time.ZoneOffset.UTC;
 import static org.neo4j.helpers.collection.Iterators.iteratorsEqual;
+import static org.neo4j.values.storable.TimeConstants.NANOS_PER_SECOND;
 
 /**
  * Used for turning parameters into appropriate types in the compiled runtime
@@ -376,27 +377,27 @@ class ParameterConverter implements AnyValueWriter<RuntimeException>
     }
 
     @Override
-    public void writeTime( long nanosOfDayLocal, int offsetSeconds )
+    public void writeTime( long nanosOfDayUTC, int offsetSeconds )
     {
-        writeValue( OffsetTime.of( LocalTime.ofNanoOfDay( nanosOfDayLocal ), ZoneOffset.ofTotalSeconds( offsetSeconds ) ) );
+        writeValue( OffsetTime.of( LocalTime.ofNanoOfDay( nanosOfDayUTC + offsetSeconds * NANOS_PER_SECOND ), ZoneOffset.ofTotalSeconds( offsetSeconds ) ) );
     }
 
     @Override
     public void writeLocalDateTime( long epochSecond, int nano )
     {
-        writeValue( LocalDateTime.ofInstant( Instant.ofEpochSecond(epochSecond, nano), UTC ) );
+        writeValue( LocalDateTime.ofInstant( Instant.ofEpochSecond( epochSecond, nano ), UTC ) );
     }
 
     @Override
     public void writeDateTime( long epochSecondUTC, int nano, int offsetSeconds )
     {
-        writeValue( ZonedDateTime.ofInstant( Instant.ofEpochSecond(epochSecondUTC, nano), ZoneOffset.ofTotalSeconds( offsetSeconds ) ) );
+        writeValue( ZonedDateTime.ofInstant( Instant.ofEpochSecond( epochSecondUTC, nano ), ZoneOffset.ofTotalSeconds( offsetSeconds ) ) );
     }
 
     @Override
     public void writeDateTime( long epochSecondUTC, int nano, String zoneId )
     {
-        writeValue( ZonedDateTime.ofInstant( Instant.ofEpochSecond(epochSecondUTC, nano), ZoneId.of( zoneId ) ) );
+        writeValue( ZonedDateTime.ofInstant( Instant.ofEpochSecond( epochSecondUTC, nano ), ZoneId.of( zoneId ) ) );
     }
 
     private interface Writer

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/ParameterConverter.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/ParameterConverter.java
@@ -47,6 +47,7 @@ import org.neo4j.values.storable.CoordinateReferenceSystem;
 import org.neo4j.values.storable.DurationValue;
 import org.neo4j.values.storable.TextArray;
 import org.neo4j.values.storable.TextValue;
+import org.neo4j.values.storable.TimeUtil;
 import org.neo4j.values.storable.Values;
 import org.neo4j.values.virtual.MapValue;
 import org.neo4j.values.virtual.NodeValue;
@@ -54,7 +55,6 @@ import org.neo4j.values.virtual.RelationshipValue;
 
 import static java.time.ZoneOffset.UTC;
 import static org.neo4j.helpers.collection.Iterators.iteratorsEqual;
-import static org.neo4j.values.storable.TimeConstants.NANOS_PER_SECOND;
 
 /**
  * Used for turning parameters into appropriate types in the compiled runtime
@@ -379,7 +379,9 @@ class ParameterConverter implements AnyValueWriter<RuntimeException>
     @Override
     public void writeTime( long nanosOfDayUTC, int offsetSeconds )
     {
-        writeValue( OffsetTime.of( LocalTime.ofNanoOfDay( nanosOfDayUTC + offsetSeconds * NANOS_PER_SECOND ), ZoneOffset.ofTotalSeconds( offsetSeconds ) ) );
+        writeValue( OffsetTime.of(
+                LocalTime.ofNanoOfDay( TimeUtil.nanosOfDayToLocal( nanosOfDayUTC, offsetSeconds ) ),
+                ZoneOffset.ofTotalSeconds( offsetSeconds ) ) );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/ArrayEncoder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/ArrayEncoder.java
@@ -180,9 +180,9 @@ public final class ArrayEncoder
         }
 
         @Override
-        public void writeTime( long nanosOfDayLocal, int offsetSeconds ) throws RuntimeException
+        public void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws RuntimeException
         {
-            builder.append( TimeValue.time( nanosOfDayLocal, ZoneOffset.ofTotalSeconds( offsetSeconds ) ).prettyPrint() );
+            builder.append( TimeValue.time( nanosOfDayUTC, ZoneOffset.ofTotalSeconds( offsetSeconds ) ).prettyPrint() );
             builder.append( '|' );
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedTimeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedTimeSchemaKey.java
@@ -40,8 +40,6 @@ class ZonedTimeSchemaKey extends NativeSchemaKey<ZonedTimeSchemaKey>
             Integer.BYTES + /* zoneOffsetSeconds */
             Long.BYTES;     /* entityId */
 
-    private static final long NANOS_PER_SECOND = 1_000_000_000L;
-
     long nanosOfDayUTC;
     int zoneOffsetSeconds;
 
@@ -51,8 +49,7 @@ class ZonedTimeSchemaKey extends NativeSchemaKey<ZonedTimeSchemaKey>
         // We need to check validity upfront without throwing exceptions, because the PageCursor might give garbage bytes
         if ( TimeZones.validZoneOffset( zoneOffsetSeconds ) )
         {
-            return TimeValue.time( nanosOfDayUTC + zoneOffsetSeconds * NANOS_PER_SECOND,
-                                   ZoneOffset.ofTotalSeconds( zoneOffsetSeconds ) );
+            return TimeValue.time( nanosOfDayUTC, ZoneOffset.ofTotalSeconds( zoneOffsetSeconds ) );
         }
         return NO_VALUE;
     }
@@ -90,9 +87,9 @@ class ZonedTimeSchemaKey extends NativeSchemaKey<ZonedTimeSchemaKey>
     }
 
     @Override
-    public void writeTime( long nanosOfDayLocal, int offsetSeconds )
+    public void writeTime( long nanosOfDayUTC, int offsetSeconds )
     {
-        this.nanosOfDayUTC = nanosOfDayLocal - offsetSeconds * NANOS_PER_SECOND;
+        this.nanosOfDayUTC = nanosOfDayUTC;
         this.zoneOffsetSeconds = offsetSeconds;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
@@ -585,11 +585,11 @@ public class PropertyStore extends CommonAbstractStore<PropertyRecord,NoStoreHea
         }
 
         @Override
-        public void writeTime( long nanosOfDayLocal, int offsetSeconds ) throws IllegalArgumentException
+        public void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws IllegalArgumentException
         {
             if ( allowStorePointsAndTemporal )
             {
-                block.setValueBlocks( TemporalType.encodeTime( keyId, nanosOfDayLocal, offsetSeconds ) );
+                block.setValueBlocks( TemporalType.encodeTime( keyId, nanosOfDayUTC, offsetSeconds ) );
             }
             else
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TemporalType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TemporalType.java
@@ -510,7 +510,7 @@ public enum TemporalType
         return data;
     }
 
-    public static long[] encodeTime( int keyId, long nanoOfDayLocal, int secondOffset )
+    public static long[] encodeTime( int keyId, long nanoOfDayUTC, int secondOffset )
     {
         int idBits = StandardFormatSettings.PROPERTY_TOKEN_MAXIMUM_ID_BITS;
         int minuteOffset = secondOffset / 60;
@@ -521,7 +521,7 @@ public enum TemporalType
         long[] data = new long[BLOCKS_TIME];
         // Offset are always in the range +-18:00, so minuteOffset will never require more than 12 bits
         data[0] = keyAndType | temporalTypeBits | ((long) minuteOffset << 32);
-        data[1] = nanoOfDayLocal;
+        data[1] = nanoOfDayUTC;
 
         return data;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/BaseToObjectValueWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/BaseToObjectValueWriter.java
@@ -429,9 +429,10 @@ public abstract class BaseToObjectValueWriter<E extends Exception> implements An
     }
 
     @Override
-    public void writeTime( long nanosOfDayLocal, int offsetSeconds ) throws RuntimeException
+    public void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws RuntimeException
     {
-        writeValue( OffsetTime.of( LocalTime.ofNanoOfDay( nanosOfDayLocal ), ZoneOffset.ofTotalSeconds( offsetSeconds ) ) );
+        writeValue( OffsetTime.ofInstant( Instant.ofEpochSecond( 0, nanosOfDayUTC ),
+                                          ZoneOffset.ofTotalSeconds( offsetSeconds ) ) );
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
@@ -24,7 +24,6 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.Period;
 import java.time.temporal.ChronoUnit;
-import java.time.temporal.IsoFields;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAmount;
 import java.time.temporal.TemporalUnit;
@@ -56,6 +55,10 @@ import static java.util.Objects.requireNonNull;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 import static org.neo4j.values.storable.NumberType.NO_NUMBER;
 import static org.neo4j.values.storable.NumberValue.safeCastFloatingPoint;
+import static org.neo4j.values.storable.TimeConstants.AVG_DAYS_PER_MONTH;
+import static org.neo4j.values.storable.TimeConstants.AVG_SECONDS_PER_MONTH;
+import static org.neo4j.values.storable.TimeConstants.NANOS_PER_SECOND;
+import static org.neo4j.values.storable.TimeConstants.SECONDS_PER_DAY;
 
 /**
  * We use our own implementation because neither {@link java.time.Duration} nor {@link java.time.Period} fits our needs.
@@ -192,11 +195,6 @@ public final class DurationValue extends ScalarValue implements TemporalAmount, 
                     .thenComparingLong( d -> d.months )
                     .thenComparingLong( d -> d.days )
                     .thenComparingLong( d -> d.seconds );
-    static final int NANOS_PER_SECOND = 1_000_000_000;
-    static final long SECONDS_PER_DAY = DAYS.getDuration().getSeconds();
-    /** 30.4375 days = 30 days, 10 hours, 30 minutes */
-    private static final double AVERAGE_DAYS_PER_MONTH = 365.2425 / 12;
-    private static final long AVG_SECONDS_PER_MONTH = 2_629_746;
     private final long months;
     private final long days;
     private final long seconds;
@@ -630,7 +628,7 @@ public final class DurationValue extends ScalarValue implements TemporalAmount, 
     {
         str.append( '.' );
         int n = nanos < 0 ? -nanos : nanos;
-        for ( int mod = NANOS_PER_SECOND; mod > 1 && n > 0; n %= mod )
+        for ( int mod = (int)NANOS_PER_SECOND; mod > 1 && n > 0; n %= mod )
         {
             str.append( n / (mod /= 10) );
         }
@@ -912,7 +910,7 @@ public final class DurationValue extends ScalarValue implements TemporalAmount, 
     private static DurationValue approximate( double months, double days, double seconds, double nanos )
     {
         long m = (long) months;
-        days += AVERAGE_DAYS_PER_MONTH * (months - m);
+        days += AVG_DAYS_PER_MONTH * (months - m);
         long d = (long) days;
         seconds += SECONDS_PER_DAY * (days - d);
         long s = (long) seconds;

--- a/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
@@ -55,10 +55,10 @@ import static java.util.Objects.requireNonNull;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 import static org.neo4j.values.storable.NumberType.NO_NUMBER;
 import static org.neo4j.values.storable.NumberValue.safeCastFloatingPoint;
-import static org.neo4j.values.storable.TimeConstants.AVG_DAYS_PER_MONTH;
-import static org.neo4j.values.storable.TimeConstants.AVG_SECONDS_PER_MONTH;
-import static org.neo4j.values.storable.TimeConstants.NANOS_PER_SECOND;
-import static org.neo4j.values.storable.TimeConstants.SECONDS_PER_DAY;
+import static org.neo4j.values.storable.TimeUtil.AVG_DAYS_PER_MONTH;
+import static org.neo4j.values.storable.TimeUtil.AVG_SECONDS_PER_MONTH;
+import static org.neo4j.values.storable.TimeUtil.NANOS_PER_SECOND;
+import static org.neo4j.values.storable.TimeUtil.SECONDS_PER_DAY;
 
 /**
  * We use our own implementation because neither {@link java.time.Duration} nor {@link java.time.Period} fits our needs.

--- a/community/values/src/main/java/org/neo4j/values/storable/TimeConstants.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TimeConstants.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import static java.time.temporal.ChronoUnit.DAYS;
+
+@SuppressWarnings( "WeakerAccess" )
+public class TimeConstants
+{
+    public static final long NANOS_PER_SECOND = 1_000_000_000L;
+    public static final long SECONDS_PER_DAY = DAYS.getDuration().getSeconds();
+    public static final long NANOS_PER_DAY = NANOS_PER_SECOND * SECONDS_PER_DAY;
+    /** 30.4375 days = 30 days, 10 hours, 30 minutes */
+    public static final double AVG_DAYS_PER_MONTH = 365.2425 / 12;
+    public static final long AVG_SECONDS_PER_MONTH = 2_629_746;
+
+    private TimeConstants()
+    {
+    }
+
+    public static long asValidLocalTime( long nanosPerDayUTC )
+    {
+        if ( nanosPerDayUTC < 0 )
+        {
+            return nanosPerDayUTC + NANOS_PER_DAY;
+        }
+        if ( nanosPerDayUTC >= NANOS_PER_DAY )
+        {
+            return nanosPerDayUTC - NANOS_PER_DAY;
+        }
+        return nanosPerDayUTC;
+    }
+
+    public static OffsetTime truncateOffsetToMinutes( OffsetTime value )
+    {
+        int offsetMinutes = value.getOffset().getTotalSeconds() / 60;
+        ZoneOffset truncatedOffset = ZoneOffset.ofTotalSeconds( offsetMinutes * 60 );
+        return value.withOffsetSameInstant( truncatedOffset );
+    }
+}

--- a/community/values/src/main/java/org/neo4j/values/storable/TimeConstants.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TimeConstants.java
@@ -38,17 +38,17 @@ public class TimeConstants
     {
     }
 
-    public static long asValidLocalTime( long nanosPerDayUTC )
+    public static long asValidTime( long nanosPerDay )
     {
-        if ( nanosPerDayUTC < 0 )
+        if ( nanosPerDay < 0 )
         {
-            return nanosPerDayUTC + NANOS_PER_DAY;
+            return nanosPerDay + NANOS_PER_DAY;
         }
-        if ( nanosPerDayUTC >= NANOS_PER_DAY )
+        if ( nanosPerDay >= NANOS_PER_DAY )
         {
-            return nanosPerDayUTC - NANOS_PER_DAY;
+            return nanosPerDay - NANOS_PER_DAY;
         }
-        return nanosPerDayUTC;
+        return nanosPerDay;
     }
 
     public static OffsetTime truncateOffsetToMinutes( OffsetTime value )

--- a/community/values/src/main/java/org/neo4j/values/storable/TimeUtil.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TimeUtil.java
@@ -25,7 +25,7 @@ import java.time.ZoneOffset;
 import static java.time.temporal.ChronoUnit.DAYS;
 
 @SuppressWarnings( "WeakerAccess" )
-public class TimeConstants
+public class TimeUtil
 {
     public static final long NANOS_PER_SECOND = 1_000_000_000L;
     public static final long SECONDS_PER_DAY = DAYS.getDuration().getSeconds();
@@ -34,7 +34,7 @@ public class TimeConstants
     public static final double AVG_DAYS_PER_MONTH = 365.2425 / 12;
     public static final long AVG_SECONDS_PER_MONTH = 2_629_746;
 
-    private TimeConstants()
+    private TimeUtil()
     {
     }
 
@@ -56,5 +56,15 @@ public class TimeConstants
         int offsetMinutes = value.getOffset().getTotalSeconds() / 60;
         ZoneOffset truncatedOffset = ZoneOffset.ofTotalSeconds( offsetMinutes * 60 );
         return value.withOffsetSameInstant( truncatedOffset );
+    }
+
+    public static long nanosOfDayToLocal( long nanosOfDayUTC, int offsetSeconds )
+    {
+        return nanosOfDayUTC + offsetSeconds * NANOS_PER_SECOND;
+    }
+
+    public static long nanosOfDayToUTC( long nanosOfDayLocal, int offsetSeconds )
+    {
+        return nanosOfDayLocal - offsetSeconds * NANOS_PER_SECOND;
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/TimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TimeValue.java
@@ -276,7 +276,12 @@ public final class TimeValue extends TemporalValue<OffsetTime,TimeValue>
     int unsafeCompareTo( Value otherValue )
     {
         TimeValue other = (TimeValue) otherValue;
-        return value.compareTo( other.value );
+        int compare = Long.compare( nanosOfDayUTC, other.nanosOfDayUTC );
+        if ( compare == 0 )
+        {
+            compare = Integer.compare( value.getOffset().getTotalSeconds(), other.value.getOffset().getTotalSeconds() );
+        }
+        return compare;
     }
 
     @Override
@@ -379,7 +384,7 @@ public final class TimeValue extends TemporalValue<OffsetTime,TimeValue>
     @Override
     TimeValue replacement( OffsetTime time )
     {
-        return time == value ? this : new TimeValue( time, nanosOfDayUTC );
+        return time == value ? this : new TimeValue( time );
     }
 
     private static final String OFFSET_PATTERN = "(?<zone>Z|[+-](?<zoneHour>[0-9]{2})(?::?(?<zoneMinute>[0-9]{2}))?)";

--- a/community/values/src/main/java/org/neo4j/values/storable/TimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TimeValue.java
@@ -44,13 +44,12 @@ import org.neo4j.values.virtual.MapValue;
 import org.neo4j.values.virtual.VirtualValues;
 
 import static java.lang.Integer.parseInt;
-import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static java.util.Objects.requireNonNull;
 import static org.neo4j.values.storable.DateTimeValue.parseZoneName;
 import static org.neo4j.values.storable.LocalTimeValue.optInt;
 import static org.neo4j.values.storable.LocalTimeValue.parseTime;
-import static org.neo4j.values.storable.TimeConstants.NANOS_PER_SECOND;
+import static org.neo4j.values.storable.TimeUtil.NANOS_PER_SECOND;
 
 public final class TimeValue extends TemporalValue<OffsetTime,TimeValue>
 {
@@ -255,7 +254,7 @@ public final class TimeValue extends TemporalValue<OffsetTime,TimeValue>
     private TimeValue( OffsetTime value )
     {
         // truncate the offset to whole minutes
-        this.value = TimeConstants.truncateOffsetToMinutes( value );
+        this.value = TimeUtil.truncateOffsetToMinutes( value );
         this.nanosOfDayUTC = getNanosOfDayUTC( this.value );
     }
 
@@ -268,7 +267,7 @@ public final class TimeValue extends TemporalValue<OffsetTime,TimeValue>
 
     private TimeValue( OffsetTime value, long nanosOfDayUTC )
     {
-        this.value = TimeConstants.truncateOffsetToMinutes( value );
+        this.value = TimeUtil.truncateOffsetToMinutes( value );
         this.nanosOfDayUTC = nanosOfDayUTC;
     }
 

--- a/community/values/src/main/java/org/neo4j/values/storable/ValueWriter.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ValueWriter.java
@@ -89,7 +89,13 @@ public interface ValueWriter<E extends Exception>
 
     void writeLocalTime( long nanoOfDay ) throws E;
 
-    void writeTime( long nanosOfDayLocal, int offsetSeconds ) throws E;
+    /**
+     * Write time value
+     *
+     * @param nanosOfDayUTC nanoseconds of day in UTC. will be between -18h and +42h
+     * @param offsetSeconds time zone offset in seconds
+     */
+    void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws E;
 
     void writeLocalDateTime( long epochSecond, int nano ) throws E;
 
@@ -185,7 +191,7 @@ public interface ValueWriter<E extends Exception>
         }
 
         @Override
-        public void writeTime( long nanosOfDayLocal, int offsetSeconds ) throws E
+        public void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws E
         {   // no-op
         }
 

--- a/community/values/src/main/java/org/neo4j/values/utils/PrettyPrinter.java
+++ b/community/values/src/main/java/org/neo4j/values/utils/PrettyPrinter.java
@@ -195,10 +195,10 @@ public class PrettyPrinter implements AnyValueWriter<RuntimeException>
     }
 
     @Override
-    public void writeTime( long nanosOfDayLocal, int offsetSeconds ) throws RuntimeException
+    public void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws RuntimeException
     {
-        append( "{time: {nanosOfDayLocal: " );
-        append( Long.toString( nanosOfDayLocal ) );
+        append( "{time: {nanosOfDayUTC: " );
+        append( Long.toString( nanosOfDayUTC ) );
         append( ", offsetSeconds: " );
         append( Long.toString( offsetSeconds ) );
         append( "}}" );

--- a/community/values/src/test/java/org/neo4j/values/storable/BufferValueWriter.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/BufferValueWriter.java
@@ -196,9 +196,9 @@ public class BufferValueWriter implements ValueWriter<RuntimeException>
     }
 
     @Override
-    public void writeTime( long nanosOfDayLocal, int offsetSeconds ) throws RuntimeException
+    public void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws RuntimeException
     {
-        buffer.add( TimeValue.time( nanosOfDayLocal, ZoneOffset.ofTotalSeconds( offsetSeconds ) ) );
+        buffer.add( TimeValue.time( nanosOfDayUTC, ZoneOffset.ofTotalSeconds( offsetSeconds ) ) );
     }
 
     @Override

--- a/community/values/src/test/java/org/neo4j/values/storable/ThrowingValueWriter.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/ThrowingValueWriter.java
@@ -149,7 +149,7 @@ public abstract class ThrowingValueWriter<E extends Exception> implements ValueW
     }
 
     @Override
-    public void writeTime( long nanosOfDayLocal, int offsetSeconds ) throws E
+    public void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws E
     {
         throw exception( "writeTime" );
     }

--- a/community/values/src/test/java/org/neo4j/values/storable/TimeValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/TimeValueTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertSame;
 import static org.neo4j.values.storable.LocalTimeValue.inUTC;
 import static org.neo4j.values.storable.LocalTimeValue.localTime;
-import static org.neo4j.values.storable.TimeConstants.asValidTime;
+import static org.neo4j.values.storable.TimeUtil.asValidTime;
 import static org.neo4j.values.storable.TimeValue.parse;
 import static org.neo4j.values.storable.TimeValue.time;
 import static org.neo4j.values.utils.AnyValueTestUtil.assertEqual;

--- a/community/values/src/test/java/org/neo4j/values/storable/TimeValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/TimeValueTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertSame;
 import static org.neo4j.values.storable.LocalTimeValue.inUTC;
 import static org.neo4j.values.storable.LocalTimeValue.localTime;
+import static org.neo4j.values.storable.TimeConstants.asValidLocalTime;
 import static org.neo4j.values.storable.TimeValue.parse;
 import static org.neo4j.values.storable.TimeValue.time;
 import static org.neo4j.values.utils.AnyValueTestUtil.assertEqual;
@@ -114,10 +115,10 @@ public class TimeValueTest
             ValueWriter<RuntimeException> writer = new ThrowingValueWriter.AssertOnly()
             {
                 @Override
-                public void writeTime( long nanosOfDayLocal, int offsetSeconds ) throws RuntimeException
+                public void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws RuntimeException
                 {
-                    values.add( time( nanosOfDayLocal, ZoneOffset.ofTotalSeconds( offsetSeconds ) ) );
-                    locals.add( localTime( nanosOfDayLocal ) );
+                    values.add( time( nanosOfDayUTC, ZoneOffset.ofTotalSeconds( offsetSeconds ) ) );
+                    locals.add( localTime( asValidLocalTime( nanosOfDayUTC ) ) );
                 }
             };
 
@@ -126,7 +127,7 @@ public class TimeValueTest
 
             // then
             assertEquals( singletonList( time ), values );
-            assertEquals( singletonList( localTime( time.getLocalTimePart() ) ), locals );
+            assertEquals( singletonList( inUTC( time ) ), locals );
         }
     }
 

--- a/community/values/src/test/java/org/neo4j/values/storable/TimeValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/TimeValueTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertSame;
 import static org.neo4j.values.storable.LocalTimeValue.inUTC;
 import static org.neo4j.values.storable.LocalTimeValue.localTime;
-import static org.neo4j.values.storable.TimeConstants.asValidLocalTime;
+import static org.neo4j.values.storable.TimeConstants.asValidTime;
 import static org.neo4j.values.storable.TimeValue.parse;
 import static org.neo4j.values.storable.TimeValue.time;
 import static org.neo4j.values.utils.AnyValueTestUtil.assertEqual;
@@ -118,7 +118,7 @@ public class TimeValueTest
                 public void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws RuntimeException
                 {
                     values.add( time( nanosOfDayUTC, ZoneOffset.ofTotalSeconds( offsetSeconds ) ) );
-                    locals.add( localTime( asValidLocalTime( nanosOfDayUTC ) ) );
+                    locals.add( localTime( asValidTime( nanosOfDayUTC ) ) );
                 }
             };
 


### PR DESCRIPTION
This is different from the first implementation though, in that it stores
nanosPerDayUTC in the range -18h to +42h instead of wrapping around to the
next day. This makes the on-disc format directly semantically comparable,
which will be useful if we do predicate push-down in the future.