### PR TITLE
Wait for complete download in core life start

### DIFF
--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupDelegator.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupDelegator.java
@@ -29,7 +29,6 @@ import org.neo4j.causalclustering.catchup.storecopy.RemoteStore;
 import org.neo4j.causalclustering.catchup.storecopy.StoreCopyClient;
 import org.neo4j.causalclustering.catchup.storecopy.StoreCopyFailedException;
 import org.neo4j.causalclustering.catchup.storecopy.StoreIdDownloadFailedException;
-import org.neo4j.causalclustering.catchup.storecopy.StreamingTransactionsFailedException;
 import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
@@ -53,14 +52,7 @@ class BackupDelegator extends LifecycleAdapter
 
     void copy( AdvertisedSocketAddress fromAddress, StoreId expectedStoreId, Path destDir ) throws StoreCopyFailedException
     {
-        try
-        {
-            remoteStore.copy( new CatchupAddressProvider.SingleAddressProvider( fromAddress ), expectedStoreId, destDir.toFile() );
-        }
-        catch ( StreamingTransactionsFailedException e )
-        {
-            throw new StoreCopyFailedException( e );
-        }
+        remoteStore.copy( new CatchupAddressProvider.SingleAddressProvider( fromAddress ), expectedStoreId, destDir.toFile() );
     }
 
     CatchupResult tryCatchingUp( AdvertisedSocketAddress fromAddress, StoreId expectedStoreId, Path storeDir ) throws StoreCopyFailedException

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupDelegatorTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupDelegatorTest.java
@@ -34,7 +34,6 @@ import org.neo4j.causalclustering.catchup.storecopy.RemoteStore;
 import org.neo4j.causalclustering.catchup.storecopy.StoreCopyClient;
 import org.neo4j.causalclustering.catchup.storecopy.StoreCopyFailedException;
 import org.neo4j.causalclustering.catchup.storecopy.StoreIdDownloadFailedException;
-import org.neo4j.causalclustering.catchup.storecopy.StreamingTransactionsFailedException;
 import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 
@@ -117,7 +116,7 @@ public class BackupDelegatorTest
 
     @Test
     public void retrieveStoreDelegatesToStoreCopyService()
-            throws StoreCopyFailedException, StreamingTransactionsFailedException, CatchupAddressResolutionException
+            throws StoreCopyFailedException, CatchupAddressResolutionException
     {
         // given
         StoreId storeId = new StoreId( 92, 5, 7, 32 );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/CopiedStoreRecovery.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/CopiedStoreRecovery.java
@@ -57,11 +57,11 @@ public class CopiedStoreRecovery extends LifecycleAdapter
         shutdown = true;
     }
 
