### PR TITLE
Improve scan speed by avoiding division and modulus

### DIFF
--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/PageAwareByteArrayCursor.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/PageAwareByteArrayCursor.java
@@ -323,6 +323,18 @@ class PageAwareByteArrayCursor extends PageCursor
     }
 
     @Override
+    public void mark()
+    {
+        current.mark();
+    }
+
+    @Override
+    public void setOffsetToMark()
+    {
+        current.setOffsetToMark();
+    }
+
+    @Override
     public void rewind()
     {
         current.rewind();

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageCursor.java
@@ -200,6 +200,16 @@ public abstract class PageCursor implements AutoCloseable
     public abstract int getOffset();
 
     /**
+     * Mark the current offset. Only one offset can be marked at any time.
+     */
+    public abstract void mark();
+
+    /**
+     * Set the offset to the marked offset. This does not modify the value of the mark.
+     */
+    public abstract void setOffsetToMark();
+
+    /**
      * Get the file page id that the cursor is currently positioned at, or
      * UNBOUND_PAGE_ID if next() has not yet been called on this cursor, or returned false.
      * A call to rewind() will make the current page id unbound as well, until

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/CompositePageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/CompositePageCursor.java
@@ -381,6 +381,20 @@ public class CompositePageCursor extends PageCursor
     }
 
     @Override
+    public void mark()
+    {
+        first.mark();
+        second.mark();
+    }
+
+    @Override
+    public void setOffsetToMark()
+    {
+        first.setOffsetToMark();
+        second.setOffsetToMark();
+    }
+
+    @Override
     public long getCurrentPageId()
     {
         return cursor( 0 ).getCurrentPageId();

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/DelegatingPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/DelegatingPageCursor.java
@@ -130,6 +130,18 @@ public class DelegatingPageCursor extends PageCursor
     }
 
     @Override
+    public void mark()
+    {
+        delegate.mark();
+    }
+
+    @Override
+    public void setOffsetToMark()
+    {
+        delegate.setOffsetToMark();
+    }
+
+    @Override
     public void close()
     {
         delegate.close();

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
@@ -75,6 +75,7 @@ abstract class MuninnPageCursor extends PageCursor
     private int filePageSize;
     protected final VersionContextSupplier versionContextSupplier;
     private int offset;
+    private int mark;
     private boolean outOfBounds;
     private boolean isLinkedCursor;
     // This is a String with the exception message if usePreciseCursorErrorStackTraces is false, otherwise it is a
@@ -953,6 +954,18 @@ abstract class MuninnPageCursor extends PageCursor
     public final int getOffset()
     {
         return offset;
+    }
+
+    @Override
+    public void mark()
+    {
+        this.mark = offset;
+    }
+
+    @Override
+    public void setOffsetToMark()
+    {
+        this.offset = mark;
     }
 
     @Override

--- a/community/io/src/test/java/org/neo4j/io/pagecache/ByteArrayPageCursor.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/ByteArrayPageCursor.java
@@ -204,6 +204,18 @@ public class ByteArrayPageCursor extends PageCursor
     }
 
     @Override
+    public void mark()
+    {
+        buffer.mark();
+    }
+
+    @Override
+    public void setOffsetToMark()
+    {
+        buffer.reset();
+    }
+
+    @Override
     public long getCurrentPageId()
     {
         throw new UnsupportedOperationException();

--- a/community/io/src/test/java/org/neo4j/io/pagecache/StubPageCursor.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/StubPageCursor.java
@@ -41,6 +41,7 @@ public class StubPageCursor extends PageCursor
     private boolean needsRetry;
     protected StubPageCursor linkedCursor;
     private boolean writeLocked;
+    private int mark;
 
     public StubPageCursor( long initialPageId, int pageSize )
     {
@@ -418,6 +419,18 @@ public class StubPageCursor extends PageCursor
             throw new IndexOutOfBoundsException();
         }
         currentOffset = offset;
+    }
+
+    @Override
+    public void mark()
+    {
+        this.mark = currentOffset;
+    }
+
+    @Override
+    public void setOffsetToMark()
+    {
+        this.currentOffset = this.mark;
     }
 
     @Override

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/CompositePageCursorTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/CompositePageCursorTest.java
@@ -698,6 +698,35 @@ public class CompositePageCursorTest
     }
 
     @Test
+    public void markCompositeCursor()
+    {
+        // GIVEN
+        first.setOffset( 1 );
+        second.setOffset( 2 );
+        PageCursor pageCursor = CompositePageCursor.compose( first, PAGE_SIZE, second, PAGE_SIZE );
+
+        first.getByte();
+        second.getLong();
+
+        int firstMark = first.getOffset();
+        int secondMark = second.getOffset();
+        pageCursor.mark();
+
+        first.getByte();
+        second.getLong();
+
+        assertNotEquals( firstMark, first.getOffset() );
+        assertNotEquals( secondMark, second.getOffset() );
+
+        // WHEN
+        pageCursor.setOffsetToMark();
+
+        // THEN
+        assertEquals( firstMark, first.getOffset() );
+        assertEquals( secondMark, second.getOffset() );
+    }
+
+    @Test
     public void getOffsetMustReturnOffsetIntoView()
     {
         PageCursor pageCursor = CompositePageCursor.compose( first, PAGE_SIZE, second, PAGE_SIZE );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
@@ -707,6 +707,12 @@ public class AllStoreHolder extends Read
     }
 
     @Override
+    void nodeAdvance( NodeRecord record, PageCursor pageCursor )
+    {
+        nodes.nextRecordByCursor( record, RecordLoad.CHECK, pageCursor );
+    }
+
+    @Override
     void relationship( RelationshipRecord record, long reference, PageCursor pageCursor )
     {
         // When scanning, we inspect RelationshipRecord.inUse(), so using RecordLoad.CHECK is fine

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
@@ -720,6 +720,13 @@ public class AllStoreHolder extends Read
     }
 
     @Override
+    void relationshipAdvance( RelationshipRecord record, PageCursor pageCursor )
+    {
+        // When scanning, we inspect RelationshipRecord.inUse(), so using RecordLoad.CHECK is fine
+        relationships.nextRecordByCursor( record, RecordLoad.CHECK, pageCursor );
+    }
+
+    @Override
     void relationshipFull( RelationshipRecord record, long reference, PageCursor pageCursor )
     {
         // We need to load forcefully for relationship chain traversal since otherwise we cannot

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeCursor.java
@@ -44,6 +44,7 @@ class DefaultNodeCursor extends NodeRecord implements NodeCursor
     private PageCursor pageCursor;
     private long next;
     private long highMark;
+    private long nextStoreReference;
     private HasChanges hasChanges = HasChanges.MAYBE;
     private LongSet addedNodes;
 
@@ -67,6 +68,7 @@ class DefaultNodeCursor extends NodeRecord implements NodeCursor
         }
         this.next = 0;
         this.highMark = read.nodeHighMark();
+        this.nextStoreReference = NO_ID;
         this.read = read;
         this.hasChanges = HasChanges.MAYBE;
         this.addedNodes = LongSets.immutable.empty();
@@ -85,6 +87,7 @@ class DefaultNodeCursor extends NodeRecord implements NodeCursor
         this.next = reference;
         //This marks the cursor as a "single cursor"
         this.highMark = NO_ID;
+        this.nextStoreReference = NO_ID;
         this.read = read;
         this.hasChanges = HasChanges.MAYBE;
         this.addedNodes = LongSets.immutable.empty();
@@ -225,9 +228,16 @@ class DefaultNodeCursor extends NodeRecord implements NodeCursor
                 next++;
                 setInUse( false );
             }
+            else if ( nextStoreReference == next )
+            {
+                read.nodeAdvance( this, pageCursor );
+                next++;
+                nextStoreReference++;
+            }
             else
             {
                 read.node( this, next++, pageCursor );
+                nextStoreReference = next;
             }
 
             if ( next > highMark )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Read.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Read.java
@@ -587,6 +587,8 @@ abstract class Read implements TxStateHolder,
 
     abstract void node( NodeRecord record, long reference, PageCursor pageCursor );
 
+    abstract void nodeAdvance( NodeRecord record, PageCursor pageCursor );
+
     abstract void relationship( RelationshipRecord record, long reference, PageCursor pageCursor );
 
     abstract void relationshipFull( RelationshipRecord record, long reference, PageCursor pageCursor );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Read.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Read.java
@@ -591,6 +591,8 @@ abstract class Read implements TxStateHolder,
 
     abstract void relationship( RelationshipRecord record, long reference, PageCursor pageCursor );
 
+    abstract void relationshipAdvance( RelationshipRecord record, PageCursor pageCursor );
+
     abstract void relationshipFull( RelationshipRecord record, long reference, PageCursor pageCursor );
 
     abstract void property( PropertyRecord record, long reference, PageCursor pageCursor );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
@@ -1066,6 +1066,10 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord,HEAD
     @Override
     public void nextRecordByCursor( RECORD record, RecordLoad mode, PageCursor cursor ) throws UnderlyingStorageException
     {
+        if ( cursor.getOffset() % recordSize != 0 )
+        {
+            System.out.println("hi");
+        }
         assert cursor.getOffset() % recordSize == 0 : "Cursor offset is record start";
         assert cursor.getCurrentPageId() >= -1 : "Pages are assumed to be positive or -1 if not initialized";
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
@@ -331,9 +331,11 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord,HEAD
         {
             if ( cursor.next() )
             {
+                cursor.setOffset( offset );
+                cursor.mark();
                 do
                 {
-                    cursor.setOffset( offset );
+                    cursor.setOffsetToMark();
                     cursor.getBytes( data );
                 }
                 while ( cursor.shouldRetry() );
@@ -392,9 +394,11 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord,HEAD
             boolean recordIsInUse = false;
             if ( cursor.next() )
             {
+                cursor.setOffset( offset );
+                cursor.mark();
                 do
                 {
-                    cursor.setOffset( offset );
+                    cursor.setOffsetToMark();
                     recordIsInUse = isInUse( cursor );
                 }
                 while ( cursor.shouldRetry() );
@@ -1052,9 +1056,11 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord,HEAD
         if ( cursor.next( pageId ) )
         {
             // There is a page in the store that covers this record, go read it
+            cursor.setOffset( offset );
+            cursor.mark();
             do
             {
-                prepareForReading( cursor, offset, record );
+                prepareForReading( cursor, record );
                 recordFormat.read( record, cursor, mode, recordSize );
             }
             while ( cursor.shouldRetry() );
@@ -1191,7 +1197,7 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord,HEAD
         }
     }
 
-    private void prepareForReading( PageCursor cursor, int offset, RECORD record )
+    private void prepareForReading( PageCursor cursor, RECORD record )
     {
         // Mark this record as unused. This to simplify implementations of readRecord.
         // readRecord can behave differently depending on RecordLoad argument and so it may be that
@@ -1199,7 +1205,7 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord,HEAD
         // can still be initialized data. Know that for many record stores, deleting a record means
         // just setting one byte or bit in that record.
         record.setInUse( false );
-        cursor.setOffset( offset );
+        cursor.setOffsetToMark();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
@@ -1066,12 +1066,10 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord,HEAD
     @Override
     public void nextRecordByCursor( RECORD record, RecordLoad mode, PageCursor cursor ) throws UnderlyingStorageException
     {
-        if ( cursor.getOffset() % recordSize != 0 )
+        if ( cursor.getCurrentPageId() < -1 )
         {
-            System.out.println("hi");
+            throw new IllegalArgumentException( "Pages are assumed to be positive or -1 if not initialized" );
         }
-        assert cursor.getOffset() % recordSize == 0 : "Cursor offset is record start";
-        assert cursor.getCurrentPageId() >= -1 : "Pages are assumed to be positive or -1 if not initialized";
 
         try
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
@@ -1081,7 +1081,7 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord,HEAD
             long pageId = cursor.getCurrentPageId();
             if ( offset >= storeFile.pageSize() || pageId < 0 )
             {
-                if ( !cursor.next( pageId + 1 ) )
+                if ( !cursor.next() )
                 {
                     verifyAfterNotRead( record, mode );
                     return;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordStore.java
@@ -131,6 +131,21 @@ public interface RecordStore<RECORD extends AbstractBaseRecord> extends IdSequen
     void getRecordByCursor( long id, RECORD target, RecordLoad mode, PageCursor cursor ) throws InvalidRecordException;
 
     /**
+     * Reads a record from the store into {@code target}, see
+     * {@link RecordStore#getRecord(long, AbstractBaseRecord, RecordLoad)}.
+     * <p>
+     * This method requires that the cursor page and offset point to the first byte of the record in target on calling.
+     * The provided page cursor will be used to get the record, and in doing this it will be redirected to the
+     * next page if the input record was the last on it's page.
+     *
+     * @param target the record to fill.
+     * @param mode loading behaviour, read more in {@link RecordStore#getRecord(long, AbstractBaseRecord, RecordLoad)}.
+     * @param cursor the PageCursor to use for record loading.
+     * @throws InvalidRecordException if record not in use and the {@code mode} allows for throwing.
+     */
+    void nextRecordByCursor( RECORD target, RecordLoad mode, PageCursor cursor ) throws InvalidRecordException;
+
+    /**
      * For stores that have other stores coupled underneath, the "top level" record will have a flag
      * saying whether or not it's light. Light means that no records from the coupled store have been loaded yet.
      * This method can load those records and enrich the target record with those, marking it as heavy.
@@ -293,6 +308,12 @@ public interface RecordStore<RECORD extends AbstractBaseRecord> extends IdSequen
         public void getRecordByCursor( long id, R target, RecordLoad mode, PageCursor cursor ) throws InvalidRecordException
         {
             actual.getRecordByCursor( id, target, mode, cursor );
+        }
+
+        @Override
+        public void nextRecordByCursor( R target, RecordLoad mode, PageCursor cursor ) throws InvalidRecordException
+        {
+            actual.nextRecordByCursor( target, mode, cursor );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/BaseOneByteHeaderRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/BaseOneByteHeaderRecordFormat.java
@@ -34,6 +34,7 @@ import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
  */
 public abstract class BaseOneByteHeaderRecordFormat<RECORD extends AbstractBaseRecord> extends BaseRecordFormat<RECORD>
 {
+    protected static final int HEADER_SIZE = 1;
     private final int inUseBitMaskForFirstByte;
 
     protected BaseOneByteHeaderRecordFormat( Function<StoreHeader,Integer> recordSize, int recordHeaderSize,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/NodeRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/NodeRecordFormat.java
@@ -30,7 +30,6 @@ public class NodeRecordFormat extends BaseOneByteHeaderRecordFormat<NodeRecord>
 {
     // in_use(byte)+next_rel_id(int)+next_prop_id(int)+labels(5)+extra(byte)
     public static final int RECORD_SIZE = 15;
-    private static final int HEADER_SIZE = 1;
 
     public NodeRecordFormat()
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/NodeRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/NodeRecordFormat.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.store.format.standard;
 
-import java.io.IOException;
-
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.kernel.impl.store.format.BaseOneByteHeaderRecordFormat;
 import org.neo4j.kernel.impl.store.format.BaseRecordFormat;
@@ -32,6 +30,7 @@ public class NodeRecordFormat extends BaseOneByteHeaderRecordFormat<NodeRecord>
 {
     // in_use(byte)+next_rel_id(int)+next_prop_id(int)+labels(5)+extra(byte)
     public static final int RECORD_SIZE = 15;
+    private static final int HEADER_SIZE = 1;
 
     public NodeRecordFormat()
     {
@@ -67,6 +66,11 @@ public class NodeRecordFormat extends BaseOneByteHeaderRecordFormat<NodeRecord>
             record.initialize( inUse,
                     BaseRecordFormat.longFromIntAndMod( nextProp, propModifier ), dense,
                     BaseRecordFormat.longFromIntAndMod( nextRel, relModifier ), labels );
+        }
+        else
+        {
+            int nextOffset = cursor.getOffset() + recordSize - HEADER_SIZE;
+            cursor.setOffset( nextOffset );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/RelationshipRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/RelationshipRecordFormat.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.store.format.standard;
 
-import java.io.IOException;
-
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.kernel.impl.store.format.BaseOneByteHeaderRecordFormat;
 import org.neo4j.kernel.impl.store.format.BaseRecordFormat;
@@ -35,7 +33,6 @@ public class RelationshipRecordFormat extends BaseOneByteHeaderRecordFormat<Rela
     // first_prev_rel_id(int)+first_next_rel_id+second_prev_rel_id(int)+
     // second_next_rel_id+next_prop_id(int)+first-in-chain-markers(1)
     public static final int RECORD_SIZE = 34;
-    private static final int HEADER_SIZE = 1;
 
     public RelationshipRecordFormat()
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/RelationshipRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/RelationshipRecordFormat.java
@@ -35,6 +35,7 @@ public class RelationshipRecordFormat extends BaseOneByteHeaderRecordFormat<Rela
     // first_prev_rel_id(int)+first_next_rel_id+second_prev_rel_id(int)+
     // second_next_rel_id+next_prop_id(int)+first-in-chain-markers(1)
     public static final int RECORD_SIZE = 34;
+    private static final int HEADER_SIZE = 1;
 
     public RelationshipRecordFormat()
     {
@@ -101,6 +102,11 @@ public class RelationshipRecordFormat extends BaseOneByteHeaderRecordFormat<Rela
                     BaseRecordFormat.longFromIntAndMod( secondNextRel, secondNextRelMod ),
                     (extraByte & 0x1) != 0,
                     (extraByte & 0x2) != 0 );
+        }
+        else
+        {
+            int nextOffset = cursor.getOffset() + recordSize - HEADER_SIZE;
+            cursor.setOffset( nextOffset );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageReader.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageReader.java
@@ -602,6 +602,22 @@ public interface StorageReader extends AutoCloseable
         void getRecordByCursor( long reference, RECORD record, RecordLoad mode, PageCursor cursor )
                 throws InvalidRecordException;
 
+        /**
+         * Reads a record from the store into {@code target}, see
+         * {@link RecordStore#getRecord(long, AbstractBaseRecord, RecordLoad)}.
+         * <p>
+         * This method requires that the cursor page and offset point to the first byte of the record in target on calling.
+         * The provided page cursor will be used to get the record, and in doing this it will be redirected to the
+         * next page if the input record was the last on it's page.
+         *
+         * @param record the record to fill.
+         * @param mode loading behaviour, read more in {@link RecordStore#getRecord(long, AbstractBaseRecord, RecordLoad)}.
+         * @param cursor the PageCursor to use for record loading.
+         * @throws InvalidRecordException if record not in use and the {@code mode} allows for throwing.
+         */
+        void nextRecordByCursor( RECORD record, RecordLoad mode, PageCursor cursor )
+                throws InvalidRecordException;
+
         long getHighestPossibleIdInUse();
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/MockStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/MockStore.java
@@ -580,6 +580,12 @@ public class MockStore extends Read implements TestRule
     }
 
     @Override
+    void nodeAdvance( NodeRecord record, PageCursor pageCursor )
+    {
+        initialize( record, record.getId() + 1, nodes );
+    }
+
+    @Override
     void relationship( RelationshipRecord record, long reference, PageCursor pageCursor )
     {
         throw new UnsupportedOperationException( "not implemented" );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/MockStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/MockStore.java
@@ -592,6 +592,12 @@ public class MockStore extends Read implements TestRule
     }
 
     @Override
+    void relationshipAdvance( RelationshipRecord record, PageCursor pageCursor )
+    {
+        throw new UnsupportedOperationException( "not implemented" );
+    }
+
+    @Override
     void relationshipFull( RelationshipRecord record, long reference, PageCursor pageCursor )
     {
         throw new UnsupportedOperationException( "not implemented" );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/AbstractRecordFormatTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/AbstractRecordFormatTest.java
@@ -104,56 +104,57 @@ public abstract class AbstractRecordFormatTest
     @Test
     public void node() throws Exception
     {
-        verifyWriteAndRead( formats::node, generators::node, keys::node );
+        verifyWriteAndRead( formats::node, generators::node, keys::node, true );
     }
 
     @Test
     public void relationship() throws Exception
     {
-        verifyWriteAndRead( formats::relationship, generators::relationship, keys::relationship );
+        verifyWriteAndRead( formats::relationship, generators::relationship, keys::relationship, true );
     }
 
     @Test
     public void property() throws Exception
     {
-        verifyWriteAndRead( formats::property, generators::property, keys::property );
+        verifyWriteAndRead( formats::property, generators::property, keys::property, false );
     }
 
     @Test
     public void relationshipGroup() throws Exception
     {
-        verifyWriteAndRead( formats::relationshipGroup, generators::relationshipGroup, keys::relationshipGroup );
+        verifyWriteAndRead( formats::relationshipGroup, generators::relationshipGroup, keys::relationshipGroup, false );
     }
 
     @Test
     public void relationshipTypeToken() throws Exception
     {
         verifyWriteAndRead( formats::relationshipTypeToken, generators::relationshipTypeToken,
-                keys::relationshipTypeToken );
+                keys::relationshipTypeToken, false );
     }
 
     @Test
     public void propertyKeyToken() throws Exception
     {
-        verifyWriteAndRead( formats::propertyKeyToken, generators::propertyKeyToken, keys::propertyKeyToken );
+        verifyWriteAndRead( formats::propertyKeyToken, generators::propertyKeyToken, keys::propertyKeyToken, false );
     }
 
     @Test
     public void labelToken() throws Exception
     {
-        verifyWriteAndRead( formats::labelToken, generators::labelToken, keys::labelToken );
+        verifyWriteAndRead( formats::labelToken, generators::labelToken, keys::labelToken, false );
     }
 
     @Test
     public void dynamic() throws Exception
     {
-        verifyWriteAndRead( formats::dynamic, generators::dynamic, keys::dynamic );
+        verifyWriteAndRead( formats::dynamic, generators::dynamic, keys::dynamic, false );
     }
 
     private <R extends AbstractBaseRecord> void verifyWriteAndRead(
             Supplier<RecordFormat<R>> formatSupplier,
             Supplier<Generator<R>> generatorSupplier,
-            Supplier<RecordKey<R>> keySupplier ) throws IOException
+            Supplier<RecordKey<R>> keySupplier,
+            boolean assertPostReadOffset ) throws IOException
     {
         // GIVEN
         try ( PagedFile storeFile = pageCache.map( new File( "store-" + name.getMethodName() ), PAGE_SIZE, CREATE ) )
@@ -176,7 +177,7 @@ public abstract class AbstractRecordFormatTest
                 try
                 {
                     writeRecord( written, format, storeFile, recordSize, idSequence );
-                    readAndVerifyRecord( written, read, format, key, storeFile, recordSize );
+                    readAndVerifyRecord( written, read, format, key, storeFile, recordSize, assertPostReadOffset );
                     idSequence.reset();
                 }
                 catch ( Throwable t )
@@ -190,14 +191,14 @@ public abstract class AbstractRecordFormatTest
     }
 
     private <R extends AbstractBaseRecord> void readAndVerifyRecord( R written, R read, RecordFormat<R> format,
-            RecordKey<R> key, PagedFile storeFile, int recordSize ) throws IOException
+            RecordKey<R> key, PagedFile storeFile, int recordSize, boolean assertPostReadOffset ) throws IOException
     {
         try ( PageCursor cursor = storeFile.io( 0, PagedFile.PF_SHARED_READ_LOCK ) )
         {
             assertedNext( cursor );
             read.setId( written.getId() );
 
-            /**
+            /*
              Retry loop is needed here because format does not handle retries on the primary cursor.
              Same retry is done on the store level in {@link org.neo4j.kernel.impl.store.CommonAbstractStore}
              */
@@ -209,6 +210,11 @@ public abstract class AbstractRecordFormatTest
             }
             while ( cursor.shouldRetry() );
             assertWithinBounds( written, cursor, "reading" );
+            if ( assertPostReadOffset )
+            {
+                assertEquals( "Cursor is positioned on first byte of next record after a read",
+                              offset + recordSize, cursor.getOffset() );
+            }
             cursor.checkAndClearCursorException();
 
             // THEN

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormat.java
@@ -160,6 +160,9 @@ abstract class BaseHighLimitRecordFormat<RECORD extends AbstractBaseRecord>
             record.setUseFixedReferences( isUseFixedReferences( headerByte ) );
             doReadInternal( record, primaryCursor, recordSize, headerByte, inUse );
         }
+
+        // Set cursor offset to next record to prepare next read in case of scanning.
+        primaryCursor.setOffset( primaryStartOffset + recordSize );
     }
 
     private boolean isUseFixedReferences( byte headerByte )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/BaseHighLimitRecordFormatV3_0_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/BaseHighLimitRecordFormatV3_0_0.java
@@ -147,6 +147,8 @@ abstract class BaseHighLimitRecordFormatV3_0_0<RECORD extends AbstractBaseRecord
         {
             doReadInternal( record, primaryCursor, recordSize, headerByte, inUse );
         }
+
+        primaryCursor.setOffset( primaryStartOffset + recordSize );
     }
 
     private String illegalSecondaryReferenceMessage( long secondaryId )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/BaseHighLimitRecordFormatV3_0_6.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/BaseHighLimitRecordFormatV3_0_6.java
@@ -150,6 +150,8 @@ abstract class BaseHighLimitRecordFormatV3_0_6<RECORD extends AbstractBaseRecord
             record.setUseFixedReferences( isUseFixedReferences( headerByte ) );
             doReadInternal( record, primaryCursor, recordSize, headerByte, inUse );
         }
