### PR TITLE
Additional HTTP header validation in the CORS filter

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/modules/RESTApiModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/RESTApiModule.java
@@ -70,7 +70,7 @@ public class RESTApiModule implements ServerModule
         URI restApiUri = restApiUri( );
 
         webServer.addFilter( new CollectUserAgentFilter( clientNames() ), "/*" );
-        webServer.addFilter( new CorsFilter(), "/*" );
+        webServer.addFilter( new CorsFilter( logProvider ), "/*" );
         webServer.addJAXRSClasses( getClassNames(), restApiUri.toString(), null );
         loadPlugins();
     }

--- a/community/server/src/main/java/org/neo4j/server/web/HttpHeaderUtils.java
+++ b/community/server/src/main/java/org/neo4j/server/web/HttpHeaderUtils.java
@@ -87,4 +87,33 @@ public class HttpHeaderUtils
         }
         return GraphDatabaseSettings.UNSPECIFIED_TIMEOUT;
     }
+
+    /**
+     * Validates given HTTP header name. Does not allow blank names and names with control characters, like '\n' (LF) and '\r' (CR).
+     * Can be used to detect and neutralize CRLF in HTTP headers.
+     *
+     * @param name the HTTP header name, like 'Accept' or 'Content-Type'.
+     * @return {@code true} when given name represents a valid HTTP header, {@code false} otherwise.
+     */
+    public static boolean isValidHttpHeaderName( String name )
+    {
+        if ( name == null || name.length() == 0 )
+        {
+            return false;
+        }
+        boolean isBlank = true;
+        for ( int i = 0; i < name.length(); i++ )
+        {
+            char c = name.charAt( i );
+            if ( Character.isISOControl( c ) )
+            {
+                return false;
+            }
+            if ( !Character.isWhitespace( c ) )
+            {
+                isBlank = false;
+            }
+        }
+        return !isBlank;
+    }
 }

--- a/community/server/src/main/java/org/neo4j/server/web/HttpMethod.java
+++ b/community/server/src/main/java/org/neo4j/server/web/HttpMethod.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.web;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+import static java.util.Collections.unmodifiableMap;
+
+public enum HttpMethod
+{
+    OPTIONS,
+    GET,
+    HEAD,
+    POST,
+    PUT,
+    PATCH,
+    DELETE,
+    TRACE,
+    CONNECT;
+
+    private static final Map<String,HttpMethod> methodsByName = indexMethodsByName();
+
+    @Nullable
+    public static HttpMethod valueOfOrNull( String name )
+    {
+        return methodsByName.get( name );
+    }
+
+    private static Map<String,HttpMethod> indexMethodsByName()
+    {
+        HttpMethod[] methods = HttpMethod.values();
+        Map<String,HttpMethod> result = new HashMap<>( methods.length * 2 );
+        for ( HttpMethod method : methods )
+        {
+            result.put( method.name(), method );
+        }
+        return unmodifiableMap( result );
+    }
+}

