### PR TITLE
Cleanup leftovers from previous population on any new index population

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceIntegrationTest.java
@@ -252,7 +252,7 @@ public class ConsistencyCheckServiceIntegrationTest
         String propKey = "propKey";
 
         // Given a lucene index
-        GraphDatabaseService db = getGraphDatabaseService( storeDir, defaultSchemaProvider, LUCENE10.param() );
+        GraphDatabaseService db = getGraphDatabaseService( storeDir, defaultSchemaProvider, LUCENE10.providerName() );
         createIndex( db, label, propKey );
         try ( Transaction tx = db.beginTx() )
         {
@@ -264,7 +264,7 @@ public class ConsistencyCheckServiceIntegrationTest
 
         ConsistencyCheckService service = new ConsistencyCheckService();
         Config configuration =
-                Config.defaults( settings( defaultSchemaProvider, NATIVE20.param() ) );
+                Config.defaults( settings( defaultSchemaProvider, NATIVE20.providerName() ) );
         Result result = runFullConsistencyCheck( service, configuration, storeDir );
         assertTrue( result.isSuccessful() );
     }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GroupingRecoveryCleanupWorkCollector.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GroupingRecoveryCleanupWorkCollector.java
@@ -36,6 +36,7 @@ public class GroupingRecoveryCleanupWorkCollector extends LifecycleAdapter imple
 {
     private final Queue<CleanupJob> jobs;
     private final JobScheduler jobScheduler;
+    private volatile boolean started;
 
     /**
      * @param jobScheduler {@link JobScheduler} to queue {@link CleanupJob} into.
@@ -49,20 +50,25 @@ public class GroupingRecoveryCleanupWorkCollector extends LifecycleAdapter imple
     @Override
     public void init()
     {
+        started = false;
         jobs.clear();
     }
 
     @Override
     public void add( CleanupJob job )
     {
+        if ( started )
+        {
+            throw new IllegalStateException( "Index clean jobs can't be added after collector start." );
+        }
         jobs.add( job );
-
     }
 
     @Override
     public void start()
     {
         scheduleJobs();
+        started = true;
     }
 
     private void scheduleJobs()

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GroupingRecoveryCleanupWorkCollectorTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GroupingRecoveryCleanupWorkCollectorTest.java
@@ -104,31 +104,7 @@ public class GroupingRecoveryCleanupWorkCollectorTest
     }
 
     @Test
-    public void scheduleJobsThatWhereAddedAfterStart()
-    {
-        List<CleanupJob> allRuns = new ArrayList<>();
-        List<CleanupJob> expectedJobs = new ArrayList<>();
-
-        collector.init();
-        collector.start();
-
-        assertSame( expectedJobs, allRuns );
-
-        DummyJob firstJob = new DummyJob( "first", allRuns );
-        expectedJobs.add( firstJob );
-        collector.add( firstJob );
-
-        assertSame( expectedJobs, allRuns );
-
-        DummyJob secondJob = new DummyJob( "second", allRuns );
-        expectedJobs.add( secondJob );
-        collector.add( secondJob );
-
-        assertSame( expectedJobs, allRuns );
-    }
-
-    @Test
-    public void mustNotScheduleOldJobsOnStartStopStart()
+    public void mustNotScheduleOldJobsOnStartStopStart() throws Throwable
     {
         // given
         List<CleanupJob> allRuns = new ArrayList<>();

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GroupingRecoveryCleanupWorkCollectorTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GroupingRecoveryCleanupWorkCollectorTest.java
@@ -150,6 +150,23 @@ public class GroupingRecoveryCleanupWorkCollectorTest
         assertSame( expectedJobs, allRuns );
     }
 
+    @Test
+    public void throwOnAddingJobsAfterStart()
+    {
+        collector.init();
+        collector.start();
+
+        try
+        {
+            collector.add( new DummyJob( "first", new ArrayList<>() ) );
+            fail( "Collector should not acccept new jobs after start." );
+        }
+        catch ( IllegalStateException ise )
+        {
+            // expected
+        }
+    }
+
     private void addAll( Collection<CleanupJob> jobs )
     {
         jobs.forEach( collector::add );

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -516,23 +516,23 @@ public class GraphDatabaseSettings implements LoadableConfig
         NATIVE10( "lucene+native-1.0" ),
         LUCENE10( "lucene-1.0" );
 
-        private final String param;
+        private final String providerName;
 
-        SchemaIndex( String param )
+        SchemaIndex( String providerName )
         {
-            this.param = param;
+            this.providerName = providerName;
         }
 
-        public String param()
+        public String providerName()
         {
-            return param;
+            return providerName;
         }
     }
 
     @Description( "Index provider to use when creating new indexes." )
     public static final Setting<String> default_schema_provider =
             setting( "dbms.index.default_schema_provider",
-                    optionsIgnoreCase( SchemaIndex.NATIVE20.param(), SchemaIndex.NATIVE10.param(), SchemaIndex.LUCENE10.param() ),
+                    optionsIgnoreCase( SchemaIndex.NATIVE20.providerName(), SchemaIndex.NATIVE10.providerName(), SchemaIndex.LUCENE10.providerName() ),
                     null );
 
     @Description( "Location where Neo4j keeps the logical transaction logs." )

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/GraphDatabaseConfigurationMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/GraphDatabaseConfigurationMigrator.java
@@ -126,7 +126,8 @@ public class GraphDatabaseConfigurationMigrator extends BaseConfigurationMigrato
             {
                 if ( value.equals( Settings.FALSE ) )
                 {
-                    rawConfiguration.putIfAbsent( GraphDatabaseSettings.default_schema_provider.name(), GraphDatabaseSettings.SchemaIndex.LUCENE10.param() );
+                    rawConfiguration.putIfAbsent( GraphDatabaseSettings.default_schema_provider.name(),
+                            GraphDatabaseSettings.SchemaIndex.LUCENE10.providerName() );
                 }
             }
         } );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulator.java
@@ -38,18 +38,20 @@ class FusionIndexPopulator extends FusionIndexBase<IndexPopulator> implements In
 {
     private final long indexId;
     private final DropAction dropAction;
+    private final boolean archiveFailedIndex;
 
-    FusionIndexPopulator( IndexPopulator[] populators, Selector selector, long indexId, DropAction dropAction )
+    FusionIndexPopulator( IndexPopulator[] populators, Selector selector, long indexId, DropAction dropAction, boolean archiveFailedIndex )
     {
         super( populators, selector );
         this.indexId = indexId;
         this.dropAction = dropAction;
+        this.archiveFailedIndex = archiveFailedIndex;
     }
 
     @Override
     public void create() throws IOException
     {
-        dropAction.drop( indexId );
+        dropAction.drop( indexId, archiveFailedIndex );
         forAll( IndexPopulator::create, instances );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulator.java
@@ -49,6 +49,7 @@ class FusionIndexPopulator extends FusionIndexBase<IndexPopulator> implements In
     @Override
     public void create() throws IOException
     {
+        dropAction.drop( indexId );
         forAll( IndexPopulator::create, instances );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/TestGraphDatabaseConfigurationMigrator.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/TestGraphDatabaseConfigurationMigrator.java
@@ -172,7 +172,7 @@ public class TestGraphDatabaseConfigurationMigrator
     {
         Map<String,String> migratedProperties = migrator.apply( stringMap( "unsupported.dbms.enable_native_schema_index", "false" ), getLog() );
         assertEquals( "Old property should be migrated to new",
-                migratedProperties, stringMap( "dbms.index.default_schema_provider", LUCENE10.param() ));
+                migratedProperties, stringMap( "dbms.index.default_schema_provider", LUCENE10.providerName() ));
 
         assertContainsWarningMessage("unsupported.dbms.enable_native_schema_index has been replaced with dbms.index.default_schema_provider.");
     }
@@ -180,8 +180,8 @@ public class TestGraphDatabaseConfigurationMigrator
     @Test
     public void skipMigrationOfEnableNativeSchemaIndexIfNotPresent()
     {
-        Map<String,String> migratedProperties = migrator.apply( stringMap( "dbms.index.default_schema_provider", NATIVE10.param() ), getLog() );
-        assertEquals( "Nothing to migrate", migratedProperties, stringMap( "dbms.index.default_schema_provider", NATIVE10.param() ) );
+        Map<String,String> migratedProperties = migrator.apply( stringMap( "dbms.index.default_schema_provider", NATIVE10.providerName() ), getLog() );
+        assertEquals( "Nothing to migrate", migratedProperties, stringMap( "dbms.index.default_schema_provider", NATIVE10.providerName() ) );
         logProvider.assertNoLoggingOccurred();
     }
 
@@ -189,11 +189,11 @@ public class TestGraphDatabaseConfigurationMigrator
     public void skipMigrationOfEnableNativeSchemaIndexIfDefaultSchemaIndexConfigured()
     {
         Map<String,String> migratedProperties = migrator.apply( stringMap(
-                "dbms.index.default_schema_provider", NATIVE10.param(),
+                "dbms.index.default_schema_provider", NATIVE10.providerName(),
                 "unsupported.dbms.enable_native_schema_index", "false"
                 ), getLog() );
         assertEquals( "Should keep pre configured default schema index.",
-                migratedProperties, stringMap( "dbms.index.default_schema_provider", NATIVE10.param() ) );
+                migratedProperties, stringMap( "dbms.index.default_schema_provider", NATIVE10.providerName() ) );
         assertContainsWarningMessage();
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulatorTest.java
@@ -146,6 +146,14 @@ public class FusionIndexPopulatorTest
     }
 
     @Test
+    public void createRemoveAnyLeftOversThatWasThereInIndexDirectoryBeforePopulation() throws IOException
+    {
+        fusionIndexPopulator.create();
+
+        verify( dropAction ).drop( indexId );
+    }
+
+    @Test
     public void createMustThrowIfAnyThrow() throws Exception
     {
         for ( IndexPopulator alivePopulator : alivePopulators )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulatorTest.java
@@ -119,7 +119,7 @@ public class FusionIndexPopulatorTest
                 throw new RuntimeException();
             }
         }
-        fusionIndexPopulator = new FusionIndexPopulator( populators, fusionVersion.selector(), indexId, dropAction );
+        fusionIndexPopulator = new FusionIndexPopulator( populators, fusionVersion.selector(), indexId, dropAction, false );
     }
 
     private void resetMocks()
@@ -150,7 +150,7 @@ public class FusionIndexPopulatorTest
     {
         fusionIndexPopulator.create();
 
-        verify( dropAction ).drop( indexId );
+        verify( dropAction ).drop( indexId, false );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexProviderTest.java
@@ -318,7 +318,7 @@ public class FusionIndexProviderTest
                 providers[SPATIAL],
                 providers[TEMPORAL],
                 providers[LUCENE],
-                fusionVersion.selector(), DESCRIPTOR, 10, NONE, mock( FileSystemAbstraction.class ) );
+                fusionVersion.selector(), DESCRIPTOR, 10, NONE, mock( FileSystemAbstraction.class ), true );
     }
 
     private IndexProvider mockProvider( Class<? extends IndexProvider> providerClass, String name )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexProviderTest.java
@@ -318,7 +318,7 @@ public class FusionIndexProviderTest
                 providers[SPATIAL],
                 providers[TEMPORAL],
                 providers[LUCENE],
-                fusionVersion.selector(), DESCRIPTOR, 10, NONE, mock( FileSystemAbstraction.class ), true );
+                fusionVersion.selector(), DESCRIPTOR, 10, NONE, mock( FileSystemAbstraction.class ), false );
     }
 
     private IndexProvider mockProvider( Class<? extends IndexProvider> providerClass, String name )

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/builder/LuceneIndexStorageBuilder.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/builder/LuceneIndexStorageBuilder.java
@@ -37,7 +37,6 @@ public class LuceneIndexStorageBuilder
     private FileSystemAbstraction fileSystem;
     private File indexRootFolder;
     private PartitionedIndexStorage indexStorage;
-    private boolean archiveFailed;
 
     private LuceneIndexStorageBuilder()
     {
@@ -65,7 +64,7 @@ public class LuceneIndexStorageBuilder
             Objects.requireNonNull( directoryFactory );
             Objects.requireNonNull( fileSystem );
             Objects.requireNonNull( indexRootFolder );
-            indexStorage = new PartitionedIndexStorage( directoryFactory, fileSystem, indexRootFolder, archiveFailed );
+            indexStorage = new PartitionedIndexStorage( directoryFactory, fileSystem, indexRootFolder );
         }
         return indexStorage;
     }
@@ -115,12 +114,6 @@ public class LuceneIndexStorageBuilder
     public LuceneIndexStorageBuilder withIndexStorage( PartitionedIndexStorage indexStorage )
     {
         this.indexStorage = indexStorage;
-        return this;
-    }
-
-    public LuceneIndexStorageBuilder archivingFailed( boolean archiveFailed )
-    {
-        this.archiveFailed = archiveFailed;
         return this;
     }
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/IndexStorageFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/IndexStorageFactory.java
@@ -35,8 +35,8 @@ public class IndexStorageFactory
         this.structure = structure;
     }
 
-    public PartitionedIndexStorage indexStorageOf( long indexId, boolean archiveFailed )
+    public PartitionedIndexStorage indexStorageOf( long indexId )
     {
-        return new PartitionedIndexStorage( dirFactory, fileSystem, structure.directoryForIndex( indexId ), archiveFailed );
+        return new PartitionedIndexStorage( dirFactory, fileSystem, structure.directoryForIndex( indexId ) );
     }
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/PartitionedIndexStorage.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/PartitionedIndexStorage.java
@@ -21,8 +21,6 @@ package org.neo4j.kernel.api.impl.index.storage;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.IOContext;
-import org.apache.lucene.store.IndexInput;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,8 +30,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
 
 import org.neo4j.io.IOUtils;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -56,15 +52,12 @@ public class PartitionedIndexStorage
 
     private final DirectoryFactory directoryFactory;
     private final FileSystemAbstraction fileSystem;
-    private final boolean archiveFailed;
     private final FolderLayout folderLayout;
     private final FailureStorage failureStorage;
 
-    public PartitionedIndexStorage( DirectoryFactory directoryFactory, FileSystemAbstraction fileSystem,
-            File rootFolder, boolean archiveFailed )
+    public PartitionedIndexStorage( DirectoryFactory directoryFactory, FileSystemAbstraction fileSystem, File rootFolder )
     {
         this.fileSystem = fileSystem;
-        this.archiveFailed = archiveFailed;
         this.folderLayout = new IndexFolderLayout( rootFolder );
         this.directoryFactory = directoryFactory;
         this.failureStorage = new FailureStorage( fileSystem, folderLayout );
@@ -146,7 +139,7 @@ public class PartitionedIndexStorage
      */
     public void prepareFolder( File folder ) throws IOException
     {
-        cleanupFolder( folder, archiveFailed );
+        cleanupFolder( folder );
         fileSystem.mkdirs( folder );
     }
 
@@ -159,40 +152,15 @@ public class PartitionedIndexStorage
      */
     public void cleanupFolder( File folder ) throws IOException
     {
-        cleanupFolder( folder, false );
-    }
-
-    private void cleanupFolder( File folder, boolean archiveFailed ) throws IOException
-    {
         List<File> partitionFolders = listFolders( folder );
         if ( !partitionFolders.isEmpty() )
         {
-            try ( ZipOutputStream zip = archiveFile( folder, archiveFailed ) )
+            for ( File partitionFolder : partitionFolders )
             {
-                byte[] buffer = null;
-                if ( zip != null )
-                {
-                    buffer = new byte[4 * 1024];
-                }
-                for ( File partitionFolder : partitionFolders )
-                {
-                    cleanupLuceneDirectory( partitionFolder, zip, buffer );
-                }
+                cleanupLuceneDirectory( partitionFolder );
             }
         }
         fileSystem.deleteRecursively( folder );
-    }
-
-    private ZipOutputStream archiveFile( File folder, boolean archiveFailed ) throws IOException
-    {
-        ZipOutputStream zip = null;
-        if ( archiveFailed )
-        {
-            File archiveFile = new File( folder.getParent(),
-                    "archive-" + folder.getName() + "-" + System.currentTimeMillis() + ".zip" );
-            zip = new ZipOutputStream( fileSystem.openAsOutputStream( archiveFile, false ) );
-        }
-        return zip;
     }
 
     /**
@@ -256,38 +224,15 @@ public class PartitionedIndexStorage
      * Uses {@link FileUtils#windowsSafeIOOperation(FileUtils.FileOperation)} underneath.
      *
      * @param folder the path to the directory to cleanup.
-     * @param zip an optional zip output stream to archive files into.
-     * @param buffer a byte buffer to use for copying bytes from the files into the archive.
      * @throws IOException if removal operation fails.
      */
-    private void cleanupLuceneDirectory( File folder, ZipOutputStream zip, byte[] buffer ) throws IOException
+    private void cleanupLuceneDirectory( File folder ) throws IOException
     {
         try ( Directory dir = directoryFactory.open( folder ) )
         {
-            String folderName = folder.getName() + "/";
-            if ( zip != null )
-            {
-                zip.putNextEntry( new ZipEntry( folderName ) );
-                zip.closeEntry();
-            }
             String[] indexFiles = dir.listAll();
             for ( String indexFile : indexFiles )
             {
-                if ( zip != null )
-                {
-                    zip.putNextEntry( new ZipEntry( folderName + indexFile ) );
-                    try ( IndexInput input = dir.openInput( indexFile, IOContext.READ ) )
-                    {
-                        for ( long pos = 0, size = input.length(); pos < size; )
-                        {
-                            int read = Math.min( buffer.length, (int) (size - pos) );
-                            input.readBytes( buffer, 0, read );
-                            pos += read;
-                            zip.write( buffer, 0, read );
-                        }
-                    }
-                    zip.closeEntry();
-                }
                 FileUtils.windowsSafeIOOperation( () -> dir.deleteFile( indexFile ) );
             }
         }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProvider.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProvider.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.api.impl.schema;
 import java.io.File;
 import java.io.IOException;
 
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.internal.kernel.api.IndexCapability;
 import org.neo4j.internal.kernel.api.InternalIndexState;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -168,7 +167,7 @@ public class LuceneIndexProvider extends IndexProvider
 
     private PartitionedIndexStorage getIndexStorage( long indexId )
     {
-        return indexStorageFactory.indexStorageOf( indexId, config.get( GraphDatabaseSettings.archive_failed_index ) );
+        return indexStorageFactory.indexStorageOf( indexId );
     }
 
     private boolean indexIsOnline( PartitionedIndexStorage indexStorage, SchemaIndexDescriptor descriptor ) throws IOException

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderFactory.java
@@ -108,7 +108,7 @@ public class LuceneIndexProviderFactory extends
 
         String defaultSchemaProvider = config.get( GraphDatabaseSettings.default_schema_provider );
         int priority = LuceneIndexProvider.PRIORITY;
-        if ( GraphDatabaseSettings.SchemaIndex.LUCENE10.param().equals( defaultSchemaProvider ) )
+        if ( GraphDatabaseSettings.SchemaIndex.LUCENE10.providerName().equals( defaultSchemaProvider ) )
         {
             priority = 100;
         }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderFactory.java
@@ -96,6 +96,7 @@ public class LuceneIndexProviderFactory extends
             RecoveryCleanupWorkCollector recoveryCleanupWorkCollector )
     {
         boolean readOnly = IndexProviderFactoryUtil.isReadOnly( config, operationalMode );
+        boolean archiveFailedIndex = config.get( GraphDatabaseSettings.archive_failed_index );
         IndexDirectoryStructure.Factory baseDirStructure = directoriesByProviderKey( storeDir );
         IndexDirectoryStructure.Factory childDirectoryStructure = directoriesBySubProvider( baseDirStructure.forProvider( PROVIDER_DESCRIPTOR ) );
 
@@ -112,7 +113,7 @@ public class LuceneIndexProviderFactory extends
             priority = 100;
         }
         return new FusionIndexProvider( EMPTY, EMPTY, spatial, temporal, lucene, new FusionSelector00(),
-                PROVIDER_DESCRIPTOR, priority, directoriesByProvider( storeDir ), fs );
+                PROVIDER_DESCRIPTOR, priority, directoriesByProvider( storeDir ), fs, archiveFailedIndex );
     }
 
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexBuilder.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexBuilder.java
@@ -23,7 +23,6 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 
 import org.neo4j.function.Factory;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.api.impl.index.IndexWriterConfigs;
 import org.neo4j.kernel.api.impl.index.builder.AbstractLuceneIndexBuilder;
 import org.neo4j.kernel.api.impl.index.partition.ReadOnlyIndexPartitionFactory;
