### PR TITLE
Obsfucate the LDAP system password in toString and debug.log

### DIFF
--- a/community/configuration/src/main/java/org/neo4j/configuration/ConfigOptions.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/ConfigOptions.java
@@ -61,7 +61,7 @@ public class ConfigOptions
                             setting.documentedDefaultValue(),
                         Optional.ofNullable( val.getValue() ),
                             setting.valueDescription(), setting.internal(), setting.dynamic(),
-                            setting.deprecated(), setting.replacement(), setting.isSecret() );
+                            setting.deprecated(), setting.replacement(), setting.secret() );
                 } )
                 .collect( Collectors.toList() );
     }

--- a/community/configuration/src/main/java/org/neo4j/configuration/ConfigOptions.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/ConfigOptions.java
@@ -61,7 +61,7 @@ public class ConfigOptions
                             setting.documentedDefaultValue(),
                         Optional.ofNullable( val.getValue() ),
                             setting.valueDescription(), setting.internal(), setting.dynamic(),
-                            setting.deprecated(), setting.replacement() );
+                            setting.deprecated(), setting.replacement(), setting.isSecret() );
                 } )
                 .collect( Collectors.toList() );
     }

--- a/community/configuration/src/main/java/org/neo4j/configuration/ConfigValue.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/ConfigValue.java
@@ -77,7 +77,7 @@ public class ConfigValue
     @Nonnull
     public Optional<String> valueAsString()
     {
-        return value.map( ConfigValue::valueToString );
+        return this.isSecret() ? Optional.of( Secret.OBSFUCATED ) : value.map( ConfigValue::valueToString );
     }
 
     @Override

--- a/community/configuration/src/main/java/org/neo4j/configuration/ConfigValue.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/ConfigValue.java
@@ -34,6 +34,7 @@ public class ConfigValue
     private final Optional<?> value;
     private final String valueDescription;
     private final boolean internal;
+    private final boolean isSecret;
     private final boolean dynamic;
     private final boolean deprecated;
     private final Optional<String> replacement;
@@ -41,7 +42,7 @@ public class ConfigValue
     public ConfigValue( @Nonnull String name, @Nonnull Optional<String> description,
             @Nonnull Optional<String> documentedDefaultValue, @Nonnull Optional<?> value,
             @Nonnull String valueDescription, boolean internal, boolean dynamic, boolean deprecated,
-            @Nonnull Optional<String> replacement )
+            @Nonnull Optional<String> replacement, boolean isSecret )
     {
         this.name = name;
         this.description = description;
@@ -49,6 +50,7 @@ public class ConfigValue
         this.value = value;
         this.valueDescription = valueDescription;
         this.internal = internal;
+        this.isSecret = isSecret;
         this.dynamic = dynamic;
         this.deprecated = deprecated;
         this.replacement = replacement;
@@ -98,6 +100,11 @@ public class ConfigValue
     public boolean internal()
     {
         return internal;
+    }
+
+    public boolean isSecret()
+    {
+        return isSecret;
     }
 
     public boolean dynamic()

--- a/community/configuration/src/main/java/org/neo4j/configuration/ConfigValue.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/ConfigValue.java
@@ -34,7 +34,7 @@ public class ConfigValue
     private final Optional<?> value;
     private final String valueDescription;
     private final boolean internal;
-    private final boolean isSecret;
+    private final boolean secret;
     private final boolean dynamic;
     private final boolean deprecated;
     private final Optional<String> replacement;
@@ -42,7 +42,7 @@ public class ConfigValue
     public ConfigValue( @Nonnull String name, @Nonnull Optional<String> description,
             @Nonnull Optional<String> documentedDefaultValue, @Nonnull Optional<?> value,
             @Nonnull String valueDescription, boolean internal, boolean dynamic, boolean deprecated,
-            @Nonnull Optional<String> replacement, boolean isSecret )
+            @Nonnull Optional<String> replacement, boolean secret )
     {
         this.name = name;
         this.description = description;
@@ -50,7 +50,7 @@ public class ConfigValue
         this.value = value;
         this.valueDescription = valueDescription;
         this.internal = internal;
-        this.isSecret = isSecret;
+        this.secret = secret;
         this.dynamic = dynamic;
         this.deprecated = deprecated;
         this.replacement = replacement;
@@ -77,7 +77,7 @@ public class ConfigValue
     @Nonnull
     public Optional<String> valueAsString()
     {
-        return this.isSecret() ? Optional.of( Secret.OBSFUCATED ) : value.map( ConfigValue::valueToString );
+        return this.secret() ? Optional.of( Secret.OBSFUCATED ) : value.map( ConfigValue::valueToString );
     }
 
     @Override
@@ -102,9 +102,9 @@ public class ConfigValue
         return internal;
     }
 