-    public synchronized void recoverCopiedStore( File tempStore ) throws StoreCopyFailedException
+    public synchronized void recoverCopiedStore( File tempStore ) throws DatabaseShutdownException
     {
         if ( shutdown )
         {
-            throw new StoreCopyFailedException( "Abort store-copied store recovery due to database shutdown" );
+            throw new DatabaseShutdownException( "Abort store-copied store recovery due to database shutdown" );
         }
 
         try

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/DatabaseShutdownException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/DatabaseShutdownException.java
@@ -19,9 +19,9 @@
  */
 package org.neo4j.causalclustering.catchup.storecopy;
 
-public class StreamingTransactionsFailedException extends Exception
+public class DatabaseShutdownException extends Exception
 {
-    StreamingTransactionsFailedException( String message )
+    DatabaseShutdownException( String message )
     {
         super( message );
     }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStore.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStore.java
@@ -119,7 +119,7 @@ public class RemoteStore
     }
 
     public void copy( CatchupAddressProvider addressProvider, StoreId expectedStoreId, File destDir )
-            throws StoreCopyFailedException, StreamingTransactionsFailedException
+            throws StoreCopyFailedException
     {
         try
         {
@@ -133,12 +133,11 @@ public class RemoteStore
 
             // Even for cluster store copy, we still write the transaction logs into the store directory itself
             // because the destination directory is temporary. We will copy them to the correct place later.
-            boolean keepTxLogsInStoreDir = true;
-            CatchupResult catchupResult =
-                    pullTransactions( addressProvider.primary(), expectedStoreId, destDir, lastFlushedTxId, true, keepTxLogsInStoreDir );
+            CatchupResult catchupResult = pullTransactions( addressProvider.primary(), expectedStoreId, destDir,
+                    lastFlushedTxId, true, true );
             if ( catchupResult != SUCCESS_END_OF_STREAM )
             {
-                throw new StreamingTransactionsFailedException( "Failed to pull transactions: " + catchupResult );
+                throw new StoreCopyFailedException( "Failed to pull transactions: " + catchupResult );
             }
         }
         catch ( CatchupAddressResolutionException | IOException e )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyProcess.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyProcess.java
@@ -49,7 +49,7 @@ public class StoreCopyProcess
     }
 
     public void replaceWithStoreFrom( CatchupAddressProvider addressProvider, StoreId expectedStoreId )
-            throws IOException, StoreCopyFailedException, StreamingTransactionsFailedException
+            throws IOException, StoreCopyFailedException, DatabaseShutdownException
     {
         try ( TemporaryStoreDirectory tempStore = new TemporaryStoreDirectory( fs, pageCache, localDatabase.storeDir() ) )
         {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
@@ -177,7 +177,7 @@ public class CoreServerModule
         CoreStateDownloader downloader = createCoreStateDownloader( servicesToStopOnStoreCopy, catchUpClient );
 
         this.downloadService = new CoreStateDownloaderService( platformModule.jobScheduler, downloader, commandApplicationProcess, logProvider,
-                new ExponentialBackoffStrategy( 1, 30, SECONDS ).newTimeout() );
+                new ExponentialBackoffStrategy( 1, 30, SECONDS ).newTimeout(), databaseHealthSupplier );
 
         this.membershipWaiterLifecycle = createMembershipWaiterLifecycle();
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
@@ -285,7 +285,7 @@ public class CoreServerModule
     {
         return new CoreLife( consensusModule.raftMachine(),
                 localDatabase, clusteringModule.clusterBinder(), commandApplicationProcess, coreStateMachinesModule.coreStateMachines,
-                handler, snapshotService );
+                handler, snapshotService, downloadService );
     }
 
     public CommandApplicationProcess commandApplicationProcess()

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CoreSnapshotService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CoreSnapshotService.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.causalclustering.core.state;
 
+import java.io.IOException;
+
 import org.neo4j.causalclustering.core.consensus.RaftMachine;
 import org.neo4j.causalclustering.core.consensus.log.RaftLog;
 import org.neo4j.causalclustering.core.state.snapshot.CoreSnapshot;
@@ -63,7 +65,7 @@ public class CoreSnapshotService
         }
     }
 
