### PR TITLE
Close page cache instances and shutdown test dbs.

### DIFF
--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/StoreInfoCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/StoreInfoCommandTest.java
@@ -37,6 +37,7 @@ import java.util.function.Consumer;
 
 import org.neo4j.commandline.admin.CommandLocator;
 import org.neo4j.commandline.admin.Usage;
+import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
@@ -188,7 +189,10 @@ public class StoreInfoCommandTest
     {
         File neoStoreFile = createNeoStoreFile();
         long value = MetaDataStore.versionStringToLong( storeVersion );
-        MetaDataStore.setRecord( pageCacheRule.getPageCache( fsRule.get() ), neoStoreFile, STORE_VERSION, value );
+        try ( PageCache pageCache = pageCacheRule.getPageCache( fsRule.get() ) )
+        {
+            MetaDataStore.setRecord( pageCache, neoStoreFile, STORE_VERSION, value );
+        }
     }
 
     private File createNeoStoreFile() throws IOException

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -4114,13 +4114,14 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         AtomicInteger flushCounter = new AtomicInteger();
         PageSwapperFactory swapperFactory = flushCountingPageSwapperFactory( flushCounter );
         swapperFactory.open( fs, Configuration.EMPTY );
-        PageCache cache = createPageCache( swapperFactory, maxPages, PageCacheTracer.NULL,
-                PageCursorTracerSupplier.NULL, EmptyVersionContextSupplier.EMPTY );
-        File file = file( "a" );
-        try ( PagedFile pf = cache.map( file, filePageSize, DELETE_ON_CLOSE );
-              WritableByteChannel channel = pf.openWritableByteChannel() )
+        try ( PageCache cache = createPageCache( swapperFactory, maxPages, PageCacheTracer.NULL, PageCursorTracerSupplier.NULL,
+                EmptyVersionContextSupplier.EMPTY ) )
         {
-            generateFileWithRecords( channel, recordCount, recordSize );
+            File file = file( "a" );
+            try ( PagedFile pf = cache.map( file, filePageSize, DELETE_ON_CLOSE ); WritableByteChannel channel = pf.openWritableByteChannel() )
+            {
+                generateFileWithRecords( channel, recordCount, recordSize );
+            }
         }
         assertThat( flushCounter.get(), lessThan( recordCount / recordsPerFilePage ) );
     }
@@ -4131,13 +4132,14 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         AtomicInteger flushCounter = new AtomicInteger();
         PageSwapperFactory swapperFactory = flushCountingPageSwapperFactory( flushCounter );
         swapperFactory.open( fs, Configuration.EMPTY );
-        PageCache cache = createPageCache( swapperFactory, maxPages, PageCacheTracer.NULL,
-                PageCursorTracerSupplier.NULL, EmptyVersionContextSupplier.EMPTY );
-        File file = file( "a" );
-        try ( PagedFile pf = cache.map( file, filePageSize );
-              WritableByteChannel channel = pf.openWritableByteChannel() )
+        try ( PageCache cache = createPageCache( swapperFactory, maxPages, PageCacheTracer.NULL, PageCursorTracerSupplier.NULL,
+                EmptyVersionContextSupplier.EMPTY ) )
         {
-            generateFileWithRecords( channel, recordCount, recordSize );
+            File file = file( "a" );
+            try ( PagedFile pf = cache.map( file, filePageSize ); WritableByteChannel channel = pf.openWritableByteChannel() )
+            {
+                generateFileWithRecords( channel, recordCount, recordSize );
+            }
         }
         assertThat( flushCounter.get(), is( recordCount / recordsPerFilePage ) );
     }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -4114,14 +4114,13 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         AtomicInteger flushCounter = new AtomicInteger();
         PageSwapperFactory swapperFactory = flushCountingPageSwapperFactory( flushCounter );
         swapperFactory.open( fs, Configuration.EMPTY );