+
+        primaryCursor.setOffset( primaryStartOffset );
     }
 
     private boolean isUseFixedReferences( byte headerByte )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/BaseHighLimitRecordFormatV3_0_6.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/BaseHighLimitRecordFormatV3_0_6.java
@@ -151,7 +151,7 @@ abstract class BaseHighLimitRecordFormatV3_0_6<RECORD extends AbstractBaseRecord
             doReadInternal( record, primaryCursor, recordSize, headerByte, inUse );
         }
 
-        primaryCursor.setOffset( primaryStartOffset );
+        primaryCursor.setOffset( primaryStartOffset + recordSize );
     }
 
     private boolean isUseFixedReferences( byte headerByte )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v310/BaseHighLimitRecordFormatV3_1_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v310/BaseHighLimitRecordFormatV3_1_0.java
@@ -161,6 +161,8 @@ abstract class BaseHighLimitRecordFormatV3_1_0<RECORD extends AbstractBaseRecord
             record.setUseFixedReferences( isUseFixedReferences( headerByte ) );
             doReadInternal( record, primaryCursor, recordSize, headerByte, inUse );
         }
+
+        primaryCursor.setOffset( primaryStartOffset + recordSize );
     }
 
     private boolean isUseFixedReferences( byte headerByte )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v320/BaseHighLimitRecordFormatV3_2_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v320/BaseHighLimitRecordFormatV3_2_0.java
