### PR TITLE
Fixes a CSV trim issue with fields containing only whitespace

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
@@ -22,9 +22,11 @@ package org.neo4j.csv.reader;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
+import java.util.Arrays;
 
 import org.neo4j.csv.reader.Source.Chunk;
 
+import static java.lang.Character.isWhitespace;
 import static java.lang.String.format;
 import static org.neo4j.csv.reader.Mark.END_OF_LINE_CHARACTER;
 
@@ -37,7 +39,6 @@ public class BufferedCharSeeker implements CharSeeker
     private static final char EOL_CHAR_2 = '\r';
     private static final char EOF_CHAR = (char) -1;
     private static final char BACK_SLASH = '\\';
-    private static final char WHITESPACE = ' ';
 
     private char[] buffer;
     private int dataLength;
@@ -99,11 +100,14 @@ public class BufferedCharSeeker implements CharSeeker
             ch = nextChar( skippedChars );
             if ( quoteDepth == 0 )
             {   // In normal mode, i.e. not within quotes
-                if ( isWhitespace( ch ) && trim )
-                {
+                if ( ch == untilChar )
+                {   // We found a delimiter, set marker and return true
+                    return setMark( mark, endOffset, skippedChars, ch, isQuoted );
+                }
+                else if ( trim && isWhitespace( ch ) )
+                {   // Only check for left+trim whitespace as long as we haven't found a non-whitespace character
                     if ( seekStartPos == bufferPos - 1/* -1 since we just advanced one */ )
-                    {
-                        // We found a whitespace, which was the first of the value and we've been told to trim that off
+                    {   // We found a whitespace, which is before the first non-whitespace of the value and we've been told to trim that off
                         seekStartPos++;
                     }
                 }
@@ -124,18 +128,12 @@ public class BufferedCharSeeker implements CharSeeker
                     }
                     break;
                 }
-                else if ( ch == untilChar )
-                {   // We found a delimiter, set marker and return true
-                    return setMark( mark, endOffset, skippedChars, ch, isQuoted );
+                else if ( isQuoted )
+                {   // This value is quoted, i.e. started with a quote and has also seen a quote
+                    throw new DataAfterQuoteException( this,
+                            new String( buffer, seekStartPos, bufferPos - seekStartPos ) );
                 }
-                else
-                {   // This is a character to include as part of the current value
-                    if ( isQuoted )
-                    {   // This value is quoted, i.e. started with a quote and has also seen a quote
-                        throw new DataAfterQuoteException( this,
-                                new String( buffer, seekStartPos, bufferPos - seekStartPos ) );
-                    }
-                }
+                // else this is a character to include as part of the current value
             }
             else
             {   // In quoted mode, i.e. within quotes
@@ -217,7 +215,18 @@ public class BufferedCharSeeker implements CharSeeker
 
     private boolean isWhitespace( int ch )
     {
-        return ch == WHITESPACE;
+        return ch == ' ' |
+                ch == Character.SPACE_SEPARATOR |
+                ch == Character.PARAGRAPH_SEPARATOR |
+                ch == '\u00A0' |
+                ch == '\u001C' |
+                ch == '\u001D' |
+                ch == '\u001E' |
+                ch == '\u001F' |
+                ch == '\u2007' |
+                ch == '\u202F' |
+                ch == '\t';
+
     }
 
     private void repositionChar( int offset, int stepsBack )

--- a/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
@@ -194,15 +194,21 @@ public class BufferedCharSeeker implements CharSeeker
 
     private boolean setMark( Mark mark, int endOffset, int skippedChars, int ch, boolean isQuoted )
     {
-        int pos = (trim ? rtrim( bufferPos ) : bufferPos) - endOffset - skippedChars;
+        int pos = (trim ? rtrim() : bufferPos) - endOffset - skippedChars;
         mark.set( seekStartPos, pos, ch, isQuoted );
         return true;
     }
 
-    private int rtrim( int start )
+    /**
+     * Starting from the current position, {@link #bufferPos}, scan backwards as long as whitespace is found.
+     * Although it cannot scan further back than the start of this field is, i.e. {@link #seekStartPos}.
+     *
+     * @return the right index of the value to pass into {@link Mark}. This is only called if {@link Configuration#trimStrings()} is {@code true}.
+     */
+    private int rtrim()
     {
-        int index = start;
-        while ( isWhitespace( buffer[index - 1 /*bufferPos has advanced*/ - 1 /*don't check the last read char (delim or EOF)*/] ) )
+        int index = bufferPos;
+        while ( index - 1 > seekStartPos && isWhitespace( buffer[index - 1 /*bufferPos has advanced*/ - 1 /*don't check the last read char (delim or EOF)*/] ) )
         {
             index--;
         }

--- a/community/csv/src/test/java/org/neo4j/csv/reader/BufferedCharSeekerTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/BufferedCharSeekerTest.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.csv.reader;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,6 +31,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 
@@ -42,6 +44,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.neo4j.csv.reader.CharSeekers.charSeeker;
 import static org.neo4j.csv.reader.Readables.wrap;
+import static org.neo4j.helpers.collection.Iterators.array;
 
 @RunWith( Parameterized.class )
 public class BufferedCharSeekerTest
@@ -272,10 +275,7 @@ public class BufferedCharSeekerTest
         assertNextValue( seeker, mark, COMMA, "dos" );
         assertNextValue( seeker, mark, COMMA, "tres" );
         assertNextValueNotExtracted( seeker, mark, COMMA );
-        assertTrue( mark.isEndOfLine() );
-
-        // THEN
-        assertFalse( seeker.seek( mark, COMMA ) );
+        assertEnd( seeker, mark, COMMA );
     }
 
     @Test
@@ -436,8 +436,7 @@ public class BufferedCharSeekerTest
         assertNextValue( seeker, mark, COMMA, "four" );
         assertNextValue( seeker, mark, COMMA, "five" );
         assertNextValue( seeker, mark, COMMA, "s\"ix" );
-        assertTrue( mark.isEndOfLine() );
-        assertFalse( seeker.seek( mark, COMMA ) );
+        assertEnd( seeker, mark, COMMA );
     }
 
     @Test
@@ -457,8 +456,7 @@ public class BufferedCharSeekerTest
         assertNextValue( seeker, mark, COMMA, "abc" );
         assertNextValue( seeker, mark, COMMA, "def" );
         assertNextValue( seeker, mark, COMMA, "ghi" );
-        assertTrue( mark.isEndOfLine() );
-        assertFalse( seeker.seek( mark, COMMA ) );
+        assertEnd( seeker, mark, COMMA );
     }
 
     @Test
