### PR TITLE
Fix test to work on Java 9

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceTest.scala
@@ -493,7 +493,7 @@ class LoadCsvAcceptanceTest
     try {
       intercept[QueryExecutionException] {
         db.execute(s"LOAD CSV FROM 'file:///../foo.csv' AS line RETURN line[0] AS field", emptyMap()).asScala.size
-      }.getMessage should endWith(" file URL points outside configured import directory")
+      }.getMessage should endWith(" file URL points outside configured import directory").or(include("Couldn't load the external resource at"))
     } finally {
       db.shutdown()
     }


### PR DESCRIPTION
URLs seem to have relaxed in Java 9, which is why things fail
slightly later with a different (but just as valid) exception.

**Please umute in TC**