### PR TITLE
Better testing of temporal exceptions

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
@@ -96,8 +96,10 @@ trait CypherComparisonSupport extends CypherTestSupport {
     self.kernelMonitors.addMonitorListener(newRuntimeMonitor)
   }
 
-  protected def failWithError(expectedSpecificFailureFrom: TestConfiguration, query: String, message: Seq[String], params: (String, Any)*):
-  Unit = {
+  protected def failWithError(expectedSpecificFailureFrom: TestConfiguration,
+                                      query: String,
+                                      message: Seq[String],
+                                      params: Map[String, Any] = Map.empty): Unit = {
     // Never consider Morsel even if test requests it
     val expectedSpecificFailureFromEffective = expectedSpecificFailureFrom - Configs.Morsel
 
@@ -107,7 +109,7 @@ trait CypherComparisonSupport extends CypherTestSupport {
       thisScenario.prepare()
       val expectedToFailWithSpecificMessage = expectedSpecificFailureFromEffective.containsScenario(thisScenario)
 
-      val tryResult: Try[InternalExecutionResult] = Try(innerExecute(s"CYPHER ${thisScenario.preparserOptions} $query", params.toMap))
+      val tryResult: Try[InternalExecutionResult] = Try(innerExecute(s"CYPHER ${thisScenario.preparserOptions} $query", params))
       tryResult match {
         case (Success(_)) =>
           if (expectedToFailWithSpecificMessage) {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionEngineTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionEngineTest.scala
@@ -895,7 +895,7 @@ order by a.COL1""".format(a, b))
   }
 
   test("merge should not support map parameters for defining properties") {
-    failWithError(Configs.AbsolutelyAll, "MERGE (n:User {merge_map})", List("Parameter maps cannot be used in MERGE patterns"), params = ("merge_map", Map("email" -> "test")) )
+    failWithError(Configs.AbsolutelyAll, "MERGE (n:User {merge_map})", List("Parameter maps cannot be used in MERGE patterns"), params = Map("merge_map" -> Map("email" -> "test")))
   }
 
   test("should return null on all comparisons against null") {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MutatingIntegrationTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MutatingIntegrationTest.scala
@@ -213,7 +213,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
       Map("name" -> "Peter", "prefers" -> "Java"))
 
     val errorMessages = List("If you want to create multiple nodes, please use UNWIND.", "Parameter provided for node creation is not a Map")
-    failWithError(Configs.UpdateConf - Configs.Rule2_3 + Configs.Procs, "create ({params})", params = "params" -> maps, message = errorMessages)
+    failWithError(Configs.UpdateConf - Configs.Rule2_3 + Configs.Procs, "create ({params})", params = Map("params" -> maps), message = errorMessages)
   }
 
   test("fail to create from two iterables") {
@@ -227,7 +227,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
       Map("name" -> "Peter"))
     val query = "create (a {params1}), (b {params2})"
     val errorMessages = List("If you want to create multiple nodes, please use UNWIND.", "Parameter provided for node creation is not a Map", "If you create multiple elements, you can only create one of each.")
-    failWithError(Configs.UpdateConf + Configs.Procs, query, message = errorMessages, params = "params1" -> maps1, "params2" -> maps2)
+    failWithError(Configs.UpdateConf + Configs.Procs, query, message = errorMessages, params = Map("params1" -> maps1, "params2" -> maps2))
   }
 
   test("first read then write") {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexContainsScanAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexContainsScanAcceptanceTest.scala
@@ -187,6 +187,6 @@ class NodeIndexContainsScanAcceptanceTest extends ExecutionEngineFunSuite with C
       TestConfiguration(Versions.all, Planners.Cost, Runtimes(Runtimes.Interpreted, Runtimes.Default)) +
       TestConfiguration(Versions.V2_3, Planners.Rule, Runtimes(Runtimes.Interpreted, Runtimes.Default)),
       query, message = List("Expected a string value, but got 42","Expected a string value, but got Long(42)","Expected two strings, but got London and 42"),
-      params = "param" -> 42)
+      params = Map("param" -> 42))
   }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexEndsWithScanAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexEndsWithScanAcceptanceTest.scala
@@ -187,6 +187,6 @@ class NodeIndexEndsWithScanAcceptanceTest extends ExecutionEngineFunSuite with C
     val query = "MATCH (l:Location) WHERE l.name ENDS WITH {param} RETURN l"
     val message = List("Expected a string value, but got 42","Expected a string value, but got Long(42)","Expected two strings, but got London and 42")
 
-    failWithError(config, query, message, params = "param" -> 42)
+    failWithError(config, query, message, params = Map("param" -> 42))
   }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ParameterValuesAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ParameterValuesAcceptanceTest.scala
@@ -147,13 +147,13 @@ class ParameterValuesAcceptanceTest extends ExecutionEngineFunSuite with CypherC
   test("match with misspelled parameter should return error for empty db") {
     // all versions of 3.3 and 3.4
     val config = Configs.Version3_4 + Configs.Version3_3 + Configs.Procs - Configs.AllRulePlanners
-    failWithError(config, "MATCH (n:Person {name:{name}}) RETURN n", Seq("Expected parameter(s): name"), params = "nam" -> "Neo")
+    failWithError(config, "MATCH (n:Person {name:{name}}) RETURN n", Seq("Expected parameter(s): name"), params = Map("nam" -> "Neo"))
   }
 
   test("match with misspelled parameter should return error for non-empty db") {
     // all versions of 3.3 and 3.4
     val config = Configs.Version3_4 + Configs.Version3_3 + Configs.Procs - Configs.AllRulePlanners - Configs.Compiled
-    failWithError(config, "CREATE (n:Person) WITH n MATCH (n:Person {name:{name}}) RETURN n", Seq("Expected parameter(s): name"), params = "nam" -> "Neo")
+    failWithError(config, "CREATE (n:Person) WITH n MATCH (n:Person {name:{name}}) RETURN n", Seq("Expected parameter(s): name"), params = Map("nam" -> "Neo"))
   }
 
   test("explain with missing parameter should NOT return error for empty db") {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SetAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SetAcceptanceTest.scala
@@ -158,7 +158,7 @@ class SetAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTest
   //Not suitable for the TCK
   test("should fail at runtime when the expression is not a node or a relationship") {
     failWithError(expectedToFail2, "SET (CASE WHEN true THEN {node} END).name = 'neo4j' RETURN count(*)",
-      List("The expression GenericCase(Vector((true,{node})),None) should have been a node or a relationship"), params= "node" -> 42)
+      List("The expression GenericCase(Vector((true,{node})),None) should have been a node or a relationship"), params = Map("node" -> 42))
   }
 
   //Not suitable for the TCK

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
@@ -74,34 +74,37 @@ class SpatialFunctionsAcceptanceTest extends ExecutionEngineFunSuite with Cypher
   }
 
   test("point function should not work with literal map and incorrect cartesian CRS") {
-    failWithError(pointConfig, "RETURN point({x: 2.3, y: 4.5, crs: 'cart'}) as point", List("'cart' is not a supported coordinate reference system for points",
+    failWithError(pointConfig + Configs.Procs,
+      "RETURN point({x: 2.3, y: 4.5, crs: 'cart'}) as point", List("'cart' is not a supported coordinate reference system for points",
       "Unknown coordinate reference system: cart"))
   }
 
   test("point function should not work with literal map of 2 coordinates and incorrect cartesian-3D crs") {
-    failWithError(pointConfig, "RETURN point({x: 2.3, y: 4.5, crs: 'cartesian-3D'}) as point", List(
+    failWithError(pointConfig + Configs.Procs, "RETURN point({x: 2.3, y: 4.5, crs: 'cartesian-3D'}) as point", List(
       "'cartesian-3D' is not a supported coordinate reference system for points",
       "Cannot create point with 3D coordinate reference system and 2 coordinates. Please consider using equivalent 2D coordinate reference system"))
   }
 
   test("point function should not work with literal map of 3 coordinates and incorrect cartesian crs") {
-    failWithError(pointConfig - Configs.Version3_1 - Configs.AllRulePlanners, "RETURN point({x: 2.3, y: 4.5, z: 6.7, crs: 'cartesian'}) as point", List(
-      "Cannot create point with 2D coordinate reference system and 3 coordinates. Please consider using equivalent 3D coordinate reference system"))
+    failWithError(pointConfig - Configs.Version3_1 - Configs.AllRulePlanners + Configs.Procs,
+      "RETURN point({x: 2.3, y: 4.5, z: 6.7, crs: 'cartesian'}) as point",
+      List("Cannot create point with 2D coordinate reference system and 3 coordinates. Please consider using equivalent 3D coordinate reference system"))
   }
 
   test("point function should not work with literal map and incorrect geographic CRS") {
-    failWithError(pointConfig, "RETURN point({x: 2.3, y: 4.5, crs: 'WGS84'}) as point", List("'WGS84' is not a supported coordinate reference system for points",
-      "Unknown coordinate reference system: WGS84"))
+    failWithError(pointConfig + Configs.Procs, "RETURN point({x: 2.3, y: 4.5, crs: 'WGS84'}) as point",
+      List("'WGS84' is not a supported coordinate reference system for points", "Unknown coordinate reference system: WGS84"))
   }
 
   test("point function should not work with literal map of 2 coordinates and incorrect WGS84-3D crs") {
-    failWithError(pointConfig, "RETURN point({x: 2.3, y: 4.5, crs: 'WGS-84-3D'}) as point", List(
+    failWithError(pointConfig + Configs.Procs, "RETURN point({x: 2.3, y: 4.5, crs: 'WGS-84-3D'}) as point", List(
       "'WGS-84-3D' is not a supported coordinate reference system for points",
       "Cannot create point with 3D coordinate reference system and 2 coordinates. Please consider using equivalent 2D coordinate reference system"))
   }
 
   test("point function should not work with literal map of 3 coordinates and incorrect WGS84 crs") {
-    failWithError(pointConfig - Configs.Version3_1 - Configs.AllRulePlanners, "RETURN point({x: 2.3, y: 4.5, z: 6.7, crs: 'wgs-84'}) as point", List(
+    failWithError(pointConfig - Configs.Version3_1 - Configs.AllRulePlanners + Configs.Procs,
+      "RETURN point({x: 2.3, y: 4.5, z: 6.7, crs: 'wgs-84'}) as point", List(
       "Cannot create point with 2D coordinate reference system and 3 coordinates. Please consider using equivalent 3D coordinate reference system"))
   }
 
@@ -114,33 +117,33 @@ class SpatialFunctionsAcceptanceTest extends ExecutionEngineFunSuite with Cypher
   }
 
   test("point function should throw on unrecognized map entry") {
-    val stillWithoutFix = Configs.Version3_1 + Configs.Version3_3 + Configs.AllRulePlanners
-    failWithError(pointConfig - stillWithoutFix, "RETURN point({x: 2, y:3, a: 4}) as point", Seq("Unknown key 'a' for creating new point"))
+    val stillWithoutFix = Configs.Version3_1 + Configs.AllRulePlanners
+    failWithError(pointConfig - stillWithoutFix + Configs.Procs, "RETURN point({x: 2, y:3, a: 4}) as point", Seq("Unknown key 'a' for creating new point"))
   }
 
   test("should fail properly if missing cartesian coordinates") {
-    failWithError(pointConfig, "RETURN point({params}) as point",
+    failWithError(pointConfig + Configs.Procs, "RETURN point({params}) as point",
       List("A cartesian point must contain 'x' and 'y'",
            "A point must contain either 'x' and 'y' or 'latitude' and 'longitude'" /* in version < 3.4 */),
       params = Map("params" -> Map("y" -> 1.0, "crs" -> "cartesian")))
   }
 
   test("should fail properly if missing geographic longitude") {
-    failWithError(pointConfig, "RETURN point({params}) as point",
+    failWithError(pointConfig + Configs.Procs, "RETURN point({params}) as point",
       List("A wgs-84 point must contain 'latitude' and 'longitude'",
            "A point must contain either 'x' and 'y' or 'latitude' and 'longitude'" /* in version < 3.4 */),
       params = Map("params" -> Map("latitude" -> 1.0, "crs" -> "WGS-84")))
   }
 
   test("should fail properly if missing geographic latitude") {
-    failWithError(pointConfig, "RETURN point({params}) as point",
+    failWithError(pointConfig + Configs.Procs, "RETURN point({params}) as point",
       List("A wgs-84 point must contain 'latitude' and 'longitude'",
            "A point must contain either 'x' and 'y' or 'latitude' and 'longitude'" /* in version < 3.4 */),
       params = Map("params" -> Map("longitude" -> 1.0, "crs" -> "WGS-84")))
   }
 
   test("should fail properly if unknown coordinate system") {
-    failWithError(pointConfig, "RETURN point({params}) as point", List("'WGS-1337' is not a supported coordinate reference system for points",
+    failWithError(pointConfig + Configs.Procs, "RETURN point({params}) as point", List("'WGS-1337' is not a supported coordinate reference system for points",
       "Unknown coordinate reference system: WGS-1337"),
       params = Map("params" -> Map("x" -> 1, "y" -> 2, "crs" -> "WGS-1337")))
   }
@@ -170,7 +173,7 @@ class SpatialFunctionsAcceptanceTest extends ExecutionEngineFunSuite with Cypher
   }
 
   test("should not allow Cartesian CRS with latitude/longitude coordinates") {
-    failWithError(pointConfig, "RETURN point({longitude: 2.3, latitude: 4.5, crs: 'cartesian'}) as point",
+    failWithError(pointConfig + Configs.Procs, "RETURN point({longitude: 2.3, latitude: 4.5, crs: 'cartesian'}) as point",
       List("'cartesian' is not a supported coordinate reference system for geographic points",
         "Geographic points does not support coordinate reference system: cartesian"))
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
@@ -122,27 +122,27 @@ class SpatialFunctionsAcceptanceTest extends ExecutionEngineFunSuite with Cypher
     failWithError(pointConfig, "RETURN point({params}) as point",
       List("A cartesian point must contain 'x' and 'y'",
            "A point must contain either 'x' and 'y' or 'latitude' and 'longitude'" /* in version < 3.4 */),
-      params = "params" -> Map("y" -> 1.0, "crs" -> "cartesian"))
+      params = Map("params" -> Map("y" -> 1.0, "crs" -> "cartesian")))
   }
 
   test("should fail properly if missing geographic longitude") {
     failWithError(pointConfig, "RETURN point({params}) as point",
       List("A wgs-84 point must contain 'latitude' and 'longitude'",
            "A point must contain either 'x' and 'y' or 'latitude' and 'longitude'" /* in version < 3.4 */),
-      params = "params" -> Map("latitude" -> 1.0, "crs" -> "WGS-84"))
+      params = Map("params" -> Map("latitude" -> 1.0, "crs" -> "WGS-84")))
   }
 
   test("should fail properly if missing geographic latitude") {
     failWithError(pointConfig, "RETURN point({params}) as point",
       List("A wgs-84 point must contain 'latitude' and 'longitude'",
            "A point must contain either 'x' and 'y' or 'latitude' and 'longitude'" /* in version < 3.4 */),
-      params = "params" -> Map("longitude" -> 1.0, "crs" -> "WGS-84"))
+      params = Map("params" -> Map("longitude" -> 1.0, "crs" -> "WGS-84")))
   }
 
   test("should fail properly if unknown coordinate system") {
     failWithError(pointConfig, "RETURN point({params}) as point", List("'WGS-1337' is not a supported coordinate reference system for points",
       "Unknown coordinate reference system: WGS-1337"),
-      params = "params" -> Map("x" -> 1, "y" -> 2, "crs" -> "WGS-1337"))
+      params = Map("params" -> Map("x" -> 1, "y" -> 2, "crs" -> "WGS-1337")))
   }
 
   test("should default to Cartesian if missing cartesian CRS") {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TemporalAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TemporalAcceptanceTest.scala
@@ -29,6 +29,9 @@ import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
 
 class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with CypherComparisonSupport {
 
+  private val failConf1 = Configs.Interpreted + Configs.Procs - Configs.OldAndRule
+  private val failConf2 = Configs.Interpreted + Configs.Procs - Configs.Version2_3
+
   // Getting current value of a temporal
 
   test("should return something for current time/date/etc") {
@@ -127,301 +130,301 @@ class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistic
   {
     val query = "WITH datetime('1984-07-07T12:34+03:00[Europe/Stockholm]') as d RETURN d"
     val errorMsg = "Timezone and offset do not match"
-    failWithError(Configs.Interpreted - Configs.Version2_3 + Configs.Procs, query, Seq(errorMsg))
+    failWithError(Configs.Interpreted - Configs.Version2_3 + Configs.Procs, query, Seq(errorMsg), Seq("IllegalArgumentException"))
   }
 
   // Failing when selecting a wrong group
 
   test("should not select time from date") {
-    shouldNotSelectWithArg[IllegalArgumentException]("date({year:1984, month: 2, day:11})",
+    shouldNotSelectWithArg("date({year:1984, month: 2, day:11})",
       Seq("localtime", "time", "localdatetime", "datetime"), Seq("{time:x}", "x"))
   }
 
   test("should not select date from time") {
-    shouldNotSelectWithArg[IllegalArgumentException]("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})",
+    shouldNotSelectWithArg("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})",
       Seq("date", "localdatetime", "datetime"), Seq("{date:x}", "x"))
   }
 
   test("should not select date from local time") {
-    shouldNotSelectWithArg[IllegalArgumentException]("localtime({hour: 12, minute: 30, second: 40})",
+    shouldNotSelectWithArg("localtime({hour: 12, minute: 30, second: 40})",
       Seq("date", "localdatetime", "datetime"), Seq("{date:x}", "x"))
   }
 
   test("should not select datetime from date") {
-    shouldNotSelectWithArg[IllegalArgumentException]("date({year:1984, month: 2, day:11})",
+    shouldNotSelectWithArg("date({year:1984, month: 2, day:11})",
       Seq("localdatetime", "datetime"), Seq("{datetime:x}", "x"))
   }
 
   test("should not select datetime from time") {
-    shouldNotSelectWithArg[IllegalArgumentException]("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})",
+    shouldNotSelectWithArg("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})",
       Seq("localdatetime", "datetime"), Seq("{datetime:x}", "x"))
   }
 
   test("should not select datetime from local time") {
-    shouldNotSelectWithArg[IllegalArgumentException]("localtime({hour: 12, minute: 30, second: 40})",
+    shouldNotSelectWithArg("localtime({hour: 12, minute: 30, second: 40})",
       Seq("localdatetime", "datetime"), Seq("{datetime:x}", "x"))
   }
 
   test("should not select time into date") {
-    shouldNotSelectWithArg[IllegalArgumentException]("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})",
+    shouldNotSelectWithArg("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})",
       Seq("date"), Seq("{time:x}", "{hour: 12}", "{minute: 30}", "{second: 40}", "{year:1984, month: 2, day:11, timezone: '+1:00'}"))
   }
 
   test("should not select date into time") {
-    shouldNotSelectWithArg[IllegalArgumentException]("date({year:1984, month: 2, day:11})",
+    shouldNotSelectWithArg("date({year:1984, month: 2, day:11})",
       Seq("time"), Seq("{date:x}", "{year: 1984}", "{month: 2}", "{day: 11}"))
   }
 
   test("should not select date into local time") {
-    shouldNotSelectWithArg[IllegalArgumentException]("date({year:1984, month: 2, day:11})",
+    shouldNotSelectWithArg("date({year:1984, month: 2, day:11})",
       Seq("localtime"), Seq("{date:x}", "{year: 1984}", "{month: 2}", "{day: 11}"))
   }
 
   test("should not select datetime into date") {
-    shouldNotSelectWithArg[IllegalArgumentException]("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})",
+    shouldNotSelectWithArg("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})",
       Seq("date"), Seq("{datetime:x}"))
   }
 
   test("should not select datetime into time") {
-    shouldNotSelectWithArg[IllegalArgumentException]("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})",
+    shouldNotSelectWithArg("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})",
       Seq("time"), Seq("{datetime:x}"))
   }
 
   test("should not select datetime into local time") {
-    shouldNotSelectWithArg[IllegalArgumentException]("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})",
+    shouldNotSelectWithArg("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})",
       Seq("localtime"), Seq("{datetime:x}"))
   }
 
   // Truncating with wrong receiver or argument
 
   test("should not truncate to millennium with wrong receiver") {
-    shouldNotTruncate[UnsupportedTemporalTypeException](Seq("time", "localtime"), "millennium",
-      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"))
+    shouldNotTruncate(Seq("time", "localtime"), "millennium",
+      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"), "UnsupportedTemporalTypeException")
   }
 
   test("should not truncate to millennium with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("datetime", "localdatetime", "date"), "millennium",
-      Seq("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})", "localtime({hour: 12, minute: 30, second: 40})"))
+    shouldNotTruncate(Seq("datetime", "localdatetime", "date"), "millennium",
+      Seq("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})", "localtime({hour: 12, minute: 30, second: 40})"), "IllegalArgumentException")
   }
 
   test("should not truncate to century with wrong receiver") {
-    shouldNotTruncate[UnsupportedTemporalTypeException](Seq("time", "localtime"), "century",
-      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"))
+    shouldNotTruncate(Seq("time", "localtime"), "century",
+      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"), "UnsupportedTemporalTypeException")
   }
 
   test("should not truncate to century with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("datetime", "localdatetime", "date"), "century",
-      Seq("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})", "localtime({hour: 12, minute: 30, second: 40})"))
+    shouldNotTruncate(Seq("datetime", "localdatetime", "date"), "century",
+      Seq("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})", "localtime({hour: 12, minute: 30, second: 40})"), "IllegalArgumentException")
   }
 
   test("should not truncate to decade with wrong receiver") {
-    shouldNotTruncate[UnsupportedTemporalTypeException](Seq("time", "localtime"), "decade",
-      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"))
+    shouldNotTruncate(Seq("time", "localtime"), "decade",
+      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"), "UnsupportedTemporalTypeException")
   }
 
   test("should not truncate to decade with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("datetime", "localdatetime", "date"), "decade",
-      Seq("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})", "localtime({hour: 12, minute: 30, second: 40})"))
+    shouldNotTruncate(Seq("datetime", "localdatetime", "date"), "decade",
+      Seq("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})", "localtime({hour: 12, minute: 30, second: 40})"), "IllegalArgumentException")
   }
 
   test("should not truncate to year with wrong receiver") {
-    shouldNotTruncate[UnsupportedTemporalTypeException](Seq("time", "localtime"), "year",
-      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"))
+    shouldNotTruncate(Seq("time", "localtime"), "year",
+      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"), "UnsupportedTemporalTypeException")
   }
 
   test("should not truncate to year with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("datetime", "localdatetime", "date"), "year",
-      Seq("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})", "localtime({hour: 12, minute: 30, second: 40})"))
+    shouldNotTruncate(Seq("datetime", "localdatetime", "date"), "year",
+      Seq("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})", "localtime({hour: 12, minute: 30, second: 40})"), "IllegalArgumentException")
   }
 
   test("should not truncate to weekYear with wrong receiver") {
-    shouldNotTruncate[UnsupportedTemporalTypeException](Seq("time", "localtime"), "weekYear",
-      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"))
+    shouldNotTruncate(Seq("time", "localtime"), "weekYear",
+      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"), "UnsupportedTemporalTypeException")
   }
 
   test("should not truncate to weekYear with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("datetime", "localdatetime", "date"), "weekYear",
-      Seq("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})", "localtime({hour: 12, minute: 30, second: 40})"))
+    shouldNotTruncate(Seq("datetime", "localdatetime", "date"), "weekYear",
+      Seq("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})", "localtime({hour: 12, minute: 30, second: 40})"), "IllegalArgumentException")
   }
 
   test("should not truncate to quarter with wrong receiver") {
-    shouldNotTruncate[UnsupportedTemporalTypeException](Seq("time", "localtime"), "quarter",
-      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"))
+    shouldNotTruncate(Seq("time", "localtime"), "quarter",
+      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"), "UnsupportedTemporalTypeException")
   }
 
   test("should not truncate to quarter with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("datetime", "localdatetime", "date"), "quarter",
-      Seq("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})", "localtime({hour: 12, minute: 30, second: 40})"))
+    shouldNotTruncate(Seq("datetime", "localdatetime", "date"), "quarter",
+      Seq("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})", "localtime({hour: 12, minute: 30, second: 40})"), "IllegalArgumentException")
   }
 
   test("should not truncate to month with wrong receiver") {
-    shouldNotTruncate[UnsupportedTemporalTypeException](Seq("time", "localtime"), "month",
-      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"))
+    shouldNotTruncate(Seq("time", "localtime"), "month",
+      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"), "UnsupportedTemporalTypeException")
   }
 
   test("should not truncate to month with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("datetime", "localdatetime", "date"), "month",
-      Seq("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})", "localtime({hour: 12, minute: 30, second: 40})"))
+    shouldNotTruncate(Seq("datetime", "localdatetime", "date"), "month",
+      Seq("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})", "localtime({hour: 12, minute: 30, second: 40})"), "IllegalArgumentException")
   }
 
   test("should not truncate to week with wrong receiver") {
-    shouldNotTruncate[UnsupportedTemporalTypeException](Seq("time", "localtime"), "week",
-      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"))
+    shouldNotTruncate(Seq("time", "localtime"), "week",
+      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"), "UnsupportedTemporalTypeException")
   }
 
   test("should not truncate to week with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("datetime", "localdatetime", "date"), "week",
-      Seq("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})", "localtime({hour: 12, minute: 30, second: 40})"))
+    shouldNotTruncate(Seq("datetime", "localdatetime", "date"), "week",
+      Seq("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})", "localtime({hour: 12, minute: 30, second: 40})"), "IllegalArgumentException")
   }
 
   test("should not truncate to day with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("datetime", "localdatetime", "date"), "day",
-      Seq("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})", "localtime({hour: 12, minute: 30, second: 40})"))
+    shouldNotTruncate(Seq("datetime", "localdatetime", "date"), "day",
+      Seq("time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})", "localtime({hour: 12, minute: 30, second: 40})"), "IllegalArgumentException")
   }
 
   test("should not truncate to hour with wrong receiver") {
-    shouldNotTruncate[UnsupportedTemporalTypeException](Seq("date"), "hour",
-      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"))
+    shouldNotTruncate(Seq("date"), "hour",
+      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"), "UnsupportedTemporalTypeException")
   }
 
   test("should not truncate datetime to hour with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("datetime"), "hour",
+    shouldNotTruncate(Seq("datetime"), "hour",
       Seq("date({year:1984, month: 2, day:11})",
         "time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})",
-        "localtime({hour: 12, minute: 30, second: 40})"))
+        "localtime({hour: 12, minute: 30, second: 40})"), "IllegalArgumentException")
   }
 
   test("should not truncate localdatetime to hour with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("localdatetime"), "hour",
+    shouldNotTruncate(Seq("localdatetime"), "hour",
       Seq("date({year:1984, month: 2, day:11})",
         "time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})",
-        "localtime({hour: 12, minute: 30, second: 40})"))
+        "localtime({hour: 12, minute: 30, second: 40})"), "IllegalArgumentException")
   }
 
   test("should not truncate time to hour with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("time"), "hour",
-      Seq("date({year:1984, month: 2, day:11})"))
+    shouldNotTruncate(Seq("time"), "hour",
+      Seq("date({year:1984, month: 2, day:11})"), "IllegalArgumentException")
   }
 
   test("should not truncate localtime to hour with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("localtime"), "hour",
-      Seq("date({year:1984, month: 2, day:11})"))
+    shouldNotTruncate(Seq("localtime"), "hour",
+      Seq("date({year:1984, month: 2, day:11})"), "IllegalArgumentException")
   }
 
   test("should not truncate to minute with wrong receiver") {
-    shouldNotTruncate[UnsupportedTemporalTypeException](Seq("date"), "minute",
-      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"))
+    shouldNotTruncate(Seq("date"), "minute",
+      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"), "UnsupportedTemporalTypeException")
   }
 
   test("should not truncate datetime to minute with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("datetime"), "minute",
+    shouldNotTruncate(Seq("datetime"), "minute",
       Seq("date({year:1984, month: 2, day:11})",
         "time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})",
-        "localtime({hour: 12, minute: 30, second: 40})"))
+        "localtime({hour: 12, minute: 30, second: 40})"), "IllegalArgumentException")
   }
 
   test("should not truncate localdatetime to minute with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("localdatetime"), "minute",
+    shouldNotTruncate(Seq("localdatetime"), "minute",
       Seq("date({year:1984, month: 2, day:11})",
         "time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})",
-        "localtime({hour: 12, minute: 30, second: 40})"))
+        "localtime({hour: 12, minute: 30, second: 40})"), "IllegalArgumentException")
   }
 
   test("should not truncate time to minute with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("time"), "minute",
-      Seq("date({year:1984, month: 2, day:11})"))
+    shouldNotTruncate(Seq("time"), "minute",
+      Seq("date({year:1984, month: 2, day:11})"), "IllegalArgumentException")
   }
 
   test("should not truncate localtime to minute with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("localtime"), "minute",
-      Seq("date({year:1984, month: 2, day:11})"))
+    shouldNotTruncate(Seq("localtime"), "minute",
+      Seq("date({year:1984, month: 2, day:11})"), "IllegalArgumentException")
   }
 
   test("should not truncate to second with wrong receiver") {
-    shouldNotTruncate[UnsupportedTemporalTypeException](Seq("date"), "second",
-      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"))
+    shouldNotTruncate(Seq("date"), "second",
+      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"), "UnsupportedTemporalTypeException")
   }
 
   test("should not truncate datetime to second with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("datetime"), "second",
+    shouldNotTruncate(Seq("datetime"), "second",
       Seq("date({year:1984, month: 2, day:11})",
         "time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})",
-        "localtime({hour: 12, minute: 30, second: 40})"))
+        "localtime({hour: 12, minute: 30, second: 40})"), "IllegalArgumentException")
   }
 
   test("should not truncate localdatetime to second with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("localdatetime"), "second",
+    shouldNotTruncate(Seq("localdatetime"), "second",
       Seq("date({year:1984, month: 2, day:11})",
         "time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})",
-        "localtime({hour: 12, minute: 30, second: 40})"))
+        "localtime({hour: 12, minute: 30, second: 40})"), "IllegalArgumentException")
   }
 
   test("should not truncate time to second with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("time"), "second",
-      Seq("date({year:1984, month: 2, day:11})"))
+    shouldNotTruncate(Seq("time"), "second",
+      Seq("date({year:1984, month: 2, day:11})"), "IllegalArgumentException")
   }
 
   test("should not truncate localtime to second with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("localtime"), "second",
-      Seq("date({year:1984, month: 2, day:11})"))
+    shouldNotTruncate(Seq("localtime"), "second",
+      Seq("date({year:1984, month: 2, day:11})"), "IllegalArgumentException")
   }
 
   test("should not truncate to millisecond with wrong receiver") {
-    shouldNotTruncate[UnsupportedTemporalTypeException](Seq("date"), "millisecond",
-      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"))
+    shouldNotTruncate(Seq("date"), "millisecond",
+      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"), "UnsupportedTemporalTypeException")
   }
 
   test("should not truncate datetime to millisecond with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("datetime"), "millisecond",
+    shouldNotTruncate(Seq("datetime"), "millisecond",
       Seq("date({year:1984, month: 2, day:11})",
         "time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})",
-        "localtime({hour: 12, minute: 30, second: 40})"))
+        "localtime({hour: 12, minute: 30, second: 40})"), "IllegalArgumentException")
   }
 
   test("should not truncate localdatetime to millisecond with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("localdatetime"), "millisecond",
+    shouldNotTruncate(Seq("localdatetime"), "millisecond",
       Seq("date({year:1984, month: 2, day:11})",
         "time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})",
-        "localtime({hour: 12, minute: 30, second: 40})"))
+        "localtime({hour: 12, minute: 30, second: 40})"), "IllegalArgumentException")
   }
 
   test("should not truncate time to millisecond with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("time"), "millisecond",
-      Seq("date({year:1984, month: 2, day:11})"))
+    shouldNotTruncate(Seq("time"), "millisecond",
+      Seq("date({year:1984, month: 2, day:11})"), "IllegalArgumentException")
   }
 
   test("should not truncate localtime to millisecond with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("localtime"), "millisecond",
-      Seq("date({year:1984, month: 2, day:11})"))
+    shouldNotTruncate(Seq("localtime"), "millisecond",
+      Seq("date({year:1984, month: 2, day:11})"), "IllegalArgumentException")
   }
 
   test("should not truncate to microsecond with wrong receiver") {
-    shouldNotTruncate[UnsupportedTemporalTypeException](Seq("date"), "microsecond",
-      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"))
+    shouldNotTruncate(Seq("date"), "microsecond",
+      Seq("datetime({year:1984, month: 2, day:11, hour: 12, minute: 30, second: 40, timezone:'+01:00'})"), "UnsupportedTemporalTypeException")
   }
 
   test("should not truncate datetime to microsecond with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("datetime"), "microsecond",
+    shouldNotTruncate(Seq("datetime"), "microsecond",
       Seq("date({year:1984, month: 2, day:11})",
         "time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})",
-        "localtime({hour: 12, minute: 30, second: 40})"))
+        "localtime({hour: 12, minute: 30, second: 40})"), "IllegalArgumentException")
   }
 
   test("should not truncate localdatetime to microsecond with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("localdatetime"), "microsecond",
+    shouldNotTruncate(Seq("localdatetime"), "microsecond",
       Seq("date({year:1984, month: 2, day:11})",
         "time({hour: 12, minute: 30, second: 40, timezone:'+01:00'})",
-        "localtime({hour: 12, minute: 30, second: 40})"))
+        "localtime({hour: 12, minute: 30, second: 40})"), "IllegalArgumentException")
   }
 
   test("should not truncate time to microsecond with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("time"), "microsecond",
-      Seq("date({year:1984, month: 2, day:11})"))
+    shouldNotTruncate(Seq("time"), "microsecond",
+      Seq("date({year:1984, month: 2, day:11})"), "IllegalArgumentException")
   }
 
   test("should not truncate localtime to microsecond with wrong argument") {
-    shouldNotTruncate[IllegalArgumentException](Seq("localtime"), "microsecond",
-      Seq("date({year:1984, month: 2, day:11})"))
+    shouldNotTruncate(Seq("localtime"), "microsecond",
+      Seq("date({year:1984, month: 2, day:11})"), "IllegalArgumentException")
   }
 
   // Arithmetic
@@ -490,9 +493,7 @@ class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistic
     for (func <- Seq("inMonths", "inDays"); arg1 <- args; arg2 <- args) {
       val query = s"RETURN duration.$func($arg1, $arg2)"
       withClue(s"Executing $query") {
-        an[UnsupportedTemporalTypeException] shouldBe thrownBy {
-          println(graph.execute(query).next())
-        }
+        failWithError(failConf2, query, Seq.empty, Seq("UnsupportedTemporalTypeException"))
       }
     }
   }
@@ -503,9 +504,11 @@ class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistic
     for (op <- Seq("<", "<=", ">", ">=")) {
       val query = s"RETURN duration('P1Y1M') $op duration('P1Y30D')"
       withClue(s"Executing $query") {
-        an[QueryExecutionException] shouldBe thrownBy {
-          println(graph.execute(query).next())
-        }
+        /**
+          *  Version 3.3 returns null instead due to running with 3.4 runtime
+          *  SyntaxException come from the 3.4 planner and IncomparableValuesException from earlier runtimes
+          */
+        failWithError(Configs.Version3_4 + Configs.OldAndRule + Configs.Procs, query, Seq.empty, Seq("SyntaxException", "IncomparableValuesException"))
       }
     }
   }
@@ -514,6 +517,7 @@ class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistic
     for (op <- Seq("<", "<=", ">", ">=")) {
       val query = "RETURN $d1 " + op + " $d2 as x"
       withClue(s"Executing $query") {
+        // TODO: change to using executeWith when compiled supports temporal parameters
         val res = innerExecuteDeprecated(query, Map("d1" -> DurationValue.duration(1, 0, 0 ,0), "d2" -> DurationValue.duration(0, 30, 0 ,0))).toList
         res should be(List(Map("x" -> null)))
       }
@@ -526,31 +530,26 @@ class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistic
     for (func <- Seq("time", "localtime", "date", "datetime", "localdatetime", "duration")) {
       val query = s"RETURN $func('', '', '', '')"
       withClue(s"Executing $query") {
-        an[QueryExecutionException] shouldBe thrownBy {
-          println(graph.execute(query).next())
-        }
+        failWithError(Configs.AbsolutelyAll - Configs.Version2_3, query,
+          Seq("Function call does not provide the required number of arguments"), Seq("SyntaxException"))
       }
     }
   }
 
-  private def shouldNotTruncate[E : Manifest](receivers: Seq[String], truncationUnit: String, args: Seq[String]): Unit = {
+  private def shouldNotTruncate(receivers: Seq[String], truncationUnit: String, args: Seq[String], errorType: String): Unit = {
     for (receiver <- receivers; arg <- args) {
       val query = s"RETURN $receiver.truncate('$truncationUnit', $arg)"
       withClue(s"Executing $query") {
-        an[E] shouldBe thrownBy {
-          println(graph.execute(query).next())
-        }
+        failWithError(failConf2, query, Seq.empty, Seq(errorType))
       }
     }
   }
 
-  private def shouldNotSelectWithArg[E : Manifest](withX: String, returnFuncs: Seq[String], args: Seq[String]): Unit = {
+  private def shouldNotSelectWithArg(withX: String, returnFuncs: Seq[String], args: Seq[String]): Unit = {
     for (func <- returnFuncs; arg <- args) {
       val query = s"WITH $withX as x RETURN $func($arg)"
       withClue(s"Executing $query") {
-        an[E] shouldBe thrownBy {
-          println(graph.execute(query).next())
-        }
+        failWithError(failConf2, query, Seq.empty, Seq("IllegalArgumentException"))
       }
     }
   }
@@ -559,9 +558,7 @@ class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistic
     for (acc <- accessors) {
       val query = s"RETURN $typ($args).$acc"
       withClue(s"Executing $query") {
-        an[UnsupportedTemporalTypeException] shouldBe thrownBy {
-          println(graph.execute(query).next())
-        }
+        failWithError(failConf1, query, Seq.empty, Seq("UnsupportedTemporalTypeException"))
       }
     }
   }
@@ -570,9 +567,7 @@ class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistic
     for (arg <- args) {
       val query = s"RETURN $func($arg)"
       withClue(s"Executing $query") {
-        an[IllegalArgumentException] shouldBe thrownBy {
-          println(graph.execute(query).next())
-        }
+        failWithError(failConf2, query, Seq.empty, Seq("IllegalArgumentException"))
       }
     }
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TemporalAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TemporalAcceptanceTest.scala
@@ -127,7 +127,7 @@ class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistic
   {
     val query = "WITH datetime('1984-07-07T12:34+03:00[Europe/Stockholm]') as d RETURN d"
     val errorMsg = "Timezone and offset do not match"
-    failWithError(Configs.Interpreted - Configs.Version2_3, query, Seq(errorMsg))
+    failWithError(Configs.Interpreted - Configs.Version2_3 + Configs.Procs, query, Seq(errorMsg))
   }
 
   // Failing when selecting a wrong group

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UsingAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UsingAcceptanceTest.scala
@@ -157,7 +157,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
         |RETURN n""".stripMargin
 
     // WHEN
-    failWithError(Configs.AbsolutelyAll + Configs.Morsel, query, List("No such index"), params = "foo" -> 42)
+    failWithError(Configs.AbsolutelyAll + Configs.Morsel, query, List("No such index"), params = Map("foo" -> 42))
   }
 
   test("should succeed (i.e. no warnings or errors) if executing a query using a 'USING INDEX' which can be fulfilled") {


### PR DESCRIPTION
Refactoring of the `failWithError` method to allow better checks of Java exceptions