@@ -103,8 +102,7 @@ public class LuceneSchemaIndexBuilder extends AbstractLuceneIndexBuilder<LuceneS
         }
         else
         {
-            Boolean archiveFailed = getConfig( GraphDatabaseSettings.archive_failed_index );
-            PartitionedIndexStorage storage = storageBuilder.archivingFailed( archiveFailed ).build();
+            PartitionedIndexStorage storage = storageBuilder.build();
             return new WritableDatabaseSchemaIndex( storage, descriptor, samplingConfig,
                     new WritableIndexPartitionFactory( writerConfigFactory ) );
         }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory10.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory10.java
@@ -89,7 +89,7 @@ public class NativeLuceneFusionIndexProviderFactory10 extends
 
         String defaultSchemaProvider = config.get( GraphDatabaseSettings.default_schema_provider );
         int priority = PRIORITY;
-        if ( GraphDatabaseSettings.SchemaIndex.NATIVE10.param().equals( defaultSchemaProvider ) )
+        if ( GraphDatabaseSettings.SchemaIndex.NATIVE10.providerName().equals( defaultSchemaProvider ) )
         {
             priority = 100;
         }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory10.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory10.java
@@ -77,6 +77,7 @@ public class NativeLuceneFusionIndexProviderFactory10 extends
     {
         IndexDirectoryStructure.Factory childDirectoryStructure = subProviderDirectoryStructure( storeDir );
         boolean readOnly = IndexProviderFactoryUtil.isReadOnly( config, operationalMode );
+        boolean archiveFailedIndex = config.get( GraphDatabaseSettings.archive_failed_index );
 
         NumberIndexProvider number =
                 IndexProviderFactoryUtil.numberProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
@@ -93,7 +94,7 @@ public class NativeLuceneFusionIndexProviderFactory10 extends
             priority = 100;
         }
         return new FusionIndexProvider( EMPTY, number, spatial, temporal, lucene, new FusionSelector10(),
-                DESCRIPTOR, priority, directoriesByProvider( storeDir ), fs );
+                DESCRIPTOR, priority, directoriesByProvider( storeDir ), fs, archiveFailedIndex );
     }
 
     private static IndexDirectoryStructure.Factory subProviderDirectoryStructure( File storeDir )

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory20.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory20.java
@@ -77,6 +77,7 @@ public class NativeLuceneFusionIndexProviderFactory20 extends
     {
         IndexDirectoryStructure.Factory childDirectoryStructure = subProviderDirectoryStructure( storeDir );
         boolean readOnly = IndexProviderFactoryUtil.isReadOnly( config, operationalMode );
+        boolean archiveFailedIndex = config.get( GraphDatabaseSettings.archive_failed_index );
 
         StringIndexProvider string =
                 IndexProviderFactoryUtil.stringProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
@@ -95,7 +96,7 @@ public class NativeLuceneFusionIndexProviderFactory20 extends
             priority = 100;
         }
         return new FusionIndexProvider( string, number, spatial, temporal, lucene, new FusionSelector20(),
-                DESCRIPTOR, priority, directoriesByProvider( storeDir ), fs );
+                DESCRIPTOR, priority, directoriesByProvider( storeDir ), fs, archiveFailedIndex );
     }
 
     public static IndexDirectoryStructure.Factory subProviderDirectoryStructure( File storeDir )

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory20.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionIndexProviderFactory20.java
@@ -91,7 +91,7 @@ public class NativeLuceneFusionIndexProviderFactory20 extends
 
         String defaultSchemaProvider = config.get( GraphDatabaseSettings.default_schema_provider );
         int priority = PRIORITY;
