### PR TITLE
Fix raw usages in native index

### DIFF
--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/IndexQuery.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/IndexQuery.java
@@ -70,7 +70,7 @@ public abstract class IndexQuery
      * @param toInclusive the upper bound is inclusive if true.
      * @return an {@link IndexQuery} instance to be used for querying an index.
      */
-    public static RangePredicate range( int propertyKeyId,
+    public static RangePredicate<?> range( int propertyKeyId,
                                         Number from, boolean fromInclusive,
                                         Number to, boolean toInclusive )
     {
@@ -79,7 +79,7 @@ public abstract class IndexQuery
                                          to == null ? null : Values.numberValue( to ), toInclusive );
     }
 
-    public static RangePredicate range( int propertyKeyId,
+    public static RangePredicate<?> range( int propertyKeyId,
                                         String from, boolean fromInclusive,
                                         String to, boolean toInclusive )
     {
@@ -88,7 +88,7 @@ public abstract class IndexQuery
                                        to == null ? null : Values.stringValue( to ), toInclusive );
     }
 
-    public static <VALUE extends Value> RangePredicate range( int propertyKeyId,
+    public static <VALUE extends Value> RangePredicate<?> range( int propertyKeyId,
                                                               VALUE from, boolean fromInclusive,
                                                               VALUE to, boolean toInclusive )
     {
@@ -124,7 +124,7 @@ public abstract class IndexQuery
     /**
      * Create IndexQuery for retrieving all indexed entries of the given value group.
      */
-    public static RangePredicate range( int propertyKeyId, ValueGroup valueGroup )
+    public static RangePredicate<?> range( int propertyKeyId, ValueGroup valueGroup )
     {
         if ( valueGroup == ValueGroup.GEOMETRY )
         {
@@ -137,7 +137,7 @@ public abstract class IndexQuery
      * Create IndexQuery for retrieving all indexed entries with spatial value of the given
      * coordinate reference system.
      */
-    public static RangePredicate range( int propertyKeyId, CoordinateReferenceSystem crs )
+    public static RangePredicate<?> range( int propertyKeyId, CoordinateReferenceSystem crs )
     {
         return new GeometryRangePredicate( propertyKeyId, crs, null, true, null, true );
     }
@@ -510,8 +510,7 @@ public abstract class IndexQuery
         @Override
         public boolean acceptsValue( Value value )
         {
-            return value != null && Values.isTextValue( value ) &&
-                    ((TextValue)value).stringValue().startsWith( prefix );
+            return Values.isTextValue( value ) && ((TextValue) value).stringValue().startsWith( prefix );
         }
 
         public String prefix()
@@ -539,7 +538,7 @@ public abstract class IndexQuery
         @Override
         public boolean acceptsValue( Value value )
         {
-            return value != null && Values.isTextValue( value ) && ((String)value.asObject()).contains( contains );
+            return Values.isTextValue( value ) && ((String) value.asObject()).contains( contains );
         }
 
         public String contains()
@@ -567,7 +566,7 @@ public abstract class IndexQuery
         @Override
         public boolean acceptsValue( Value value )
         {
-            return value != null && Values.isTextValue( value ) && ((String)value.asObject()).endsWith( suffix );
+            return Values.isTextValue( value ) && ((String) value.asObject()).endsWith( suffix );
         }
 
         public String suffix()

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/IndexQueryTest.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/IndexQueryTest.java
@@ -97,7 +97,7 @@ public class IndexQueryTest
     @Test
     public void testNumRange_FalseForIrrelevant()
     {
-        RangePredicate p = IndexQuery.range( propId, 11, true, 13, true );
+        RangePredicate<?> p = IndexQuery.range( propId, 11, true, 13, true );
 
         assertFalseForOtherThings( p );
     }
@@ -105,7 +105,7 @@ public class IndexQueryTest
     @Test
     public void testNumRange_InclusiveLowerInclusiveUpper()
     {
-        RangePredicate p = IndexQuery.range( propId, 11, true, 13, true );
+        RangePredicate<?> p = IndexQuery.range( propId, 11, true, 13, true );
 
         assertFalse( test( p, 10 ) );
         assertTrue( test( p, 11 ) );
@@ -117,7 +117,7 @@ public class IndexQueryTest
     @Test
     public void testNumRange_ExclusiveLowerExclusiveLower()
     {
-        RangePredicate p = IndexQuery.range( propId, 11, false, 13, false );
+        RangePredicate<?> p = IndexQuery.range( propId, 11, false, 13, false );
 
         assertFalse( test( p, 11 ) );
         assertTrue( test( p, 12 ) );
@@ -127,7 +127,7 @@ public class IndexQueryTest
     @Test
     public void testNumRange_InclusiveLowerExclusiveUpper()
     {
-        RangePredicate p = IndexQuery.range( propId, 11, true, 13, false );
+        RangePredicate<?> p = IndexQuery.range( propId, 11, true, 13, false );
 
         assertFalse( test( p, 10 ) );
         assertTrue( test( p, 11 ) );
@@ -138,7 +138,7 @@ public class IndexQueryTest
     @Test
     public void testNumRange_ExclusiveLowerInclusiveUpper()
     {
-        RangePredicate p = IndexQuery.range( propId, 11, false, 13, true );
+        RangePredicate<?> p = IndexQuery.range( propId, 11, false, 13, true );
 
         assertFalse( test( p, 11 ) );
         assertTrue( test( p, 12 ) );
@@ -149,7 +149,7 @@ public class IndexQueryTest
     @Test
     public void testNumRange_LowerNullValue()
     {
-        RangePredicate p = IndexQuery.range( propId, null, true, 13, true );
+        RangePredicate<?> p = IndexQuery.range( propId, null, true, 13, true );
 
         assertTrue( test( p, 10 ) );
         assertTrue( test( p, 11 ) );
@@ -161,7 +161,7 @@ public class IndexQueryTest
     @Test
     public void testNumRange_UpperNullValue()
     {
-        RangePredicate p = IndexQuery.range( propId, 11, true, null, true );
+        RangePredicate<?> p = IndexQuery.range( propId, 11, true, null, true );
 
         assertFalse( test( p, 10 ) );
         assertTrue( test( p, 11 ) );
@@ -173,7 +173,7 @@ public class IndexQueryTest
     @Test
     public void testNumRange_ComparingBigDoublesAndLongs()
     {
-        RangePredicate p = IndexQuery.range( propId, 9007199254740993L, true, null, true );
+        RangePredicate<?> p = IndexQuery.range( propId, 9007199254740993L, true, null, true );
 
         assertFalse( test( p, 9007199254740992D ) );
     }
@@ -183,7 +183,7 @@ public class IndexQueryTest
     @Test
     public void testStringRange_FalseForIrrelevant()
     {
-        RangePredicate p = IndexQuery.range( propId, "bbb", true, "bee", true );
+        RangePredicate<?> p = IndexQuery.range( propId, "bbb", true, "bee", true );
 
         assertFalseForOtherThings( p );
     }
@@ -191,7 +191,7 @@ public class IndexQueryTest
     @Test
     public void testStringRange_InclusiveLowerInclusiveUpper()
     {
-        RangePredicate p = IndexQuery.range( propId, "bbb", true, "bee", true );
+        RangePredicate<?> p = IndexQuery.range( propId, "bbb", true, "bee", true );
 
         assertFalse( test( p, "bba" ) );
         assertTrue( test( p, "bbb" ) );
@@ -203,7 +203,7 @@ public class IndexQueryTest
     @Test
     public void testStringRange_ExclusiveLowerInclusiveUpper()
     {
-        RangePredicate p = IndexQuery.range( propId, "bbb", false, "bee", true );
+        RangePredicate<?> p = IndexQuery.range( propId, "bbb", false, "bee", true );
 
         assertFalse( test( p, "bbb" ) );
         assertTrue( test( p, "bbba" ) );
@@ -214,7 +214,7 @@ public class IndexQueryTest
     @Test
     public void testStringRange_InclusiveLowerExclusiveUpper()
     {
-        RangePredicate p = IndexQuery.range( propId, "bbb", true, "bee", false );
+        RangePredicate<?> p = IndexQuery.range( propId, "bbb", true, "bee", false );
 
         assertFalse( test( p, "bba" ) );
         assertTrue( test( p, "bbb" ) );
@@ -225,7 +225,7 @@ public class IndexQueryTest
     @Test
     public void testStringRange_ExclusiveLowerExclusiveUpper()
     {
-        RangePredicate p = IndexQuery.range( propId, "bbb", false, "bee", false );
+        RangePredicate<?> p = IndexQuery.range( propId, "bbb", false, "bee", false );
 
         assertFalse( test( p, "bbb" ) );
         assertTrue( test( p, "bbba" ) );
@@ -236,7 +236,7 @@ public class IndexQueryTest
     @Test
     public void testStringRange_UpperUnbounded()
     {
-        RangePredicate p = IndexQuery.range( propId, "bbb", false, null, false );
+        RangePredicate<?> p = IndexQuery.range( propId, "bbb", false, null, false );
 
         assertFalse( test( p, "bbb" ) );
         assertTrue( test( p, "bbba" ) );
@@ -246,7 +246,7 @@ public class IndexQueryTest
     @Test
     public void testStringRange_LowerUnbounded()
     {
-        RangePredicate p = IndexQuery.range( propId, null, false, "bee", false );
+        RangePredicate<?> p = IndexQuery.range( propId, null, false, "bee", false );
 
         assertTrue( test( p, "" ) );
         assertTrue( test( p, "bed" ) );
@@ -274,7 +274,7 @@ public class IndexQueryTest
     @Test
     public void testGeometryRange_FalseForIrrelevant()
     {
-        RangePredicate p = IndexQuery.range( propId, gps2, true, gps5, true );
+        RangePredicate<?> p = IndexQuery.range( propId, gps2, true, gps5, true );
 
         assertFalseForOtherThings( p );
     }
@@ -282,7 +282,7 @@ public class IndexQueryTest
     @Test
     public void testGeometryRange_InclusiveLowerInclusiveUpper()
     {
-        RangePredicate p = IndexQuery.range( propId, gps2, true, gps5, true );
+        RangePredicate<?> p = IndexQuery.range( propId, gps2, true, gps5, true );
 
         assertFalse( test( p, gps1 ) );
         assertTrue( test( p, gps2 ) );
@@ -298,7 +298,7 @@ public class IndexQueryTest
     @Test
     public void testGeometryRange_ExclusiveLowerInclusiveUpper()
     {
-        RangePredicate p = IndexQuery.range( propId, gps2, false, gps5, true );
+        RangePredicate<?> p = IndexQuery.range( propId, gps2, false, gps5, true );
 
         assertFalse( test( p, gps2 ) );
         assertTrue( test( p, gps3 ) );
@@ -313,7 +313,7 @@ public class IndexQueryTest
     @Test
     public void testGeometryRange_InclusiveLowerExclusiveUpper()
     {
-        RangePredicate p = IndexQuery.range( propId, gps2, true, gps5, false );
+        RangePredicate<?> p = IndexQuery.range( propId, gps2, true, gps5, false );
 
         assertFalse( test( p, gps1 ) );
         assertTrue( test( p, gps2 ) );
@@ -328,7 +328,7 @@ public class IndexQueryTest
     @Test
     public void testGeometryRange_ExclusiveLowerExclusiveUpper()
     {
-        RangePredicate p = IndexQuery.range( propId, gps2, false, gps5, false );
+        RangePredicate<?> p = IndexQuery.range( propId, gps2, false, gps5, false );
 
         assertFalse( test( p, gps2 ) );
         assertTrue( test( p, gps3 ) );
@@ -343,7 +343,7 @@ public class IndexQueryTest
     @Test
     public void testGeometryRange_UpperUnbounded()
     {
-        RangePredicate p = IndexQuery.range( propId, gps2, false, null, false );
+        RangePredicate<?> p = IndexQuery.range( propId, gps2, false, null, false );
 
         assertFalse( test( p, gps2 ) );
         assertTrue( test( p, gps3 ) );
@@ -357,7 +357,7 @@ public class IndexQueryTest
     @Test
     public void testGeometryRange_LowerUnbounded()
     {
-        RangePredicate p = IndexQuery.range( propId, null, false, gps5, false );
+        RangePredicate<?> p = IndexQuery.range( propId, null, false, gps5, false );
 
         assertTrue( test( p, gps1 ) );
         assertTrue( test( p, gps3 ) );
@@ -371,7 +371,7 @@ public class IndexQueryTest
     @Test
     public void testGeometryRange_Cartesian()
     {
-        RangePredicate p = IndexQuery.range( propId, car1, false, car2, true );
+        RangePredicate<?> p = IndexQuery.range( propId, car1, false, car2, true );
 
         assertFalse( test( p, gps1 ) );
         assertFalse( test( p, gps3 ) );
@@ -387,7 +387,7 @@ public class IndexQueryTest
     @Test
     public void testGeometryRange_Cartesian3D()
     {
-        RangePredicate p = IndexQuery.range( propId, car3, true, car4, true );
+        RangePredicate<?> p = IndexQuery.range( propId, car3, true, car4, true );
 
         assertFalse( test( p, gps1 ) );
         assertFalse( test( p, gps3 ) );
@@ -403,7 +403,7 @@ public class IndexQueryTest
     @Test
     public void testGeometryRange_WGS84_3D()
     {
-        RangePredicate p = IndexQuery.range( propId, gps1_3d, true, gps2_3d, true );
+        RangePredicate<?> p = IndexQuery.range( propId, gps1_3d, true, gps2_3d, true );
 
         assertFalse( test( p, gps1 ) );
         assertFalse( test( p, gps3 ) );
@@ -419,7 +419,7 @@ public class IndexQueryTest
     @Test
     public void testDateRange()
     {
-        RangePredicate p = IndexQuery.range( propId, DateValue.date( 2014, 7, 7 ), true, DateValue.date( 2017,3, 7 ), false );
+        RangePredicate<?> p = IndexQuery.range( propId, DateValue.date( 2014, 7, 7 ), true, DateValue.date( 2017,3, 7 ), false );
 
         assertFalse( test( p, DateValue.date( 2014, 6, 8 ) ) );
         assertTrue( test( p, DateValue.date( 2014, 7, 7 ) ) );
@@ -433,7 +433,7 @@ public class IndexQueryTest
     @Test
     public void testValueGroupRange()
     {
-        RangePredicate p = IndexQuery.range( propId, ValueGroup.DATE );
+        RangePredicate<?> p = IndexQuery.range( propId, ValueGroup.DATE );
 
         assertTrue( test( p, DateValue.date( -4000, 1, 31 ) ) );
         assertTrue( test( p, DateValue.date( 2018, 3, 7 ) ) );
@@ -445,7 +445,7 @@ public class IndexQueryTest
     @Test
     public void testCRSRange()
     {
-        RangePredicate p = IndexQuery.range( propId, CoordinateReferenceSystem.WGS84 );
+        RangePredicate<?> p = IndexQuery.range( propId, CoordinateReferenceSystem.WGS84 );
 
         assertTrue( test( p, gps2 ) );
         assertFalse( test( p, DateValue.date( -4000, 1, 31 ) ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -868,7 +868,7 @@ public class StateHandlingStatementOperations implements
 
         case range:
             assertSinglePredicate( predicates );
-            IndexQuery.RangePredicate rangePred = (IndexQuery.RangePredicate) firstPredicate;
+            IndexQuery.RangePredicate<?> rangePred = (IndexQuery.RangePredicate<?>) firstPredicate;
             return filterIndexStateChangesForRangeSeek( state, index, rangePred.valueGroup(),
                                                         rangePred.fromValue(), rangePred.fromInclusive(),
                                                         rangePred.toValue(), rangePred.toInclusive(),

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ConflictDetectingValueMerger.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ConflictDetectingValueMerger.java
@@ -34,7 +34,7 @@ import org.neo4j.values.storable.ValueTuple;
  *
  * @param <VALUE> type of values being merged.
  */
-class ConflictDetectingValueMerger<KEY extends NativeSchemaKey, VALUE extends NativeSchemaValue> implements ValueMerger<KEY,VALUE>
+class ConflictDetectingValueMerger<KEY extends NativeSchemaKey<KEY>, VALUE extends NativeSchemaValue> implements ValueMerger<KEY,VALUE>
 {
     private final boolean compareEntityIds;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/FilteringNativeHitIndexProgressor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/FilteringNativeHitIndexProgressor.java
@@ -27,7 +27,7 @@ import org.neo4j.index.internal.gbptree.Hit;
 import org.neo4j.internal.kernel.api.IndexQuery;
 import org.neo4j.values.storable.Value;
 
-class FilteringNativeHitIndexProgressor<KEY extends NativeSchemaKey, VALUE extends NativeSchemaValue> extends NativeHitIndexProgressor<KEY,VALUE>
+class FilteringNativeHitIndexProgressor<KEY extends NativeSchemaKey<KEY>, VALUE extends NativeSchemaValue> extends NativeHitIndexProgressor<KEY,VALUE>
 {
     private final IndexQuery[] filter;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/FilteringNativeHitIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/FilteringNativeHitIterator.java
@@ -27,7 +27,7 @@ import org.neo4j.index.internal.gbptree.Hit;
 import org.neo4j.internal.kernel.api.IndexQuery;
 import org.neo4j.values.storable.Value;
 
-class FilteringNativeHitIterator<KEY extends NativeSchemaKey, VALUE extends NativeSchemaValue> extends NativeHitIterator<KEY,VALUE>
+class FilteringNativeHitIterator<KEY extends NativeSchemaKey<KEY>, VALUE extends NativeSchemaValue> extends NativeHitIterator<KEY,VALUE>
 {
     private final IndexQuery[] filters;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/FullScanNonUniqueIndexSampler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/FullScanNonUniqueIndexSampler.java
@@ -37,7 +37,7 @@ import org.neo4j.storageengine.api.schema.IndexSample;
  * @param <KEY> type of keys in tree.
  * @param <VALUE> type of values in tree.
  */
-class FullScanNonUniqueIndexSampler<KEY extends NativeSchemaKey, VALUE extends NativeSchemaValue>
+class FullScanNonUniqueIndexSampler<KEY extends NativeSchemaKey<KEY>, VALUE extends NativeSchemaValue>
         extends NonUniqueIndexSampler.Adapter
 {
     private final GBPTree<KEY,VALUE> gbpTree;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeAllEntriesReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeAllEntriesReader.java
@@ -30,7 +30,7 @@ import org.neo4j.index.internal.gbptree.GBPTree;
 import org.neo4j.index.internal.gbptree.Hit;
 import org.neo4j.index.internal.gbptree.Layout;
 
-public class NativeAllEntriesReader<KEY extends NativeSchemaKey,VALUE extends NativeSchemaValue> implements BoundedIterable<Long>
+public class NativeAllEntriesReader<KEY extends NativeSchemaKey<KEY>,VALUE extends NativeSchemaValue> implements BoundedIterable<Long>
 {
     private final GBPTree<KEY,VALUE> tree;
     private final Layout<KEY,VALUE> layout;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeHitIndexProgressor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeHitIndexProgressor.java
@@ -28,7 +28,7 @@ import org.neo4j.index.internal.gbptree.Hit;
 import org.neo4j.storageengine.api.schema.IndexProgressor;
 import org.neo4j.values.storable.Value;
 
-public class NativeHitIndexProgressor<KEY extends NativeSchemaKey, VALUE extends NativeSchemaValue> implements IndexProgressor
+public class NativeHitIndexProgressor<KEY extends NativeSchemaKey<KEY>, VALUE extends NativeSchemaValue> implements IndexProgressor
 {
     final RawCursor<Hit<KEY,VALUE>,IOException> seeker;
     final NodeValueClient client;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeHitIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeHitIterator.java
@@ -36,7 +36,7 @@ import org.neo4j.values.storable.Value;
  * @param <KEY> type of {@link NumberSchemaKey}.
  * @param <VALUE> type of {@link NativeSchemaValue}.
  */
-public class NativeHitIterator<KEY extends NativeSchemaKey, VALUE extends NativeSchemaValue>
+public class NativeHitIterator<KEY extends NativeSchemaKey<KEY>, VALUE extends NativeSchemaValue>
         extends PrimitiveLongCollections.PrimitiveLongBaseIterator
         implements PrimitiveLongResourceIterator
 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeIndexProvider.java
@@ -43,7 +43,7 @@ import org.neo4j.kernel.impl.storemigration.StoreMigrationParticipant;
  * @param <KEY> type of {@link NativeSchemaKey}
  * @param <VALUE> type of {@link NativeSchemaValue}
  */
-abstract class NativeIndexProvider<KEY extends NativeSchemaKey,VALUE extends NativeSchemaValue> extends IndexProvider
+abstract class NativeIndexProvider<KEY extends NativeSchemaKey<KEY>,VALUE extends NativeSchemaValue> extends IndexProvider
 {
     protected final PageCache pageCache;
     protected final FileSystemAbstraction fs;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndex.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndex.java
@@ -38,7 +38,7 @@ import static org.neo4j.helpers.Format.duration;
 import static org.neo4j.helpers.collection.MapUtil.map;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_READER;
 
-class NativeSchemaIndex<KEY extends NativeSchemaKey, VALUE extends NativeSchemaValue>
+class NativeSchemaIndex<KEY extends NativeSchemaKey<KEY>, VALUE extends NativeSchemaValue>
 {
     final PageCache pageCache;
     final File storeFile;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexAccessor.java
@@ -31,8 +31,8 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexAccessor;
-import org.neo4j.kernel.api.index.PropertyAccessor;
 import org.neo4j.kernel.api.index.IndexProvider;
+import org.neo4j.kernel.api.index.PropertyAccessor;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
@@ -42,7 +42,7 @@ import static org.neo4j.helpers.collection.Iterators.asResourceIterator;
 import static org.neo4j.helpers.collection.Iterators.iterator;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_WRITER;
 
-public abstract class NativeSchemaIndexAccessor<KEY extends NativeSchemaKey, VALUE extends NativeSchemaValue>
+public abstract class NativeSchemaIndexAccessor<KEY extends NativeSchemaKey<KEY>, VALUE extends NativeSchemaValue>
         extends NativeSchemaIndex<KEY,VALUE> implements IndexAccessor
 {
     private final NativeSchemaIndexUpdater<KEY,VALUE> singleUpdater;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexPopulator.java
@@ -38,9 +38,9 @@ import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexPopulator;
+import org.neo4j.kernel.api.index.IndexProvider;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.PropertyAccessor;
-import org.neo4j.kernel.api.index.IndexProvider;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
 import org.neo4j.kernel.impl.api.index.sampling.DefaultNonUniqueIndexSampler;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
@@ -59,7 +59,7 @@ import static org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor.Type.UNIQU
  * @param <KEY> type of {@link NativeSchemaKey}.
  * @param <VALUE> type of {@link NativeSchemaValue}.
  */
-abstract class NativeSchemaIndexPopulator<KEY extends NativeSchemaKey, VALUE extends NativeSchemaValue>
+abstract class NativeSchemaIndexPopulator<KEY extends NativeSchemaKey<KEY>, VALUE extends NativeSchemaValue>
         extends NativeSchemaIndex<KEY,VALUE> implements IndexPopulator
 {
     static final byte BYTE_FAILED = 0;
@@ -297,7 +297,7 @@ abstract class NativeSchemaIndexPopulator<KEY extends NativeSchemaKey, VALUE ext
         tree.checkpoint( IOLimiter.unlimited(), pc -> pc.putByte( BYTE_ONLINE ) );
     }
 
-    static class IndexUpdateApply<KEY extends NativeSchemaKey, VALUE extends NativeSchemaValue>
+    static class IndexUpdateApply<KEY extends NativeSchemaKey<KEY>, VALUE extends NativeSchemaValue>
     {
         private final GBPTree<KEY,VALUE> tree;
         private final KEY treeKey;
@@ -324,7 +324,7 @@ abstract class NativeSchemaIndexPopulator<KEY extends NativeSchemaKey, VALUE ext
         }
     }
 
-    static class IndexUpdateWork<KEY extends NativeSchemaKey, VALUE extends NativeSchemaValue>
+    static class IndexUpdateWork<KEY extends NativeSchemaKey<KEY>, VALUE extends NativeSchemaValue>
             implements Work<IndexUpdateApply<KEY,VALUE>,IndexUpdateWork<KEY,VALUE>>
     {
         private final Collection<? extends IndexEntryUpdate<?>> updates;
@@ -335,7 +335,7 @@ abstract class NativeSchemaIndexPopulator<KEY extends NativeSchemaKey, VALUE ext
         }
 
         @Override
-        public IndexUpdateWork<KEY,VALUE> combine( IndexUpdateWork work )
+        public IndexUpdateWork<KEY,VALUE> combine( IndexUpdateWork<KEY,VALUE> work )
         {
             ArrayList<IndexEntryUpdate<?>> combined = new ArrayList<>( updates );
             combined.addAll( work.updates );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexReader.java
@@ -40,7 +40,7 @@ import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.storageengine.api.schema.IndexSampler;
 import org.neo4j.values.storable.Value;
 
-abstract class NativeSchemaIndexReader<KEY extends NativeSchemaKey, VALUE extends NativeSchemaValue>
+abstract class NativeSchemaIndexReader<KEY extends NativeSchemaKey<KEY>, VALUE extends NativeSchemaValue>
         implements IndexReader
 {
     private final GBPTree<KEY,VALUE> tree;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexUpdater.java
@@ -26,7 +26,7 @@ import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexUpdater;
 
-class NativeSchemaIndexUpdater<KEY extends NativeSchemaKey, VALUE extends NativeSchemaValue>
+class NativeSchemaIndexUpdater<KEY extends NativeSchemaKey<KEY>, VALUE extends NativeSchemaValue>
         implements IndexUpdater
 {
     private final KEY treeKey;
@@ -76,7 +76,7 @@ class NativeSchemaIndexUpdater<KEY extends NativeSchemaKey, VALUE extends Native
         }
     }
 
-    static <KEY extends NativeSchemaKey, VALUE extends NativeSchemaValue> void processUpdate( KEY treeKey, VALUE treeValue,
+    static <KEY extends NativeSchemaKey<KEY>, VALUE extends NativeSchemaValue> void processUpdate( KEY treeKey, VALUE treeValue,
             IndexEntryUpdate<?> update, Writer<KEY,VALUE> writer, ConflictDetectingValueMerger<KEY,VALUE> conflictDetectingValueMerger )
             throws IOException, IndexEntryConflictException
     {
@@ -96,7 +96,7 @@ class NativeSchemaIndexUpdater<KEY extends NativeSchemaKey, VALUE extends Native
         }
     }
 
-    private static <KEY extends NativeSchemaKey, VALUE extends NativeSchemaValue> void processRemove( KEY treeKey,
+    private static <KEY extends NativeSchemaKey<KEY>, VALUE extends NativeSchemaValue> void processRemove( KEY treeKey,
             IndexEntryUpdate<?> update, Writer<KEY,VALUE> writer ) throws IOException
     {
         // todo Do we need to verify that we actually removed something at all?
@@ -105,7 +105,7 @@ class NativeSchemaIndexUpdater<KEY extends NativeSchemaKey, VALUE extends Native
         writer.remove( treeKey );
     }
 
-    private static <KEY extends NativeSchemaKey, VALUE extends NativeSchemaValue> void processChange( KEY treeKey, VALUE treeValue,
+    private static <KEY extends NativeSchemaKey<KEY>, VALUE extends NativeSchemaValue> void processChange( KEY treeKey, VALUE treeValue,
             IndexEntryUpdate<?> update, Writer<KEY,VALUE> writer,
             ConflictDetectingValueMerger<KEY,VALUE> conflictDetectingValueMerger )
             throws IOException, IndexEntryConflictException
@@ -121,7 +121,7 @@ class NativeSchemaIndexUpdater<KEY extends NativeSchemaKey, VALUE extends Native
         conflictDetectingValueMerger.checkConflict( update.values() );
     }
 
-    static <KEY extends NativeSchemaKey, VALUE extends NativeSchemaValue> void processAdd( KEY treeKey, VALUE treeValue,
+    static <KEY extends NativeSchemaKey<KEY>, VALUE extends NativeSchemaValue> void processAdd( KEY treeKey, VALUE treeValue,
             IndexEntryUpdate<?> update, Writer<KEY,VALUE> writer,
             ConflictDetectingValueMerger<KEY,VALUE> conflictDetectingValueMerger )
             throws IOException, IndexEntryConflictException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaKey.java
@@ -28,7 +28,7 @@ import org.neo4j.values.storable.ValueWriter;
  * This is the abstraction of what NativeSchemaIndex with friends need from a schema key.
  * Note that it says nothing about how keys are compared, serialized, read, written, etc. That is the job of Layout.
  */
-abstract class NativeSchemaKey<SELF extends NativeSchemaKey> extends ValueWriter.Adapter<RuntimeException>
+abstract class NativeSchemaKey<SELF extends NativeSchemaKey<SELF>> extends ValueWriter.Adapter<RuntimeException>
 {
     static final boolean DEFAULT_COMPARE_ID = true;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberSchemaIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberSchemaIndexReader.java
@@ -32,7 +32,8 @@ import org.neo4j.values.storable.Values;
 
 class NumberSchemaIndexReader<VALUE extends NativeSchemaValue> extends NativeSchemaIndexReader<NumberSchemaKey,VALUE>
 {
-    NumberSchemaIndexReader( GBPTree<NumberSchemaKey,VALUE> tree, Layout<NumberSchemaKey,VALUE> layout, IndexSamplingConfig samplingConfig, SchemaIndexDescriptor descriptor )
+    NumberSchemaIndexReader( GBPTree<NumberSchemaKey,VALUE> tree, Layout<NumberSchemaKey,VALUE> layout,
+            IndexSamplingConfig samplingConfig, SchemaIndexDescriptor descriptor )
     {
         super( tree, layout, samplingConfig, descriptor );
     }
@@ -64,7 +65,7 @@ class NumberSchemaIndexReader<VALUE extends NativeSchemaValue> extends NativeSch
             treeKeyTo.from( Long.MAX_VALUE, exactPredicate.value() );
             break;
         case range:
-            RangePredicate rangePredicate = (RangePredicate) predicate;
+            RangePredicate<?> rangePredicate = (RangePredicate<?>) predicate;
             initFromForRange( rangePredicate, treeKeyFrom );
             initToForRange( rangePredicate, treeKeyTo );
             break;
@@ -74,7 +75,7 @@ class NumberSchemaIndexReader<VALUE extends NativeSchemaValue> extends NativeSch
         return false;
     }
 
-    private void initToForRange( RangePredicate rangePredicate, NumberSchemaKey treeKeyTo )
+    private void initToForRange( RangePredicate<?> rangePredicate, NumberSchemaKey treeKeyTo )
     {
         Value toValue = rangePredicate.toValue();
         if ( toValue == Values.NO_VALUE )
@@ -88,7 +89,7 @@ class NumberSchemaIndexReader<VALUE extends NativeSchemaValue> extends NativeSch
         }
     }
 
-    private void initFromForRange( RangePredicate rangePredicate, NumberSchemaKey treeKeyFrom )
+    private void initFromForRange( RangePredicate<?> rangePredicate, NumberSchemaKey treeKeyFrom )
     {
         Value fromValue = rangePredicate.fromValue();
         if ( fromValue == Values.NO_VALUE )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberSchemaIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NumberSchemaIndexReader.java
@@ -30,9 +30,9 @@ import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
 
-class NumberSchemaIndexReader<KEY extends NumberSchemaKey, VALUE extends NativeSchemaValue> extends NativeSchemaIndexReader<KEY,VALUE>
+class NumberSchemaIndexReader<VALUE extends NativeSchemaValue> extends NativeSchemaIndexReader<NumberSchemaKey,VALUE>
 {
-    NumberSchemaIndexReader( GBPTree<KEY,VALUE> tree, Layout<KEY,VALUE> layout, IndexSamplingConfig samplingConfig, SchemaIndexDescriptor descriptor )
+    NumberSchemaIndexReader( GBPTree<NumberSchemaKey,VALUE> tree, Layout<NumberSchemaKey,VALUE> layout, IndexSamplingConfig samplingConfig, SchemaIndexDescriptor descriptor )
     {
         super( tree, layout, samplingConfig, descriptor );
     }
@@ -49,7 +49,7 @@ class NumberSchemaIndexReader<KEY extends NumberSchemaKey, VALUE extends NativeS
     }
 
     @Override
-    boolean initializeRangeForQuery( KEY treeKeyFrom, KEY treeKeyTo, IndexQuery[] predicates )
+    boolean initializeRangeForQuery( NumberSchemaKey treeKeyFrom, NumberSchemaKey treeKeyTo, IndexQuery[] predicates )
     {
         IndexQuery predicate = predicates[0];
         switch ( predicate.type() )
@@ -74,7 +74,7 @@ class NumberSchemaIndexReader<KEY extends NumberSchemaKey, VALUE extends NativeS
         return false;
     }
 
-    private void initToForRange( RangePredicate rangePredicate, KEY treeKeyTo )
+    private void initToForRange( RangePredicate rangePredicate, NumberSchemaKey treeKeyTo )
     {
         Value toValue = rangePredicate.toValue();
         if ( toValue == Values.NO_VALUE )
@@ -88,7 +88,7 @@ class NumberSchemaIndexReader<KEY extends NumberSchemaKey, VALUE extends NativeS
         }
     }
 
-    private void initFromForRange( RangePredicate rangePredicate, KEY treeKeyFrom )
+    private void initFromForRange( RangePredicate rangePredicate, NumberSchemaKey treeKeyFrom )
     {
         Value fromValue = rangePredicate.fromValue();
         if ( fromValue == Values.NO_VALUE )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SchemaLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SchemaLayout.java
@@ -22,7 +22,7 @@ package org.neo4j.kernel.impl.index.schema;
 import org.neo4j.index.internal.gbptree.Layout;
 import org.neo4j.io.pagecache.PageCursor;
 
-abstract class SchemaLayout<KEY extends NativeSchemaKey> extends Layout.Adapter<KEY,NativeSchemaValue>
+abstract class SchemaLayout<KEY extends NativeSchemaKey<KEY>> extends Layout.Adapter<KEY,NativeSchemaValue>
 {
     private final long identifier;
     private final int majorVersion;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialHitIndexProgressor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialHitIndexProgressor.java
@@ -26,7 +26,7 @@ import org.neo4j.cursor.RawCursor;
 import org.neo4j.index.internal.gbptree.Hit;
 import org.neo4j.values.storable.Value;
 
-class SpatialHitIndexProgressor<KEY extends NativeSchemaKey, VALUE extends NativeSchemaValue> extends NativeHitIndexProgressor<KEY, VALUE>
+class SpatialHitIndexProgressor<KEY extends NativeSchemaKey<KEY>, VALUE extends NativeSchemaValue> extends NativeHitIndexProgressor<KEY, VALUE>
 {
     SpatialHitIndexProgressor( RawCursor<Hit<KEY,VALUE>,IOException> seeker, NodeValueClient client,
             Collection<RawCursor<Hit<KEY,VALUE>,IOException>> toRemoveFromOnClose )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialHitIndexProgressor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialHitIndexProgressor.java
@@ -26,16 +26,16 @@ import org.neo4j.cursor.RawCursor;
 import org.neo4j.index.internal.gbptree.Hit;
 import org.neo4j.values.storable.Value;
 
-class SpatialHitIndexProgressor<KEY extends NativeSchemaKey<KEY>, VALUE extends NativeSchemaValue> extends NativeHitIndexProgressor<KEY, VALUE>
+class SpatialHitIndexProgressor<VALUE extends NativeSchemaValue> extends NativeHitIndexProgressor<SpatialSchemaKey, VALUE>
 {
-    SpatialHitIndexProgressor( RawCursor<Hit<KEY,VALUE>,IOException> seeker, NodeValueClient client,
-            Collection<RawCursor<Hit<KEY,VALUE>,IOException>> toRemoveFromOnClose )
+    SpatialHitIndexProgressor( RawCursor<Hit<SpatialSchemaKey,VALUE>,IOException> seeker, NodeValueClient client,
+            Collection<RawCursor<Hit<SpatialSchemaKey,VALUE>,IOException>> toRemoveFromOnClose )
     {
         super( seeker, client, toRemoveFromOnClose );
     }
 
     @Override
-    Value[] extractValues( KEY key )
+    Value[] extractValues( SpatialSchemaKey key )
     {
         return null;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexAccessor.java
@@ -204,7 +204,7 @@ class SpatialIndexAccessor extends SpatialIndexCache<SpatialIndexAccessor.PartAc
         }
 
         @Override
-        public SpatialIndexPartReader<SpatialSchemaKey,NativeSchemaValue> newReader()
+        public SpatialIndexPartReader<NativeSchemaValue> newReader()
         {
             return new SpatialIndexPartReader<>( tree, layout, samplingConfig, descriptor, searchConfiguration );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPartReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPartReader.java
@@ -49,7 +49,8 @@ public class SpatialIndexPartReader<VALUE extends NativeSchemaValue> extends Nat
     private final SpatialLayout spatial;
     private final SpaceFillingCurveConfiguration configuration;
 
-    SpatialIndexPartReader( GBPTree<SpatialSchemaKey,VALUE> tree, Layout<SpatialSchemaKey,VALUE> layout, IndexSamplingConfig samplingConfig, SchemaIndexDescriptor descriptor,
+    SpatialIndexPartReader( GBPTree<SpatialSchemaKey,VALUE> tree, Layout<SpatialSchemaKey,VALUE> layout,
+            IndexSamplingConfig samplingConfig, SchemaIndexDescriptor descriptor,
             SpaceFillingCurveConfiguration configuration )
     {
         super( tree, layout, samplingConfig, descriptor );
@@ -167,7 +168,8 @@ public class SpatialIndexPartReader<VALUE extends NativeSchemaValue> extends Nat
     }
 
     @Override
-    void startSeekForInitializedRange( IndexProgressor.NodeValueClient client, SpatialSchemaKey treeKeyFrom, SpatialSchemaKey treeKeyTo, IndexQuery[] query, boolean needFilter )
+    void startSeekForInitializedRange( IndexProgressor.NodeValueClient client, SpatialSchemaKey treeKeyFrom,
+            SpatialSchemaKey treeKeyTo, IndexQuery[] query, boolean needFilter )
     {
         if ( layout.compare( treeKeyFrom, treeKeyTo ) > 0 )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPartReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPartReader.java
@@ -44,12 +44,12 @@ import org.neo4j.values.storable.Value;
 
 import static java.lang.String.format;
 
-public class SpatialIndexPartReader<KEY extends SpatialSchemaKey, VALUE extends NativeSchemaValue> extends NativeSchemaIndexReader<KEY,VALUE>
+public class SpatialIndexPartReader<VALUE extends NativeSchemaValue> extends NativeSchemaIndexReader<SpatialSchemaKey,VALUE>
 {
     private final SpatialLayout spatial;
     private final SpaceFillingCurveConfiguration configuration;
 
-    SpatialIndexPartReader( GBPTree<KEY,VALUE> tree, Layout<KEY,VALUE> layout, IndexSamplingConfig samplingConfig, SchemaIndexDescriptor descriptor,
+    SpatialIndexPartReader( GBPTree<SpatialSchemaKey,VALUE> tree, Layout<SpatialSchemaKey,VALUE> layout, IndexSamplingConfig samplingConfig, SchemaIndexDescriptor descriptor,
             SpaceFillingCurveConfiguration configuration )
     {
         super( tree, layout, samplingConfig, descriptor );
@@ -74,7 +74,7 @@ public class SpatialIndexPartReader<KEY extends SpatialSchemaKey, VALUE extends 
     }
 
     @Override
-    boolean initializeRangeForQuery( KEY treeKeyFrom, KEY treeKeyTo, IndexQuery[] predicates )
+    boolean initializeRangeForQuery( SpatialSchemaKey treeKeyFrom, SpatialSchemaKey treeKeyTo, IndexQuery[] predicates )
     {
         throw new UnsupportedOperationException( "Cannot initialize 1D range in multidimensional spatial index reader" );
     }
@@ -116,8 +116,8 @@ public class SpatialIndexPartReader<KEY extends SpatialSchemaKey, VALUE extends 
 
     private void startSeekForExists( IndexProgressor.NodeValueClient client, IndexQuery... predicates )
     {
-        KEY treeKeyFrom = layout.newKey();
-        KEY treeKeyTo = layout.newKey();
+        SpatialSchemaKey treeKeyFrom = layout.newKey();
+        SpatialSchemaKey treeKeyTo = layout.newKey();
         treeKeyFrom.initAsLowest();
         treeKeyTo.initAsHighest();
         startSeekForInitializedRange( client, treeKeyFrom, treeKeyTo, predicates, false );
@@ -125,8 +125,8 @@ public class SpatialIndexPartReader<KEY extends SpatialSchemaKey, VALUE extends 
 
     private void startSeekForExact( IndexProgressor.NodeValueClient client, Value value, IndexQuery... predicates )
     {
-        KEY treeKeyFrom = layout.newKey();
-        KEY treeKeyTo = layout.newKey();
+        SpatialSchemaKey treeKeyFrom = layout.newKey();
+        SpatialSchemaKey treeKeyTo = layout.newKey();
         treeKeyFrom.from( Long.MIN_VALUE, value );
         treeKeyTo.from( Long.MAX_VALUE, value );
         startSeekForInitializedRange( client, treeKeyFrom, treeKeyTo, predicates, false );
@@ -146,11 +146,11 @@ public class SpatialIndexPartReader<KEY extends SpatialSchemaKey, VALUE extends 
             List<SpaceFillingCurve.LongRange> ranges = curve.getTilesIntersectingEnvelope( envelope, configuration );
             for ( SpaceFillingCurve.LongRange range : ranges )
             {
-                KEY treeKeyFrom = layout.newKey();
-                KEY treeKeyTo = layout.newKey();
+                SpatialSchemaKey treeKeyFrom = layout.newKey();
+                SpatialSchemaKey treeKeyTo = layout.newKey();
                 treeKeyFrom.fromDerivedValue( Long.MIN_VALUE, range.min );
                 treeKeyTo.fromDerivedValue( Long.MAX_VALUE, range.max + 1 );
-                RawCursor<Hit<KEY,VALUE>,IOException> seeker = makeIndexSeeker( treeKeyFrom, treeKeyTo );
+                RawCursor<Hit<SpatialSchemaKey,VALUE>,IOException> seeker = makeIndexSeeker( treeKeyFrom, treeKeyTo );
                 IndexProgressor hitProgressor = new SpatialHitIndexProgressor<>( seeker, client, openSeekers );
                 multiProgressor.initialize( descriptor, hitProgressor, query );
             }
@@ -167,7 +167,7 @@ public class SpatialIndexPartReader<KEY extends SpatialSchemaKey, VALUE extends 
     }
 
     @Override
-    void startSeekForInitializedRange( IndexProgressor.NodeValueClient client, KEY treeKeyFrom, KEY treeKeyTo, IndexQuery[] query, boolean needFilter )
+    void startSeekForInitializedRange( IndexProgressor.NodeValueClient client, SpatialSchemaKey treeKeyFrom, SpatialSchemaKey treeKeyTo, IndexQuery[] query, boolean needFilter )
     {
         if ( layout.compare( treeKeyFrom, treeKeyTo ) > 0 )
         {
@@ -176,7 +176,7 @@ public class SpatialIndexPartReader<KEY extends SpatialSchemaKey, VALUE extends 
         }
         try
         {
-            RawCursor<Hit<KEY,VALUE>,IOException> seeker = makeIndexSeeker( treeKeyFrom, treeKeyTo );
+            RawCursor<Hit<SpatialSchemaKey,VALUE>,IOException> seeker = makeIndexSeeker( treeKeyFrom, treeKeyTo );
             IndexProgressor hitProgressor = new SpatialHitIndexProgressor<>( seeker, client, openSeekers );
             client.initialize( descriptor, hitProgressor, query );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexReader.java
@@ -90,7 +90,7 @@ class SpatialIndexReader extends SpatialIndexCache<SpatialIndexPartReader<Native
             loadAll();
             BridgingIndexProgressor multiProgressor = new BridgingIndexProgressor( cursor, descriptor.schema().getPropertyIds() );
             cursor.initialize( descriptor, multiProgressor, predicates );
-            for ( NativeSchemaIndexReader reader : this )
+            for ( NativeSchemaIndexReader<SpatialSchemaKey,NativeSchemaValue> reader : this )
             {
                 reader.query( multiProgressor, indexOrder, predicates );
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexReader.java
@@ -39,7 +39,7 @@ import org.neo4j.values.storable.Value;
 
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.forAll;
 
-class SpatialIndexReader extends SpatialIndexCache<SpatialIndexPartReader<SpatialSchemaKey,NativeSchemaValue>,IOException> implements IndexReader
+class SpatialIndexReader extends SpatialIndexCache<SpatialIndexPartReader<NativeSchemaValue>,IOException> implements IndexReader
 {
     private final SchemaIndexDescriptor descriptor;
 
@@ -112,7 +112,7 @@ class SpatialIndexReader extends SpatialIndexCache<SpatialIndexPartReader<Spatia
                 {
                     throw new IllegalArgumentException( "Wrong type of predicate, couldn't get CoordinateReferenceSystem" );
                 }
-                SpatialIndexPartReader<SpatialSchemaKey,NativeSchemaValue> part = uncheckedSelect( crs );
+                SpatialIndexPartReader<NativeSchemaValue> part = uncheckedSelect( crs );
                 if ( part != null )
                 {
                     part.query( cursor, indexOrder, predicates );
@@ -144,7 +144,7 @@ class SpatialIndexReader extends SpatialIndexCache<SpatialIndexPartReader<Spatia
      * To create TemporalIndexPartReaders on demand, the PartFactory maintains a reference to the parent TemporalIndexAccessor.
      * The creation of a part reader can then be delegated to the correct PartAccessor.
      */
-    static class PartFactory implements Factory<SpatialIndexPartReader<SpatialSchemaKey,NativeSchemaValue>,IOException>
+    static class PartFactory implements Factory<SpatialIndexPartReader<NativeSchemaValue>,IOException>
     {
         private final SpatialIndexAccessor accessor;
 
@@ -154,7 +154,7 @@ class SpatialIndexReader extends SpatialIndexCache<SpatialIndexPartReader<Spatia
         }
 
         @Override
-        public SpatialIndexPartReader<SpatialSchemaKey,NativeSchemaValue> newSpatial( CoordinateReferenceSystem crs ) throws IOException
+        public SpatialIndexPartReader<NativeSchemaValue> newSpatial( CoordinateReferenceSystem crs ) throws IOException
         {
             return accessor.selectOrElse( crs, SpatialIndexAccessor.PartAccessor::newReader, null );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringSchemaIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringSchemaIndexReader.java
@@ -24,8 +24,8 @@ import org.neo4j.index.internal.gbptree.Layout;
 import org.neo4j.internal.kernel.api.IndexOrder;
 import org.neo4j.internal.kernel.api.IndexQuery;
 import org.neo4j.internal.kernel.api.IndexQuery.ExactPredicate;
-import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
 import org.neo4j.internal.kernel.api.IndexQuery.RangePredicate;
+import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
@@ -67,7 +67,7 @@ class StringSchemaIndexReader extends NativeSchemaIndexReader<StringSchemaKey,Na
             treeKeyTo.from( Long.MAX_VALUE, exactPredicate.value() );
             return false;
         case range:
-            RangePredicate rangePredicate = (RangePredicate)predicate;
+            RangePredicate<?> rangePredicate = (RangePredicate<?>)predicate;
             initFromForRange( rangePredicate, treeKeyFrom );
             initToForRange( rangePredicate, treeKeyTo );
             return false;
@@ -86,7 +86,7 @@ class StringSchemaIndexReader extends NativeSchemaIndexReader<StringSchemaKey,Na
         }
     }
 
-    private void initFromForRange( RangePredicate rangePredicate, StringSchemaKey treeKeyFrom )
+    private void initFromForRange( RangePredicate<?> rangePredicate, StringSchemaKey treeKeyFrom )
     {
         Value fromValue = rangePredicate.fromValue();
         if ( fromValue == Values.NO_VALUE )
@@ -100,7 +100,7 @@ class StringSchemaIndexReader extends NativeSchemaIndexReader<StringSchemaKey,Na
         }
     }
 
-    private void initToForRange( RangePredicate rangePredicate, StringSchemaKey treeKeyTo )
+    private void initToForRange( RangePredicate<?> rangePredicate, StringSchemaKey treeKeyTo )
     {
         Value toValue = rangePredicate.toValue();
         if ( toValue == Values.NO_VALUE )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
@@ -36,9 +36,9 @@ import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexPopulator;
+import org.neo4j.kernel.api.index.IndexProvider;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.PropertyAccessor;
-import org.neo4j.kernel.api.index.IndexProvider;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
@@ -169,7 +169,7 @@ class TemporalIndexAccessor extends TemporalIndexCache<TemporalIndexAccessor.Par
         return Iterators.stream( iterator() ).anyMatch( NativeSchemaIndexAccessor::isDirty );
     }
 
-    static class PartAccessor<KEY extends NativeSchemaKey> extends NativeSchemaIndexAccessor<KEY, NativeSchemaValue>
+    static class PartAccessor<KEY extends NativeSchemaKey<KEY>> extends NativeSchemaIndexAccessor<KEY, NativeSchemaValue>
     {
         private final Layout<KEY,NativeSchemaValue> layout;
         private final SchemaIndexDescriptor descriptor;
@@ -263,7 +263,7 @@ class TemporalIndexAccessor extends TemporalIndexCache<TemporalIndexAccessor.Par
             return createPartAccessor( temporalIndexFiles.duration() );
         }
 
-        private <KEY extends NativeSchemaKey> PartAccessor<KEY> createPartAccessor( TemporalIndexFiles.FileLayout<KEY> fileLayout ) throws IOException
+        private <KEY extends NativeSchemaKey<KEY>> PartAccessor<KEY> createPartAccessor( TemporalIndexFiles.FileLayout<KEY> fileLayout ) throws IOException
         {
             if ( !fs.fileExists( fileLayout.indexFile ) )
             {
@@ -272,7 +272,7 @@ class TemporalIndexAccessor extends TemporalIndexCache<TemporalIndexAccessor.Par
             return new PartAccessor<>( pageCache, fs, fileLayout, recoveryCleanupWorkCollector, monitor, descriptor, indexId, samplingConfig );
         }
 
-        private <KEY extends NativeSchemaKey> void createEmptyIndex( TemporalIndexFiles.FileLayout<KEY> fileLayout ) throws IOException
+        private <KEY extends NativeSchemaKey<KEY>> void createEmptyIndex( TemporalIndexFiles.FileLayout<KEY> fileLayout ) throws IOException
         {
             IndexPopulator populator = new TemporalIndexPopulator.PartPopulator<>( pageCache, fs, fileLayout, monitor, descriptor, indexId, samplingConfig );
             populator.create();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexFiles.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexFiles.java
@@ -116,7 +116,7 @@ class TemporalIndexFiles
 
     // .... we will add more explicit accessor methods later
 
-    static class FileLayout<KEY extends NativeSchemaKey>
+    static class FileLayout<KEY extends NativeSchemaKey<KEY>>
     {
         final File indexFile;
         final Layout<KEY,NativeSchemaValue> layout;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPartReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPartReader.java
@@ -29,7 +29,7 @@ import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
 
-class TemporalIndexPartReader<KEY extends NativeSchemaKey> extends NativeSchemaIndexReader<KEY,NativeSchemaValue>
+class TemporalIndexPartReader<KEY extends NativeSchemaKey<KEY>> extends NativeSchemaIndexReader<KEY,NativeSchemaValue>
 {
     TemporalIndexPartReader( GBPTree<KEY,NativeSchemaValue> tree,
                              Layout<KEY,NativeSchemaValue> layout,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPartReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPartReader.java
@@ -68,7 +68,7 @@ class TemporalIndexPartReader<KEY extends NativeSchemaKey<KEY>> extends NativeSc
             break;
 
         case range:
-            IndexQuery.RangePredicate rangePredicate = (IndexQuery.RangePredicate) predicate;
+            IndexQuery.RangePredicate<?> rangePredicate = (IndexQuery.RangePredicate<?>) predicate;
             initFromForRange( rangePredicate, treeKeyFrom );
             initToForRange( rangePredicate, treeKeyTo );
             break;
@@ -79,7 +79,7 @@ class TemporalIndexPartReader<KEY extends NativeSchemaKey<KEY>> extends NativeSc
         return false; // no filtering
     }
 
-    private void initFromForRange( IndexQuery.RangePredicate rangePredicate, KEY treeKeyFrom )
+    private void initFromForRange( IndexQuery.RangePredicate<?> rangePredicate, KEY treeKeyFrom )
     {
         Value fromValue = rangePredicate.fromValue();
         if ( fromValue == Values.NO_VALUE )
@@ -93,7 +93,7 @@ class TemporalIndexPartReader<KEY extends NativeSchemaKey<KEY>> extends NativeSc
         }
     }
 
-    private void initToForRange( IndexQuery.RangePredicate rangePredicate, KEY treeKeyTo )
+    private void initToForRange( IndexQuery.RangePredicate<?> rangePredicate, KEY treeKeyTo )
     {
         Value toValue = rangePredicate.toValue();
         if ( toValue == Values.NO_VALUE )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulator.java
@@ -29,9 +29,9 @@ import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexPopulator;
+import org.neo4j.kernel.api.index.IndexProvider;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.PropertyAccessor;
-import org.neo4j.kernel.api.index.IndexProvider;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
 import org.neo4j.kernel.impl.api.index.sampling.DefaultNonUniqueIndexSampler;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
@@ -173,7 +173,7 @@ class TemporalIndexPopulator extends TemporalIndexCache<TemporalIndexPopulator.P
         }
     }
 
-    static class PartPopulator<KEY extends NativeSchemaKey> extends NativeSchemaIndexPopulator<KEY, NativeSchemaValue>
+    static class PartPopulator<KEY extends NativeSchemaKey<KEY>> extends NativeSchemaIndexPopulator<KEY, NativeSchemaValue>
     {
         List<IndexEntryUpdate<?>> updates = new ArrayList<>();
 
@@ -277,7 +277,7 @@ class TemporalIndexPopulator extends TemporalIndexCache<TemporalIndexPopulator.P
             return create( temporalIndexFiles.duration() );
         }
 
-        private <KEY extends NativeSchemaKey> PartPopulator<KEY> create( TemporalIndexFiles.FileLayout<KEY> fileLayout ) throws IOException
+        private <KEY extends NativeSchemaKey<KEY>> PartPopulator<KEY> create( TemporalIndexFiles.FileLayout<KEY> fileLayout ) throws IOException
         {
             PartPopulator<KEY> populator = new PartPopulator<>( pageCache, fs, fileLayout, monitor, descriptor, indexId, samplingConfig );
             populator.create();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexReader.java
@@ -21,10 +21,8 @@ package org.neo4j.kernel.impl.index.schema;
 
 import java.io.IOException;
 
-import org.neo4j.collection.primitive.PrimitiveLongResourceCollections;
 import org.neo4j.collection.primitive.PrimitiveLongResourceIterator;
 import org.neo4j.graphdb.Resource;
-import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.internal.kernel.api.IndexOrder;
 import org.neo4j.internal.kernel.api.IndexQuery;
@@ -90,7 +88,7 @@ class TemporalIndexReader extends TemporalIndexCache<TemporalIndexPartReader<?>,
             loadAll();
             BridgingIndexProgressor multiProgressor = new BridgingIndexProgressor( cursor, descriptor.schema().getPropertyIds() );
             cursor.initialize( descriptor, multiProgressor, predicates );
-            for ( NativeSchemaIndexReader reader : this )
+            for ( NativeSchemaIndexReader<?,NativeSchemaValue> reader : this )
             {
                 reader.query( multiProgressor, indexOrder, predicates );
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeValueIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeValueIndexCursor.java
@@ -234,7 +234,7 @@ final class DefaultNodeValueIndexCursor extends IndexCursor<IndexProgressor>
         }
     }
 
-    private void rangeQuery( SchemaIndexDescriptor descriptor, IndexQuery.RangePredicate predicate )
+    private void rangeQuery( SchemaIndexDescriptor descriptor, IndexQuery.RangePredicate<?> predicate )
     {
         ValueGroup valueGroup = predicate.valueGroup();
         this.needsValues = valueGroup == ValueGroup.TEXT || valueGroup == ValueGroup.NUMBER;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
@@ -396,7 +396,7 @@ public class StateHandlingStatementOperationsTest
         } );
 
         IndexReader indexReader = addMockedIndexReader( storageStatement );
-        RangePredicate indexQuery =
+        RangePredicate<?> indexQuery =
                 IndexQuery.range( index.schema().getPropertyId(), lower.asObject(), true, upper.asObject(), false );
         when( indexReader.query( indexQuery ) ).thenReturn(
                 PrimitiveLongCollections.resourceIterator( PrimitiveLongCollections.iterator( 43L, 44L, 46L ), null )
@@ -435,7 +435,7 @@ public class StateHandlingStatementOperationsTest
 
         StoreReadLayer storeReadLayer = mock( StoreReadLayer.class );
         IndexReader indexReader = addMockedIndexReader( statement );
-        RangePredicate rangePredicate =
+        RangePredicate<?> rangePredicate =
                 IndexQuery.range( index.schema().getPropertyId(), "Anne", true, "Bill", false );
         when( indexReader.query( rangePredicate ) ).thenReturn(
                 PrimitiveLongCollections.resourceIterator( PrimitiveLongCollections.iterator( 43L, 44L, 46L ), null ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LayoutTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/LayoutTestUtil.java
@@ -38,7 +38,7 @@ import org.neo4j.test.rule.RandomRule;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
 
-abstract class LayoutTestUtil<KEY extends NativeSchemaKey, VALUE extends NativeSchemaValue>
+abstract class LayoutTestUtil<KEY extends NativeSchemaKey<KEY>, VALUE extends NativeSchemaValue>
 {
     private static final Comparator<IndexEntryUpdate<SchemaIndexDescriptor>> UPDATE_COMPARATOR = ( u1, u2 ) ->
             Values.COMPARATOR.compare( u1.values()[0], u2.values()[0] );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeNonUniqueSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeNonUniqueSchemaIndexPopulatorTest.java
@@ -31,10 +31,9 @@ import org.neo4j.storageengine.api.schema.IndexSample;
 import org.neo4j.values.storable.Values;
 
 import static org.junit.Assert.assertEquals;
-
 import static org.neo4j.kernel.impl.index.schema.LayoutTestUtil.countUniqueValues;
 
-public abstract class NativeNonUniqueSchemaIndexPopulatorTest<KEY extends NativeSchemaKey,VALUE extends NativeSchemaValue>
+public abstract class NativeNonUniqueSchemaIndexPopulatorTest<KEY extends NativeSchemaKey<KEY>,VALUE extends NativeSchemaValue>
         extends NativeSchemaIndexPopulatorTest<KEY,VALUE>
 {
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexAccessorTest.java
@@ -82,7 +82,7 @@ import static org.neo4j.values.storable.Values.of;
  * <li>{@link NumberSchemaIndexReader}</li>
  * </ul>
  */
-public abstract class NativeSchemaIndexAccessorTest<KEY extends NativeSchemaKey, VALUE extends NativeSchemaValue>
+public abstract class NativeSchemaIndexAccessorTest<KEY extends NativeSchemaKey<KEY>, VALUE extends NativeSchemaValue>
         extends NativeSchemaIndexTestUtil<KEY,VALUE>
 {
     NativeSchemaIndexAccessor<KEY,VALUE> accessor;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexPopulatorTest.java
@@ -62,7 +62,7 @@ import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_WRITER;
 import static org.neo4j.kernel.impl.index.schema.NativeSchemaIndexPopulator.BYTE_FAILED;
 import static org.neo4j.kernel.impl.index.schema.NativeSchemaIndexPopulator.BYTE_ONLINE;
 
-public abstract class NativeSchemaIndexPopulatorTest<KEY extends NativeSchemaKey,VALUE extends NativeSchemaValue>
+public abstract class NativeSchemaIndexPopulatorTest<KEY extends NativeSchemaKey<KEY>,VALUE extends NativeSchemaValue>
         extends NativeSchemaIndexTestUtil<KEY,VALUE>
 {
     private static final int LARGE_AMOUNT_OF_UPDATES = 1_000;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexTestUtil.java
@@ -43,7 +43,6 @@ import org.neo4j.test.rule.PageCacheRule;
 import org.neo4j.test.rule.RandomRule;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
-import org.neo4j.test.rule.fs.FileSystemRule;
 
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
@@ -54,11 +53,11 @@ import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_READER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_WRITER;
 import static org.neo4j.test.rule.PageCacheRule.config;
 
-public abstract class NativeSchemaIndexTestUtil<KEY extends NativeSchemaKey,VALUE extends NativeSchemaValue>
+public abstract class NativeSchemaIndexTestUtil<KEY extends NativeSchemaKey<KEY>,VALUE extends NativeSchemaValue>
 {
     static final long NON_EXISTENT_ENTITY_ID = 1_000_000_000;
 
-    final FileSystemRule fs = new DefaultFileSystemRule();
+    final DefaultFileSystemRule fs = new DefaultFileSystemRule();
     private final TestDirectory directory = TestDirectory.testDirectory( getClass(), fs.get() );
     private final PageCacheRule pageCacheRule = new PageCacheRule( config().withAccessChecks( true ) );
     protected final RandomRule random = new RandomRule();
@@ -158,7 +157,7 @@ public abstract class NativeSchemaIndexTestUtil<KEY extends NativeSchemaKey,VALU
         VALUE intoValue = layout.newValue();
         layout.copyKey( from.key(), intoKey );
         copyValue( from.value(), intoValue );
-        return new SimpleHit( intoKey, intoValue );
+        return new SimpleHit<>( intoKey, intoValue );
     }
 
     private Hit<KEY,VALUE>[] convertToHits( IndexEntryUpdate<SchemaIndexDescriptor>[] updates,
@@ -178,7 +177,7 @@ public abstract class NativeSchemaIndexTestUtil<KEY extends NativeSchemaKey,VALU
 
     private Hit<KEY,VALUE> hit( final KEY key, final VALUE value )
     {
-        return new SimpleHit( key, value );
+        return new SimpleHit<>( key, value );
     }
 
     void assertFilePresent()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeUniqueSchemaIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeUniqueSchemaIndexPopulatorTest.java
@@ -30,13 +30,12 @@ import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
 import org.neo4j.storageengine.api.schema.IndexSample;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import static java.util.Arrays.asList;
-
-public abstract class NativeUniqueSchemaIndexPopulatorTest<KEY extends NativeSchemaKey,VALUE extends NativeSchemaValue>
+public abstract class NativeUniqueSchemaIndexPopulatorTest<KEY extends NativeSchemaKey<KEY>,VALUE extends NativeSchemaValue>
         extends NativeSchemaIndexPopulatorTest<KEY,VALUE>
 {
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberSchemaIndexAccessorTest.java
@@ -58,7 +58,7 @@ public abstract class NumberSchemaIndexAccessorTest extends NativeSchemaIndexAcc
 
         // when
         IndexReader reader = accessor.newReader();
-        IndexQuery.RangePredicate supportedQuery =
+        IndexQuery.RangePredicate<?> supportedQuery =
                 IndexQuery.range( 0, Double.NEGATIVE_INFINITY, true, Double.POSITIVE_INFINITY, true );
 
         for ( IndexOrder supportedOrder : NumberIndexProvider.CAPABILITY.orderCapability( ValueGroup.NUMBER ) )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexReaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexReaderTest.java
@@ -231,7 +231,7 @@ public class FusionIndexReaderTest
     public void mustSelectStringForRangeStringPredicate() throws Exception
     {
         // given
-        RangePredicate stringRange = IndexQuery.range( PROP_KEY, "abc", true, "def", false );
+        RangePredicate<?> stringRange = IndexQuery.range( PROP_KEY, "abc", true, "def", false );
 
         // then
         verifyQueryWithCorrectReader( stringReader, stringRange );
@@ -241,7 +241,7 @@ public class FusionIndexReaderTest
     public void mustSelectNumberForRangeNumericPredicate() throws Exception
     {
         // given
-        RangePredicate numberRange = IndexQuery.range( PROP_KEY, 0, true, 1, false );
+        RangePredicate<?> numberRange = IndexQuery.range( PROP_KEY, 0, true, 1, false );
 
         // then
         verifyQueryWithCorrectReader( numberReader, numberRange );
@@ -253,7 +253,7 @@ public class FusionIndexReaderTest
         // given
         PointValue from = Values.pointValue( CoordinateReferenceSystem.Cartesian, 1.0, 1.0);
         PointValue to = Values.pointValue( CoordinateReferenceSystem.Cartesian, 2.0, 2.0);
-        RangePredicate geometryRange = IndexQuery.range( PROP_KEY, from, true, to, false );
+        RangePredicate<?> geometryRange = IndexQuery.range( PROP_KEY, from, true, to, false );
 
         // then
         verifyQueryWithCorrectReader( spatialReader, geometryRange );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/reader/PartitionedIndexReaderTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/reader/PartitionedIndexReaderTest.java
@@ -100,7 +100,7 @@ public class PartitionedIndexReaderTest
     {
         PartitionedIndexReader indexReader = createPartitionedReaderFromReaders();
 
-        IndexQuery.RangePredicate query = IndexQuery.range( 1, 1, true, 2, true );
+        IndexQuery.RangePredicate<?> query = IndexQuery.range( 1, 1, true, 2, true );
         when( indexReader1.query( query ) ).thenReturn( PrimitiveLongResourceCollections.iterator( null, 1 ) );
         when( indexReader2.query( query ) ).thenReturn( PrimitiveLongResourceCollections.iterator( null, 2 ) );
         when( indexReader3.query( query ) ).thenReturn( PrimitiveLongResourceCollections.iterator( null, 3 ) );
@@ -115,7 +115,7 @@ public class PartitionedIndexReaderTest
     {
         PartitionedIndexReader indexReader = createPartitionedReaderFromReaders();
 
-        IndexQuery.RangePredicate query = IndexQuery.range( 1, "a", false, "b", true );
+        IndexQuery.RangePredicate<?> query = IndexQuery.range( 1, "a", false, "b", true );
         when( indexReader1.query( query ) ).thenReturn( PrimitiveLongResourceCollections.iterator( null, 1 ) );
         when( indexReader2.query( query ) ).thenReturn( PrimitiveLongResourceCollections.iterator( null, 2 ) );
         when( indexReader3.query( query ) ).thenReturn( PrimitiveLongResourceCollections.iterator( null, 3 ) );


### PR DESCRIPTION
Fix the raw usages in the native index code to not defer compile-time errors to runtime.

The compiler is a friend, not a foe.