### PR TITLE
Return hit ratio as part of the page cache bean

### DIFF
--- a/enterprise/management/src/main/java/org/neo4j/management/PageCache.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/PageCache.java
@@ -57,4 +57,10 @@ public interface PageCache
                   "This number should be zero, or at least not growing, in a healthy database. " +
                   "Otherwise it could indicate drive failure, storage space, or permission problems." )
     long getEvictionExceptions();
+
+    @Description( "Ratio of hits to the total number of lookups in the page cache" )
+    default double getHitRatio()
+    {
+       return Double.NaN;
+    }
 }

--- a/enterprise/management/src/main/java/org/neo4j/management/impl/PageCacheBean.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/impl/PageCacheBean.java
@@ -101,6 +101,12 @@ public final class PageCacheBean extends ManagementBeanProvider
         }
 
         @Override
+        public double getHitRatio()
+        {
+            return pageCacheCounters.hitRatio();
+        }
+
+        @Override
         public long getEvictionExceptions()
         {
             return pageCacheCounters.evictionExceptions();


### PR DESCRIPTION
Exposes the page cache hit ratio through jmx
_Neo4j Browser will display this value on the `:sysinfo` frame_

_Resolves failing interface checks when forward merged to 3.4 (reverted in https://github.com/neo4j/neo4j/pull/11358)_