+        File file = file( "a" );
         try ( PageCache cache = createPageCache( swapperFactory, maxPages, PageCacheTracer.NULL, PageCursorTracerSupplier.NULL,
-                EmptyVersionContextSupplier.EMPTY ) )
+                EmptyVersionContextSupplier.EMPTY );
+              PagedFile pf = cache.map( file, filePageSize, DELETE_ON_CLOSE );
+              WritableByteChannel channel = pf.openWritableByteChannel() )
         {
-            File file = file( "a" );
-            try ( PagedFile pf = cache.map( file, filePageSize, DELETE_ON_CLOSE ); WritableByteChannel channel = pf.openWritableByteChannel() )
-            {
-                generateFileWithRecords( channel, recordCount, recordSize );
-            }
+            generateFileWithRecords( channel, recordCount, recordSize );
         }
         assertThat( flushCounter.get(), lessThan( recordCount / recordsPerFilePage ) );
     }
@@ -4132,14 +4131,13 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         AtomicInteger flushCounter = new AtomicInteger();
         PageSwapperFactory swapperFactory = flushCountingPageSwapperFactory( flushCounter );
         swapperFactory.open( fs, Configuration.EMPTY );
+        File file = file( "a" );
         try ( PageCache cache = createPageCache( swapperFactory, maxPages, PageCacheTracer.NULL, PageCursorTracerSupplier.NULL,
-                EmptyVersionContextSupplier.EMPTY ) )
+                EmptyVersionContextSupplier.EMPTY );
+              PagedFile pf = cache.map( file, filePageSize );
+              WritableByteChannel channel = pf.openWritableByteChannel() )
         {
-            File file = file( "a" );
-            try ( PagedFile pf = cache.map( file, filePageSize ); WritableByteChannel channel = pf.openWritableByteChannel() )
-            {
-                generateFileWithRecords( channel, recordCount, recordSize );
-            }
+            generateFileWithRecords( channel, recordCount, recordSize );
         }
         assertThat( flushCounter.get(), is( recordCount / recordsPerFilePage ) );
     }

--- a/community/io/src/test/java/org/neo4j/test/rule/fs/EphemeralFileSystemRule.java
+++ b/community/io/src/test/java/org/neo4j/test/rule/fs/EphemeralFileSystemRule.java
@@ -19,11 +19,7 @@
  */
 package org.neo4j.test.rule.fs;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
