### PR TITLE
Fix inequality checks for spatial index

### DIFF
--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/SemanticIndexAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/SemanticIndexAcceptanceTest.scala
@@ -48,7 +48,7 @@ class SemanticIndexAcceptanceTest extends ExecutionEngineFunSuite with PropertyC
       ValueSetup[LongValue]("longs", longGen, x => x.minus(1L), x => x.plus(1L)),
       ValueSetup[DoubleValue]("doubles", doubleGen, x => x.minus(0.1), x => x.plus(0.1)),
       ValueSetup[TextValue]("strings", textGen, changeLastChar(c => (c - 1).toChar), changeLastChar(c => (c + 1).toChar)),
-//      ValueSetup[PointValue]("points", pointGen, modifyPoint(_ - 0.1), modifyPoint(_ + 0.1)), // TODO: here is a bug
+      ValueSetup[PointValue]("points", pointGen, modifyPoint(_ - 0.1), modifyPoint(_ + 0.1)),
       ValueSetup[DateValue]("dates", dateGen, x => x.sub(oneDay), x => x.add(oneDay)),
       ValueSetup[DateTimeValue]("dateTimes", dateTimeGen, x => x.sub(oneDay), x => x.add(oneDay)),
       ValueSetup[LocalDateTimeValue]("localDateTimes", localDateTimeGen, x => x.sub(oneDay), x => x.add(oneDay)),

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
@@ -60,7 +60,7 @@ trait GraphDatabaseTestSupport extends CypherTestSupport with GraphIcing {
     graph = new GraphDatabaseCypherService(graphOps)
   }
 