--- a/community/server/src/test/java/org/neo4j/server/rest/web/CorsFilterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/CorsFilterTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.web;
+
+import org.junit.Test;
+
+import java.util.List;
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.neo4j.logging.NullLogProvider;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.enumeration;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.neo4j.server.rest.web.CorsFilter.ACCESS_CONTROL_ALLOW_HEADERS;
+import static org.neo4j.server.rest.web.CorsFilter.ACCESS_CONTROL_ALLOW_METHODS;
+import static org.neo4j.server.rest.web.CorsFilter.ACCESS_CONTROL_ALLOW_ORIGIN;
+import static org.neo4j.server.rest.web.CorsFilter.ACCESS_CONTROL_REQUEST_HEADERS;
+import static org.neo4j.server.rest.web.CorsFilter.ACCESS_CONTROL_REQUEST_METHOD;
+
+public class CorsFilterTest
+{
+    private final HttpServletRequest emptyRequest = requestMock( emptyList(), emptyList() );
+    private final HttpServletResponse response = responseMock();
+    private final FilterChain chain = filterChainMock();
+
+    private final CorsFilter filter = new CorsFilter( NullLogProvider.getInstance() );
+
+    @Test
+    public void shouldCallChainDoFilter() throws Exception
+    {
+        filter.doFilter( emptyRequest, response, chain );
+
+        verify( chain ).doFilter( emptyRequest, response );
+    }
+
+    @Test
+    public void shouldSetAccessControlAllowOrigin() throws Exception
+    {
+        filter.doFilter( emptyRequest, response, filterChainMock() );
+
+        verify( response ).setHeader( ACCESS_CONTROL_ALLOW_ORIGIN, "*" );
+    }
+
+    @Test
+    public void shouldAttachNoHttpMethodsToAccessControlAllowMethodsWhenHeaderIsEmpty() throws Exception
+    {
+        filter.doFilter( emptyRequest, response, chain );
+
+        verify( response, never() ).addHeader( eq( ACCESS_CONTROL_ALLOW_METHODS ), anyString() );
+    }
+
+    @Test
+    public void shouldAttachNoHttpMethodsToAccessControlAllowMethodsWhenHeaderIsNull() throws Exception
+    {
+        HttpServletRequest request = requestMock();
+        when( request.getHeaders( ACCESS_CONTROL_REQUEST_METHOD ) ).thenReturn( null );
+
+        filter.doFilter( request, response, chain );
+
+        verify( response, never() ).addHeader( eq( ACCESS_CONTROL_ALLOW_METHODS ), anyString() );
+    }
+
+    @Test
+    public void shouldAttachValidHttpMethodsToAccessControlAllowMethods() throws Exception
+    {
+        List<String> accessControlRequestMethods = asList( "GET", "WRONG", "POST", "TAKE", "CONNECT" );
+        HttpServletRequest request = requestMock( accessControlRequestMethods, emptyList() );
+
+        filter.doFilter( request, response, chain );
+
+        verify( response ).addHeader( ACCESS_CONTROL_ALLOW_METHODS, "GET" );
+        verify( response ).addHeader( ACCESS_CONTROL_ALLOW_METHODS, "POST" );
+        verify( response ).addHeader( ACCESS_CONTROL_ALLOW_METHODS, "CONNECT" );
+
+        verify( response, never() ).addHeader( ACCESS_CONTROL_ALLOW_METHODS, "TAKE" );
+        verify( response, never() ).addHeader( ACCESS_CONTROL_ALLOW_METHODS, "WRONG" );
+    }
+
+    @Test
+    public void shouldAttachNoRequestHeadersToAccessControlAllowHeadersWhenHeaderIsEmpty() throws Exception
+    {
+        filter.doFilter( emptyRequest, response, chain );
+
+        verify( response, never() ).addHeader( eq( ACCESS_CONTROL_ALLOW_HEADERS ), anyString() );
+    }
+
+    @Test
+    public void shouldAttachNoRequestHeadersToAccessControlAllowHeadersWhenHeaderIsNull() throws Exception
+    {
+        HttpServletRequest request = requestMock();
+        when( request.getHeaders( ACCESS_CONTROL_REQUEST_HEADERS ) ).thenReturn( null );
+
+        filter.doFilter( request, response, chain );
+
+        verify( response, never() ).addHeader( eq( ACCESS_CONTROL_ALLOW_HEADERS ), anyString() );
+    }
+
+    @Test
+    public void shouldAttachRequestHeadersToAccessControlAllowHeaders() throws Exception
+    {
+        List<String> accessControlRequestHeaders = asList( "Accept", "Content-Length", "Content-Type" );
+        HttpServletRequest request = requestMock( emptyList(), accessControlRequestHeaders );
+
+        filter.doFilter( request, response, chain );
+
+        verify( response ).addHeader( ACCESS_CONTROL_ALLOW_HEADERS, "Accept" );
+        verify( response ).addHeader( ACCESS_CONTROL_ALLOW_HEADERS, "Content-Length" );
+        verify( response ).addHeader( ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type" );
+    }
+
+    private static HttpServletRequest requestMock()
+    {
+        return requestMock( emptyList(), emptyList() );
+    }
+
+    private static HttpServletRequest requestMock( List<String> accessControlRequestMethods, List<String> accessControlRequestHeaders )
+    {
+        HttpServletRequest mock = mock( HttpServletRequest.class );
+        when( mock.getHeaders( ACCESS_CONTROL_REQUEST_METHOD ) ).thenReturn( enumeration( accessControlRequestMethods ) );
+        when( mock.getHeaders( ACCESS_CONTROL_REQUEST_HEADERS ) ).thenReturn( enumeration( accessControlRequestHeaders ) );
+        return mock;
+    }
+
+    private static HttpServletResponse responseMock()
+    {
+        return mock( HttpServletResponse.class );
+    }
+
+    private static FilterChain filterChainMock()
+    {
+        return mock( FilterChain.class );
+    }
+}

--- a/community/server/src/test/java/org/neo4j/server/rest/web/CorsFilterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/CorsFilterTest.java
@@ -122,16 +122,22 @@ public class CorsFilterTest
     }
 
     @Test
