### PR TITLE
Close auto commit transaction when execution and streaming fails

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineSPI.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineSPI.java
@@ -123,9 +123,7 @@ class TransactionStateMachineSPI implements TransactionStateMachine.SPI
 
     @Override
     public BoltResultHandle executeQuery( BoltQuerySource querySource,
-            LoginContext loginContext,
-            String statement,
-            MapValue params, ThrowingAction<KernelException> onFail )
+            LoginContext loginContext, String statement, MapValue params )
     {
         InternalTransaction internalTransaction = queryService.beginTransaction( implicit, loginContext );
         ClientConnectionInfo sourceDetails = new BoltConnectionInfo( querySource.principalName,
@@ -151,13 +149,11 @@ class TransactionStateMachineSPI implements TransactionStateMachine.SPI
                 catch ( KernelException e )
                 {
                     close( false );
-                    onFail.apply();
                     throw new QueryExecutionKernelException( e );
                 }
                 catch ( Throwable e )
                 {
                     close( false );
-                    onFail.apply();
                     throw e;
                 }
             }

--- a/community/bolt/src/test/java/org/neo4j/bolt/testing/BoltMatchers.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/testing/BoltMatchers.java
@@ -95,6 +95,29 @@ public class BoltMatchers
         };
     }
 
+    public static Matcher<RecordedBoltResponse> containsRecord( final Object... values )
+    {
+        return new BaseMatcher<RecordedBoltResponse>()
+        {
+            private AnyValue[] anyValues = Arrays.stream( values ).map( ValueUtils::of ).toArray( AnyValue[]::new );
+
+            @Override
+            public boolean matches( final Object item )
+            {
+
+                final RecordedBoltResponse response = (RecordedBoltResponse) item;
+                QueryResult.Record[] records = response.records();
+                return records.length > 0 && Arrays.equals( records[0].fields(), anyValues );
+            }
+
+            @Override
+            public void describeTo( Description description )
+            {
+                description.appendText( format( "with record %s", values ) );
+            }
+        };
+    }
+
     public static Matcher<RecordedBoltResponse> succeededWithRecord( final Object... values )
     {
         return new BaseMatcher<RecordedBoltResponse>()

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineTest.java
@@ -422,7 +422,7 @@ public class TransactionStateMachineTest
     }
 
     @Test
-    public void shouldCloseResultHandlesWhenExecutionFails() throws Exception
+    public void shouldCloseResultAndTransactionHandlesWhenExecutionFails() throws Exception
     {
         KernelTransaction transaction = newTransaction();
         TransactionStateMachine.BoltResultHandle resultHandle = newResultHandle( new RuntimeException( "some error" ) );
@@ -442,10 +442,11 @@ public class TransactionStateMachineTest
 
         assertNull( stateMachine.ctx.currentResultHandle );
         assertNull( stateMachine.ctx.currentResult );
+        assertNull( stateMachine.ctx.currentTransaction );
     }
 
     @Test
-    public void shouldCloseResultHandlesWhenConsumeFails() throws Exception
+    public void shouldCloseResultAndTransactionHandlesWhenConsumeFails() throws Exception
     {
         KernelTransaction transaction = newTransaction();
         TransactionStateMachineSPI stateMachineSPI = newTransactionStateMachineSPI( transaction );
@@ -472,6 +473,7 @@ public class TransactionStateMachineTest
 
         assertNull( stateMachine.ctx.currentResultHandle );
         assertNull( stateMachine.ctx.currentResult );
+        assertNull( stateMachine.ctx.currentTransaction );
     }
 
     @Test
@@ -500,6 +502,7 @@ public class TransactionStateMachineTest
 
         assertNull( stateMachine.ctx.currentResultHandle );
         assertNull( stateMachine.ctx.currentResult );
+        assertNotNull( stateMachine.ctx.currentTransaction );
     }
 
     @Test
@@ -535,6 +538,7 @@ public class TransactionStateMachineTest
 
         assertNull( stateMachine.ctx.currentResultHandle );
         assertNull( stateMachine.ctx.currentResult );
+        assertNotNull( stateMachine.ctx.currentTransaction );
     }
 
     private static KernelTransaction newTransaction()
@@ -571,8 +575,8 @@ public class TransactionStateMachineTest
         TransactionStateMachineSPI stateMachineSPI = mock( TransactionStateMachineSPI.class );
 
         when( stateMachineSPI.beginTransaction( any() ) ).thenReturn( mock( KernelTransaction.class ) );
-        when( stateMachineSPI.executeQuery( any(), any(), anyString(), any(), any() ) ).thenReturn( resultHandle );
-        when( stateMachineSPI.executeQuery( any(), any(), eq( "FAIL" ), any(), any() ) ).thenThrow( new TransactionTerminatedException( failureStatus ) );
+        when( stateMachineSPI.executeQuery( any(), any(), anyString(), any() ) ).thenReturn( resultHandle );
+        when( stateMachineSPI.executeQuery( any(), any(), eq( "FAIL" ), any() ) ).thenThrow( new TransactionTerminatedException( failureStatus ) );
 
         return stateMachineSPI;
     }
@@ -583,7 +587,7 @@ public class TransactionStateMachineTest
         TransactionStateMachineSPI stateMachineSPI = mock( TransactionStateMachineSPI.class );
 
         when( stateMachineSPI.beginTransaction( any() ) ).thenReturn( transaction );
-        when( stateMachineSPI.executeQuery( any(), any(), anyString(), any(), any() ) ).thenReturn( resultHandle );
+        when( stateMachineSPI.executeQuery( any(), any(), anyString(), any() ) ).thenReturn( resultHandle );
 
         return stateMachineSPI;
     }
@@ -594,7 +598,7 @@ public class TransactionStateMachineTest
         TransactionStateMachineSPI stateMachineSPI = mock( TransactionStateMachineSPI.class );
 
         when( stateMachineSPI.beginTransaction( any() ) ).thenReturn( transaction );
-        when( stateMachineSPI.executeQuery( any(), any(), anyString(), any(), any() ) ).thenReturn( resultHandle );
+        when( stateMachineSPI.executeQuery( any(), any(), anyString(), any() ) ).thenReturn( resultHandle );
 
         return stateMachineSPI;
     }


### PR DESCRIPTION
The auto-commit transaction opened was not being closed at all in case of an error during streaming of results back to the client. This PR ensures that the auto-commit transaction is closed always.