@@ -161,6 +161,8 @@ abstract class BaseHighLimitRecordFormatV3_2_0<RECORD extends AbstractBaseRecord
             record.setUseFixedReferences( isUseFixedReferences( headerByte ) );
             doReadInternal( record, primaryCursor, recordSize, headerByte, inUse );
         }
+
+        primaryCursor.setOffset( primaryStartOffset + recordSize );
     }
 
     private boolean isUseFixedReferences( byte headerByte )

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormatTest.java
@@ -79,10 +79,10 @@ public class RelationshipRecordFormatTest
         long recordId = 0xF1F1F1F1F1F1L;
         int recordOffset = cursor.getOffset();
 
-        RelationshipRecord record = createRecord( format, recordId, false, false );
-        RelationshipRecord firstInSecondChain = createRecord( format, recordId, false, true );
-        RelationshipRecord firstInFirstChain = createRecord( format, recordId, true, false );
-        RelationshipRecord firstInBothChains = createRecord( format, recordId, true, true );
+        RelationshipRecord record = createCompactRecord( format, recordId, false, false );
+        RelationshipRecord firstInSecondChain = createCompactRecord( format, recordId, false, true );
+        RelationshipRecord firstInFirstChain = createCompactRecord( format, recordId, true, false );
+        RelationshipRecord firstInBothChains = createCompactRecord( format, recordId, true, true );
 
         checkRecord( format, recordSize, cursor, recordId, recordOffset, record );
         checkRecord( format, recordSize, cursor, recordId, recordOffset, firstInSecondChain );