-    public void shouldAttachRequestHeadersToAccessControlAllowHeaders() throws Exception
+    public void shouldAttachValidRequestHeadersToAccessControlAllowHeaders() throws Exception
     {
-        List<String> accessControlRequestHeaders = asList( "Accept", "Content-Length", "Content-Type" );
+        List<String> accessControlRequestHeaders = asList( "Accept", "X-Wrong\nHeader", "Content-Type", "Accept\r", "Illegal\r\nHeader", "", null, "   " );
         HttpServletRequest request = requestMock( emptyList(), accessControlRequestHeaders );
 
         filter.doFilter( request, response, chain );
 
         verify( response ).addHeader( ACCESS_CONTROL_ALLOW_HEADERS, "Accept" );
-        verify( response ).addHeader( ACCESS_CONTROL_ALLOW_HEADERS, "Content-Length" );
         verify( response ).addHeader( ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type" );
+
+        verify( response, never() ).addHeader( ACCESS_CONTROL_ALLOW_HEADERS, null );
+        verify( response, never() ).addHeader( ACCESS_CONTROL_ALLOW_HEADERS, "" );
+        verify( response, never() ).addHeader( ACCESS_CONTROL_ALLOW_HEADERS, "   " );
+        verify( response, never() ).addHeader( ACCESS_CONTROL_ALLOW_HEADERS, "X-Wrong\nHeader" );
+        verify( response, never() ).addHeader( ACCESS_CONTROL_ALLOW_HEADERS, "Accept\r" );
+        verify( response, never() ).addHeader( ACCESS_CONTROL_ALLOW_HEADERS, "Illegal\r\nHeader" );
     }
 
     private static HttpServletRequest requestMock()

--- a/community/server/src/test/java/org/neo4j/server/web/HttpHeaderUtilsTest.java
+++ b/community/server/src/test/java/org/neo4j/server/web/HttpHeaderUtilsTest.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.server.web;
 
+import org.apache.http.HttpHeaders;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,7 +31,12 @@ import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.logging.Log;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
+import static org.neo4j.server.web.HttpHeaderUtils.MAX_EXECUTION_TIME_HEADER;
+import static org.neo4j.server.web.HttpHeaderUtils.getTransactionTimeout;
+import static org.neo4j.server.web.HttpHeaderUtils.isValidHttpHeaderName;
 
 public class HttpHeaderUtilsTest
 {
@@ -47,9 +53,9 @@ public class HttpHeaderUtilsTest
     @Test
     public void retrieveCustomTransactionTimeout()
     {
-        when( request.getHeader( HttpHeaderUtils.MAX_EXECUTION_TIME_HEADER ) ).thenReturn( "100" );
+        when( request.getHeader( MAX_EXECUTION_TIME_HEADER ) ).thenReturn( "100" );
         Log log = logProvider.getLog( HttpServletRequest.class );
-        long transactionTimeout = HttpHeaderUtils.getTransactionTimeout( request, log );
+        long transactionTimeout = getTransactionTimeout( request, log );
         assertEquals( "Transaction timeout should be retrieved.", 100, transactionTimeout );
         logProvider.assertNoLoggingOccurred();
     }
@@ -58,7 +64,7 @@ public class HttpHeaderUtilsTest
     public void defaultValueWhenCustomTransactionTimeoutNotSpecified()
     {
         Log log = logProvider.getLog( HttpServletRequest.class );
-        long transactionTimeout = HttpHeaderUtils.getTransactionTimeout( request, log );
+        long transactionTimeout = getTransactionTimeout( request, log );
         assertEquals( "Transaction timeout not specified.", 0, transactionTimeout );
         logProvider.assertNoLoggingOccurred();
     }
@@ -66,11 +72,35 @@ public class HttpHeaderUtilsTest
     @Test
     public void defaultValueWhenCustomTransactionTimeoutNotANumber()
     {
-        when( request.getHeader( HttpHeaderUtils.MAX_EXECUTION_TIME_HEADER ) ).thenReturn( "aa" );
+        when( request.getHeader( MAX_EXECUTION_TIME_HEADER ) ).thenReturn( "aa" );
         Log log = logProvider.getLog( HttpServletRequest.class );
-        long transactionTimeout = HttpHeaderUtils.getTransactionTimeout( request, log );
+        long transactionTimeout = getTransactionTimeout( request, log );
         assertEquals( "Transaction timeout not specified.", 0, transactionTimeout );
         logProvider.assertContainsMessageContaining("Fail to parse `max-execution-time` " +
                 "header with value: 'aa'. Should be a positive number.");
+    }
+
+    @Test
+    public void shouldCheckHttpHeaders()
+    {
+        assertFalse( isValidHttpHeaderName( null ) );
+        assertFalse( isValidHttpHeaderName( "" ) );
+        assertFalse( isValidHttpHeaderName( " " ) );
+        assertFalse( isValidHttpHeaderName( "      " ) );
+        assertFalse( isValidHttpHeaderName( " \r " ) );
+        assertFalse( isValidHttpHeaderName( " \r\n\t " ) );
+
+        assertTrue( isValidHttpHeaderName( HttpHeaders.ACCEPT ) );
+        assertTrue( isValidHttpHeaderName( HttpHeaders.ACCEPT_ENCODING ) );
+        assertTrue( isValidHttpHeaderName( HttpHeaders.AGE ) );
+        assertTrue( isValidHttpHeaderName( HttpHeaders.CONTENT_ENCODING ) );
+        assertTrue( isValidHttpHeaderName( HttpHeaders.EXPIRES ) );
+        assertTrue( isValidHttpHeaderName( HttpHeaders.IF_MATCH ) );
+        assertTrue( isValidHttpHeaderName( HttpHeaders.TRANSFER_ENCODING ) );
+        assertTrue( isValidHttpHeaderName( "Weird Header With Spaces" ) );
+
+        assertFalse( isValidHttpHeaderName( "My\nHeader" ) );
+        assertFalse( isValidHttpHeaderName( "Other\rStrange-Header" ) );
+        assertFalse( isValidHttpHeaderName( "Header-With-Tab\t" ) );
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/web/HttpMethodTest.java
+++ b/community/server/src/test/java/org/neo4j/server/web/HttpMethodTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.web;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class HttpMethodTest
+{
+    @Test
+    public void shouldLookupExistingMethodByName()
+    {
+        for ( HttpMethod method : HttpMethod.values() )
+        {
+            assertEquals( method, HttpMethod.valueOfOrNull( method.toString() ) );
+        }
+    }
+
+    @Test
+    public void shouldLookupNonExistingMethodByName()
+    {
+        assertNull( HttpMethod.valueOfOrNull( "get" ) );
+        assertNull( HttpMethod.valueOfOrNull( "post" ) );
+        assertNull( HttpMethod.valueOfOrNull( "PoSt" ) );
+        assertNull( HttpMethod.valueOfOrNull( "WRONG" ) );
+        assertNull( HttpMethod.valueOfOrNull( "" ) );
+    }
+
+    @Test
+    public void shouldLookupNothingByNull()
+    {
+        assertNull( HttpMethod.valueOfOrNull( null ) );
+    }
+}


### PR DESCRIPTION
PR makes CORS filter validate HTTP methods attached to the `Access-Control-Allow-Methods` response header and headers attached to the `Access-Control-Allow-Headers` response header. Illegal methods and headers are logged and ignored.