-    public boolean isSecret()
+    public boolean secret()
     {
-        return isSecret;
+        return secret;
     }
 
     public boolean dynamic()

--- a/community/configuration/src/main/java/org/neo4j/configuration/LoadableConfig.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/LoadableConfig.java
@@ -76,6 +76,9 @@ public interface LoadableConfig
                     final Internal internalAnnotation = f.getAnnotation( Internal.class );
                     setting.setInternal( internalAnnotation != null );
 
+                    final Secret secretAnnotation = f.getAnnotation( Secret.class );
+                    setting.makeSecret( secretAnnotation != null );
+
                     final Dynamic dynamicAnnotation = f.getAnnotation( Dynamic.class );
                     setting.setDynamic( dynamicAnnotation != null );
                 }

--- a/community/configuration/src/main/java/org/neo4j/configuration/LoadableConfig.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/LoadableConfig.java
@@ -77,7 +77,7 @@ public interface LoadableConfig
                     setting.setInternal( internalAnnotation != null );
 
                     final Secret secretAnnotation = f.getAnnotation( Secret.class );
-                    setting.makeSecret( secretAnnotation != null );
+                    setting.setSecret( secretAnnotation != null );
 
                     final Dynamic dynamicAnnotation = f.getAnnotation( Dynamic.class );
                     setting.setDynamic( dynamicAnnotation != null );

--- a/community/configuration/src/main/java/org/neo4j/configuration/Secret.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/Secret.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Target;
 
 /**
  * Used to define a configuration setting as secret, which means we should not show the value in logs.
+ * It is supported in configs set using LoadableConfig, but not for group settings, like connectors and SSL policies.
  */
 @Retention( RetentionPolicy.RUNTIME )
 @Target( {ElementType.TYPE, ElementType.FIELD} )

--- a/community/configuration/src/main/java/org/neo4j/configuration/Secret.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/Secret.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.configuration;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to define a configuration setting as secret, which means we should not show the value in logs.
+ */
+@Retention( RetentionPolicy.RUNTIME )
+@Target( {ElementType.TYPE, ElementType.FIELD} )
+public @interface Secret
+{
+    String OBSFUCATED = "##########";
+}

--- a/community/configuration/src/test/java/org/neo4j/configuration/ConfigValueTest.java
+++ b/community/configuration/src/test/java/org/neo4j/configuration/ConfigValueTest.java
@@ -42,7 +42,7 @@ public class ConfigValueTest
         assertFalse( value.deprecated() );
         assertEquals( Optional.empty(), value.replacement() );
         assertFalse( value.internal() );
-        assertFalse( value.isSecret() );
+        assertFalse( value.secret() );
     }
 
     @Test
@@ -52,7 +52,7 @@ public class ConfigValueTest
                 "description", true, false, false, Optional.empty(), false );
 
         assertTrue( value.internal() );
-        assertFalse( value.isSecret() );
+        assertFalse( value.secret() );
     }
 
     @Test
@@ -66,7 +66,7 @@ public class ConfigValueTest
         assertFalse( value.deprecated() );
         assertEquals( Optional.empty(), value.replacement() );
         assertFalse( value.internal() );