-    public synchronized void installSnapshot( CoreSnapshot coreSnapshot ) throws Exception
+    public synchronized void installSnapshot( CoreSnapshot coreSnapshot ) throws IOException
     {
         long snapshotPrevIndex = coreSnapshot.prevIndex();
         raftLog.skip( snapshotPrevIndex, coreSnapshot.prevTerm() );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloader.java
@@ -35,6 +35,7 @@ import org.neo4j.causalclustering.core.state.machines.CoreStateMachines;
 import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
+import org.neo4j.kernel.impl.util.DebugUtil;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloader.java
@@ -19,24 +19,28 @@
  */
 package org.neo4j.causalclustering.core.state.snapshot;
 
+import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
 import org.neo4j.causalclustering.catchup.CatchUpClient;
+import org.neo4j.causalclustering.catchup.CatchUpClientException;
 import org.neo4j.causalclustering.catchup.CatchUpResponseAdaptor;
-import org.neo4j.causalclustering.catchup.CatchupResult;
 import org.neo4j.causalclustering.catchup.CatchupAddressProvider;
+import org.neo4j.causalclustering.catchup.CatchupAddressResolutionException;
+import org.neo4j.causalclustering.catchup.CatchupResult;
 import org.neo4j.causalclustering.catchup.storecopy.CommitStateHelper;
+import org.neo4j.causalclustering.catchup.storecopy.DatabaseShutdownException;
 import org.neo4j.causalclustering.catchup.storecopy.LocalDatabase;
 import org.neo4j.causalclustering.catchup.storecopy.RemoteStore;
 import org.neo4j.causalclustering.catchup.storecopy.StoreCopyFailedException;
 import org.neo4j.causalclustering.catchup.storecopy.StoreCopyProcess;
+import org.neo4j.causalclustering.catchup.storecopy.StoreIdDownloadFailedException;
 import org.neo4j.causalclustering.core.state.CoreSnapshotService;
 import org.neo4j.causalclustering.core.state.machines.CoreStateMachines;
-import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
-import org.neo4j.kernel.impl.util.DebugUtil;
 import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.lifecycle.LifecycleException;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 
@@ -56,10 +60,10 @@ public class CoreStateDownloader
     private final CoreSnapshotService snapshotService;
     private CommitStateHelper commitStateHelper;
 
-    public CoreStateDownloader( LocalDatabase localDatabase, Lifecycle startStopOnStoreCopy,
-            RemoteStore remoteStore, CatchUpClient catchUpClient, LogProvider logProvider,
-            StoreCopyProcess storeCopyProcess, CoreStateMachines coreStateMachines,
-            CoreSnapshotService snapshotService, CommitStateHelper commitStateHelper )
+    public CoreStateDownloader( LocalDatabase localDatabase, Lifecycle startStopOnStoreCopy, RemoteStore remoteStore,
+            CatchUpClient catchUpClient, LogProvider logProvider, StoreCopyProcess storeCopyProcess,
+            CoreStateMachines coreStateMachines, CoreSnapshotService snapshotService,
+            CommitStateHelper commitStateHelper )
     {
         this.localDatabase = localDatabase;
         this.startStopOnStoreCopy = startStopOnStoreCopy;
@@ -72,97 +76,160 @@ public class CoreStateDownloader
         this.commitStateHelper = commitStateHelper;
     }
 
-    void downloadSnapshot( CatchupAddressProvider addressProvider ) throws StoreCopyFailedException
+    /**
+     * Tries to catchup this instance by downloading a snapshot. A snapshot consists of both the
+     * comparatively small state of the cluster state machines as well as the database store. The
+     * store is however caught up using two different approach. If it is possible to catchup by
+     * pulling transactions, then this will be sufficient, but if the store is lagging too far
+     * behind then a complete store copy will be attempted.
+     *
+     * @param addressProvider Provider of addresses to catchup from.
+     * @return True if the operation succeeded, and false otherwise.
+     * @throws LifecycleException A major database component failed to start or stop.
+     * @throws IOException An issue with I/O.
+     * @throws DatabaseShutdownException The database is shutting down.
+     */
+    boolean downloadSnapshot( CatchupAddressProvider addressProvider )
+            throws LifecycleException, IOException, DatabaseShutdownException
     {
+        /* Extract some key properties before shutting it down. */
+        boolean isEmptyStore = localDatabase.isEmpty();
+
+        /*
+         *  There is no reason to try to recover if there are no transaction logs and in fact it is
+         *  also problematic for the initial transaction pull during the snapshot download because the
+         *  kernel will create a transaction log with a header where previous index points to the same
+         *  index as that written down into the metadata store. This is problematic because we have no
+         *  guarantee that there are later transactions and we need at least one transaction in
+         *  the log to figure out the Raft log index (see {@link RecoverConsensusLogIndex}).
+         */
+        if ( commitStateHelper.hasTxLogs( localDatabase.storeDir() ) )
+        {
+            log.info( "Recovering local database" );
+            ensure( localDatabase::start, "start local database" );
+            ensure( localDatabase::stop, "stop local database" );
+        }
+
+        AdvertisedSocketAddress primary;
+        StoreId remoteStoreId;
         try
         {
-            /* Extract some key properties before shutting it down. */
-            boolean isEmptyStore = localDatabase.isEmpty();
+            primary = addressProvider.primary();
+            remoteStoreId = remoteStore.getStoreId( primary );
+        }
+        catch ( CatchupAddressResolutionException | StoreIdDownloadFailedException e )
+        {
+            log.warn( "Store copy failed", e );
+            return false;
+        }
 
-            /*
-             *  There is no reason to try to recover if there are no transaction logs and in fact it is
-             *  also problematic for the initial transaction pull during the snapshot download because the
-             *  kernel will create a transaction log with a header where previous index points to the same
-             *  index as that written down into the metadata store. This is problematic because we have no
-             *  guarantee that there are later transactions and we need at least one transaction in
-             *  the log to figure out the Raft log index (see {@link RecoverConsensusLogIndex}).
-             */
-            if ( commitStateHelper.hasTxLogs( localDatabase.storeDir() ) )
+        if ( !isEmptyStore && !remoteStoreId.equals( localDatabase.storeId() ) )
+        {
+            log.error( "Store copy failed due to store ID mismatch" );
+            return false;
+        }
+
+        ensure( startStopOnStoreCopy::stop, "stop auxiliary services before store copy" );
+        ensure( localDatabase::stopForStoreCopy, "stop local database for store copy" );
+
+        log.info( "Downloading snapshot from core server at %s", primary );
+
+        /* The core snapshot must be copied before the store, because the store has a dependency on
+         * the state of the state machines. The store will thus be at or ahead of the state machines,
+         * in consensus log index, and application of commands will bring them in sync. Any such commands
+         * that carry transactions will thus be ignored by the transaction/token state machines, since they
+         * are ahead, and the correct decisions for their applicability have already been taken as encapsulated
+         * in the copied store. */
+
+        CoreSnapshot coreSnapshot;
+        try
+        {
+            coreSnapshot = catchUpClient.makeBlockingRequest( primary, new CoreSnapshotRequest(),
+                    new CatchUpResponseAdaptor<CoreSnapshot>()
+                    {
+                        @Override
+                        public void onCoreSnapshot( CompletableFuture<CoreSnapshot> signal, CoreSnapshot response )
+                        {
+                            signal.complete( response );
+                        }
+                    } );
+        }
+        catch ( CatchUpClientException e )
+        {
+            log.warn( "Store copy failed", e );
+            return false;
+        }
+
+        if ( !isEmptyStore )
+        {
+            StoreId localStoreId = localDatabase.storeId();
+            CatchupResult catchupResult;
+            try
             {
-                log.info( "Recovering local database" );
-                localDatabase.start();
-                localDatabase.stop();
+                catchupResult = remoteStore.tryCatchingUp( primary, localStoreId, localDatabase.storeDir(), false );
+            }
+            catch ( StoreCopyFailedException e )
+            {
+                log.warn( "Failed to catch up", e );
+                return false;
             }
 
-            AdvertisedSocketAddress primary = addressProvider.primary();
-            StoreId remoteStoreId = remoteStore.getStoreId( primary );
-            if ( !isEmptyStore && !remoteStoreId.equals( localDatabase.storeId() ) )
+            if ( catchupResult == E_TRANSACTION_PRUNED )
             {
-                throw new StoreCopyFailedException( "StoreId mismatch and not empty" );
+                log.warn( format( "Failed to pull transactions from (%s). They may have been pruned away", primary ) );
+                localDatabase.delete();
+                isEmptyStore = true;
             }
-
-            startStopOnStoreCopy.stop();
-            localDatabase.stopForStoreCopy();
-
-            log.info( "Downloading snapshot from core server at %s", addressProvider );
-
-            /* The core snapshot must be copied before the store, because the store has a dependency on
-             * the state of the state machines. The store will thus be at or ahead of the state machines,
-             * in consensus log index, and application of commands will bring them in sync. Any such commands
-             * that carry transactions will thus be ignored by the transaction/token state machines, since they
-             * are ahead, and the correct decisions for their applicability have already been taken as encapsulated
-             * in the copied store. */
-
-            CoreSnapshot coreSnapshot = catchUpClient.makeBlockingRequest( primary, new CoreSnapshotRequest(), new CatchUpResponseAdaptor<CoreSnapshot>()
+            else if ( catchupResult != SUCCESS_END_OF_STREAM )
             {
-                @Override
-                public void onCoreSnapshot( CompletableFuture<CoreSnapshot> signal, CoreSnapshot response )
-                {
-                    signal.complete( response );
-                }
-            } );
+                log.warn( format( "Unexpected catchup operation result %s from %s", catchupResult, primary ) );
+                return false;
+            }
+        }
 
-            if ( isEmptyStore )
+        if ( isEmptyStore )
+        {
+            try
             {
                 storeCopyProcess.replaceWithStoreFrom( addressProvider, remoteStoreId );
             }
-            else
+            catch ( StoreCopyFailedException e )
             {
-                StoreId localStoreId = localDatabase.storeId();
-                CatchupResult catchupResult = remoteStore.tryCatchingUp( primary, localStoreId, localDatabase.storeDir(), false );
-
-                if ( catchupResult == E_TRANSACTION_PRUNED )
-                {
-                    log.info( format( "Failed to pull transactions from (%s). They may have been pruned away", primary ) );
-                    localDatabase.delete();
-
-                    storeCopyProcess.replaceWithStoreFrom( addressProvider, localStoreId );
-                }
-                else if ( catchupResult != SUCCESS_END_OF_STREAM )
-                {
-                    throw new StoreCopyFailedException( "Failed to download store: " + catchupResult );
-                }
+                log.warn( "Failed to copy and replace store", e );
+                return false;
             }
-
-            /* We install the snapshot after the store has been downloaded,
-             * so that we are not left with a state ahead of the store. */
-            snapshotService.installSnapshot( coreSnapshot );
-            log.info( "Core snapshot installed: " + coreSnapshot );
-
-            /* Starting the database will invoke the commit process factory in
-             * the EnterpriseCoreEditionModule, which has important side-effects. */
-            log.info( "Starting local database" );
-            localDatabase.start();
-            coreStateMachines.installCommitProcess( localDatabase.getCommitProcess() );
-            startStopOnStoreCopy.start();
         }
-        catch ( StoreCopyFailedException e )
+
+        /* We install the snapshot after the store has been downloaded,
+         * so that we are not left with a state ahead of the store. */
+        snapshotService.installSnapshot( coreSnapshot );
+        log.info( "Core snapshot installed: " + coreSnapshot );
+
+        /* Starting the database will invoke the commit process factory in
+         * the EnterpriseCoreEditionModule, which has important side-effects. */
+        log.info( "Starting local database" );
+        ensure( localDatabase::start, "start local database after store copy" );
+
+        coreStateMachines.installCommitProcess( localDatabase.getCommitProcess() );
+        ensure( startStopOnStoreCopy::start, "start auxiliary services after store copy" );
+
+        return true;
+    }
+
+    public interface LifecycleAction
+    {
+        void perform() throws Throwable;
+    }
+
+    private static void ensure( LifecycleAction action, String operation )
+    {
+        try
         {
-            throw e;
+            action.perform();
         }
-        catch ( Throwable e )
+        catch ( Throwable cause )
         {
-            throw new StoreCopyFailedException( e );
+            throw new LifecycleException( "Failed to " + operation, cause );
         }
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderService.java
@@ -82,4 +82,9 @@ public class CoreStateDownloaderService extends LifecycleAdapter
             currentJob.stop();
         }
     }
