### PR TITLE
Unflake QueryResultsSerializationTest

### DIFF
--- a/community/server/src/test/java/org/neo4j/test/server/SharedServerTestBase.java
+++ b/community/server/src/test/java/org/neo4j/test/server/SharedServerTestBase.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Callable;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.server.NeoServer;
+import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.helpers.ServerHelper;
 import org.neo4j.test.rule.SuppressOutput;
 
@@ -51,7 +52,8 @@ public class SharedServerTestBase
         suppressAll().call( (Callable<Void>) () ->
         {
             ServerHolder.setServerBuilderProperty( GraphDatabaseSettings.cypher_hints_error.name(), "true" );
-            ServerHolder.setServerBuilderProperty( GraphDatabaseSettings.transaction_timeout.name(), "120s" );
+            ServerHolder.setServerBuilderProperty( GraphDatabaseSettings.transaction_timeout.name(), "300s" );
+            ServerHolder.setServerBuilderProperty( ServerSettings.transaction_idle_timeout.name(), "300s" );
             server = ServerHolder.allocate();
             ServerHelper.cleanTheDatabase( server );
             return null;


### PR DESCRIPTION
Increased transaction time out value to `300s` and added explicit `dbms.rest.transaction.idle_timeout=300s` configuration property.