-        assertFalse( value.isSecret() );
+        assertFalse( value.secret() );
     }
 
     @Test
@@ -80,7 +80,7 @@ public class ConfigValueTest
         assertTrue( value.deprecated() );
         assertEquals( "new_name", value.replacement().get() );
         assertFalse( value.internal() );
-        assertFalse( value.isSecret() );
+        assertFalse( value.secret() );
     }
 
     @Test
@@ -94,7 +94,7 @@ public class ConfigValueTest
         assertTrue( value.deprecated() );
         assertEquals( "new_name", value.replacement().get() );
         assertFalse( value.internal() );
-        assertFalse( value.isSecret() );
+        assertFalse( value.secret() );
         assertEquals( "a simple integer", value.valueDescription() );
     }
 
@@ -109,7 +109,7 @@ public class ConfigValueTest
         assertFalse( value.deprecated() );
         assertEquals( Optional.empty(), value.replacement() );
         assertFalse( value.internal() );
-        assertTrue( value.isSecret() );
+        assertTrue( value.secret() );
     }
 
     @Test

--- a/community/configuration/src/test/java/org/neo4j/configuration/ConfigValueTest.java
+++ b/community/configuration/src/test/java/org/neo4j/configuration/ConfigValueTest.java
@@ -42,6 +42,7 @@ public class ConfigValueTest
         assertFalse( value.deprecated() );
         assertEquals( Optional.empty(), value.replacement() );
         assertFalse( value.internal() );
+        assertFalse( value.isSecret() );
     }
 
     @Test
@@ -51,6 +52,7 @@ public class ConfigValueTest
                 "description", true, false, false, Optional.empty(), false );
 
         assertTrue( value.internal() );
+        assertFalse( value.isSecret() );
     }
 
     @Test
@@ -64,6 +66,7 @@ public class ConfigValueTest
         assertFalse( value.deprecated() );
         assertEquals( Optional.empty(), value.replacement() );
         assertFalse( value.internal() );
+        assertFalse( value.isSecret() );
     }
 
     @Test
@@ -77,6 +80,7 @@ public class ConfigValueTest
         assertTrue( value.deprecated() );
         assertEquals( "new_name", value.replacement().get() );
         assertFalse( value.internal() );
+        assertFalse( value.isSecret() );
     }
 
     @Test
@@ -90,7 +94,22 @@ public class ConfigValueTest
         assertTrue( value.deprecated() );
         assertEquals( "new_name", value.replacement().get() );
         assertFalse( value.internal() );
+        assertFalse( value.isSecret() );
         assertEquals( "a simple integer", value.valueDescription() );
+    }
+
+    @Test
+    public void handlesSecretValue() throws Exception
+    {
+        ConfigValue value = new ConfigValue( "name", Optional.empty(), Optional.empty(), Optional.of( "secret" ),
+                "description", false, false, false, Optional.empty(), true );
+
+        assertEquals( Optional.of( "secret" ), value.value() );
+        assertEquals( Secret.OBSFUCATED, value.toString() );
+        assertFalse( value.deprecated() );
+        assertEquals( Optional.empty(), value.replacement() );
+        assertFalse( value.internal() );
+        assertTrue( value.isSecret() );
     }
 
     @Test

--- a/community/configuration/src/test/java/org/neo4j/configuration/ConfigValueTest.java
+++ b/community/configuration/src/test/java/org/neo4j/configuration/ConfigValueTest.java
@@ -35,7 +35,7 @@ public class ConfigValueTest
     public void handlesEmptyValue() throws Exception
     {
         ConfigValue value = new ConfigValue( "name", Optional.empty(), Optional.empty(), Optional.empty(),
-                "description", false, false, false, Optional.empty() );
+                "description", false, false, false, Optional.empty(), false );
 
         assertEquals( Optional.empty(), value.value() );
         assertEquals( "null", value.toString() );