-  protected def graphDatabaseFactory(config: Map[Setting[_], String] = databaseConfig()): TestGraphDatabaseFactory = {
+  protected def graphDatabaseFactory(): TestGraphDatabaseFactory = {
     val factory = createDatabaseFactory()
     this match {
       case custom: FakeClock =>

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -827,58 +827,6 @@ public class GraphDatabaseSettings implements LoadableConfig
     public static final Setting<Boolean> archive_failed_index = setting(
             "unsupported.dbms.index.archive_failed", BOOLEAN, FALSE );
 
-    @Description( "When searching the spatial index we need to convert a 2D range in the quad tree into a set of 1D ranges on the " +
-            "underlying 1D space filling curve index. There is a balance to be made between many small 1D ranges that have few false " +
-            "positives, and fewer, larger 1D ranges that have more false positives. The former has a more efficient filtering of false " +
-            "positives, while the latter will have a more efficient search of the numerical index. The maximum depth to which the quad tree is " +
-            "processed when mapping 2D to 1D is based on the size of the search area compared to the size of the 2D tiles at that depth. " +
-            "This setting will cause the algorithm to search deeper, reducing false positives." )
-    @Internal
-    public static final Setting<Integer> space_filling_curve_extra_levels = setting(
-            "unsupported.dbms.index.spatial.curve.extra_levels", INTEGER, "1" );
-
-    @Description( "When searching the spatial index we need to convert a 2D range in the quad tree into a set of 1D ranges on the " +
-            "underlying 1D space filling curve index. There is a balance to be made between many small 1D ranges that have few false " +
-            "positives, and fewer, larger 1D ranges that have more false positives. The former has a more efficient filtering of false " +
-            "positives, while the latter will have a more efficient search of the numerical index. The maximum depth to which the quad tree is " +
-            "processed when mapping 2D to 1D is based on the size of the search area compared to the size of the 2D tiles at that depth. " +
-            "When traversing the tree to this depth, we can stop early based on when the search envelope overlaps the current tile by " +
-            "more than a certain threshold. The threshold is calculated based on depth, from the `top_threshold` at the top of the tree " +
-            "to the `bottom_threshold` at the depth calculated by the area comparison. Setting the top to 0.99 and the bottom to 0.5, " +
-            "for example would mean that if we reached the maximum depth, and the search area overlapped the current tile by more than " +
-            "50%, we would stop traversing the tree, and return the 1D range for that entire tile to the search set. If the overlap is even " +
-            "higher, we would stop higher in the tree. This technique reduces the number of 1D ranges passed to the underlying space filling " +
-            "curve index. Setting this value to zero turns off this feature." )
-    @Internal
-    public static final Setting<Double> space_filling_curve_top_threshold = setting(
-            "unsupported.dbms.index.spatial.curve.top_threshold", DOUBLE, "0" );
-
-    @Description( "When searching the spatial index we need to convert a 2D range in the quad tree into a set of 1D ranges on the " +
-            "underlying 1D space filling curve index. There is a balance to be made between many small 1D ranges that have few false " +
-            "positives, and fewer, larger 1D ranges that have more false positives. The former has a more efficient filtering of false " +
-            "positives, while the latter will have a more efficient search of the numerical index. The maximum depth to which the quad tree is " +
-            "processed when mapping 2D to 1D is based on the size of the search area compared to the size of the 2D tiles at that depth. " +
-            "When traversing the tree to this depth, we can stop early based on when the search envelope overlaps the current tile by " +
-            "more than a certain threshold. The threshold is calculated based on depth, from the `top_threshold` at the top of the tree " +
-            "to the `bottom_threshold` at the depth calculated by the area comparison. Setting the top to 0.99 and the bottom to 0.5, " +
-            "for example would mean that if we reached the maximum depth, and the search area overlapped the current tile by more than " +
-            "50%, we would stop traversing the tree, and return the 1D range for that entire tile to the search set. If the overlap is even " +
-            "higher, we would stop higher in the tree. This technique reduces the number of 1D ranges passed to the underlying space filling " +
-            "curve index. Setting this value to zero turns off this feature." )
-    @Internal
-    public static final Setting<Double> space_filling_curve_bottom_threshold = setting(
-            "unsupported.dbms.index.spatial.curve.bottom_threshold", DOUBLE, "0" );
-
-    @Description( "The maximum number of bits to use for levels in the quad tree representing the spatial index. When creating the spatial index, we " +
-            "simulate a quad tree using a 2D (or 3D) to 1D mapping function. This requires that the extents of the index and the depth " +
-            "of the tree be defined in advance, so ensure the 2D to 1D mapping is deterministic and repeatable. This setting will define " +
-            "the maximum depth of any future spatial index created, calculated as max_bits / dimensions. For example 60 bits will define 30 levels in 2D " +
-            "and 20 levels in 3D. Existing indexes will not be changed, and need to be recreated if you wish to use the new value. " +
-            "For 2D indexes, a value of 30 is the largest supported. For 3D indexes 20 is the largest." )
-    @Internal
-    public static final Setting<Integer> space_filling_curve_max_bits = setting(
-            "unsupported.dbms.index.spatial.curve.max_bits", INTEGER, "60" );
-
     // Needed to validate config, accessed via reflection
     @SuppressWarnings( "unused" )
     public static final BoltConnectorValidator boltValidator = new BoltConnectorValidator();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexAccessor.java
@@ -255,6 +255,10 @@ class SpatialIndexAccessor extends SpatialIndexCache<SpatialIndexAccessor.PartAc
             {
                 createEmptyIndex( fileLayout );
             }
+            else
+            {
+                fileLayout.readHeader( pageCache );
+            }
             return new PartAccessor( pageCache,
                                      fs,
                                      fileLayout,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPartReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPartReader.java
@@ -140,11 +140,9 @@ public class SpatialIndexPartReader<KEY extends SpatialSchemaKey, VALUE extends 
             BridgingIndexProgressor multiProgressor = new BridgingIndexProgressor( client, descriptor.schema().getPropertyIds() );
             client.initialize( descriptor, multiProgressor, query );
             SpaceFillingCurve curve = spatial.getSpaceFillingCurve();
-            Envelope completeEnvelope = curve.getRange();
-            double[] from = rangePredicate.from() == null ? completeEnvelope.getMin() : rangePredicate.from().coordinate();
-            double[] to = rangePredicate.to() == null ? completeEnvelope.getMax() : rangePredicate.to().coordinate();
-            Envelope envelope = new Envelope( from, to );
-            List<SpaceFillingCurve.LongRange> ranges = curve.getTilesIntersectingEnvelope( envelope, configuration );
+            double[] from = rangePredicate.from() == null ? null : rangePredicate.from().coordinate();
+            double[] to = rangePredicate.to() == null ? null : rangePredicate.to().coordinate();
+            List<SpaceFillingCurve.LongRange> ranges = curve.getTilesIntersectingEnvelope( from, to, configuration );
             for ( SpaceFillingCurve.LongRange range : ranges )
             {
                 KEY treeKeyFrom = layout.newKey();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPartReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPartReader.java
@@ -38,6 +38,7 @@ import org.neo4j.internal.kernel.api.IndexQuery.ExactPredicate;
 import org.neo4j.internal.kernel.api.IndexQuery.GeometryRangePredicate;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
+import org.neo4j.kernel.impl.index.schema.config.SpaceFillingCurveSettings;
 import org.neo4j.kernel.impl.index.schema.fusion.BridgingIndexProgressor;
 import org.neo4j.storageengine.api.schema.IndexProgressor;
 import org.neo4j.values.storable.Value;
@@ -139,7 +140,7 @@ public class SpatialIndexPartReader<KEY extends SpatialSchemaKey, VALUE extends 
             BridgingIndexProgressor multiProgressor = new BridgingIndexProgressor( client, descriptor.schema().getPropertyIds() );
             client.initialize( descriptor, multiProgressor, query );
             SpaceFillingCurve curve = spatial.getSpaceFillingCurve();
-            Envelope completeEnvelope = SpatialIndexFiles.envelopeFromCRS( spatial.crs );
+            Envelope completeEnvelope = curve.getRange();
             double[] from = rangePredicate.from() == null ? completeEnvelope.getMin() : rangePredicate.from().coordinate();
             double[] to = rangePredicate.to() == null ? completeEnvelope.getMax() : rangePredicate.to().coordinate();
             Envelope envelope = new Envelope( from, to );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexProvider.java
@@ -38,6 +38,8 @@ import org.neo4j.kernel.api.index.IndexProvider;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
+import org.neo4j.kernel.impl.index.schema.config.SpaceFillingCurveSettingsFactory;
+import org.neo4j.kernel.impl.index.schema.config.SpatialIndexSettings;
 import org.neo4j.kernel.impl.storemigration.StoreMigrationParticipant;
 
 public class SpatialIndexProvider extends IndexProvider
@@ -51,7 +53,7 @@ public class SpatialIndexProvider extends IndexProvider
     private final RecoveryCleanupWorkCollector recoveryCleanupWorkCollector;
     private final boolean readOnly;
     private final SpaceFillingCurveConfiguration configuration;
-    private final Integer maxBits;
+    private final SpaceFillingCurveSettingsFactory settingsFactory;
 
     public SpatialIndexProvider( PageCache pageCache, FileSystemAbstraction fs,
             IndexDirectoryStructure.Factory directoryStructure, Monitor monitor,
@@ -64,14 +66,19 @@ public class SpatialIndexProvider extends IndexProvider
         this.recoveryCleanupWorkCollector = recoveryCleanupWorkCollector;
         this.readOnly = readOnly;
         this.configuration = getConfiguredSpaceFillingCurveConfiguration( config );
-        this.maxBits = config.get( GraphDatabaseSettings.space_filling_curve_max_bits );
+        this.settingsFactory = getConfiguredSpaceFillingCurveSettings( config );
+    }
+
+    private SpaceFillingCurveSettingsFactory getConfiguredSpaceFillingCurveSettings( Config config )
+    {
+        return new SpaceFillingCurveSettingsFactory( config );
     }
 
     private static SpaceFillingCurveConfiguration getConfiguredSpaceFillingCurveConfiguration( Config config )
     {
-        int extraLevels = config.get( GraphDatabaseSettings.space_filling_curve_extra_levels );
-        double topThreshold = config.get( GraphDatabaseSettings.space_filling_curve_top_threshold );
-        double bottomThreshold = config.get( GraphDatabaseSettings.space_filling_curve_bottom_threshold );
+        int extraLevels = config.get( SpatialIndexSettings.space_filling_curve_extra_levels );
+        double topThreshold = config.get( SpatialIndexSettings.space_filling_curve_top_threshold );
+        double bottomThreshold = config.get( SpatialIndexSettings.space_filling_curve_bottom_threshold );
 
         if ( topThreshold == 0.0 || bottomThreshold == 0.0 )
         {
@@ -90,21 +97,21 @@ public class SpatialIndexProvider extends IndexProvider
         {
             throw new UnsupportedOperationException( "Can't create populator for read only index" );
         }
-        SpatialIndexFiles files = new SpatialIndexFiles( directoryStructure(), indexId, fs, maxBits );
+        SpatialIndexFiles files = new SpatialIndexFiles( directoryStructure(), indexId, fs, settingsFactory );
         return new SpatialIndexPopulator( indexId, descriptor, samplingConfig, files, pageCache, fs, monitor, configuration );
     }
 
     @Override
     public IndexAccessor getOnlineAccessor( long indexId, SchemaIndexDescriptor descriptor, IndexSamplingConfig samplingConfig ) throws IOException
     {
-        SpatialIndexFiles files = new SpatialIndexFiles( directoryStructure(), indexId, fs, maxBits );
+        SpatialIndexFiles files = new SpatialIndexFiles( directoryStructure(), indexId, fs, settingsFactory );
         return new SpatialIndexAccessor( indexId, descriptor, samplingConfig, pageCache, fs, recoveryCleanupWorkCollector, monitor, files, configuration );
     }
 
     @Override
     public String getPopulationFailure( long indexId, SchemaIndexDescriptor descriptor ) throws IllegalStateException
     {
-        SpatialIndexFiles spatialIndexFiles = new SpatialIndexFiles( directoryStructure(), indexId, fs, maxBits );
+        SpatialIndexFiles spatialIndexFiles = new SpatialIndexFiles( directoryStructure(), indexId, fs, settingsFactory );
 
         try
         {
@@ -127,7 +134,7 @@ public class SpatialIndexProvider extends IndexProvider
     @Override
     public InternalIndexState getInitialState( long indexId, SchemaIndexDescriptor descriptor )
     {
-        SpatialIndexFiles spatialIndexFiles = new SpatialIndexFiles( directoryStructure(), indexId, fs, maxBits );
+        SpatialIndexFiles spatialIndexFiles = new SpatialIndexFiles( directoryStructure(), indexId, fs, settingsFactory );
 
         InternalIndexState state = InternalIndexState.ONLINE;
         for ( SpatialIndexFiles.SpatialFileLayout subIndex : spatialIndexFiles.existing() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/config/SpaceFillingCurveSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/config/SpaceFillingCurveSettings.java
@@ -180,6 +180,7 @@ public class SpaceFillingCurveSettings
     {
         return headerBytes ->
         {
+            headerBytes.get();  // ignore state
             int typeId = headerBytes.getInt();
             SpatialIndexType indexType = SpatialIndexType.get( typeId );
             if ( indexType == null )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/config/SpaceFillingCurveSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/config/SpaceFillingCurveSettings.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema.config;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+
+import org.neo4j.gis.spatial.index.Envelope;
+import org.neo4j.gis.spatial.index.curves.HilbertSpaceFillingCurve2D;
+import org.neo4j.gis.spatial.index.curves.HilbertSpaceFillingCurve3D;
+import org.neo4j.gis.spatial.index.curves.SpaceFillingCurve;
+
+/**
+ * These settings affect the creation of the 2D (or 3D) to 1D mapper.
+ * Changing these will change the values of the 1D mapping, and require re-indexing, so
+ * once data has been indexed, do not change these without recreating the index.
+ */
+public class SpaceFillingCurveSettings
+{
+    private static final String SPATIAL_INDEX_TYPE = "SingleSpaceFillingCurve";
+    private int dimensions;
+    private int maxLevels;
+    private Envelope extents;
+
+    public SpaceFillingCurveSettings( int dimensions, int maxBits, Envelope extents )
+    {
+        this.dimensions = dimensions;
+        this.extents = extents;
+        int maxConfigured = maxBits / dimensions;
+        int maxSupported = (dimensions == 2) ? HilbertSpaceFillingCurve2D.MAX_LEVEL : HilbertSpaceFillingCurve3D.MAX_LEVEL;
+        this.maxLevels = Math.min( maxConfigured, maxSupported );
+    }
+
+    /**
+     * @return The number of dimensions (2D or 3D)
+     */
+    public int getDimensions()
+    {
+        return dimensions;
+    }
+
+    /**
+     * @return The number of levels in the 2D (or 3D) to 1D mapping tree.
+     */
+    public int maxLevels()
+    {
+        return maxLevels;
+    }
+
+    /**
+     * The space filling curve is configured up front to cover a specific region of 2D (or 3D) space.
+     * Any points outside this space will be mapped as if on the edges. This means that if these extents
+     * do not match the real extents of the data being indexed, the index will be less efficient. Making
+     * the extents too big means than only a small area is used causing more points to map to fewer 1D
+     * values and requiring more post filtering. If the extents are too small, many points will lie on
+     * the edges, and also cause additional post-index filtering costs.
+     *
+     * @return the extents of the 2D (or 3D) region that is covered by the space filling curve.
+     */
+    public Envelope indexExtents()
+    {
+        return extents;
+    }
+
+    /**
+     * Make an instance of the SpaceFillingCurve that can perform the 2D (or 3D) to 1D mapping based on these settings.
+     *
+     * @return a configured instance of SpaceFillingCurve
+     */
+    public SpaceFillingCurve curve()
+    {
+        if ( dimensions == 2 )
+        {
+            return new HilbertSpaceFillingCurve2D( extents, maxLevels );
+        }
+        else if ( dimensions == 3 )
+        {
+            return new HilbertSpaceFillingCurve3D( extents, maxLevels );
+        }
+        else
+        {
+            throw new IllegalArgumentException( "Cannot create spatial index with other than 2D or 3D coordinate reference system: " + dimensions + "D" );
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format( "Space filling curves settings: dimensions=%d, maxLevels=%d, min=%s, max=%s", dimensions, maxLevels,
+                Arrays.toString( extents.getMin() ), Arrays.toString( extents.getMax() ) );
+    }
+
+    public void read( BufferedReader in ) throws IOException
+    {
+        this.dimensions = -1;
+        this.maxLevels = -1;
+        double[] min = null;
+        double[] max = null;
+
+        String line;
+        while ( (line = in.readLine()) != null )
+        {
+            String[] fields = line.trim().split( "\\t", 2 );
+            switch ( fields[0] )
+            {
+            case "indexType":
+                if ( !fields[1].equals( SPATIAL_INDEX_TYPE ) )
+                {
+                    throw new IllegalArgumentException( "Unknown spatial index type: " + fields[1] );
+                }
+                break;
+            case "dimensions":
+                this.dimensions = Integer.parseInt( fields[1].trim() );
+                break;
+            case "maxLevels":
+                this.maxLevels = Integer.parseInt( fields[1].trim() );
+                break;
+            case "min":
+                min = splitDoubleArray( fields[1].trim() );
+                break;
+            case "max":
+                max = splitDoubleArray( fields[1].trim() );
+                break;
+            default:
+                break;
+            }
+        }
+
+        if ( min == null || max == null || dimensions < 2 || maxLevels < 0 || min.length != this.dimensions || max.length != this.dimensions )
+        {
+            throw new IllegalArgumentException(
+                    String.format( "Invalid space filling curves settings: dimensions=%d, maxLevels=%d, min=%s, max=%s", dimensions, maxLevels,
+                            Arrays.toString( min ), Arrays.toString( max ) ) );
+        }
+        this.extents = new Envelope( min, max );
+    }
+
+    private double[] splitDoubleArray( String field )
+    {
+        return Arrays.stream( field.substring( 1, field.length() - 1 ).split( "," ) ).mapToDouble( Double::parseDouble ).toArray();
+    }
+
+    public void write( PrintWriter out ) throws IOException
+    {
+        out.println( "indexType\t" + SPATIAL_INDEX_TYPE );
+        out.println( "dimensions\t" + dimensions );
+        out.println( "maxLevels\t" + maxLevels );
+        out.println( "min\t" + Arrays.toString( extents.getMin() ) );
+        out.println( "max\t" + Arrays.toString( extents.getMax() ) );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/config/SpaceFillingCurveSettingsFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/config/SpaceFillingCurveSettingsFactory.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema.config;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.configuration.ConfigValue;
+import org.neo4j.gis.spatial.index.Envelope;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.values.storable.CoordinateReferenceSystem;
+
+/**
+ * These settings affect the creation of the 2D (or 3D) to 1D mapper.
+ * Changing these will change the values of the 1D mapping, and require re-indexing, so
+ * once data has been indexed, do not change these without recreating the index.
+ */
+public class SpaceFillingCurveSettingsFactory
+{
+    private int maxBits;
+    private HashMap<CoordinateReferenceSystem,SpaceFillingCurveSettings> settings = new HashMap<>();
+    private static final double DEFAULT_MIN_EXTENT = -1000000;
+    private static final double DEFAULT_MAX_EXTENT = 1000000;
+    private static final double DEFAULT_MIN_LATITUDE = -90;
+    private static final double DEFAULT_MAX_LATITUDE = 90;
+    private static final double DEFAULT_MIN_LONGITUDE = -180;
+    private static final double DEFAULT_MAX_LONGITUDE = 180;
+    private static final String SPATIAL_SETTING_PREFIX = "unsupported.dbms.db.spatial.crs.";
+
+    private class EnvelopeSettings
+    {
+        CoordinateReferenceSystem crs;
+        double[] min;
+        double[] max;
+
+        EnvelopeSettings( CoordinateReferenceSystem crs )
+        {
+            this.crs = crs;
+            this.min = new double[crs.getDimension()];
+            this.max = new double[crs.getDimension()];
+            Arrays.fill( this.min, Double.NaN );
+            Arrays.fill( this.max, Double.NaN );
+        }
+
+        Envelope asEnvelope()
+        {
+            return envelopeFromCRS( crs.getDimension(), crs.isGeographic(), this );
+        }
+    }
+
+    public SpaceFillingCurveSettingsFactory( Config config )
+    {
+        this.maxBits = config.get( SpatialIndexSettings.space_filling_curve_max_bits );
+        HashMap<CoordinateReferenceSystem,EnvelopeSettings> env = new HashMap<>();
+        for ( Map.Entry<String,ConfigValue> entry : config.getConfigValues().entrySet() )
+        {
+            String key = entry.getKey();
+            String value = entry.getValue().toString();
+            if ( key.startsWith( SPATIAL_SETTING_PREFIX ) )
+            {
+                String[] fields = key.replace( SPATIAL_SETTING_PREFIX, "" ).split( "\\." );
+                CoordinateReferenceSystem crs = CoordinateReferenceSystem.byName( fields[0] );
+                EnvelopeSettings envelopeSettings = env.computeIfAbsent( crs, EnvelopeSettings::new );
+                int index = "xyz".indexOf( fields[1].toLowerCase() );
+                if ( index < 0 )
+                {
+                    throw new IllegalArgumentException( "Invalid spatial coordinate key: " + fields[1] );
+                }
+                switch ( fields[2].toLowerCase() )
+                {
+                case "min":
+                    envelopeSettings.min[index] = Double.parseDouble( value );
+                    break;
+                case "max":
+                    envelopeSettings.max[index] = Double.parseDouble( value );
+                    break;
+                default:
+                    throw new IllegalArgumentException( "Invalid spatial coordinate key: " + fields[2] );
+                }
+            }
+        }
+        for ( Map.Entry<CoordinateReferenceSystem,EnvelopeSettings> entry : env.entrySet() )
+        {
+            CoordinateReferenceSystem crs = entry.getKey();
+            settings.put( crs, new SpaceFillingCurveSettings( crs.getDimension(), this.maxBits, entry.getValue().asEnvelope() ) );
+        }
+    }
+
+    /**
+     * The space filling curve is configured up front to cover a specific region of 2D (or 3D) space,
+     * and the mapping tree is configured up front to have a specific maximum depth. These settings
+     * are stored in an instance of SpaceFillingCurveSettings and are determined by the Coordinate
+     * Reference System, and any neo4j.conf settings to override the CRS defaults.
+     *
+     * @return The settings for the specified coordinate reference system
+     */
+    public SpaceFillingCurveSettings settingsFor( CoordinateReferenceSystem crs )
+    {
+        if ( settings.containsKey( crs ) )
+        {
+            return settings.get( crs );
+        }
+        else
+        {
+            return new SpaceFillingCurveSettings( crs.getDimension(), maxBits,
+                    envelopeFromCRS( crs.getDimension(), crs.isGeographic(), new EnvelopeSettings( crs ) ) );
+        }
+    }
+
+    private static Envelope envelopeFromCRS( int dimension, boolean geographic, EnvelopeSettings envelopeSettings )
+    {
+        assert dimension >= 2;
+        double[] min = new double[dimension];
+        double[] max = new double[dimension];
+        int cartesianStartIndex = 0;
+        if ( geographic )
+        {
+            // Geographic CRS default to extent of the earth in degrees
+            min[0] = valOrDefault( envelopeSettings.min[0], DEFAULT_MIN_LONGITUDE );
+            max[0] = valOrDefault( envelopeSettings.max[0], DEFAULT_MAX_LONGITUDE );
+            min[1] = valOrDefault( envelopeSettings.min[1], DEFAULT_MIN_LATITUDE );
+            max[1] = valOrDefault( envelopeSettings.max[1], DEFAULT_MAX_LATITUDE );
+            cartesianStartIndex = 2;    // if geographic index has higher than 2D, then other dimensions are cartesian
+        }
+        for ( int i = cartesianStartIndex; i < dimension; i++ )
+        {
+            min[i] = valOrDefault( envelopeSettings.min[i], DEFAULT_MIN_EXTENT );
+            max[i] = valOrDefault( envelopeSettings.max[i], DEFAULT_MAX_EXTENT );
+        }
+        return new Envelope( min, max );
+    }
+
+    private static double valOrDefault( double val, double def )
+    {
+        return Double.isNaN( val ) ? def : val;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/config/SpatialIndexSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/config/SpatialIndexSettings.java
@@ -84,69 +84,163 @@ public class SpatialIndexSettings implements LoadableConfig
 
     // TODO useful descriptions
     // TODO dynamic list of settings to avoid code duplication
-    @Description( "Index extents" )
+    @Description( "The minimum x value for the index extents for 2D Cartesian spatial index. " +
+            "The 2D to 1D mapping function divides all 2D space into discrete tiles, and orders these using a space filling curve designed " +
+            "to optimize the requirement that tiles that are close together in this ordered list are also close together in 2D space. " +
+            "This requires that the extents of the 2D space be known in advance and never changed. If you do change these settings, you " +
+            "need to recreate any affected index in order for the settings to apply, otherwise the index will retain the previous settings." )
     @Internal
     public static final Setting<Integer> spatial_crs_Cartesian_x_min = setting( "unsupported.dbms.db.spatial.crs.Cartesian.x.min", INTEGER, "-1000000" );
-    @Description( "Index extents" )
+
+    @Description( "The maximum x value for the index extents for 2D Cartesian spatial index. " +
+            "The 2D to 1D mapping function divides all 2D space into discrete tiles, and orders these using a space filling curve designed " +
+            "to optimize the requirement that tiles that are close together in this ordered list are also close together in 2D space. " +
+            "This requires that the extents of the 2D space be known in advance and never changed. If you do change these settings, you " +
+            "need to recreate any affected index in order for the settings to apply, otherwise the index will retain the previous settings." )
     @Internal
     public static final Setting<Integer> spatial_crs_Cartesian_x_max = setting( "unsupported.dbms.db.spatial.crs.Cartesian.x.max", INTEGER, "1000000" );
-    @Description( "Index extents" )
+
+    @Description( "The minimum y value for the index extents for 2D Cartesian spatial index. " +
+            "The 2D to 1D mapping function divides all 2D space into discrete tiles, and orders these using a space filling curve designed " +
+            "to optimize the requirement that tiles that are close together in this ordered list are also close together in 2D space. " +
+            "This requires that the extents of the 2D space be known in advance and never changed. If you do change these settings, you " +
+            "need to recreate any affected index in order for the settings to apply, otherwise the index will retain the previous settings." )
     @Internal
     public static final Setting<Integer> spatial_crs_Cartesian_y_min = setting( "unsupported.dbms.db.spatial.crs.Cartesian.y.min", INTEGER, "-1000000" );
-    @Description( "Index extents" )
+
+    @Description( "The maximum y value for the index extents for 2D Cartesian spatial index. " +
+            "The 2D to 1D mapping function divides all 2D space into discrete tiles, and orders these using a space filling curve designed " +
+            "to optimize the requirement that tiles that are close together in this ordered list are also close together in 2D space. " +
+            "This requires that the extents of the 2D space be known in advance and never changed. If you do change these settings, you " +
+            "need to recreate any affected index in order for the settings to apply, otherwise the index will retain the previous settings." )
     @Internal
     public static final Setting<Integer> spatial_crs_Cartesian_y_max = setting( "unsupported.dbms.db.spatial.crs.Cartesian.y.max", INTEGER, "1000000" );
 
-    @Description( "Index extents" )
+    @Description( "The minimum x value for the index extents for 3D Cartesian spatial index. " +
+            "The 3D to 1D mapping function divides all 3D space into discrete blocks, and orders these using a space filling curve designed " +
+            "to optimize the requirement that blocks that are close together in this ordered list are also close together in 3D space. " +
+            "This requires that the extents of the 3D space be known in advance and never changed. If you do change these settings, you " +
+            "need to recreate any affected index in order for the settings to apply, otherwise the index will retain the previous settings." )
     @Internal
     public static final Setting<Integer> spatial_crs_Cartesian_3D_x_min = setting( "unsupported.dbms.db.spatial.crs.Cartesian-3D.x.min", INTEGER, "-1000000" );
-    @Description( "Index extents" )
+
+    @Description( "The maximum x value for the index extents for 3D Cartesian spatial index. " +
+            "The 3D to 1D mapping function divides all 3D space into discrete blocks, and orders these using a space filling curve designed " +
+            "to optimize the requirement that blocks that are close together in this ordered list are also close together in 3D space. " +
+            "This requires that the extents of the 3D space be known in advance and never changed. If you do change these settings, you " +
+            "need to recreate any affected index in order for the settings to apply, otherwise the index will retain the previous settings." )
     @Internal
     public static final Setting<Integer> spatial_crs_Cartesian_3D_x_max = setting( "unsupported.dbms.db.spatial.crs.Cartesian-3D.x.max", INTEGER, "1000000" );
-    @Description( "Index extents" )
+
+    @Description( "The minimum y value for the index extents for 3D Cartesian spatial index. " +
+            "The 3D to 1D mapping function divides all 3D space into discrete blocks, and orders these using a space filling curve designed " +
+            "to optimize the requirement that blocks that are close together in this ordered list are also close together in 3D space. " +
+            "This requires that the extents of the 3D space be known in advance and never changed. If you do change these settings, you " +
+            "need to recreate any affected index in order for the settings to apply, otherwise the index will retain the previous settings." )
     @Internal
     public static final Setting<Integer> spatial_crs_Cartesian_3D_y_min = setting( "unsupported.dbms.db.spatial.crs.Cartesian-3D.y.min", INTEGER, "-1000000" );
-    @Description( "Index extents" )
+
+    @Description( "The maximum y value for the index extents for 3D Cartesian spatial index. " +
+            "The 3D to 1D mapping function divides all 3D space into discrete blocks, and orders these using a space filling curve designed " +
+            "to optimize the requirement that blocks that are close together in this ordered list are also close together in 3D space. " +
+            "This requires that the extents of the 3D space be known in advance and never changed. If you do change these settings, you " +
+            "need to recreate any affected index in order for the settings to apply, otherwise the index will retain the previous settings." )
     @Internal
     public static final Setting<Integer> spatial_crs_Cartesian_3D_y_max = setting( "unsupported.dbms.db.spatial.crs.Cartesian-3D.y.max", INTEGER, "1000000" );
 
-    @Description( "Index extents" )
+    @Description( "The minimum z value for the index extents for 3D Cartesian spatial index. " +
+            "The 3D to 1D mapping function divides all 3D space into discrete blocks, and orders these using a space filling curve designed " +
+            "to optimize the requirement that blocks that are close together in this ordered list are also close together in 3D space. " +
+            "This requires that the extents of the 3D space be known in advance and never changed. If you do change these settings, you " +
+            "need to recreate any affected index in order for the settings to apply, otherwise the index will retain the previous settings." )
     @Internal
     public static final Setting<Integer> spatial_crs_Cartesian_3D_z_min = setting( "unsupported.dbms.db.spatial.crs.Cartesian-3D.z.min", INTEGER, "-1000000" );
-    @Description( "Index extents" )
+
+    @Description( "The maximum z value for the index extents for 3D Cartesian spatial index. " +
+            "The 3D to 1D mapping function divides all 3D space into discrete blocks, and orders these using a space filling curve designed " +
+            "to optimize the requirement that blocks that are close together in this ordered list are also close together in 3D space. " +
+            "This requires that the extents of the 3D space be known in advance and never changed. If you do change these settings, you " +
+            "need to recreate any affected index in order for the settings to apply, otherwise the index will retain the previous settings." )
     @Internal
     public static final Setting<Integer> spatial_crs_Cartesian_3D_z_max = setting( "unsupported.dbms.db.spatial.crs.Cartesian-3D.z.max", INTEGER, "1000000" );
 
-    @Description( "Index extents" )
+    @Description( "The minimum x value for the index extents for 2D WGS-84 (Geographic) spatial index. " +
+            "The 2D to 1D mapping function divides all 2D space into discrete tiles, and orders these using a space filling curve designed " +
+            "to optimize the requirement that tiles that are close together in this ordered list are also close together in 2D space. " +
+            "This requires that the extents of the 2D space be known in advance and never changed. If you do change these settings, you " +
+            "need to recreate any affected index in order for the settings to apply, otherwise the index will retain the previous settings." )
     @Internal
     public static final Setting<Integer> spatial_crs_WGS_84_x_min = setting( "unsupported.dbms.db.spatial.crs.WGS-84.x.min", INTEGER, "-180" );
-    @Description( "Index extents" )
+
+    @Description( "The maximum x value for the index extents for 2D WGS-84 (Geographic) spatial index. " +
+            "The 2D to 1D mapping function divides all 2D space into discrete tiles, and orders these using a space filling curve designed " +
+            "to optimize the requirement that tiles that are close together in this ordered list are also close together in 2D space. " +
+            "This requires that the extents of the 2D space be known in advance and never changed. If you do change these settings, you " +
+            "need to recreate any affected index in order for the settings to apply, otherwise the index will retain the previous settings." )
     @Internal
     public static final Setting<Integer> spatial_crs_WGS_84_x_max = setting( "unsupported.dbms.db.spatial.crs.WGS-84.x.max", INTEGER, "180" );
-    @Description( "Index extents" )
+
+    @Description( "The minimum y value for the index extents for 2D WGS-84 (Geographic) spatial index. " +
+            "The 2D to 1D mapping function divides all 2D space into discrete tiles, and orders these using a space filling curve designed " +
+            "to optimize the requirement that tiles that are close together in this ordered list are also close together in 2D space. " +
+            "This requires that the extents of the 2D space be known in advance and never changed. If you do change these settings, you " +
+            "need to recreate any affected index in order for the settings to apply, otherwise the index will retain the previous settings." )
     @Internal
     public static final Setting<Integer> spatial_crs_WGS_84_y_min = setting( "unsupported.dbms.db.spatial.crs.WGS-84.y.min", INTEGER, "-90" );
-    @Description( "Index extents" )
+
+    @Description( "The maximum y value for the index extents for 2D WGS-84 (Geographic) spatial index. " +
+            "The 2D to 1D mapping function divides all 2D space into discrete tiles, and orders these using a space filling curve designed " +
+            "to optimize the requirement that tiles that are close together in this ordered list are also close together in 2D space. " +
+            "This requires that the extents of the 2D space be known in advance and never changed. If you do change these settings, you " +
+            "need to recreate any affected index in order for the settings to apply, otherwise the index will retain the previous settings." )
     @Internal
     public static final Setting<Integer> spatial_crs_WGS_84_y_max = setting( "unsupported.dbms.db.spatial.crs.WGS-84.y.max", INTEGER, "90" );
 
-    @Description( "Index extents" )
+    @Description( "The minimum x value for the index extents for 3D WGS-84 (Geographic) spatial index. " +
+            "The 3D to 1D mapping function divides all 3D space into discrete blocks, and orders these using a space filling curve designed " +
+            "to optimize the requirement that blocks that are close together in this ordered list are also close together in 3D space. " +
+            "This requires that the extents of the 3D space be known in advance and never changed. If you do change these settings, you " +
+            "need to recreate any affected index in order for the settings to apply, otherwise the index will retain the previous settings." )
     @Internal
     public static final Setting<Integer> spatial_crs_WGS_84_3D_x_min = setting( "unsupported.dbms.db.spatial.crs.WGS-84-3D.x.min", INTEGER, "-180" );
-    @Description( "Index extents" )
+
+    @Description( "The maximum x value for the index extents for 3D WGS-84 (Geographic) spatial index. " +
+            "The 3D to 1D mapping function divides all 3D space into discrete blocks, and orders these using a space filling curve designed " +
+            "to optimize the requirement that blocks that are close together in this ordered list are also close together in 3D space. " +
+            "This requires that the extents of the 3D space be known in advance and never changed. If you do change these settings, you " +
+            "need to recreate any affected index in order for the settings to apply, otherwise the index will retain the previous settings." )
     @Internal
     public static final Setting<Integer> spatial_crs_WGS_84_3D_x_max = setting( "unsupported.dbms.db.spatial.crs.WGS-84-3D.x.max", INTEGER, "180" );
-    @Description( "Index extents" )
+
+    @Description( "The minimum y value for the index extents for 3D WGS-84 (Geographic) spatial index. " +
+            "The 3D to 1D mapping function divides all 3D space into discrete blocks, and orders these using a space filling curve designed " +
+            "to optimize the requirement that blocks that are close together in this ordered list are also close together in 3D space. " +
+            "This requires that the extents of the 3D space be known in advance and never changed. If you do change these settings, you " +
+            "need to recreate any affected index in order for the settings to apply, otherwise the index will retain the previous settings." )
     @Internal
     public static final Setting<Integer> spatial_crs_WGS_84_3D_y_min = setting( "unsupported.dbms.db.spatial.crs.WGS-84-3D.y.min", INTEGER, "-90" );
-    @Description( "Index extents" )
+
+    @Description( "The maximum y value for the index extents for 3D WGS-84 (Geographic) spatial index. " +
+            "The 3D to 1D mapping function divides all 3D space into discrete blocks, and orders these using a space filling curve designed " +
+            "to optimize the requirement that blocks that are close together in this ordered list are also close together in 3D space. " +
+            "This requires that the extents of the 3D space be known in advance and never changed. If you do change these settings, you " +
+            "need to recreate any affected index in order for the settings to apply, otherwise the index will retain the previous settings." )
     @Internal
     public static final Setting<Integer> spatial_crs_WGS_84_3D_y_max = setting( "unsupported.dbms.db.spatial.crs.WGS-84-3D.y.max", INTEGER, "90" );
 
-    @Description( "Index extents" )
+    @Description( "The minimum z value for the index extents for 3D WGS-84 (Geographic) spatial index. " +
+            "The 3D to 1D mapping function divides all 3D space into discrete blocks, and orders these using a space filling curve designed " +
+            "to optimize the requirement that blocks that are close together in this ordered list are also close together in 3D space. " +
+            "This requires that the extents of the 3D space be known in advance and never changed. If you do change these settings, you " +
+            "need to recreate any affected index in order for the settings to apply, otherwise the index will retain the previous settings." )
     @Internal
     public static final Setting<Integer> spatial_crs_WGS_84_3D_z_min = setting( "unsupported.dbms.db.spatial.crs.WGS-84-3D.z.min", INTEGER, "-1000000" );
-    @Description( "Index extents" )
+
+    @Description( "The maximum z value for the index extents for 3D WGS-84 (Geographic) spatial index. " +
+            "The 3D to 1D mapping function divides all 3D space into discrete blocks, and orders these using a space filling curve designed " +
+            "to optimize the requirement that blocks that are close together in this ordered list are also close together in 3D space. " +
+            "This requires that the extents of the 3D space be known in advance and never changed. If you do change these settings, you " +
+            "need to recreate any affected index in order for the settings to apply, otherwise the index will retain the previous settings." )
     @Internal
     public static final Setting<Integer> spatial_crs_WGS_84_3D_z_max = setting( "unsupported.dbms.db.spatial.crs.WGS-84-3D.z.max", INTEGER, "1000000" );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/config/SpatialIndexSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/config/SpatialIndexSettings.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema.config;
+
+import org.neo4j.configuration.Description;
+import org.neo4j.configuration.Internal;
+import org.neo4j.configuration.LoadableConfig;
+import org.neo4j.graphdb.config.Setting;
+
+import static org.neo4j.kernel.configuration.Settings.DOUBLE;
+import static org.neo4j.kernel.configuration.Settings.INTEGER;
+import static org.neo4j.kernel.configuration.Settings.setting;
+
+public class SpatialIndexSettings implements LoadableConfig
+{
+    @Description( "When searching the spatial index we need to convert a 2D range in the quad tree into a set of 1D ranges on the " +
+            "underlying 1D space filling curve index. There is a balance to be made between many small 1D ranges that have few false " +
+            "positives, and fewer, larger 1D ranges that have more false positives. The former has a more efficient filtering of false " +
+            "positives, while the latter will have a more efficient search of the numerical index. The maximum depth to which the quad tree is " +
+            "processed when mapping 2D to 1D is based on the size of the search area compared to the size of the 2D tiles at that depth. " +
+            "This setting will cause the algorithm to search deeper, reducing false positives." )
+    @Internal
+    public static final Setting<Integer> space_filling_curve_extra_levels = setting(
+            "unsupported.dbms.index.spatial.curve.extra_levels", INTEGER, "1" );
+
+    @Description( "When searching the spatial index we need to convert a 2D range in the quad tree into a set of 1D ranges on the " +
+            "underlying 1D space filling curve index. There is a balance to be made between many small 1D ranges that have few false " +
+            "positives, and fewer, larger 1D ranges that have more false positives. The former has a more efficient filtering of false " +
+            "positives, while the latter will have a more efficient search of the numerical index. The maximum depth to which the quad tree is " +
+            "processed when mapping 2D to 1D is based on the size of the search area compared to the size of the 2D tiles at that depth. " +
+            "When traversing the tree to this depth, we can stop early based on when the search envelope overlaps the current tile by " +
+            "more than a certain threshold. The threshold is calculated based on depth, from the `top_threshold` at the top of the tree " +
+            "to the `bottom_threshold` at the depth calculated by the area comparison. Setting the top to 0.99 and the bottom to 0.5, " +
+            "for example would mean that if we reached the maximum depth, and the search area overlapped the current tile by more than " +
+            "50%, we would stop traversing the tree, and return the 1D range for that entire tile to the search set. If the overlap is even " +
+            "higher, we would stop higher in the tree. This technique reduces the number of 1D ranges passed to the underlying space filling " +
+            "curve index. Setting this value to zero turns off this feature." )
+    @Internal
+    public static final Setting<Double> space_filling_curve_top_threshold = setting(
+            "unsupported.dbms.index.spatial.curve.top_threshold", DOUBLE, "0" );
+
+    @Description( "When searching the spatial index we need to convert a 2D range in the quad tree into a set of 1D ranges on the " +
+            "underlying 1D space filling curve index. There is a balance to be made between many small 1D ranges that have few false " +
+            "positives, and fewer, larger 1D ranges that have more false positives. The former has a more efficient filtering of false " +
+            "positives, while the latter will have a more efficient search of the numerical index. The maximum depth to which the quad tree is " +
+            "processed when mapping 2D to 1D is based on the size of the search area compared to the size of the 2D tiles at that depth. " +
+            "When traversing the tree to this depth, we can stop early based on when the search envelope overlaps the current tile by " +
+            "more than a certain threshold. The threshold is calculated based on depth, from the `top_threshold` at the top of the tree " +
+            "to the `bottom_threshold` at the depth calculated by the area comparison. Setting the top to 0.99 and the bottom to 0.5, " +
+            "for example would mean that if we reached the maximum depth, and the search area overlapped the current tile by more than " +
+            "50%, we would stop traversing the tree, and return the 1D range for that entire tile to the search set. If the overlap is even " +
+            "higher, we would stop higher in the tree. This technique reduces the number of 1D ranges passed to the underlying space filling " +
+            "curve index. Setting this value to zero turns off this feature." )
+    @Internal
+    public static final Setting<Double> space_filling_curve_bottom_threshold = setting(
+            "unsupported.dbms.index.spatial.curve.bottom_threshold", DOUBLE, "0" );
+
+    @Description( "The maximum number of bits to use for levels in the quad tree representing the spatial index. When creating the spatial index, we " +
+            "simulate a quad tree using a 2D (or 3D) to 1D mapping function. This requires that the extents of the index and the depth " +
+            "of the tree be defined in advance, so ensure the 2D to 1D mapping is deterministic and repeatable. This setting will define " +
+            "the maximum depth of any future spatial index created, calculated as max_bits / dimensions. For example 60 bits will define 30 levels in 2D " +
+            "and 20 levels in 3D. Existing indexes will not be changed, and need to be recreated if you wish to use the new value. " +
+            "For 2D indexes, a value of 30 is the largest supported. For 3D indexes 20 is the largest." )
+    @Internal
+    public static final Setting<Integer> space_filling_curve_max_bits = setting(
+            "unsupported.dbms.index.spatial.curve.max_bits", INTEGER, "60" );
+
+    // TODO useful descriptions
+    // TODO dynamic list of settings to avoid code duplication
+    @Description( "Index extents" )
+    @Internal
+    public static final Setting<Integer> spatial_crs_Cartesian_x_min = setting( "unsupported.dbms.db.spatial.crs.Cartesian.x.min", INTEGER, "-1000000" );
+    @Description( "Index extents" )
+    @Internal
+    public static final Setting<Integer> spatial_crs_Cartesian_x_max = setting( "unsupported.dbms.db.spatial.crs.Cartesian.x.max", INTEGER, "1000000" );
+    @Description( "Index extents" )
+    @Internal
+    public static final Setting<Integer> spatial_crs_Cartesian_y_min = setting( "unsupported.dbms.db.spatial.crs.Cartesian.y.min", INTEGER, "-1000000" );
+    @Description( "Index extents" )
+    @Internal
+    public static final Setting<Integer> spatial_crs_Cartesian_y_max = setting( "unsupported.dbms.db.spatial.crs.Cartesian.y.max", INTEGER, "1000000" );
+
+    @Description( "Index extents" )
+    @Internal
+    public static final Setting<Integer> spatial_crs_Cartesian_3D_x_min = setting( "unsupported.dbms.db.spatial.crs.Cartesian-3D.x.min", INTEGER, "-1000000" );
+    @Description( "Index extents" )
+    @Internal
+    public static final Setting<Integer> spatial_crs_Cartesian_3D_x_max = setting( "unsupported.dbms.db.spatial.crs.Cartesian-3D.x.max", INTEGER, "1000000" );
+    @Description( "Index extents" )
+    @Internal
+    public static final Setting<Integer> spatial_crs_Cartesian_3D_y_min = setting( "unsupported.dbms.db.spatial.crs.Cartesian-3D.y.min", INTEGER, "-1000000" );
+    @Description( "Index extents" )
+    @Internal
+    public static final Setting<Integer> spatial_crs_Cartesian_3D_y_max = setting( "unsupported.dbms.db.spatial.crs.Cartesian-3D.y.max", INTEGER, "1000000" );
+
+    @Description( "Index extents" )
+    @Internal
+    public static final Setting<Integer> spatial_crs_Cartesian_3D_z_min = setting( "unsupported.dbms.db.spatial.crs.Cartesian-3D.z.min", INTEGER, "-1000000" );
+    @Description( "Index extents" )
+    @Internal
+    public static final Setting<Integer> spatial_crs_Cartesian_3D_z_max = setting( "unsupported.dbms.db.spatial.crs.Cartesian-3D.z.max", INTEGER, "1000000" );
+
+    @Description( "Index extents" )
+    @Internal
+    public static final Setting<Integer> spatial_crs_WGS_84_x_min = setting( "unsupported.dbms.db.spatial.crs.WGS-84.x.min", INTEGER, "-180" );
+    @Description( "Index extents" )
+    @Internal
+    public static final Setting<Integer> spatial_crs_WGS_84_x_max = setting( "unsupported.dbms.db.spatial.crs.WGS-84.x.max", INTEGER, "180" );
+    @Description( "Index extents" )
+    @Internal
+    public static final Setting<Integer> spatial_crs_WGS_84_y_min = setting( "unsupported.dbms.db.spatial.crs.WGS-84.y.min", INTEGER, "-90" );
+    @Description( "Index extents" )
+    @Internal
+    public static final Setting<Integer> spatial_crs_WGS_84_y_max = setting( "unsupported.dbms.db.spatial.crs.WGS-84.y.max", INTEGER, "90" );
+
+    @Description( "Index extents" )
+    @Internal
+    public static final Setting<Integer> spatial_crs_WGS_84_3D_x_min = setting( "unsupported.dbms.db.spatial.crs.WGS-84-3D.x.min", INTEGER, "-180" );
+    @Description( "Index extents" )
+    @Internal
+    public static final Setting<Integer> spatial_crs_WGS_84_3D_x_max = setting( "unsupported.dbms.db.spatial.crs.WGS-84-3D.x.max", INTEGER, "180" );
+    @Description( "Index extents" )
+    @Internal
+    public static final Setting<Integer> spatial_crs_WGS_84_3D_y_min = setting( "unsupported.dbms.db.spatial.crs.WGS-84-3D.y.min", INTEGER, "-90" );
+    @Description( "Index extents" )
+    @Internal
+    public static final Setting<Integer> spatial_crs_WGS_84_3D_y_max = setting( "unsupported.dbms.db.spatial.crs.WGS-84-3D.y.max", INTEGER, "90" );
+
+    @Description( "Index extents" )
+    @Internal
+    public static final Setting<Integer> spatial_crs_WGS_84_3D_z_min = setting( "unsupported.dbms.db.spatial.crs.WGS-84-3D.z.min", INTEGER, "-1000000" );
+    @Description( "Index extents" )
+    @Internal
+    public static final Setting<Integer> spatial_crs_WGS_84_3D_z_max = setting( "unsupported.dbms.db.spatial.crs.WGS-84-3D.z.max", INTEGER, "1000000" );
+
+}

--- a/community/kernel/src/main/resources/META-INF/services/org.neo4j.configuration.LoadableConfig
+++ b/community/kernel/src/main/resources/META-INF/services/org.neo4j.configuration.LoadableConfig
@@ -1,3 +1,4 @@
 org.neo4j.graphdb.factory.GraphDatabaseSettings
 org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory$Configuration
 org.neo4j.kernel.configuration.ssl.LegacySslPolicyConfig
+org.neo4j.kernel.impl.index.schema.config.SpatialIndexSettings

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
@@ -158,14 +158,14 @@ public abstract class IndexProviderCompatibilityTestSuite
                     populator.close( true );
                 }
                 catch ( Exception e )
-                {   // ignore
-                }
-                try
                 {
-                    populator.close( false );
-                }
-                catch ( Exception e )
-                {   // ignore
+                    try
+                    {
+                        populator.close( false );
+                    }
+                    catch ( Exception inner )
+                    {   // ignore
+                    }
                 }
             }
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/SimpleIndexPopulatorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/SimpleIndexPopulatorCompatibility.java
@@ -169,7 +169,6 @@ public class SimpleIndexPopulatorCompatibility extends IndexProviderCompatibilit
         {
             p.create();
             p.add( updates( valueSet1 ) );
-            p.close( true );
         } );
 
         // THEN
@@ -191,8 +190,6 @@ public class SimpleIndexPopulatorCompatibility extends IndexProviderCompatibilit
                     updater.process( IndexEntryUpdate.add( entry.nodeId, descriptor.schema(), entry.value ) );
                 }
             }
-
-            p.close( true );
         } );
 
         // THEN
@@ -207,7 +204,6 @@ public class SimpleIndexPopulatorCompatibility extends IndexProviderCompatibilit
         {
             p.create();
             p.add( updates( valueSet1 ) );
-            p.close( true );
         } );
 
         try ( IndexAccessor accessor = indexProvider.getOnlineAccessor( 17, descriptor, indexSamplingConfig ) )
@@ -285,7 +281,6 @@ public class SimpleIndexPopulatorCompatibility extends IndexProviderCompatibilit
                 p.create();
                 p.add( updates( valueSet1, 0 ) );
                 p.add( updates( valueSet1, offset ) );
-                p.close( true );
             } );
 
             // then

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurve.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurve.java
@@ -262,8 +262,27 @@ public abstract class SpaceFillingCurve
 
     public List<LongRange> getTilesIntersectingEnvelope( double[] fromOrNull, double[] toOrNull, SpaceFillingCurveConfiguration config )
     {
-        double[] from = fromOrNull == null ? range.getMin() : fromOrNull;
-        double[] to = toOrNull == null ? range.getMax() : toOrNull;
+        double[] from = fromOrNull == null ? range.getMin() : fromOrNull.clone();
+        double[] to = toOrNull == null ? range.getMax() : toOrNull.clone();
+
+        for ( int i = 0; i < from.length; i++ )
+        {
+            if ( from[i] > to[i] )
+            {
+                if ( fromOrNull == null )
+                {
+                    to[i] = from[i];
+                }
+                else if ( toOrNull == null )
+                {
+                    from[i] = to[i];
+                }
+                else
+                {
+                    throw new IllegalArgumentException( "Invalid range, min greater than max: " + from[i] + " > " + to[i] );
+                }
+            }
+        }
         Envelope referenceEnvelope = new Envelope( from, to );
         return getTilesIntersectingEnvelope( referenceEnvelope, config, null );
     }

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurve.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurve.java
@@ -257,11 +257,14 @@ public abstract class SpaceFillingCurve
      */
     List<LongRange> getTilesIntersectingEnvelope( Envelope referenceEnvelope )
     {
-        return getTilesIntersectingEnvelope( referenceEnvelope, new StandardConfiguration() );
+        return getTilesIntersectingEnvelope( referenceEnvelope.getMin(), referenceEnvelope.getMax(), new StandardConfiguration() );
     }
 
-    public List<LongRange> getTilesIntersectingEnvelope( Envelope referenceEnvelope, SpaceFillingCurveConfiguration config )
+    public List<LongRange> getTilesIntersectingEnvelope( double[] fromOrNull, double[] toOrNull, SpaceFillingCurveConfiguration config )
     {
+        double[] from = fromOrNull == null ? range.getMin() : fromOrNull;
+        double[] to = toOrNull == null ? range.getMax() : toOrNull;
+        Envelope referenceEnvelope = new Envelope( from, to );
         return getTilesIntersectingEnvelope( referenceEnvelope, config, null );
     }
 

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveConfiguration.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveConfiguration.java
@@ -21,6 +21,12 @@ package org.neo4j.gis.spatial.index.curves;
 
 import org.neo4j.gis.spatial.index.Envelope;
 
+/**
+ * These settings define how to optimize the 2D (or 3D) to 1D mapping of the space filling curve.
+ * They will affect the number of 1D ranges produced as well as the number of false positives expcted from the 1D index.
+ * The ideal performance depends on the behaviour of the underlying 1D index, whether it costs more to have more 1D searches,
+ * or have more false positives for post filtering.
+ */
 public interface SpaceFillingCurveConfiguration
 {
     /**

--- a/community/values/src/main/java/org/neo4j/values/storable/CoordinateReferenceSystem.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/CoordinateReferenceSystem.java
@@ -59,7 +59,7 @@ public class CoordinateReferenceSystem implements CRS
         return get( crs.getHref() );
     }
 
-    static CoordinateReferenceSystem byName( String name )
+    public static CoordinateReferenceSystem byName( String name )
     {
         for ( CoordinateReferenceSystem type : TYPES )
         {
@@ -106,7 +106,6 @@ public class CoordinateReferenceSystem implements CRS
     private final String href;
     private final int dimension;
     private final boolean geographic;
-    private final Pair<double[],double[]> indexEnvelope;
     private final CRSCalculator calculator;
 
     private CoordinateReferenceSystem( String name, CRSTable table, int code, int dimension, boolean geographic )
@@ -118,7 +117,6 @@ public class CoordinateReferenceSystem implements CRS
         this.href = table.href( code );
         this.dimension = dimension;
         this.geographic = geographic;
-        this.indexEnvelope = envelopeFromCRS( dimension, geographic, -1000000, 1000000 );
         if ( geographic )
         {
             this.calculator = new CRSCalculator.GeographicCalculator( dimension );
@@ -201,31 +199,4 @@ public class CoordinateReferenceSystem implements CRS
         return href.hashCode();
     }
 
-    public Pair<double[],double[]> getIndexEnvelope()
-    {
-        return indexEnvelope;
-    }
-
-    private static Pair<double[],double[]> envelopeFromCRS( int dimension, boolean geographic, double minCartesian, double maxCartesian )
-    {
-        assert dimension >= 2;
-        double[] min = new double[dimension];
-        double[] max = new double[dimension];
-        int cartesianStartIndex = 0;
-        if ( geographic )
-        {
-            // Geographic CRS default to extent of the earth in degrees
-            min[0] = -180.0;
-            max[0] = 180.0;
-            min[1] = -90.0;
-            max[1] = 90.0;
-            cartesianStartIndex = 2;    // if geographic index has higher than 2D, then other dimensions are cartesian
-        }
-        for ( int i = cartesianStartIndex; i < dimension; i++ )
-        {
-            min[i] = minCartesian;
-            max[i] = maxCartesian;
-        }
-        return Pair.of( min, max );
-    }
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
@@ -223,37 +223,31 @@ public class PointValue extends ScalarValue implements Point, Comparable<PointVa
         return crs;
     }
 
+    /**
+     * Checks if this point is greater than (or equal) to lower and smaller than (or equal) to upper.
+     *
+     * @param lower point this value should be greater than
+     * @param includeLower governs if the lower comparison should be inclusive
+     * @param upper point this value should be smaller than
+     * @param includeUpper governs if the upper comparison should be inclusive
+     * @return true if this value is within the described range
+     */
     public boolean withinRange( PointValue lower, boolean includeLower, PointValue upper, boolean includeUpper )
     {
-        boolean checkLower = lower != null;
-        boolean checkUpper = upper != null;
-
-        if ( checkLower && this.crs.getCode() != lower.crs.getCode() )
+        if ( lower != null )
         {
-            return false;
-        }
-        if ( checkUpper && this.crs.getCode() != upper.crs.getCode() )
-        {
-            return false;
-        }
-
-        for ( int i = 0; i < coordinate.length; i++ )
-        {
-            if ( checkLower )
+            Integer compareLower = this.unsafeTernaryCompareTo( lower );
+            if ( compareLower == null || compareLower < 0 || compareLower == 0 && !includeLower )
             {
-                int compareLower = Double.compare( this.coordinate[i], lower.coordinate[i] );
-                if ( compareLower < 0 || compareLower == 0 && !includeLower )
-                {
-                    return false;
-                }
+                return false;
             }
-            if ( checkUpper )
+        }
+        if ( upper != null )
+        {
+            Integer compareUpper = this.unsafeTernaryCompareTo( upper );
+            if ( compareUpper == null || compareUpper > 0 || compareUpper == 0 && !includeUpper )
             {
-                int compareUpper = Double.compare( this.coordinate[i], upper.coordinate[i] );
-                if ( compareUpper > 0 || compareUpper == 0 && !includeUpper )
-                {
-                    return false;
-                }
+                return false;
             }
         }
         return true;

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/IndexPersistenceAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/IndexPersistenceAcceptanceTest.scala
@@ -178,8 +178,8 @@ class IndexPersistenceAcceptanceTest extends IndexingTestSupport {
     }.toMap
     val expected = Values.pointValue(CoordinateReferenceSystem.WGS84, 10, 50)
     val node = data(expected)
-    val min = Values.pointValue(CoordinateReferenceSystem.WGS84, 0, 40)
-    val max = Values.pointValue(CoordinateReferenceSystem.WGS84, 20, 60)
+    val min = Values.pointValue(CoordinateReferenceSystem.WGS84, 1, 41)
+    val max = Values.pointValue(CoordinateReferenceSystem.WGS84, 19, 59)
 
     assertRangeScanFor(">", min, "<", max, node)
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/IndexPersistenceAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/IndexPersistenceAcceptanceTest.scala
@@ -178,8 +178,8 @@ class IndexPersistenceAcceptanceTest extends IndexingTestSupport {
     }.toMap
     val expected = Values.pointValue(CoordinateReferenceSystem.WGS84, 10, 50)
     val node = data(expected)
-    val min = Values.pointValue(CoordinateReferenceSystem.WGS84, 40, 0)
-    val max = Values.pointValue(CoordinateReferenceSystem.WGS84, 60, 20)
+    val min = Values.pointValue(CoordinateReferenceSystem.WGS84, 0, 40)
+    val max = Values.pointValue(CoordinateReferenceSystem.WGS84, 20, 60)
 
     assertRangeScanFor(">", min, "<", max, node)
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialIndexResultsAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialIndexResultsAcceptanceTest.scala
@@ -336,89 +336,56 @@ class SpatialIndexResultsAcceptanceTest extends IndexingTestSupport {
 
   test("indexed points in 3D cartesian space - range queries") {
     // Given
-    graph.createIndex("Place", "location")
-    graph.execute("CREATE (p:Place) SET p.location = point({x: 0, y: 0, z: 0})")
-    graph.execute("CREATE (p:Place) SET p.location = point({x: 100000, y: 100000, z: 100000})")
-    graph.execute("CREATE (p:Place) SET p.location = point({x: -100000, y: 100000, z: 100000})")
-    graph.execute("CREATE (p:Place) SET p.location = point({x: -100000, y: -100000, z: 100000})")
-    graph.execute("CREATE (p:Place) SET p.location = point({x: 100000, y: -100000, z: 100000})")
-    graph.execute("CREATE (p:Place) SET p.location = point({x: 100000, y: 100000, z: -100000})")
-    graph.execute("CREATE (p:Place) SET p.location = point({x: -100000, y: 100000, z: -100000})")
-    graph.execute("CREATE (p:Place) SET p.location = point({x: -100000, y: -100000, z: -100000})")
-    graph.execute("CREATE (p:Place) SET p.location = point({x: 100000, y: -100000, z: -100000})")
+    createIndex()
+    val originPoint = Values.pointValue(CoordinateReferenceSystem.Cartesian_3D, 0, 0, 0)
+    val maxPoint = Values.pointValue(CoordinateReferenceSystem.Cartesian_3D, 100000, 100000, 100000)
+    val minPoint = Values.pointValue(CoordinateReferenceSystem.Cartesian_3D, -100000, -100000, -100000)
+
+    val origin = createIndexedNode(originPoint)
+    val upRightTop = createIndexedNode(maxPoint)
+    val downLeftBottom = createIndexedNode(minPoint)
+
+    val downrightTop = createIndexedNode(Values.pointValue(CoordinateReferenceSystem.Cartesian_3D, -100000, 100000, 100000))
+    val downLeftTop = createIndexedNode(Values.pointValue(CoordinateReferenceSystem.Cartesian_3D, -100000, -100000, 100000))
+    val upLeftTop = createIndexedNode(Values.pointValue(CoordinateReferenceSystem.Cartesian_3D, 100000, -100000, 100000))
+    val upRightBottom = createIndexedNode(Values.pointValue(CoordinateReferenceSystem.Cartesian_3D, 100000, 100000, -100000))
+    val downRightBottom = createIndexedNode(Values.pointValue(CoordinateReferenceSystem.Cartesian_3D, -100000, 100000, -100000))
+    val upLeftBottom = createIndexedNode(Values.pointValue(CoordinateReferenceSystem.Cartesian_3D, 100000, -100000, -100000))
     // 2D points should never be returned
-    graph.execute("CREATE (p:Place) SET p.location = point({x: -100000, y: -100000})")
-    graph.execute("CREATE (p:Place) SET p.location = point({x: 100000, y: 100000})")
+    createIndexedNode(Values.pointValue(CoordinateReferenceSystem.Cartesian, -100000, -100000))
+    createIndexedNode(Values.pointValue(CoordinateReferenceSystem.Cartesian, 100000, 100000))
 
-    // When running inequality queries expect correct results
-    Map(">" -> Set(Values.pointValue(CoordinateReferenceSystem.Cartesian_3D, 100000, 100000, 100000)),
-      ">=" -> Set(Values.pointValue(CoordinateReferenceSystem.Cartesian_3D, 100000, 100000, 100000), Values.pointValue(CoordinateReferenceSystem.Cartesian_3D, 0, 0, 0)),
-      "<" -> Set(Values.pointValue(CoordinateReferenceSystem.Cartesian_3D, -100000, -100000, -100000)),
-      "<=" -> Set(Values.pointValue(CoordinateReferenceSystem.Cartesian_3D, -100000, -100000, -100000), Values.pointValue(CoordinateReferenceSystem.Cartesian_3D, 0, 0, 0)),
-      "between" -> Set(Values.pointValue(CoordinateReferenceSystem.Cartesian_3D, 0, 0, 0))
-    ).foreach { entry =>
-      val (inequality, expected) = entry
-      withClue(s"When testing inequality '$inequality'") {
-        val query = inequality match {
-          case "between" => s"CYPHER MATCH (p:Place) WHERE p.location < point({x: 100000, y: 100000, z: 100000}) AND p.location > point({x: -100000, y: -100000, z: -100000}) RETURN p.location as point"
-          case _ => s"CYPHER MATCH (p:Place) WHERE p.location $inequality point({x: 0, y: 0, z: 0}) RETURN p.location as point"
-        }
-        val result = executeWith(indexConfig, query)
-
-        // Then
-        val plan = result.executionPlanDescription()
-        plan should useOperatorWithText("Projection", "point")
-        if (inequality == "between") {
-          plan should useOperatorWithText("NodeIndexSeekByRange", ":Place(location) < point", ":Place(location) > point")
-        } else {
-          plan should useOperatorWithText("NodeIndexSeekByRange", s":Place(location) $inequality point")
-        }
-        result.columnAs("point").toList.asInstanceOf[List[PointValue]].toSet should equal(expected)
-      }
-    }
+    assertRangeScanFor(">", originPoint, upRightTop)
+    assertRangeScanFor(">=", originPoint, origin, upRightTop)
+    assertRangeScanFor("<", originPoint, downLeftBottom)
+    assertRangeScanFor("<=", originPoint, origin, downLeftBottom)
+    assertRangeScanFor(">", minPoint, "<", maxPoint, origin, downLeftTop, downRightBottom, downrightTop, upLeftBottom, upLeftTop, upRightBottom)
   }
 
   test("indexed points 3D WGS84 space - range queries") {
     // Given
-    graph.createIndex("Place", "location")
-    graph.execute("CREATE (p:Place) SET p.location = point({latitude: 56.5, longitude: 13.0, height: 50})")
-    graph.execute("CREATE (p:Place) SET p.location = point({latitude: 56.6, longitude: 13.1, height: 100})")
-    graph.execute("CREATE (p:Place) SET p.location = point({latitude: 56.4, longitude: 13.1, height: 100})")
-    graph.execute("CREATE (p:Place) SET p.location = point({latitude: 56.4, longitude: 12.9, height: 100})")
-    graph.execute("CREATE (p:Place) SET p.location = point({latitude: 56.6, longitude: 12.9, height: 0})")
-    graph.execute("CREATE (p:Place) SET p.location = point({latitude: 56.6, longitude: 13.1, height: 0})")
-    graph.execute("CREATE (p:Place) SET p.location = point({latitude: 56.4, longitude: 13.1, height: 0})")
-    graph.execute("CREATE (p:Place) SET p.location = point({latitude: 56.4, longitude: 12.9, height: 0})")
-    graph.execute("CREATE (p:Place) SET p.location = point({latitude: 56.6, longitude: 12.9, height: 0})")
+    createIndex()
+    val maxPoint = Values.pointValue(CoordinateReferenceSystem.WGS84_3D, 56.6, 13.1, 100)
+    val midPoint = Values.pointValue(CoordinateReferenceSystem.WGS84_3D, 56.5, 13.0, 50)
+    val minPoint = Values.pointValue(CoordinateReferenceSystem.WGS84_3D, 56.4, 12.9, 0)
+
+    val n0 = createIndexedNode(midPoint)
+    val n1 = createIndexedNode(maxPoint)
+    val n2 = createIndexedNode(Values.pointValue(CoordinateReferenceSystem.WGS84_3D, 56.4, 13.1, 100))
+    val n3 = createIndexedNode(Values.pointValue(CoordinateReferenceSystem.WGS84_3D, 56.4, 12.9, 100))
+    val n4 = createIndexedNode(Values.pointValue(CoordinateReferenceSystem.WGS84_3D, 56.6, 12.9, 0))
+    val n5 = createIndexedNode(Values.pointValue(CoordinateReferenceSystem.WGS84_3D, 56.6, 13.1, 0))
+    val n6 = createIndexedNode(Values.pointValue(CoordinateReferenceSystem.WGS84_3D, 56.4, 13.1, 0))
+    val n8 = createIndexedNode(minPoint)
+    val n7 = createIndexedNode(Values.pointValue(CoordinateReferenceSystem.WGS84_3D, 56.6, 12.9, 0))
     // 2D points should never be returned
-    graph.execute("CREATE (p:Place) SET p.location = point({latitude: 56.6, longitude: 13.1})")
-    graph.execute("CREATE (p:Place) SET p.location = point({latitude: 56.4, longitude: 12.9})")
+    createIndexedNode(Values.pointValue(CoordinateReferenceSystem.WGS84, 56.6, 13.1))
+    createIndexedNode(Values.pointValue(CoordinateReferenceSystem.WGS84, 56.4, 12.9))
 
-    // When running inequality queries expect correct results
-    Map(">" -> Set(Values.pointValue(CoordinateReferenceSystem.WGS84_3D, 13.1, 56.6, 100)),
-      ">=" -> Set(Values.pointValue(CoordinateReferenceSystem.WGS84_3D, 13.1, 56.6, 100), Values.pointValue(CoordinateReferenceSystem.WGS84_3D, 13.0, 56.5, 50)),
-      "<" -> Set(Values.pointValue(CoordinateReferenceSystem.WGS84_3D, 12.9, 56.4, 0)),
-      "<=" -> Set(Values.pointValue(CoordinateReferenceSystem.WGS84_3D, 12.9, 56.4, 0), Values.pointValue(CoordinateReferenceSystem.WGS84_3D, 13.0, 56.5, 50)),
-      "between" -> Set(Values.pointValue(CoordinateReferenceSystem.WGS84_3D, 13.0, 56.5, 50))
-    ).foreach { entry =>
-      val (inequality, expected) = entry
-      withClue(s"When testing inequality '$inequality'") {
-        val query = inequality match {
-          case "between" => s"CYPHER MATCH (p:Place) WHERE p.location < point({latitude: 56.6, longitude: 13.1, height: 100}) AND p.location > point({latitude: 56.4, longitude: 12.9, height: 0}) RETURN p.location as point"
-          case _ => s"CYPHER MATCH (p:Place) WHERE p.location $inequality point({latitude: 56.5, longitude: 13.0, height: 50}) RETURN p.location as point"
-        }
-        val result = executeWith(indexConfig, query)
-
-        // Then
-        val plan = result.executionPlanDescription()
-        plan should useOperatorWithText("Projection", "point")
-        if (inequality == "between") {
-          plan should useOperatorWithText("NodeIndexSeekByRange", ":Place(location) < point", ":Place(location) > point")
-        } else {
-          plan should useOperatorWithText("NodeIndexSeekByRange", s":Place(location) $inequality point")
-        }
-        result.columnAs("point").toList.asInstanceOf[List[PointValue]].toSet should equal(expected)
-      }
-    }
+    assertRangeScanFor(">", midPoint, n1)
+    assertRangeScanFor(">=", midPoint, n0, n1)
+    assertRangeScanFor("<", midPoint, n8)
+    assertRangeScanFor("<=", midPoint, n0, n8)
+    assertRangeScanFor(">", minPoint, "<", maxPoint, n0, n2, n3, n4, n5, n6, n7)
   }
 }

--- a/enterprise/kernel/src/test/scala/org/neo4j/cypher/EnterpriseGraphDatabaseTestSupport.scala
+++ b/enterprise/kernel/src/test/scala/org/neo4j/cypher/EnterpriseGraphDatabaseTestSupport.scala
@@ -20,15 +20,12 @@
 package org.neo4j.cypher
 
 import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
-import org.neo4j.graphdb.config.Setting
 import org.neo4j.test.{TestEnterpriseGraphDatabaseFactory, TestGraphDatabaseFactory}
-
-import scala.collection.Map
 
 trait EnterpriseGraphDatabaseTestSupport extends GraphDatabaseTestSupport {
   self: CypherFunSuite =>
 
-  override protected def graphDatabaseFactory(config: Map[Setting[_], String]): TestGraphDatabaseFactory = {
+  override protected def graphDatabaseFactory(): TestGraphDatabaseFactory = {
     new TestEnterpriseGraphDatabaseFactory()
   }
 }


### PR DESCRIPTION
Fixes half-open range queries where the bound is smaller/greater than the default range.
Fixes `PointValue.withinRange` for exclusive ranges, e.g `(0,0)` is within the range when upper bound is set to `(1,0)`.

Builds on https://github.com/neo4j/neo4j/pull/11226
First commit is `
Handle range queries outside the range`