+
+    public synchronized Optional<JobHandle> downloadJob()
+    {
+        return Optional.ofNullable( jobHandle );
+    }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderService.java
@@ -20,10 +20,12 @@
 package org.neo4j.causalclustering.core.state.snapshot;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import org.neo4j.causalclustering.catchup.CatchupAddressProvider;
 import org.neo4j.causalclustering.core.state.CommandApplicationProcess;
 import org.neo4j.causalclustering.helper.TimeoutStrategy;
+import org.neo4j.kernel.internal.DatabaseHealth;
 import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.Log;
@@ -42,17 +44,17 @@ public class CoreStateDownloaderService extends LifecycleAdapter
     private PersistentSnapshotDownloader currentJob;
     private JobHandle jobHandle;
     private boolean stopped;
+    private Supplier<DatabaseHealth> dbHealth;
 
-    public CoreStateDownloaderService( JobScheduler jobScheduler, CoreStateDownloader downloader,
-            CommandApplicationProcess applicationProcess,
-            LogProvider logProvider,
-            TimeoutStrategy.Timeout downloaderPauseStrategy )
+    public CoreStateDownloaderService( JobScheduler jobScheduler, CoreStateDownloader downloader, CommandApplicationProcess applicationProcess,
+            LogProvider logProvider, TimeoutStrategy.Timeout downloaderPauseStrategy, Supplier<DatabaseHealth> dbHealth )
     {
         this.jobScheduler = jobScheduler;
         this.downloader = downloader;
         this.applicationProcess = applicationProcess;
         this.log = logProvider.getLog( getClass() );
         this.downloaderPauseStrategy = downloaderPauseStrategy;
+        this.dbHealth = dbHealth;
     }
 
     public synchronized Optional<JobHandle> scheduleDownload( CatchupAddressProvider addressProvider )
