### PR TITLE
 Use two bounding boxes for circles touching the date line

### DIFF
--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexSeeker.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexSeeker.scala
@@ -29,6 +29,8 @@ import org.neo4j.values.AnyValue
 import org.neo4j.values.storable._
 import org.neo4j.values.virtual.NodeValue
 
+import collection.JavaConverters._
+
 /**
   * Mixin trait with functionality for executing logical index queries.
   *
@@ -122,12 +124,12 @@ trait NodeIndexSeeker {
             val valueRange = range.map(expr => makeValueNeoSafe(expr(row, state)))
             (valueRange.distance, valueRange.point) match {
               case (distance: NumberValue, point: PointValue) =>
-                val bbox = point.getCoordinateReferenceSystem.getCalculator.boundingBox(point, distance.doubleValue())
-                List(List(IndexQuery.range(propertyIds.head,
-                                           bbox.first(),
-                                           range.inclusive,
-                                           bbox.other(),
-                                           range.inclusive
+                val bboxes = point.getCoordinateReferenceSystem.getCalculator.boundingBox(point, distance.doubleValue()).asScala
+                bboxes.map( bbox => List(IndexQuery.range(propertyIds.head,
+                  bbox.first(),
+                  range.inclusive,
+                  bbox.other(),
+                  range.inclusive
                 )))
               case _ => Nil
             }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexSeeker.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexSeeker.scala
@@ -52,7 +52,7 @@ trait NodeIndexSeeker {
       case _: ExactSeek |
            _: SeekByRange =>
         val indexQueries = computeIndexQueries(state, baseContext)
-        indexQueries.flatMap(query => state.query.indexSeek(indexReference, query)).toIterator
+        indexQueries.toIterator.flatMap(query => state.query.indexSeek(indexReference, query))
 
       case LockingUniqueIndexSeek =>
         val indexQueries = computeExactQueries(state, baseContext)

--- a/community/values/src/main/java/org/neo4j/values/storable/CRSCalculator.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/CRSCalculator.java
@@ -19,6 +19,10 @@
  */
 package org.neo4j.values.storable;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.neo4j.helpers.collection.Pair;
 
 import static java.lang.Math.asin;
@@ -34,7 +38,7 @@ public abstract class CRSCalculator
 {
     public abstract double distance( PointValue p1, PointValue p2 );
 
-    public abstract Pair<PointValue,PointValue> boundingBox( PointValue center, double distance );
+    public abstract List<Pair<PointValue,PointValue>> boundingBox( PointValue center, double distance );
 
     protected static double pythagoras( double[] a, double[] b )
     {
@@ -65,7 +69,7 @@ public abstract class CRSCalculator
         }
 
         @Override
-        public Pair<PointValue,PointValue> boundingBox( PointValue center, double distance )
+        public List<Pair<PointValue,PointValue>> boundingBox( PointValue center, double distance )
         {
             assert center.getCoordinateReferenceSystem().getDimension() == dimension;
             double[] coordinates = center.coordinate();
@@ -77,7 +81,7 @@ public abstract class CRSCalculator
                 max[i] = coordinates[i] + distance;
             }
             CoordinateReferenceSystem crs = center.getCoordinateReferenceSystem();
-            return Pair.of( Values.pointValue( crs, min ), Values.pointValue( crs, max ) );
+            return Collections.singletonList( Pair.of( Values.pointValue( crs, min ), Values.pointValue( crs, max ) ) );
         }
     }
 
@@ -128,11 +132,11 @@ public abstract class CRSCalculator
         @Override
         // http://janmatuschek.de/LatitudeLongitudeBoundingCoordinates
         // But calculating in degrees instead of radians to avoid rounding errors
-        public Pair<PointValue,PointValue> boundingBox( PointValue center, double distance )
+        public List<Pair<PointValue,PointValue>> boundingBox( PointValue center, double distance )
         {
             if ( distance == 0.0 )
             {
-                return Pair.of( center, center );
+                return Collections.singletonList( Pair.of( center, center ) );
             }
 
             // Extend the distance slightly to assure that all relevant points lies inside the bounding box,
@@ -151,11 +155,11 @@ public abstract class CRSCalculator
             // If your query circle includes one of the poles
             if ( latMax >= 90 )
             {
-                return boundingBoxOf( -180, 180, latMin, 90, center, distance );
+                return Collections.singletonList( boundingBoxOf( -180, 180, latMin, 90, center, distance ) );
             }
             else if ( latMin <= -90 )
             {
-                return boundingBoxOf( -180, 180, -90, latMax, center, distance );
+                return Collections.singletonList( boundingBoxOf( -180, 180, -90, latMax, center, distance ) );
             }
             else
             {
@@ -164,15 +168,28 @@ public abstract class CRSCalculator
                 double lonMax = lon + deltaLon;
 
                 // If you query circle wraps around the dateline
-                // Large rectangle covering all longitudes
-                // TODO implement two rectangle solution instead
-                if ( lonMin < -180 || lonMax > 180 )
+                if ( lonMin < -180 && lonMax > 180 )
                 {
-                    return boundingBoxOf( -180, 180, latMin, latMax, center, distance );
+                    // Large rectangle covering all longitudes
+                    return Collections.singletonList( boundingBoxOf( -180, 180, latMin, latMax, center, distance ) );
+                }
+                else if ( lonMin < -180 )
+                {
+                    // two small rectangles east and west of dateline
+                    Pair<PointValue,PointValue> box1 = boundingBoxOf( lonMin + 360, 180, latMin, latMax, center, distance );
+                    Pair<PointValue,PointValue> box2 = boundingBoxOf( -180, lonMax, latMin, latMax, center, distance );
+                    return Arrays.asList( box1, box2 );
+                }
+                else if ( lonMax > 180 )
+                {
+                    // two small rectangles east and west of dateline
+                    Pair<PointValue,PointValue> box1 = boundingBoxOf( lonMin, 180, latMin, latMax, center, distance );
+                    Pair<PointValue,PointValue> box2 = boundingBoxOf( -180, lonMax - 360, latMin, latMax, center, distance );
+                    return Arrays.asList( box1, box2 );
                 }
                 else
                 {
-                    return boundingBoxOf( lonMin, lonMax, latMin, latMax, center, distance );
+                    return Collections.singletonList( boundingBoxOf( lonMin, lonMax, latMin, latMax, center, distance ) );
                 }
             }
         }


### PR DESCRIPTION
Index seeks with distance queries where the circle touches the date line
are now planned with two small bounding boxes at either side of the
date line and concatenating the results, instead of having one
than bounding box extending over all longitudes.