-        if ( GraphDatabaseSettings.SchemaIndex.NATIVE20.param().equals( defaultSchemaProvider ) )
+        if ( GraphDatabaseSettings.SchemaIndex.NATIVE20.providerName().equals( defaultSchemaProvider ) )
         {
             priority = 100;
         }

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/NonUniqueIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/NonUniqueIndexTest.java
@@ -178,12 +178,12 @@ public class NonUniqueIndexTest
     {
         String defaultSchemaProvider = config.get( GraphDatabaseSettings.default_schema_provider );
         RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = RecoveryCleanupWorkCollector.IMMEDIATE;
-        if ( LUCENE10.param().equals( defaultSchemaProvider ) )
+        if ( LUCENE10.providerName().equals( defaultSchemaProvider ) )
         {
             return LuceneIndexProviderFactory
                     .newInstance( pageCache, storeDir, fs, monitor, config, operationalMode, recoveryCleanupWorkCollector );
         }
-        else if ( NATIVE10.param().equals( defaultSchemaProvider ) )
+        else if ( NATIVE10.providerName().equals( defaultSchemaProvider ) )
         {
             return NativeLuceneFusionIndexProviderFactory10
                     .create( pageCache, storeDir, fs, monitor, config, operationalMode, recoveryCleanupWorkCollector );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/DatabaseIndexIntegrationTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/DatabaseIndexIntegrationTest.java
@@ -147,7 +147,7 @@ public class DatabaseIndexIntegrationTest
     private WritableTestDatabaseIndex createTestLuceneIndex( DirectoryFactory dirFactory, File folder ) throws IOException
     {
         PartitionedIndexStorage indexStorage = new PartitionedIndexStorage(
-                dirFactory, fileSystemRule.get(), folder, false );
+                dirFactory, fileSystemRule.get(), folder );
         WritableTestDatabaseIndex index = new WritableTestDatabaseIndex( indexStorage );
         index.create();
         index.open();

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/storage/PartitionedIndexStorageTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/storage/PartitionedIndexStorageTest.java
@@ -68,7 +68,7 @@ public class PartitionedIndexStorageTest
     public void createIndexStorage()
     {
         fs = fsRule.get();
-        storage = new PartitionedIndexStorage( getOrCreateDirFactory( fs ), fs, testDir.graphDbDir(), false );
+        storage = new PartitionedIndexStorage( getOrCreateDirFactory( fs ), fs, testDir.graphDbDir() );
     }
 
     @Test
@@ -182,7 +182,7 @@ public class PartitionedIndexStorageTest
                 } )
         {
             PartitionedIndexStorage myStorage = new PartitionedIndexStorage( getOrCreateDirFactory( scramblingFs ),
-                    scramblingFs, testDir.graphDbDir(), false );
+                    scramblingFs, testDir.graphDbDir() );
             File parent = myStorage.getIndexFolder();
             int directoryCount = 10;
             for ( int i = 0; i < directoryCount; i++ )

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/AccessUniqueDatabaseIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/AccessUniqueDatabaseIndexTest.java
@@ -43,11 +43,9 @@ import org.neo4j.values.storable.Values;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-
+import static org.junit.Assert.assertEquals;
 import static org.neo4j.kernel.api.impl.schema.LuceneIndexProviderFactory.PROVIDER_DESCRIPTOR;
 import static org.neo4j.kernel.api.index.IndexDirectoryStructure.directoriesByProviderKey;