@@ -65,7 +67,7 @@ public class CoreStateDownloaderService extends LifecycleAdapter
         if ( currentJob == null || currentJob.hasCompleted() )
         {
             currentJob = new PersistentSnapshotDownloader( addressProvider, applicationProcess, downloader, log,
-                    downloaderPauseStrategy );
+                    downloaderPauseStrategy, dbHealth );
             jobHandle = jobScheduler.schedule( downloadSnapshot, currentJob );
             return Optional.of( jobHandle );
         }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/PersistentSnapshotDownloader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/PersistentSnapshotDownloader.java
@@ -86,6 +86,7 @@ class PersistentSnapshotDownloader implements Runnable
         }
         catch ( InterruptedException e )
         {
+            Thread.currentThread().interrupt();
             log.error( "Persistent snapshot downloader was interrupted" );
         }
         finally

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/CopiedStoreRecoveryTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/CopiedStoreRecoveryTest.java
@@ -22,7 +22,6 @@ package org.neo4j.causalclustering.catchup.storecopy;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.io.pagecache.PageCache;
@@ -48,7 +47,7 @@ public class CopiedStoreRecoveryTest
             copiedStoreRecovery.recoverCopiedStore( new File( "nowhere" ) );
             fail( "should have thrown" );
         }
-        catch ( StoreCopyFailedException ex )
+        catch ( DatabaseShutdownException ex )
         {
             // then
             assertEquals( "Abort store-copied store recovery due to database shutdown", ex.getMessage() );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderServiceTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderServiceTest.java
@@ -23,24 +23,21 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.UUID;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.neo4j.causalclustering.catchup.CatchupAddressProvider;
-import org.neo4j.causalclustering.core.consensus.LeaderListener;
-import org.neo4j.causalclustering.core.consensus.LeaderLocator;
-import org.neo4j.causalclustering.core.consensus.NoLeaderFoundException;
 import org.neo4j.causalclustering.core.state.CommandApplicationProcess;
-import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.function.Predicates;
 import org.neo4j.helpers.AdvertisedSocketAddress;
-import org.neo4j.kernel.impl.util.CountingJobScheduler;
 import org.neo4j.kernel.impl.scheduler.CentralJobScheduler;
+import org.neo4j.kernel.impl.util.CountingJobScheduler;
+import org.neo4j.kernel.internal.DatabaseHealth;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
+import org.neo4j.logging.NullLogProvider;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -52,10 +49,10 @@ import static org.neo4j.causalclustering.core.state.snapshot.PersistentSnapshotD
 
 public class CoreStateDownloaderServiceTest
 {
-    private final MemberId someMember = new MemberId( UUID.randomUUID() );
     private final AdvertisedSocketAddress someMemberAddress = new AdvertisedSocketAddress( "localhost", 1234 );
     private final CatchupAddressProvider catchupAddressProvider = CatchupAddressProvider.fromSingleAddress( someMemberAddress );
     private CentralJobScheduler centralJobScheduler;
+    private DatabaseHealth dbHealth = mock( DatabaseHealth.class );
 
     @Before
     public void create()
@@ -74,12 +71,13 @@ public class CoreStateDownloaderServiceTest
     public void shouldRunPersistentDownloader() throws Exception
     {
         CoreStateDownloader coreStateDownloader = mock( CoreStateDownloader.class );
+        when( coreStateDownloader.downloadSnapshot( any() ) ).thenReturn( true );
         final CommandApplicationProcess applicationProcess = mock( CommandApplicationProcess.class );
 
         final Log log = mock( Log.class );
         CoreStateDownloaderService coreStateDownloaderService =
                 new CoreStateDownloaderService( centralJobScheduler, coreStateDownloader, applicationProcess,
-                        logProvider( log ), new NoTimeout() );
+                        logProvider( log ), new NoTimeout(), () -> dbHealth );
         coreStateDownloaderService.scheduleDownload( catchupAddressProvider );
         waitForApplierToResume( applicationProcess );
 
@@ -89,28 +87,46 @@ public class CoreStateDownloaderServiceTest
     }
 
     @Test
-    public void shouldOnlyScheduleOnePersistentDownloaderTaskAtTheTime()
+    public void shouldOnlyScheduleOnePersistentDownloaderTaskAtTheTime() throws InterruptedException
     {
         AtomicInteger schedules = new AtomicInteger();
         CountingJobScheduler countingJobScheduler = new CountingJobScheduler( schedules, centralJobScheduler );
-        CoreStateDownloader coreStateDownloader = mock( CoreStateDownloader.class );
+        Semaphore blockDownloader = new Semaphore( 0 );
+        CoreStateDownloader coreStateDownloader = new BlockingCoreStateDownloader( blockDownloader );
         final CommandApplicationProcess applicationProcess = mock( CommandApplicationProcess.class );
 
         final Log log = mock( Log.class );
         CoreStateDownloaderService coreStateDownloaderService =
                 new CoreStateDownloaderService( countingJobScheduler, coreStateDownloader, applicationProcess,
-                        logProvider( log ), new NoTimeout() );
-
-        AtomicBoolean availableLeader = new AtomicBoolean( false );
+                        logProvider( log ), new NoTimeout(), () -> dbHealth );
 
         coreStateDownloaderService.scheduleDownload( catchupAddressProvider );
+        Thread.sleep( 50 );
         coreStateDownloaderService.scheduleDownload( catchupAddressProvider );
         coreStateDownloaderService.scheduleDownload( catchupAddressProvider );
         coreStateDownloaderService.scheduleDownload( catchupAddressProvider );
-
-        availableLeader.set( true );
 
         assertEquals( 1, schedules.get() );
+        blockDownloader.release();
+    }
+
+    static class BlockingCoreStateDownloader extends CoreStateDownloader
+    {
+        private final Semaphore semaphore;
+
+        BlockingCoreStateDownloader( Semaphore semaphore )
+        {
+            super( null, null, null, null, NullLogProvider.getInstance(), null,
+                    null, null, null );
+            this.semaphore = semaphore;
+        }
+
+        @Override
+        boolean downloadSnapshot( CatchupAddressProvider addressProvider )
+        {
+            semaphore.acquireUninterruptibly();
+            return true;
+        }
     }
 
     private void waitForApplierToResume( CommandApplicationProcess applicationProcess ) throws TimeoutException