@@ -48,8 +48,7 @@ public class ConfigValueTest
     public void handlesInternal() throws Exception
     {
         ConfigValue value = new ConfigValue( "name", Optional.empty(), Optional.empty(), Optional.empty(),
-                "description", true, false, false,
-                Optional.empty() );
+                "description", true, false, false, Optional.empty(), false );
 
         assertTrue( value.internal() );
     }
@@ -58,7 +57,7 @@ public class ConfigValueTest
     public void handlesNonEmptyValue() throws Exception
     {
         ConfigValue value = new ConfigValue( "name", Optional.empty(), Optional.empty(), Optional.of( 1 ),
-                "description", false, false, false, Optional.empty() );
+                "description", false, false, false, Optional.empty(), false );
 
         assertEquals( Optional.of( 1 ), value.value() );
         assertEquals( "1", value.toString() );
@@ -71,8 +70,7 @@ public class ConfigValueTest
     public void handlesDeprecationAndReplacement() throws Exception
     {
         ConfigValue value = new ConfigValue( "old_name", Optional.empty(), Optional.empty(), Optional.of( 1 ),
-                "description", false, false, true,
-                Optional.of( "new_name" ) );
+                "description", false, false, true, Optional.of( "new_name" ), false );
 
         assertEquals( Optional.of( 1 ), value.value() );
         assertEquals( "1", value.toString() );
@@ -85,8 +83,7 @@ public class ConfigValueTest
     public void handlesValueDescription() throws Exception
     {
         ConfigValue value = new ConfigValue( "old_name", Optional.empty(), Optional.empty(), Optional.of( 1 ),
-                "a simple integer", false, false, true,
-                Optional.of( "new_name" ) );
+                "a simple integer", false, false, true, Optional.of( "new_name" ), false );
 
         assertEquals( Optional.of( 1 ), value.value() );
         assertEquals( "1", value.toString() );

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/BaseSetting.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/BaseSetting.java
@@ -31,7 +31,7 @@ public abstract class BaseSetting<T> implements Setting<T>
     private boolean deprecated;
     private String replacement;
     private boolean internal;
-    private boolean isSecret;
+    private boolean secret;
     private boolean dynamic;
     private String documentedDefaultValue;
     private String description;
@@ -72,12 +72,12 @@ public abstract class BaseSetting<T> implements Setting<T>
     @Override
     public boolean secret()
     {
-        return this.isSecret;
+        return this.secret;
     }
 
     public void setSecret( final boolean val )
     {
-        this.isSecret = val;
+        this.secret = val;
     }
 
     @Override

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/BaseSetting.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/BaseSetting.java
@@ -31,6 +31,7 @@ public abstract class BaseSetting<T> implements Setting<T>
     private boolean deprecated;
     private String replacement;
     private boolean internal;
+    private boolean isSecret;
     private boolean dynamic;
     private String documentedDefaultValue;
     private String description;
@@ -66,6 +67,17 @@ public abstract class BaseSetting<T> implements Setting<T>
     public void setInternal( final boolean val )
     {
         this.internal = val;
+    }
+
+    @Override
+    public boolean isSecret()
+    {
+        return this.isSecret;
+    }
+
+    public void makeSecret( final boolean val )
+    {
+        this.isSecret = val;
     }
 
     @Override

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/BaseSetting.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/BaseSetting.java
@@ -70,12 +70,12 @@ public abstract class BaseSetting<T> implements Setting<T>
     }
 
     @Override
-    public boolean isSecret()
+    public boolean secret()
     {
         return this.isSecret;
     }
 
-    public void makeSecret( final boolean val )
+    public void setSecret( final boolean val )
     {
         this.isSecret = val;
     }

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/SettingGroup.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/SettingGroup.java
@@ -61,6 +61,11 @@ public interface SettingGroup<T> extends SettingValidator
     boolean internal();
 
     /**
+     * @return {@code true} if secret setting (should be hidden), false otherwise.
+     */
+    boolean isSecret();
+
+    /**
      * @return the documented default value if it needs special documentation, empty if default value is good as is.
      */
     Optional<String> documentedDefaultValue();

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/SettingGroup.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/SettingGroup.java
@@ -63,7 +63,10 @@ public interface SettingGroup<T> extends SettingValidator
     /**
      * @return {@code true} if secret setting (should be hidden), false otherwise.
      */
