### PR TITLE
Prevent deadlock during index drop/cancel and flip operations

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/SchemaLoggingIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/SchemaLoggingIT.java
@@ -57,8 +57,8 @@ public class SchemaLoggingIT
         LogMatcherBuilder match = inLog( IndexPopulationJob.class );
         logProvider.assertAtLeastOnce(
                 match.info( "Index population started: [%s]", ":User(name) [provider: {key=in-memory-index, version=1.0}]" ),
-                match.info( "Index population completed. Index is now online: [%s]",
-                        ":User(name) [provider: {key=in-memory-index, version=1.0}]" ) );
+                match.info( "Index population completed. Index [%s] is %s.",
+                        ":User(name) [provider: {key=in-memory-index, version=1.0}]", "ONLINE" ) );
     }
 
     private void createIndex( GraphDatabaseAPI db, String labelName, String property )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxyTest.java
@@ -116,8 +116,8 @@ public class FlippableIndexProxyTest
         final CountDownLatch triggerFinishFlip = new CountDownLatch( 1 );
         final CountDownLatch triggerExternalAccess = new CountDownLatch( 1 );
 
-        OtherThreadExecutor<Void> flippingThread = cleanup.add( new OtherThreadExecutor<Void>( "Flipping thread", null ) );
-        OtherThreadExecutor<Void> dropIndexThread = cleanup.add( new OtherThreadExecutor<Void>( "Drop index thread", null ) );
+        OtherThreadExecutor<Void> flippingThread = cleanup.add( new OtherThreadExecutor<>( "Flipping thread", null ) );
+        OtherThreadExecutor<Void> dropIndexThread = cleanup.add( new OtherThreadExecutor<>( "Drop index thread", null ) );
 
         // WHEN one thread starts flipping to another context
         Future<Void> flipContextFuture = flippingThread.executeDontWait( startFlipAndWaitForLatchBeforeFinishing(
@@ -152,7 +152,7 @@ public class FlippableIndexProxyTest
         // given the proxy structure
         FakePopulatingIndexProxy delegate = new FakePopulatingIndexProxy();
         FlippableIndexProxy flipper = new FlippableIndexProxy( delegate );
-        OtherThreadExecutor<Void> waiter = cleanup.add( new OtherThreadExecutor<Void>( "Waiter", null ) );
+        OtherThreadExecutor<Void> waiter = cleanup.add( new OtherThreadExecutor<>( "Waiter", null ) );
 
         // and a thread stuck in the awaitStoreScanCompletion loop
         Future<Object> waiting = waiter.executeDontWait( state -> flipper.awaitStoreScanCompleted() );
@@ -188,15 +188,15 @@ public class FlippableIndexProxyTest
             {
                 triggerExternalAccess.countDown();
                 assertTrue( awaitLatch( triggerFinishFlip ) );
-                return null;
+                return Boolean.TRUE;
             }, null );
             return null;
         };
     }
 
-    private Callable<Void> noOp()
+    private Callable<Boolean> noOp()
     {
-        return () -> null;
+        return () -> Boolean.TRUE;
     }
 
     public static IndexProxyFactory singleProxy( final IndexProxy proxy )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
@@ -335,6 +335,7 @@ public class IndexPopulationJobTest
         createNode( map( name, "irrelephant" ), FIRST );
         AssertableLogProvider logProvider = new AssertableLogProvider();
         FlippableIndexProxy index = mock( FlippableIndexProxy.class );
+        when( index.getState() ).thenReturn( InternalIndexState.ONLINE );
         IndexPopulator populator = spy( inMemoryPopulator( false ) );
         IndexPopulationJob job = newIndexPopulationJob( populator, index, indexStoreView, logProvider, false );
 
@@ -345,7 +346,7 @@ public class IndexPopulationJobTest
         LogMatcherBuilder match = inLog( IndexPopulationJob.class );
         logProvider.assertExactly(
                 match.info( "Index population started: [%s]", ":FIRST(name)" ),
-                match.info( "Index population completed. Index is now online: [%s]", ":FIRST(name)" )
+                match.info( "Index population completed. Index [%s] is %s.", ":FIRST(name)", "ONLINE" )
         );
     }
 


### PR DESCRIPTION
Always take index proxy and index population job locks in the same order
to prevent deadlocks.
Update index completion message to be:
Index population completed. Index [%s] is %s.
Where parameters are: index description, index status.