@@ -316,7 +316,8 @@ public class RelationshipRecordFormatTest
         cursor.setOffset( recordOffset );
     }
 
-    private RelationshipRecord createRecord( RelationshipRecordFormat format, long recordId,
+    // Create high-limit record which fits in one record
+    private RelationshipRecord createCompactRecord( RelationshipRecordFormat format, long recordId,
             boolean firstInFirstChain, boolean firstInSecondChain )
     {
         RelationshipRecord record = format.newRecord();
@@ -324,12 +325,12 @@ public class RelationshipRecordFormatTest
         record.setFirstInFirstChain( firstInFirstChain );
         record.setFirstInSecondChain( firstInSecondChain );
         record.setId( recordId );
-        record.setFirstNextRel( 1L );
-        record.setFirstNode( 2L );
-        record.setFirstPrevRel( 3L );
-        record.setSecondNextRel( 4L );
-        record.setSecondNode( 5L );
-        record.setSecondPrevRel( 6L );
+        record.setFirstNextRel( recordId + 1L );
+        record.setFirstNode( recordId + 2L );
+        record.setFirstPrevRel( recordId + 3L );
+        record.setSecondNextRel( recordId + 4L );
+        record.setSecondNode( recordId + 5L );
+        record.setSecondPrevRel( recordId + 6L );
         record.setType( 7 );
         return record;
     }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormatTest.java
@@ -65,6 +65,12 @@ public class RelationshipRecordFormatTest
             assertEquals( 0, pageId );
             return true;
         }
+
+        @Override
+        public boolean next()
+        {
+            return true;
+        }
     };
 
     @Test


### PR DESCRIPTION
UPDATED: reworked the implementation after some feedback. This removed some of the `PageCursor.setOffset` calls and further improved speed, now I get the following benchmark results locally:

```
                          3.4                            this PR
| --------------------- | --------------------------- | ---------------------------- | 
| all-node scan         | 328446.771 ± 2183.832 us/op | 200417.410 ± 1088.529  us/op |
| all-relationship scan | 428465.630 ± 2901.997 us/op | 325505.176 ± 50896.297 us/op |
```