### PR TITLE
Simplify page warmer stop, fix method name spelling error.

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
@@ -66,7 +66,7 @@ import org.neo4j.logging.LogProvider;
 import static java.lang.String.format;
 import static org.neo4j.consistency.internal.SchemaIndexExtensionLoader.instantiateKernelExtensions;
 import static org.neo4j.consistency.internal.SchemaIndexExtensionLoader.loadIndexProviders;
-import static org.neo4j.io.file.Files.createOrOpenAsOuputStream;
+import static org.neo4j.io.file.Files.createOrOpenAsOutputStream;
 import static org.neo4j.kernel.configuration.Settings.FALSE;
 import static org.neo4j.kernel.configuration.Settings.TRUE;
 import static org.neo4j.kernel.impl.factory.DatabaseInfo.COMMUNITY;
@@ -219,7 +219,7 @@ public class ConsistencyCheckService
         {
             try
             {
-                return new PrintWriter( createOrOpenAsOuputStream( fileSystem, reportFile, true ) );
+                return new PrintWriter( createOrOpenAsOutputStream( fileSystem, reportFile, true ) );
             }
             catch ( IOException e )
             {

--- a/community/io/src/main/java/org/neo4j/io/file/Files.java
+++ b/community/io/src/main/java/org/neo4j/io/file/Files.java
@@ -42,7 +42,7 @@ public class Files
      * @return An output stream
      * @throws IOException If an error occurs creating directories or opening the file
      */
-    public static OutputStream createOrOpenAsOuputStream( FileSystemAbstraction fileSystem, File file, boolean append ) throws IOException
+    public static OutputStream createOrOpenAsOutputStream( FileSystemAbstraction fileSystem, File file, boolean append ) throws IOException
     {
         if ( file.getParentFile() != null )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/StoreLogService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/StoreLogService.java
@@ -39,7 +39,7 @@ import org.neo4j.logging.NullLogProvider;
 import org.neo4j.logging.RotatingFileOutputStreamSupplier;
 import org.neo4j.scheduler.JobScheduler;
 
-import static org.neo4j.io.file.Files.createOrOpenAsOuputStream;
+import static org.neo4j.io.file.Files.createOrOpenAsOutputStream;
 
 public class StoreLogService extends AbstractLogService implements Lifecycle
 {
@@ -170,7 +170,7 @@ public class StoreLogService extends AbstractLogService implements Lifecycle
         FormattedLogProvider internalLogProvider;
         if ( internalLogRotationThreshold == 0 )
         {
-            OutputStream outputStream = createOrOpenAsOuputStream( fileSystem, internalLog, true );
+            OutputStream outputStream = createOrOpenAsOutputStream( fileSystem, internalLog, true );
             internalLogProvider = internalLogBuilder.toOutputStream( outputStream );
             rotationListener.accept( internalLogProvider );
             this.closeable = outputStream;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListing.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListing.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -66,7 +66,7 @@ public class NeoStoreFileListing
         this.logFiles = logFiles;
         this.storageEngine = storageEngine;
         this.neoStoreFileIndexListing = new NeoStoreFileIndexListing( labelScanStore, indexingService, explicitIndexProviders );
-        this.additionalProviders = new CopyOnWriteArrayList<>();
+        this.additionalProviders = new CopyOnWriteArraySet<>();
     }
 
     public StoreFileListingBuilder builder()

--- a/community/logging/src/main/java/org/neo4j/logging/RotatingFileOutputStreamSupplier.java
+++ b/community/logging/src/main/java/org/neo4j/logging/RotatingFileOutputStreamSupplier.java
@@ -37,7 +37,7 @@ import java.util.function.Supplier;
 import org.neo4j.io.NullOutputStream;
 import org.neo4j.io.fs.FileSystemAbstraction;
 
-import static org.neo4j.io.file.Files.createOrOpenAsOuputStream;
+import static org.neo4j.io.file.Files.createOrOpenAsOutputStream;
 
 /**
  * A {@link Supplier} of {@link OutputStream}s backed by on-disk files, which
@@ -335,7 +335,7 @@ public class RotatingFileOutputStreamSupplier implements Supplier<OutputStream>,
 
     private OutputStream openOutputFile() throws IOException
     {
-        return createOrOpenAsOuputStream( fileSystem, outputFile, true );
+        return createOrOpenAsOutputStream( fileSystem, outputFile, true );
     }
 
     private void shiftArchivedOutputFiles() throws IOException

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/AbstractInProcessServerBuilder.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/AbstractInProcessServerBuilder.java
@@ -57,7 +57,7 @@ import static org.neo4j.graphdb.factory.GraphDatabaseSettings.auth_enabled;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.data_directory;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
 import static org.neo4j.helpers.collection.Iterables.append;
-import static org.neo4j.io.file.Files.createOrOpenAsOuputStream;
+import static org.neo4j.io.file.Files.createOrOpenAsOutputStream;
 
 public abstract class AbstractInProcessServerBuilder implements TestServerBuilder
 {
@@ -130,7 +130,7 @@ public abstract class AbstractInProcessServerBuilder implements TestServerBuilde
             final OutputStream logOutputStream;
             try
             {
-                logOutputStream = createOrOpenAsOuputStream( fileSystem, new File( serverFolder, "neo4j.log" ), true );
+                logOutputStream = createOrOpenAsOutputStream( fileSystem, new File( serverFolder, "neo4j.log" ), true );
             }
             catch ( IOException e )
             {

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClientTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClientTest.java
@@ -44,6 +44,7 @@ import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.logging.FormattedLogProvider;
 import org.neo4j.logging.Level;
 import org.neo4j.logging.LogProvider;
+import org.neo4j.test.rule.SuppressOutput;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
@@ -60,6 +61,8 @@ public class StoreCopyClientTest
 {
     @Rule
     public final ExpectedException expectedException = ExpectedException.none();
+    @Rule
+    public final SuppressOutput suppressOutput = SuppressOutput.suppressAll();
 
     private final CatchUpClient catchUpClient = mock( CatchUpClient.class );
 

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmer.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmer.java
@@ -125,7 +125,10 @@ public class PageCacheWarmer extends LifecycleAdapter implements NeoStoreFileLis
      */
     private synchronized void stopWarmer()
     {
-        executor.shutdown();
+        if ( executor != null )
+        {
+            executor.shutdown();
+        }
     }
 
     /**

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmerKernelExtension.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmerKernelExtension.java
@@ -69,6 +69,7 @@ class PageCacheWarmerKernelExtension extends LifecycleAdapter
     {
         if ( config.get( GraphDatabaseSettings.pagecache_warmup_enabled ) )
         {
+            pageCacheWarmer.start();
             scheduleTryReheat();
             fileListing.get().registerStoreFileProvider( pageCacheWarmer );
         }

--- a/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/DynamicLoggingQueryExecutionMonitor.java
+++ b/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/DynamicLoggingQueryExecutionMonitor.java
@@ -36,7 +36,7 @@ import org.neo4j.logging.Log;
 import org.neo4j.logging.RotatingFileOutputStreamSupplier;
 import org.neo4j.scheduler.JobScheduler;
 
-import static org.neo4j.io.file.Files.createOrOpenAsOuputStream;
+import static org.neo4j.io.file.Files.createOrOpenAsOutputStream;
 import static org.neo4j.kernel.impl.query.QueryLogger.NO_LOG;
 
 class DynamicLoggingQueryExecutionMonitor extends LifecycleAdapter implements QueryExecutionMonitor
@@ -191,7 +191,7 @@ class DynamicLoggingQueryExecutionMonitor extends LifecycleAdapter implements Qu
 
     private void buildNonRotatingLog() throws IOException
     {
-        OutputStream logOutputStream = createOrOpenAsOuputStream( fileSystem, currentQueryLogFile, true );
+        OutputStream logOutputStream = createOrOpenAsOutputStream( fileSystem, currentQueryLogFile, true );
         log = logBuilder.toOutputStream( logOutputStream );
         closable = logOutputStream;
     }


### PR DESCRIPTION
Use plain sync block in PAgeCacheWarmer stop.
Rename Files.createOrOpenAsOuputStream -> Files.createOrOpenAsOutputStream