-
-import static org.junit.Assert.assertEquals;
 
 public class AccessUniqueDatabaseIndexTest
 {
@@ -151,7 +149,7 @@ public class AccessUniqueDatabaseIndexTest
     {
         IndexStorageFactory storageFactory = new IndexStorageFactory( directoryFactory, fileSystemRule.get(),
                 directoriesByProviderKey( storeDirectory ).forProvider( PROVIDER_DESCRIPTOR ) );
-        return storageFactory.indexStorageOf( 1, false );
+        return storageFactory.indexStorageOf( 1 );
     }
 
     private IndexEntryUpdate<?> add( long nodeId, Object propertyValue )

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DefaultSchemaIndexConfigTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DefaultSchemaIndexConfigTest.java
@@ -62,8 +62,8 @@ public class DefaultSchemaIndexConfigTest
     public void shouldUseConfiguredIndexProviderLucene() throws IndexNotFoundKernelException
     {
         // given
-        GraphDatabaseService db =
-                dbBuilder.setConfig( GraphDatabaseSettings.default_schema_provider, GraphDatabaseSettings.SchemaIndex.LUCENE10.param() ).newGraphDatabase();
+        GraphDatabaseService db = dbBuilder.setConfig( GraphDatabaseSettings.default_schema_provider,
+                GraphDatabaseSettings.SchemaIndex.LUCENE10.providerName() ).newGraphDatabase();
 
         // when
         createIndex( db );
@@ -76,8 +76,8 @@ public class DefaultSchemaIndexConfigTest
     public void shouldUseConfiguredIndexProviderNative10() throws IndexNotFoundKernelException
     {
         // given
-        GraphDatabaseService db =
-                dbBuilder.setConfig( GraphDatabaseSettings.default_schema_provider, GraphDatabaseSettings.SchemaIndex.NATIVE10.param() ).newGraphDatabase();
+        GraphDatabaseService db = dbBuilder.setConfig( GraphDatabaseSettings.default_schema_provider,
+                GraphDatabaseSettings.SchemaIndex.NATIVE10.providerName() ).newGraphDatabase();
 
         // when
         createIndex( db );
@@ -90,8 +90,8 @@ public class DefaultSchemaIndexConfigTest
     public void shouldUseConfiguredIndexProviderNative20() throws IndexNotFoundKernelException
     {
         // given
-        GraphDatabaseService db =
-                dbBuilder.setConfig( GraphDatabaseSettings.default_schema_provider, GraphDatabaseSettings.SchemaIndex.NATIVE20.param() ).newGraphDatabase();
+        GraphDatabaseService db = dbBuilder.setConfig( GraphDatabaseSettings.default_schema_provider,
+                GraphDatabaseSettings.SchemaIndex.NATIVE20.providerName() ).newGraphDatabase();
 
         // when
         createIndex( db );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexIT.java
@@ -50,7 +50,7 @@ public class FusionIndexIT
 {
     @Rule
     public DatabaseRule db = new EmbeddedDatabaseRule()
-            .withSetting( GraphDatabaseSettings.default_schema_provider, GraphDatabaseSettings.SchemaIndex.NATIVE20.param() );
+            .withSetting( GraphDatabaseSettings.default_schema_provider, GraphDatabaseSettings.SchemaIndex.NATIVE20.providerName() );
 
     private File storeDir;
     private final Label label = Label.label( "label" );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexProvider10CompatibilitySuiteTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexProvider10CompatibilitySuiteTest.java
@@ -39,7 +39,7 @@ public class FusionIndexProvider10CompatibilitySuiteTest extends IndexProviderCo
     protected IndexProvider createIndexProvider( PageCache pageCache, FileSystemAbstraction fs, File graphDbDir )
     {
         IndexProvider.Monitor monitor = IndexProvider.Monitor.EMPTY;
-        Config config = Config.defaults( stringMap( default_schema_provider.name(), NATIVE10.param() ) );
+        Config config = Config.defaults( stringMap( default_schema_provider.name(), NATIVE10.providerName() ) );
         OperationalMode mode = OperationalMode.single;
         RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = RecoveryCleanupWorkCollector.IMMEDIATE;
         return NativeLuceneFusionIndexProviderFactory10.create( pageCache, graphDbDir, fs, monitor, config, mode, recoveryCleanupWorkCollector );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexProvider20CompatibilitySuiteTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionIndexProvider20CompatibilitySuiteTest.java
@@ -39,7 +39,7 @@ public class FusionIndexProvider20CompatibilitySuiteTest extends IndexProviderCo
     protected IndexProvider createIndexProvider( PageCache pageCache, FileSystemAbstraction fs, File graphDbDir )
     {
         IndexProvider.Monitor monitor = IndexProvider.Monitor.EMPTY;
-        Config config = Config.defaults( stringMap( default_schema_provider.name(), NATIVE20.param() ) );
+        Config config = Config.defaults( stringMap( default_schema_provider.name(), NATIVE20.providerName() ) );
         OperationalMode mode = OperationalMode.single;
         RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = RecoveryCleanupWorkCollector.IMMEDIATE;
         return NativeLuceneFusionIndexProviderFactory20.create( pageCache, graphDbDir, fs, monitor, config, mode, recoveryCleanupWorkCollector );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderCompatibilitySuiteTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderCompatibilitySuiteTest.java
@@ -39,7 +39,7 @@ public class LuceneIndexProviderCompatibilitySuiteTest extends IndexProviderComp
     protected IndexProvider createIndexProvider( PageCache pageCache, FileSystemAbstraction fs, File graphDbDir )
     {
         IndexProvider.Monitor monitor = IndexProvider.Monitor.EMPTY;
-        Config config = Config.defaults( stringMap( default_schema_provider.name(), LUCENE10.param() ) );
+        Config config = Config.defaults( stringMap( default_schema_provider.name(), LUCENE10.providerName() ) );
         OperationalMode mode = OperationalMode.single;
         RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = RecoveryCleanupWorkCollector.IMMEDIATE;
         return LuceneIndexProviderFactory.newInstance( pageCache, graphDbDir, fs, monitor, config, mode, recoveryCleanupWorkCollector );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexCorruptionTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexCorruptionTest.java
@@ -37,8 +37,8 @@ import org.neo4j.kernel.api.impl.index.storage.DirectoryFactory;
 import org.neo4j.kernel.api.impl.index.storage.IndexStorageFactory;
 import org.neo4j.kernel.api.impl.index.storage.PartitionedIndexStorage;
 import org.neo4j.kernel.api.index.IndexDirectoryStructure;
-import org.neo4j.kernel.api.index.LoggingMonitor;
 import org.neo4j.kernel.api.index.IndexProvider;
+import org.neo4j.kernel.api.index.LoggingMonitor;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptorFactory;
 import org.neo4j.kernel.configuration.Config;
@@ -153,9 +153,9 @@ public class LuceneSchemaIndexCorruptionTest
         }
 
         @Override
-        public PartitionedIndexStorage indexStorageOf( long indexId, boolean archiveFailed )
+        public PartitionedIndexStorage indexStorageOf( long indexId )
         {
-            return indexId == faultyIndexId ? newFaultyPartitionedIndexStorage() : super.indexStorageOf( indexId, archiveFailed );
+            return indexId == faultyIndexId ? newFaultyPartitionedIndexStorage() : super.indexStorageOf( indexId );
         }
 
         PartitionedIndexStorage newFaultyPartitionedIndexStorage()

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/ReadOnlyLuceneSchemaIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/ReadOnlyLuceneSchemaIndexTest.java
@@ -55,7 +55,7 @@ public class ReadOnlyLuceneSchemaIndexTest
     public void setUp()
     {
         PartitionedIndexStorage indexStorage = new PartitionedIndexStorage( DirectoryFactory.PERSISTENT,
-                fileSystemRule.get(), testDirectory.directory(), false );
+                fileSystemRule.get(), testDirectory.directory() );
         Config config = Config.defaults();
         IndexSamplingConfig samplingConfig = new IndexSamplingConfig( config );
         luceneSchemaIndex = new ReadOnlyDatabaseSchemaIndex( indexStorage, SchemaIndexDescriptorFactory.forLabel( 0, 0 ),

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueDatabaseIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueDatabaseIndexPopulatorTest.java
@@ -70,7 +70,7 @@ public class NonUniqueDatabaseIndexPopulatorTest
     public void setUp()
     {
         File folder = testDir.directory( "folder" );
-        PartitionedIndexStorage indexStorage = new PartitionedIndexStorage( dirFactory, fileSystemRule.get(), folder, false );
+        PartitionedIndexStorage indexStorage = new PartitionedIndexStorage( dirFactory, fileSystemRule.get(), folder );
 
         SchemaIndexDescriptor descriptor = SchemaIndexDescriptorFactory.forSchema( labelSchemaDescriptor );
         index = LuceneSchemaIndexBuilder.create( descriptor, Config.defaults() )

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/UniqueDatabaseIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/UniqueDatabaseIndexPopulatorTest.java
@@ -99,7 +99,7 @@ public class UniqueDatabaseIndexPopulatorTest
     public void setUp()
     {
         File folder = testDir.directory( "folder" );
-        indexStorage = new PartitionedIndexStorage( directoryFactory, fileSystemRule.get(), folder, false );
+        indexStorage = new PartitionedIndexStorage( directoryFactory, fileSystemRule.get(), folder );
         index = LuceneSchemaIndexBuilder.create( descriptor, Config.defaults() )
                 .withIndexStorage( indexStorage )
                 .build();

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorLuceneTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorLuceneTest.java
@@ -29,7 +29,7 @@ public class NodeValueIndexCursorLuceneTest extends AbstractNodeValueIndexCursor
     public ReadTestSupport newTestSupport()
     {
         ReadTestSupport readTestSupport = new ReadTestSupport();
-        readTestSupport.addSetting( GraphDatabaseSettings.default_schema_provider, LUCENE10.param() );
+        readTestSupport.addSetting( GraphDatabaseSettings.default_schema_provider, LUCENE10.providerName() );
         return readTestSupport;
     }
 

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorNative10Test.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorNative10Test.java
@@ -27,7 +27,7 @@ public class NodeValueIndexCursorNative10Test extends AbstractNodeValueIndexCurs
     public ReadTestSupport newTestSupport()
     {
         ReadTestSupport readTestSupport = new ReadTestSupport();
-        readTestSupport.addSetting( GraphDatabaseSettings.default_schema_provider, GraphDatabaseSettings.SchemaIndex.NATIVE10.param() );
+        readTestSupport.addSetting( GraphDatabaseSettings.default_schema_provider, GraphDatabaseSettings.SchemaIndex.NATIVE10.providerName() );
         return readTestSupport;
     }
 

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorNative20Test.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursorNative20Test.java
@@ -27,7 +27,7 @@ public class NodeValueIndexCursorNative20Test extends AbstractNodeValueIndexCurs
     public ReadTestSupport newTestSupport()
     {
         ReadTestSupport readTestSupport = new ReadTestSupport();
-        readTestSupport.addSetting( GraphDatabaseSettings.default_schema_provider, GraphDatabaseSettings.SchemaIndex.NATIVE20.param() );
+        readTestSupport.addSetting( GraphDatabaseSettings.default_schema_provider, GraphDatabaseSettings.SchemaIndex.NATIVE20.providerName() );
         return readTestSupport;
     }
 

--- a/community/neo4j/src/test/java/org/neo4j/index/IndexFailureOnStartupTest.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/IndexFailureOnStartupTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.schema.IndexDefinition;
@@ -38,6 +39,8 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.index.IndexDirectoryStructure;
 import org.neo4j.test.rule.DatabaseRule;
 import org.neo4j.test.rule.EmbeddedDatabaseRule;
+import org.neo4j.values.storable.CoordinateReferenceSystem;
+import org.neo4j.values.storable.Values;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -109,6 +112,19 @@ public class IndexFailureOnStartupTest
     {
         // given
         db.setConfig( GraphDatabaseSettings.archive_failed_index, "true" );
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.createNode( PERSON );
+            node.setProperty( "name", "Fry" );
+            tx.success();
+        }
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.createNode( PERSON );
+            node.setProperty( "name", Values.pointValue( CoordinateReferenceSystem.WGS84, 1, 2 ) );
+            tx.success();
+        }
+
         try ( Transaction tx = db.beginTx() )
         {
             db.schema().constraintFor( PERSON ).assertPropertyIsUnique( "name" ).create();

--- a/community/neo4j/src/test/java/org/neo4j/index/IndexFailureOnStartupTest.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/IndexFailureOnStartupTest.java
@@ -35,6 +35,7 @@ import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.graphdb.schema.Schema;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.api.index.IndexDirectoryStructure;
 import org.neo4j.test.rule.DatabaseRule;
 import org.neo4j.test.rule.EmbeddedDatabaseRule;
 
@@ -127,9 +128,8 @@ public class IndexFailureOnStartupTest
     {
         try ( FileSystemAbstraction fs = new DefaultFileSystemAbstraction() )
         {
-            File indexDir = soleIndexDir( db.getStoreDir() );
-            File[] files = indexDir.getParentFile()
-                    .listFiles( pathname -> pathname.isFile() && pathname.getName().startsWith( "archive-" ) );
+            File indexDir = indexRootDirectory( db.getStoreDir() );
+            File[] files = indexDir.listFiles( pathname -> pathname.isFile() && pathname.getName().startsWith( "archive-" ) );
             if ( files == null || files.length == 0 )
             {
                 return null;
@@ -197,8 +197,18 @@ public class IndexFailureOnStartupTest
         }
     }
 
+    private static File indexRootDirectory( File base )
+    {
+        return providerDirectoryStructure( base ).rootDirectory();
+    }
+
     private static File soleIndexDir( File base )
     {
-        return subProviderDirectoryStructure( base ).forProvider( PROVIDER_DESCRIPTOR ).directoryForIndex( 1 );
+        return providerDirectoryStructure( base ).directoryForIndex( 1 );
+    }
+
+    private static IndexDirectoryStructure providerDirectoryStructure( File base )
+    {
+        return subProviderDirectoryStructure( base ).forProvider( PROVIDER_DESCRIPTOR );
     }
 }

--- a/community/neo4j/src/test/java/recovery/RecoveryCleanupIT.java
+++ b/community/neo4j/src/test/java/recovery/RecoveryCleanupIT.java
@@ -142,7 +142,7 @@ public class RecoveryCleanupIT
     public void nativeIndexMustLogCrashPointerCleanupDuringRecovery() throws Exception
     {
         // given
-        setTestConfig( GraphDatabaseSettings.default_schema_provider, NATIVE20.param() );
+        setTestConfig( GraphDatabaseSettings.default_schema_provider, NATIVE20.providerName() );
         dirtyDatabase();
 
         // when


### PR DESCRIPTION
Clean up all of the left-overs from previous index populations when new index population starts.
Also makes a run of a group of jobs more resilient to failure.