@@ -127,38 +143,6 @@ public class CoreStateDownloaderServiceTest
                 return false;
             }
         }, 1, TimeUnit.SECONDS );
-    }
-
-    private class ControllableLeaderLocator implements LeaderLocator
-    {
-        private final AtomicBoolean shouldProvideALeader;
-
-        ControllableLeaderLocator( AtomicBoolean shouldProvideALeader )
-        {
-            this.shouldProvideALeader = shouldProvideALeader;
-        }
-
-        @Override
-        public MemberId getLeader() throws NoLeaderFoundException
-        {
-            if ( shouldProvideALeader.get() )
-            {
-                return someMember;
-            }
-            throw new NoLeaderFoundException( "sorry" );
-        }
-
-        @Override
-        public void registerListener( LeaderListener listener )
-        {
-            // do nothing
-        }
-
-        @Override
-        public void unregisterListener( LeaderListener listener )
-        {
-            // do nothing
-        }
     }
 
     private LogProvider logProvider( Log log )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderTest.java
@@ -31,7 +31,6 @@ import org.neo4j.causalclustering.catchup.CatchupAddressProvider;
 import org.neo4j.causalclustering.catchup.storecopy.CommitStateHelper;
 import org.neo4j.causalclustering.catchup.storecopy.LocalDatabase;
 import org.neo4j.causalclustering.catchup.storecopy.RemoteStore;