-    boolean isSecret();
+    default boolean secret()
+    {
+        return false;
+    }
 
     /**
      * @return the documented default value if it needs special documentation, empty if default value is good as is.

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -44,10 +45,12 @@ import javax.annotation.Nullable;
 import org.neo4j.configuration.ConfigOptions;
 import org.neo4j.configuration.ConfigValue;
 import org.neo4j.configuration.LoadableConfig;
+import org.neo4j.configuration.Secret;
 import org.neo4j.graphdb.config.BaseSetting;
 import org.neo4j.graphdb.config.Configuration;
 import org.neo4j.graphdb.config.InvalidSettingException;
 import org.neo4j.graphdb.config.Setting;
+import org.neo4j.graphdb.config.SettingGroup;
 import org.neo4j.graphdb.config.SettingValidator;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.MapUtil;
@@ -82,6 +85,7 @@ public class Config implements DiagnosticsProvider, Configuration
     private final List<ConfigOptions> configOptions;
 
     private final Map<String,String> params = new CopyOnWriteHashMap<>(); // Read heavy workload
+    private final Set<String> secrets = new HashSet<>();
     private final Map<String, Collection<BiConsumer<String,String>>> updateListeners = new ConcurrentHashMap<>();
     private final ConfigurationMigrator migrator;
     private final List<ConfigurationValidator> validators = new ArrayList<>();
@@ -389,6 +393,14 @@ public class Config implements DiagnosticsProvider, Configuration
                 .filter( BaseSetting.class::isInstance )
                 .map( BaseSetting.class::cast )
                 .forEach( setting -> settingsMap.put( setting.name(), setting ) );
+
+        // Find secret settings
+        configOptions.stream()
+                .map( ConfigOptions::settingGroup )
+                .filter( SettingGroup::isSecret )
+                .filter( BaseSetting.class::isInstance )
+                .map( BaseSetting.class::cast )
+                .forEach( setting -> secrets.add( setting.name() ) );
 
         validators.addAll( additionalValidators );
         migrator = new AnnotationBasedConfigurationMigrator( settingsClasses );
@@ -741,9 +753,14 @@ public class Config implements DiagnosticsProvider, Configuration
             logger.log( "Neo4j Kernel properties:" );
             for ( Map.Entry<String,String> param : params.entrySet() )
             {
-                logger.log( "%s=%s", param.getKey(), param.getValue() );
+                logger.log( "%s=%s", param.getKey(), obsfucateIfSecret( param ) );
             }
         }
+    }
+
+    private String obsfucateIfSecret( Map.Entry<String,String> param )
+    {
+        return secrets.contains( param.getKey() ) ? Secret.OBSFUCATED : param.getValue();
     }
 
     /**
@@ -942,7 +959,7 @@ public class Config implements DiagnosticsProvider, Configuration
     {
         return params.entrySet().stream()
                 .sorted( Comparator.comparing( Map.Entry::getKey ) )
-                .map( entry -> entry.getKey() + "=" + entry.getValue() )
+                .map( entry -> entry.getKey() + "=" + obsfucateIfSecret( entry ) )
                 .collect( Collectors.joining( ", ") );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
@@ -85,7 +85,6 @@ public class Config implements DiagnosticsProvider, Configuration
     private final List<ConfigOptions> configOptions;
 
     private final Map<String,String> params = new CopyOnWriteHashMap<>(); // Read heavy workload
-    private final Set<String> secrets = new HashSet<>();
     private final Map<String, Collection<BiConsumer<String,String>>> updateListeners = new ConcurrentHashMap<>();
     private final ConfigurationMigrator migrator;
     private final List<ConfigurationValidator> validators = new ArrayList<>();
@@ -393,14 +392,6 @@ public class Config implements DiagnosticsProvider, Configuration
                 .filter( BaseSetting.class::isInstance )
                 .map( BaseSetting.class::cast )
                 .forEach( setting -> settingsMap.put( setting.name(), setting ) );
-
-        // Find secret settings
-        configOptions.stream()
-                .map( ConfigOptions::settingGroup )
-                .filter( SettingGroup::secret )
-                .filter( BaseSetting.class::isInstance )
-                .map( BaseSetting.class::cast )
-                .forEach( setting -> secrets.add( setting.name() ) );
 
         validators.addAll( additionalValidators );
         migrator = new AnnotationBasedConfigurationMigrator( settingsClasses );
@@ -767,7 +758,14 @@ public class Config implements DiagnosticsProvider, Configuration
 
     private String obsfucateIfSecret( String key, String value )
     {
-        return secrets.contains( key ) ? Secret.OBSFUCATED : value;
+        if ( settingsMap.containsKey( key ) && settingsMap.get( key ).secret() )
+        {
+            return Secret.OBSFUCATED;
+        }
+        else
+        {
+            return value;
+        }
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConnectorValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConnectorValidator.java
@@ -229,7 +229,7 @@ public abstract class ConnectorValidator implements SettingGroup<Object>
     }
 
     @Override
-    public boolean isSecret()
+    public boolean secret()
     {
         return false;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConnectorValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConnectorValidator.java
@@ -229,6 +229,12 @@ public abstract class ConnectorValidator implements SettingGroup<Object>
     }
 
     @Override
+    public boolean isSecret()
+    {
+        return false;
+    }
+
+    @Override
     public Optional<String> documentedDefaultValue()
     {
         return Optional.empty();

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Settings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Settings.java
@@ -1228,6 +1228,12 @@ public class Settings
             }
 
             @Override
+            public boolean isSecret()
+            {
+                return newSetting.isSecret();
+            }
+
+            @Override
             public Optional<String> documentedDefaultValue()
             {
                 return newSetting.documentedDefaultValue();

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Settings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Settings.java
@@ -1228,9 +1228,9 @@ public class Settings
             }
 
             @Override
-            public boolean isSecret()
+            public boolean secret()
             {
-                return newSetting.isSecret();
+                return newSetting.secret();
             }
 
             @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyConfigValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyConfigValidator.java
@@ -158,6 +158,12 @@ public class SslPolicyConfigValidator implements SettingGroup<Object>
     }
 
     @Override
+    public boolean isSecret()
+    {
+        return false;
+    }
+
+    @Override
     public Optional<String> documentedDefaultValue()
     {
         return empty();

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyConfigValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyConfigValidator.java
@@ -158,7 +158,7 @@ public class SslPolicyConfigValidator implements SettingGroup<Object>
     }
 
     @Override
-    public boolean isSecret()
+    public boolean secret()
     {
         return false;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/ConfigTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/ConfigTest.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.configuration;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -49,6 +50,7 @@ import org.neo4j.test.rule.TestDirectory;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -390,6 +392,10 @@ public class ConfigTest
     {
         @Dynamic
         public static final Setting<Boolean> boolSetting = setting( "bool_setting", BOOLEAN, Settings.TRUE );
+
+        @Dynamic
+        @Secret
+        public static final Setting<String> secretSetting = setting( "password", STRING, "secret" );
     }
 
     @Test
@@ -469,5 +475,40 @@ public class ConfigTest
 
         verify( log ).error( "Failure when notifying listeners after dynamic setting change; " +
                              "new setting might not have taken effect: Boo", exception );
+    }
+
+    @Test
+    public void updateDynamicShouldWorkWithSecret() throws Exception
+    {
+        // Given a secret dynamic setting with a registered update listener
+        String settingName = MyDynamicSettings.secretSetting.name();
+        String changedMessage = "Setting changed: '%s' changed from '%s' to '%s'";
+        Config config = Config.builder().withConfigClasses( singletonList( new MyDynamicSettings() ) ).build();
+
+        Log log = mock( Log.class );
+        config.setLogger( log );
+
+        AtomicInteger counter = new AtomicInteger( 0 );
+        config.registerDynamicUpdateListener( MyDynamicSettings.secretSetting, ( previous, update ) ->
+        {
+            counter.getAndIncrement();
+            assertThat( "Update listener should not see obsfucated secret", previous, not( CoreMatchers.equalTo( Secret.OBSFUCATED ) ) );
+            assertThat( "Update listener should not see obsfucated secret", update, not( CoreMatchers.equalTo( Secret.OBSFUCATED ) ) );
+        } );
+
+        // When changing secret settings three times
+        config.updateDynamicSetting( settingName, "another" );
+        config.updateDynamicSetting( settingName, "secret2" );
+        config.updateDynamicSetting( settingName, "" );
+
+        // Then we should see obsfucated log messages
+        InOrder order = inOrder( log );
+        order.verify( log ).info( changedMessage, settingName, "default (" + Secret.OBSFUCATED + ")", Secret.OBSFUCATED );
+        order.verify( log ).info( changedMessage, settingName, Secret.OBSFUCATED, Secret.OBSFUCATED );
+        order.verify( log ).info( changedMessage, settingName, Secret.OBSFUCATED, "default (" + Secret.OBSFUCATED + ")" );
+        verifyNoMoreInteractions( log );
+
+        // And see 3 calls to the update listener
+        assertThat( counter.get(), is( 3 ) );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/ConfigTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/ConfigTest.java
@@ -276,8 +276,8 @@ public class ConfigTest
                 .build();
 
         // Then
-        assertTrue( config.getConfigValues().get( MySettingsWithDefaults.password.name() ).isSecret() );
-        assertFalse( config.getConfigValues().get( MySettingsWithDefaults.hello.name() ).isSecret() );
+        assertTrue( config.getConfigValues().get( MySettingsWithDefaults.password.name() ).secret() );
+        assertFalse( config.getConfigValues().get( MySettingsWithDefaults.hello.name() ).secret() );
         String configText = config.toString();
         assertTrue( configText.contains( Secret.OBSFUCATED ) );
         assertFalse( configText.contains( "this should not be visible" ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/ConfigTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/ConfigTest.java
@@ -39,6 +39,7 @@ import org.neo4j.configuration.Dynamic;
 import org.neo4j.configuration.Internal;
 import org.neo4j.configuration.LoadableConfig;
 import org.neo4j.configuration.ReplacedBy;
+import org.neo4j.configuration.Secret;
 import org.neo4j.graphdb.config.InvalidSettingException;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
@@ -101,6 +102,9 @@ public class ConfigTest
 
         @Deprecated
         public static final Setting<String> oldSetting = setting( "some_setting", STRING, "Has no replacement" );
+
+        @Secret
+        public static final Setting<String> password = setting( "password", STRING, "This text should not appear in logs or toString" );
     }
 
     private static class HelloHasToBeNeo4jConfigurationValidator implements ConfigurationValidator
@@ -249,14 +253,33 @@ public class ConfigTest
     {
         // Given
         Config config = Config.builder()
-                              .withSetting( MySettingsWithDefaults.secretSetting, "false" )
-                              .withSetting( MySettingsWithDefaults.hello, "ABC" )
-                              .withConfigClasses( Arrays.asList( mySettingsWithDefaults, myMigratingSettings ) )
-                              .build();
+                .withSetting( MySettingsWithDefaults.secretSetting, "false" )
+                .withSetting( MySettingsWithDefaults.hello, "ABC" )
+                .withConfigClasses( Arrays.asList( mySettingsWithDefaults, myMigratingSettings ) )
+                .build();
 
         // Then
         assertTrue( config.getConfigValues().get( MySettingsWithDefaults.secretSetting.name() ).internal() );
         assertFalse( config.getConfigValues().get( MySettingsWithDefaults.hello.name() ).internal() );
+    }
+
+    @Test
+    public void shouldSetSecretParameter()
+    {
+        // Given
+        Config config = Config.builder()
+                .withSetting( MySettingsWithDefaults.password, "this should not be visible" )
+                .withSetting( MySettingsWithDefaults.hello, "ABC" )
+                .withConfigClasses( Arrays.asList( mySettingsWithDefaults, myMigratingSettings ) )
+                .build();
+
+        // Then
+        assertTrue( config.getConfigValues().get( MySettingsWithDefaults.password.name() ).isSecret() );
+        assertFalse( config.getConfigValues().get( MySettingsWithDefaults.hello.name() ).isSecret() );
+        String configText = config.toString();
+        assertTrue( configText.contains( Secret.OBSFUCATED ) );
+        assertFalse( configText.contains( "this should not be visible" ) );
+        assertFalse( configText.contains( config.get( MySettingsWithDefaults.password ) ) );
     }
 
     @Test

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.neo4j.configuration.Description;
 import org.neo4j.configuration.Internal;
 import org.neo4j.configuration.LoadableConfig;
+import org.neo4j.configuration.Secret;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.logging.Level;
@@ -225,6 +226,7 @@ public class SecuritySettings implements LoadableConfig
     public static final Setting<String> ldap_authorization_system_username =
             setting( "dbms.security.ldap.authorization.system_username", STRING, NO_DEFAULT );
 
+    @Secret
     @Description(
             "An LDAP system account password to use for authorization searches when " +
             "`dbms.security.ldap.authorization.use_system_account` is `true`." )

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/LdapAuthIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/LdapAuthIT.java
@@ -56,21 +56,30 @@ import javax.naming.ldap.LdapContext;
 
 import org.neo4j.bolt.v1.transport.integration.TransportTestUtil;
 import org.neo4j.bolt.v1.transport.socket.client.TransportConnection;
+import org.neo4j.configuration.Secret;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.kernel.impl.proc.Procedures;
+import org.neo4j.kernel.info.DiagnosticsPhase;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.logging.Logger;
 import org.neo4j.server.security.enterprise.auth.EnterpriseAuthAndUserManager;
 import org.neo4j.server.security.enterprise.auth.ProcedureInteractionTestBase;
 import org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles;
 import org.neo4j.server.security.enterprise.configuration.SecuritySettings;
 import org.neo4j.test.DoubleLatch;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.neo4j.bolt.v1.messaging.message.InitMessage.init;
 import static org.neo4j.bolt.v1.messaging.message.PullAllMessage.pullAll;
 import static org.neo4j.bolt.v1.messaging.message.RunMessage.run;
@@ -1188,6 +1197,19 @@ public class LdapAuthIT extends EnterpriseAuthenticationTestBase
             assertReadSucceeds();
             assertWriteFails( "tank", "reader" );
         }
+    }
+
+    @Test
+    public void shouldNotSeeSystemPassword()
+    {
+        Config config = ((GraphDatabaseAPI) server.graphDatabaseService()).getDependencyResolver().resolveDependency( Config.class );
+        String expected = "dbms.security.ldap.authorization.system_password=" + Secret.OBSFUCATED;
+        assertThat( "Should see obsfucated password in config.toString", config.toString(), containsString( expected ) );
+        String password = config.get( SecuritySettings.ldap_authorization_system_password );
+        assertThat( "Normal access should not be obsfucated", password, not( containsString( Secret.OBSFUCATED ) ) );
+        Logger log = mock( Logger.class );
+        config.dump( DiagnosticsPhase.EXPLICIT, log );
+        verify( log, atLeastOnce() ).log( "%s=%s", "dbms.security.ldap.authorization.system_password", Secret.OBSFUCATED );
     }
 
     private void clearAuthCacheFromDifferentConnection() throws Exception


### PR DESCRIPTION
changelog: Fixed visibility of LDAP system password in debug.log through new `@Secret` annotation.

Marking config settings as `@Secret` will cause them to be printed as `##########` in debug.log as well as the output of `CALL dbms.listConfig`.