### PR TITLE
Added dbms.clearQueryCache to isAdminProcedure()

### DIFF
--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
@@ -257,8 +257,9 @@ public class EnterpriseBuiltInDbmsProcedures
         private boolean isAdminProcedure( String procedureName )
         {
             return name.startsWith( "dbms.security." ) && ADMIN_PROCEDURES.contains( procedureName ) ||
-                   name.equals( "dbms.listConfig" ) ||
-                   name.equals( "dbms.setConfigValue" );
+                    name.equals( "dbms.listConfig" ) ||
+                    name.equals( "dbms.setConfigValue" ) ||
+                    name.equals( "dbms.clearQueryCaches" );
         }
     }
 


### PR DESCRIPTION
This will make it so that the procedure will correctly be displayed as "only usable by admins" in the docs and in ```CALL dbms.procedures()```