@@ -526,8 +524,7 @@ public class BufferedCharSeekerTest
         assertNextValue( seeker, mark, COMMA, "4" );
         assertNextValue( seeker, mark, COMMA, "The Cardigans" );
         assertNextValue( seeker, mark, COMMA, "1992" );
-        assertTrue( mark.isEndOfLine() );
-        assertFalse( seeker.seek( mark, COMMA ) );
+        assertEnd( seeker, mark, COMMA );
     }
 
     @Test
@@ -663,6 +660,141 @@ public class BufferedCharSeekerTest
         assertNextValue( seeker, mark, COMMA, "Waaaa" );
     }
 
+    @Test
+    public void shouldTrimStringsWithFirstLineCharacterSpace() throws IOException
+    {
+        // given
+        String line = " ,a, ,b, ";
+        seeker = seeker( line, withTrimStrings( config(), true ) );
+
+        // when/then
+        assertNextValueNotExtracted( seeker, mark, COMMA );
+        assertNextValue( seeker, mark, COMMA, "a" );
+        assertNextValueNotExtracted( seeker, mark, COMMA );
+        assertNextValue( seeker, mark, COMMA, "b" );
+        assertNextValueNotExtracted( seeker, mark, COMMA );
+        assertEnd( seeker, mark, COMMA );
+    }
+
+    @Test
+    public void shouldParseAndTrimRandomStrings() throws IOException
+    {
+        // given
+        StringBuilder builder = new StringBuilder();
+        int columns = random.nextInt( 10 ) + 5;
+        int lines = 100;
+        List<String> expected = new ArrayList<>();
+        for ( int i = 0; i < lines; i++ )
+        {
+            for ( int j = 0; j < columns; j++ )
+            {
+                if ( j > 0 )
+                {
+                    if ( random.nextBoolean() )
+                    {
+                        // Space before delimiter
+                        builder.append( " " );
+                    }
+                    builder.append( "," );
+                    if ( random.nextBoolean() )
+                    {
+                        // Space before delimiter
+                        builder.append( " " );
+                    }
+                }
+                boolean quote = random.nextBoolean();
+                if ( random.nextBoolean() )
+                {
+                    String value = "";
+                    if ( quote )
+                    {
+                        // Quote
+                        if ( random.nextBoolean() )
+                        {
+                            // Space after quote start
+                            value += " ";
+                        }
+                    }
+                    // Actual value
+                    value += String.valueOf( random.nextInt() );
+                    if ( quote )
+                    {
+                        if ( random.nextBoolean() )
+                        {
+                            // Space before quote end
+                            value += " ";
+                        }
+                    }
+                    expected.add( value );
+                    builder.append( quote ? "\"" + value + "\"" : value );
+                }
+                else
+                {
+                    expected.add( null );
+                }
+            }
+            builder.append( format( "%n" ) );
+        }
+        String data = builder.toString();
+        seeker = seeker( data, withTrimStrings( config(), true ) );
+
+        // when
+        Iterator<String> next = expected.iterator();
+        for ( int i = 0; i < lines; i++ )
+        {
+            for ( int j = 0; j < columns; j++ )
+            {
+                // then
+                String nextExpected = next.next();
+                if ( nextExpected == null )
+                {
+                    assertNextValueNotExtracted( seeker, mark, COMMA );
+                }
+                else
+                {
+                    assertNextValue( seeker, mark, COMMA, nextExpected );
+                }
+            }
+        }
+        assertEnd( seeker, mark, COMMA );
+    }
+
+    @Test
+    public void shouldParseNonLatinCharacters() throws IOException
+    {
+        // given
+        List<String[]> expected = asList(
+                array( "普通�?/普通話", "\uD83D\uDE21" ),
+                array( "\uD83D\uDE21\uD83D\uDCA9\uD83D\uDC7B", "ⲹ楡�?톜ഷۢ⼈�?�늉�?�₭샺ጚ砧攡跿家䯶�?⬖�?�犽ۼ" ),
+                array( " 㺂�?鋦毠", ";먵�?裬岰鷲趫\uA8C5얱㓙髿ᚳᬼ≩�?� " )
+        );
+        String data = lines( format( "%n" ), expected );
+
+        // when
+        seeker = seeker( data );
+
+        // then
+        for ( String[] line : expected )
+        {
+            for ( String cell : line )
+            {
+                assertNextValue( seeker, mark, COMMA, cell );
+            }
+        }
+        assertEnd( seeker, mark, COMMA );
+    }
+
+    private String lines( String newline, List<String[]> cells )
+    {
+        String[] lines = new String[cells.size()];
+        int i = 0;
+        for ( String[] columns : cells )
+        {
+            lines[i++] = StringUtils.join( columns, "," );
+        }
+        return lines( newline, lines );
+    }
+
     private String lines( String newline, String... lines )
     {
         StringBuilder builder = new StringBuilder();
@@ -751,6 +883,12 @@ public class BufferedCharSeekerTest
     {
         assertTrue( seeker.seek( mark, delimiter ) );
         assertFalse( seeker.tryExtract( mark, extractors.string() ) );
+    }
+
+    private void assertEnd( CharSeeker seeker, Mark mark, int delimiter ) throws IOException
+    {
+        assertTrue( mark.isEndOfLine() );
+        assertFalse( seeker.seek( mark, delimiter ) );
     }
 
     private String[] nextLineOfAllStrings( CharSeeker seeker, Mark mark ) throws IOException


### PR DESCRIPTION
This could result in StringIndexOutOfBounds with negative values
for some fields containing nothing but whitespace characters.

Fixes #11094
Fixes #11218