-import org.neo4j.causalclustering.catchup.storecopy.StoreCopyFailedException;
 import org.neo4j.causalclustering.catchup.storecopy.StoreCopyProcess;
 import org.neo4j.causalclustering.core.state.CoreSnapshotService;
 import org.neo4j.causalclustering.core.state.machines.CoreStateMachines;
@@ -42,7 +41,7 @@ import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.logging.NullLogProvider;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
@@ -125,15 +124,7 @@ public class CoreStateDownloaderTest
         when( remoteStore.getStoreId( remoteAddress ) ).thenReturn( remoteStoreId );
 
         // when
-        try
-        {
-            downloader.downloadSnapshot( catchupAddressProvider );
-            fail();
-        }
-        catch ( StoreCopyFailedException e )
-        {
-            // expected
-        }
+        assertFalse( downloader.downloadSnapshot( catchupAddressProvider ) );
 
         // then
         verify( remoteStore, never() ).copy( any(), any(), any() );

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/ReplaceRandomMember.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/ReplaceRandomMember.java
@@ -27,6 +27,7 @@ import org.neo4j.backup.impl.OnlineBackupCommandBuilder;
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.ClusterMember;
+import org.neo4j.causalclustering.discovery.CoreClusterMember;
 import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.helpers.AdvertisedSocketAddress;
@@ -84,8 +85,9 @@ class ReplaceRandomMember extends RepeatOnRandomMember
         log.info( "Stopping: " + oldMember );
         oldMember.shutdown();
 
-        boolean newMemberIsCore = ThreadLocalRandom.current().nextBoolean();
-        ClusterMember newMember = newMemberIsCore ? cluster.newCoreMember() : cluster.newReadReplica();
+        ClusterMember newMember = (oldMember instanceof CoreClusterMember) ?
+                cluster.newCoreMember() :
+                cluster.newReadReplica();
 
         if ( backupDir != null )
         {


### PR DESCRIPTION
Previously we would wait just for the snapshot to have been installed
and potentially double-start local database.