-import org.neo4j.io.fs.FileSystemAbstraction;
 
 public class EphemeralFileSystemRule extends FileSystemRule<EphemeralFileSystemAbstraction>
 {
@@ -61,11 +57,6 @@ public class EphemeralFileSystemRule extends FileSystemRule<EphemeralFileSystemA
     public EphemeralFileSystemAbstraction snapshot()
     {
         return fs.snapshot();
-    }
-
-    public void copyRecursivelyFromOtherFs( File from, FileSystemAbstraction fromFs, File to ) throws IOException
-    {
-        fs.copyRecursivelyFromOtherFs( from, fromFs, to );
     }
 
     public long checksum()

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
@@ -63,8 +63,8 @@ import org.neo4j.io.pagecache.tracing.cursor.context.EmptyVersionContextSupplier
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexPopulator;
-import org.neo4j.kernel.api.index.PropertyAccessor;
 import org.neo4j.kernel.api.index.IndexProvider;
+import org.neo4j.kernel.api.index.PropertyAccessor;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.LabelScanWriter;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
@@ -79,8 +79,8 @@ import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.extension.KernelExtensions;
 import org.neo4j.kernel.extension.UnsatisfiedDependencyStrategies;
 import org.neo4j.kernel.extension.dependency.HighestSelectionStrategy;
-import org.neo4j.kernel.impl.api.index.NodeUpdates;
 import org.neo4j.kernel.impl.api.index.IndexProviderMap;
+import org.neo4j.kernel.impl.api.index.NodeUpdates;
 import org.neo4j.kernel.impl.api.index.StoreScan;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.kernel.impl.api.scan.FullStoreChangeStream;
@@ -236,6 +236,7 @@ public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvide
 
         life = new LifeSupport();
         this.storeDir = storeDir;
+        storeLocker = tryLockStore( fileSystem );
         ConfiguringPageCacheFactory pageCacheFactory = new ConfiguringPageCacheFactory(
                 fileSystem, config, PageCacheTracer.NULL, PageCursorTracerSupplier.NULL, NullLog.getInstance(),
                 EmptyVersionContextSupplier.EMPTY );
@@ -247,7 +248,6 @@ public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvide
 
         StoreLogService logService = life.add( StoreLogService.withInternalLog( internalLog).build( fileSystem ) );
         msgLog = logService.getInternalLog( getClass() );
-        storeLocker = tryLockStore( fileSystem );
 
         boolean dump = config.get( GraphDatabaseSettings.dump_configuration );
         this.idGeneratorFactory = new DefaultIdGeneratorFactory( fileSystem );

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingTokenRepositoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingTokenRepositoryTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import java.util.List;
 
+import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.tracing.cursor.context.EmptyVersionContextSupplier;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.core.RelationshipTypeToken;
@@ -108,8 +109,10 @@ public class BatchingTokenRepositoryTest
     public void shouldFlushNewTokens()
     {
         // given
-        try ( NeoStores stores = new StoreFactory( storage.directory().absolutePath(), Config.defaults(),
-                new DefaultIdGeneratorFactory( storage.fileSystem() ), storage.pageCache(), storage.fileSystem(),
+
+        try ( PageCache pageCache = storage.pageCache();
+              NeoStores stores = new StoreFactory( storage.directory().absolutePath(), Config.defaults(),
+                new DefaultIdGeneratorFactory( storage.fileSystem() ), pageCache, storage.fileSystem(),
                 NullLogProvider.getInstance(), EmptyVersionContextSupplier.EMPTY )
                 .openNeoStores( true, StoreType.PROPERTY_KEY_TOKEN, StoreType.PROPERTY_KEY_TOKEN_NAME ) )
         {

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/PropertyLevelSecurityIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/PropertyLevelSecurityIT.java
@@ -19,18 +19,17 @@
  */
 package org.neo4j.server.security.enterprise.auth.plugin;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.internal.kernel.api.security.LoginContext;
@@ -44,6 +43,7 @@ import org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles;
 import org.neo4j.server.security.enterprise.configuration.SecuritySettings;
 import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.test.rule.TestDirectory;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -55,7 +55,7 @@ import static org.neo4j.server.security.auth.SecurityTestUtils.authToken;
 public class PropertyLevelSecurityIT
 {
     @Rule
-    public TemporaryFolder tmpdir = new TemporaryFolder();
+    public TestDirectory testDirectory = TestDirectory.testDirectory();
 
     private GraphDatabaseFacade db;
     private EnterpriseAuthAndUserManager authManager;
@@ -67,7 +67,7 @@ public class PropertyLevelSecurityIT
     public void setUp() throws Throwable
     {
         TestGraphDatabaseFactory s = new TestEnterpriseGraphDatabaseFactory();
-        db = (GraphDatabaseFacade) s.newImpermanentDatabaseBuilder( tmpdir.getRoot() )
+        db = (GraphDatabaseFacade) s.newImpermanentDatabaseBuilder( testDirectory.graphDbDir() )
                 .setConfig( SecuritySettings.property_level_authorization_enabled, "true" )
                 .setConfig( SecuritySettings.property_level_authorization_permissions, "Agent=alias,secret" )
                 .setConfig( GraphDatabaseSettings.auth_enabled, "true" )
@@ -85,6 +85,12 @@ public class PropertyLevelSecurityIT
         neo = authManager.login( authToken( "Neo", "eon" ) );
         smith = authManager.login( authToken( "Smith", "mr" ) );
         morpheus = authManager.login( authToken( "Morpheus", "dealwithit" ) );
+    }
+
+    @After
+    public void tearDown()
+    {
+        db.shutdown();
     }
 
     @Test


### PR DESCRIPTION
Close leaked not closed page caches.
Prevent batch importer to create page cache when directory lock can't be obtained.
Close test databases that were not shutdown before.