### PR TITLE
Change comparison of DateTimes

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeSchemaKey.java
@@ -82,7 +82,9 @@ class ZonedDateTimeSchemaKey extends NativeSchemaKey<ZonedDateTimeSchemaKey>
         if ( compare == 0 )
         {
             compare = Integer.compare( nanoOfSecond, other.nanoOfSecond );
-            if ( compare == 0 && hasValidTimeZone() && other.hasValidTimeZone() )
+            if ( compare == 0 &&
+                    TimeZones.validZoneOffset( zoneOffsetMinutes * 60 ) &&
+                    TimeZones.validZoneOffset( other.zoneOffsetMinutes * 60 ) )
             {
                 // In the rare case of comparing the same instant in different time zones, we settle for
                 // mapping to values and comparing using the general values comparator.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/ZonedDateTimeSchemaKey.java
@@ -31,10 +31,12 @@ import static java.lang.String.format;
 
 /**
  * Includes value and entity id (to be able to handle non-unique values). A value can be any {@link DateTimeValue}.
- *
- * With these keys the DateTimeValues are sorted by UTC time, and then by time zone. Time zones are sorted so that
- * DateTimeValues with zoneOffset come first (sorted by the zoneOffset), followed by DateTimeValues with zoneIds,
- * sorted by zoneNumber.
+ * <p>
+ * With these keys the DateTimeValues are sorted
+ * 1. by epochSecond
+ * 2. by nanos
+ * 3. by effective Offset west-to-east
+ * 4. non-named TimeZones before named TimeZones. Named Timezones alphabetically.
  */
 class ZonedDateTimeSchemaKey extends NativeSchemaKey<ZonedDateTimeSchemaKey>
 {
@@ -83,8 +85,9 @@ class ZonedDateTimeSchemaKey extends NativeSchemaKey<ZonedDateTimeSchemaKey>
         {
             compare = Integer.compare( nanoOfSecond, other.nanoOfSecond );
             if ( compare == 0 &&
-                    TimeZones.validZoneOffset( zoneOffsetMinutes * 60 ) &&
-                    TimeZones.validZoneOffset( other.zoneOffsetMinutes * 60 ) )
+                    // We need to check validity upfront without throwing exceptions, because the PageCursor might give garbage bytes
+                    TimeZones.validZoneOffset( zoneOffsetSeconds ) &&
+                    TimeZones.validZoneOffset( other.zoneOffsetSeconds ) )
             {
                 // In the rare case of comparing the same instant in different time zones, we settle for
                 // mapping to values and comparing using the general values comparator.
@@ -128,11 +131,5 @@ class ZonedDateTimeSchemaKey extends NativeSchemaKey<ZonedDateTimeSchemaKey>
                     "Key layout does only support DateTimeValue, tried to create key from " + value );
         }
         return value;
-    }
-
-    // We need to check validity upfront without throwing exceptions, because the PageCursor might give garbage bytes
-    private boolean hasValidTimeZone()
-    {
-        return TimeZones.validZoneId( zoneId ) || TimeZones.validZoneOffset( zoneOffsetSeconds );
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/DateTimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DateTimeValue.java
@@ -512,15 +512,9 @@ public final class DateTimeValue extends TemporalValue<ZonedDateTime,DateTimeVal
 
     private int compareNamedZonesWithMapping( ZoneId thisZone, ZoneId thatZone )
     {
-        short indexThisZone = TimeZones.map( thisZone.getId() );
-        short indexThatZone = TimeZones.map( thatZone.getId() );
-        int cmp = Short.compare( indexThisZone, indexThatZone );
-        if ( cmp == 0 )
-        {
-            cmp = thisZone.getId().compareTo( thatZone.getId() );
-        }
-
-        return cmp;
+        String thisZoneNormalized = TimeZones.map( TimeZones.map( thisZone.getId() ) );
+        String thatZoneNormalized = TimeZones.map( TimeZones.map( thatZone.getId() ) );
+        return thisZoneNormalized.compareTo( thatZoneNormalized );
     }
 
     @Override

--- a/community/values/src/test/java/org/neo4j/values/storable/ValueComparisonTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/ValueComparisonTest.java
@@ -120,8 +120,9 @@ public class ValueComparisonTest
 
             // DateTime and the likes
             datetime(2018, 2, 2, 0, 0, 0, 0, "+00:00"),
-            datetime(2018, 2, 1, 22, 30, 0, 0, "-02:00"),
-            datetime(2018, 2, 2, 1, 30, 0, 0, "+01:00"), // offsets by offsetSecond
+            datetime(2018, 2, 1, 22, 30, 0, 0, "-02:00"), // first by offsetSecond
+            datetime(2018, 2, 2, 0, 30, 0, 0, "Europe/London"),
+            datetime(2018, 2, 2, 1, 30, 0, 0, "+01:00"),
             datetime(2018, 2, 2, 1, 30, 0, 0, "Europe/Berlin"), // same offset as +01:00, but name zones come after offsets ...
             datetime(2018, 2, 2, 1, 30, 0, 0, "Europe/Prague"), // ... alphabetically
             datetime(2018, 2, 2, 1, 30, 0, 0, "Europe/Stockholm"),

--- a/community/values/src/test/java/org/neo4j/values/storable/ValueComparisonTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/ValueComparisonTest.java
@@ -120,8 +120,10 @@ public class ValueComparisonTest
 
             // DateTime and the likes
             datetime(2018, 2, 2, 0, 0, 0, 0, "+00:00"),
-            datetime(2018, 2, 2, 1, 30, 0, 0, "+01:00"),
-            datetime(2018, 2, 2, 1, 30, 0, 0, "Europe/Stockholm"), // same offset as +01:00, but name zones come after offsets
+            datetime(2018, 2, 1, 22, 30, 0, 0, "-02:00"),
+            datetime(2018, 2, 2, 1, 30, 0, 0, "+01:00"), // offsets by offsetSecond
+            datetime(2018, 2, 2, 1, 30, 0, 0, "Europe/Berlin"), // same offset as +01:00, but name zones come after offsets ...
+            datetime(2018, 2, 2, 1, 30, 0, 0, "Europe/Stockholm"), // ... alphabetically
             datetime(2018, 2, 2, 1, 0, 0, 0, "+00:00"),
             datetime(2018, 3, 2, 1, 0, 0, 0, "Europe/Berlin"),
             datetime(2018, 3, 2, 1, 0, 0, 0, "Europe/Stockholm"), // same offset as Europe/Berlin, so compared by zone name

--- a/community/values/src/test/java/org/neo4j/values/storable/ValueComparisonTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/ValueComparisonTest.java
@@ -123,7 +123,8 @@ public class ValueComparisonTest
             datetime(2018, 2, 1, 22, 30, 0, 0, "-02:00"),
             datetime(2018, 2, 2, 1, 30, 0, 0, "+01:00"), // offsets by offsetSecond
             datetime(2018, 2, 2, 1, 30, 0, 0, "Europe/Berlin"), // same offset as +01:00, but name zones come after offsets ...
-            datetime(2018, 2, 2, 1, 30, 0, 0, "Europe/Stockholm"), // ... alphabetically
+            datetime(2018, 2, 2, 1, 30, 0, 0, "Europe/Prague"), // ... alphabetically
+            datetime(2018, 2, 2, 1, 30, 0, 0, "Europe/Stockholm"),
             datetime(2018, 2, 2, 1, 0, 0, 0, "+00:00"),
             datetime(2018, 3, 2, 1, 0, 0, 0, "Europe/Berlin"),
             datetime(2018, 3, 2, 1, 0, 0, 0, "Europe/Stockholm"), // same offset as Europe/Berlin, so compared by zone name


### PR DESCRIPTION
Compare DateTimes as follows:
1. by epochSecond
2. by nanos
3. by effective Offset west-to-east
4. non-named TimeZones before named TimeZones. Named Timezones alphabetically.
(5. by chronology)

(Note: This commit will conflict with #11410. If one gets merged,
the other will need a rebase.)

@thobe If you approve, could you change the spec to reflect this?