### PR TITLE
Allow execution of snapshot queries over bolt endpoint

### DIFF
--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/EagerResult.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/EagerResult.java
@@ -232,7 +232,7 @@ class EagerResult implements Result, QueryResultProvider
 
         EagerQueryResult()
         {
-            fields = originalResult.columns().toArray( new String[originalResult.columns().size()] );
+            fields = originalResult.columns().toArray( new String[0] );
         }
 
         @Override

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/EagerResult.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/EagerResult.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.neo4j.cypher.result.QueryResult;
 import org.neo4j.graphdb.ExecutionPlanDescription;
 import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.Notification;
@@ -33,13 +34,15 @@ import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Result;
 import org.neo4j.io.pagecache.tracing.cursor.context.VersionContext;
 import org.neo4j.kernel.impl.query.QueryExecutionKernelException;
+import org.neo4j.kernel.impl.util.ValueUtils;
+import org.neo4j.values.AnyValue;
 
 import static java.lang.System.lineSeparator;
 
 /**
  * Result produced as result of eager query execution for cases when {@link SnapshotExecutionEngine} is used.
  */
-class EagerResult implements Result
+class EagerResult implements Result, QueryResultProvider
 {
     private static final String ITEM_SEPARATOR = ", ";
     private final Result originalResult;
@@ -107,6 +110,12 @@ class EagerResult implements Result
     public ExecutionPlanDescription getExecutionPlanDescription()
     {
         return originalResult.getExecutionPlanDescription();
+    }
+
+    @Override
+    public QueryResult queryResult()
+    {
+        return new EagerQueryResult();
     }
 
     @Override
@@ -213,6 +222,70 @@ class EagerResult implements Result
         public void close()
         {
             // Nothing to close.
+        }
+    }
+
+    private class EagerQueryResult implements QueryResult
+    {
+
+        private final String[] fields;
+
+        EagerQueryResult()
+        {
+            fields = originalResult.columns().toArray( new String[originalResult.columns().size()] );
+        }
+
+        @Override
+        public String[] fieldNames()
+        {
+            return fields;
+        }
+
+        @Override
+        public <E extends Exception> void accept( QueryResultVisitor<E> visitor ) throws E
+        {
+            while ( hasNext() )
+            {
+                Map<String,Object> row = next();
+                AnyValue[] anyValues = new AnyValue[fields.length];
+
+                for ( int i = 0; i < fields.length; i++ )
+                {
+                    anyValues[i] = ValueUtils.of( row.get( fields[i] ) );
+                }
+
+                visitor.visit( () -> anyValues );
+            }
+        }
+
+        @Override
+        public QueryExecutionType executionType()
+        {
+            return originalResult.getQueryExecutionType();
+        }
+
+        @Override
+        public QueryStatistics queryStatistics()
+        {
+            return originalResult.getQueryStatistics();
+        }
+
+        @Override
+        public ExecutionPlanDescription executionPlanDescription()
+        {
+            return originalResult.getExecutionPlanDescription();
+        }
+
+        @Override
+        public Iterable<Notification> getNotifications()
+        {
+            return originalResult.getNotifications();
+        }
+
+        @Override
+        public void close()
+        {
+            // nothing to close
         }
     }
 }

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ExecutionResult.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ExecutionResult.java
@@ -54,7 +54,7 @@ import org.neo4j.kernel.impl.query.QueryExecutionKernelException;
  * set, or use <code>columnAs()</code> to access a single column with result objects
  * cast to a type.
  */
-public class ExecutionResult implements ResourceIterable<Map<String,Object>>, Result
+public class ExecutionResult implements ResourceIterable<Map<String,Object>>, Result, QueryResultProvider
 {
     private final InternalExecutionResult inner;
 
@@ -394,6 +394,7 @@ public class ExecutionResult implements ResourceIterable<Map<String,Object>>, Re
         return inner;
     }
 
+    @Override
     public QueryResult queryResult()
     {
         return inner;

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/QueryResultProvider.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/QueryResultProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.javacompat;
+
+import org.neo4j.cypher.result.QueryResult;
+import org.neo4j.graphdb.Result;
+
+/**
+ * Interface for {@link Result} of query executions that are aware how to represent their result as {@link QueryResult}
+ */
+public interface QueryResultProvider
+{
+    QueryResult queryResult();
+}

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/SnapshotQueryExecutionIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/SnapshotQueryExecutionIT.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.neo4j.server.rest.transactional.integration;
 
 import org.junit.After;

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/SnapshotQueryExecutionIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/SnapshotQueryExecutionIT.java
@@ -1,0 +1,70 @@
+package org.neo4j.server.rest.transactional.integration;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.configuration.Settings;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+import org.neo4j.server.CommunityNeoServer;
+import org.neo4j.server.database.Database;
+import org.neo4j.test.server.ExclusiveServerTestBase;
+import org.neo4j.test.server.HTTP;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.neo4j.server.helpers.CommunityServerBuilder.serverOnRandomPorts;
+import static org.neo4j.test.server.HTTP.RawPayload.quotedJson;
+
+public class SnapshotQueryExecutionIT extends ExclusiveServerTestBase
+{
+
+    private CommunityNeoServer server;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        server = serverOnRandomPorts().withProperty( GraphDatabaseSettings.snapshot_query.name(), Settings.TRUE ).build();
+        server.start();
+    }
+
+    @After
+    public void tearDown()
+    {
+        if ( server != null )
+        {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void executeQueryWithSnapshotEngine()
+    {
+        Database database = server.getDatabase();
+        GraphDatabaseFacade graph = database.getGraph();
+        try ( Transaction transaction = graph.beginTx() )
+        {
+            for ( int i = 0; i < 10; i++ )
+            {
+                Node node = graph.createNode();
+                node.setProperty( "a", "b" );
+            }
+            transaction.success();
+        }
+
+        HTTP.Builder httpClientBuilder = HTTP.withBaseUri( server.baseUri() );
+        HTTP.Response transactionStart = httpClientBuilder.POST( transactionURI() );
+        assertThat( transactionStart.status(), equalTo( 201 ) );
+        HTTP.Response response =
+                httpClientBuilder.POST( transactionStart.location(), quotedJson( "{ 'statements': [ { 'statement': 'MATCH (n) RETURN n' } ] }" ) );
+        assertThat( response.status(), equalTo( 200 ) );
+    }
+
+    private String transactionURI()
+    {
+        return "db/data/transaction";
+    }
+}

--- a/integrationtests/src/test/java/org/neo4j/bolt/BoltSnapshotQueryExecutionIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/BoltSnapshotQueryExecutionIT.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt;
+
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+
+import org.neo4j.driver.v1.Config;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.driver.v1.Record;
+import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.driver.v1.TransactionWork;
+import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.util.Pair;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.EnterpriseGraphDatabaseFactory;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.HostnamePort;
+import org.neo4j.io.IOUtils;
+import org.neo4j.kernel.configuration.BoltConnector;
+import org.neo4j.kernel.configuration.ConnectorPortRegister;
+import org.neo4j.kernel.configuration.Settings;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.test.rule.TestDirectory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+public class BoltSnapshotQueryExecutionIT
+{
+    @Rule
+    public final TestDirectory testDirectory = TestDirectory.testDirectory();
+
+    private Driver driver;
+    private GraphDatabaseService db;
+
+    @After
+    public void tearDown()
+    {
+        if ( db != null )
+        {
+            db.shutdown();
+        }
+        IOUtils.closeAllSilently( driver );
+    }
+
+    @Test
+    public void executeQueryWithSnapshotEngine()
+    {
+        db = new EnterpriseGraphDatabaseFactory()
+                .newEmbeddedDatabaseBuilder( testDirectory.directory("withSnapshotEngine") )
+                .setConfig( new BoltConnector( "bolt" ).type, "BOLT" )
+                .setConfig( new BoltConnector( "bolt" ).enabled, "true" )
+                .setConfig( new BoltConnector( "bolt" ).listen_address, "localhost:0" )
+                .setConfig( GraphDatabaseSettings.snapshot_query, Settings.TRUE )
+                .newGraphDatabase();
+        initDatabase();
+        connectDirver();
+        verifyQueryExecution();
+    }
+
+    @Test
+    public void executeQueryWithoutSnapshotEngine()
+    {
+        db = new EnterpriseGraphDatabaseFactory()
+                .newEmbeddedDatabaseBuilder( testDirectory.directory( "withoutSnapshotEngine" ) )
+                .setConfig( new BoltConnector( "bolt" ).type, "BOLT" )
+                .setConfig( new BoltConnector( "bolt" ).enabled, "true" )
+                .setConfig( new BoltConnector( "bolt" ).listen_address, "localhost:0" )
+                .setConfig( GraphDatabaseSettings.snapshot_query, Settings.FALSE )
+                .newGraphDatabase();
+        initDatabase();
+        connectDirver();
+        verifyQueryExecution();
+    }
+
+    private void verifyQueryExecution()
+    {
+        try ( Session session = driver.session() )
+        {
+            session.readTransaction( (TransactionWork<Void>) tx ->
+            {
+                StatementResult statementResult = tx.run( "MATCH (n) RETURN n.name, n.profession, n.planet, n.city ORDER BY n.name" );
+                List<String> fields = Arrays.asList( "n.name", "n.profession", "n.planet", "n.city" );
+                Record amy = statementResult.next();
+                assertEquals( amy.keys(), fields );
+                assertPairs( amy.fields(), "n.name", "Amy",
+                                   "n.profession", "Student",
+                                   "n.planet", "Mars",
+                                   "n.city", "null");
+                Record fry = statementResult.next();
+                assertEquals( fry.keys(), fields );
+                assertPairs( fry.fields(), "n.name", "Fry",
+                        "n.profession", "Delivery Boy",
+                        "n.planet", "Earth",
+                        "n.city", "New York");
+                Record lila = statementResult.next();
+                assertEquals( lila.keys(), fields );
+                assertPairs( lila.fields(), "n.name", "Lila",
+                        "n.profession", "Pilot",
+                        "n.planet", "Earth",
+                        "n.city", "New York");
+                assertFalse( statementResult.hasNext() );
+                return null;
+            } );
+        }
+    }
+
+    private void connectDirver()
+    {
+        driver = GraphDatabase.driver( boltURI(), Config.build().withoutEncryption().toConfig() );
+    }
+
+    private void initDatabase()
+    {
+        try ( Transaction transaction = db.beginTx() )
+        {
+            Node fry = db.createNode();
+            fry.setProperty( "name", "Fry" );
+            fry.setProperty( "profession", "Delivery Boy" );
+            fry.setProperty( "planet", "Earth" );
+            fry.setProperty( "city", "New York" );
+            Node lila = db.createNode();
+            lila.setProperty( "name", "Lila" );
+            lila.setProperty( "profession", "Pilot" );
+            lila.setProperty( "planet", "Earth" );
+            lila.setProperty( "city", "New York" );
+            Node amy = db.createNode();
+            amy.setProperty( "name", "Amy" );
+            amy.setProperty( "profession", "Student" );
+            amy.setProperty( "planet", "Mars" );
+            transaction.success();
+        }
+    }
+
+    private void assertPairs( List<Pair<String,Value>> pairs, String key1, String value1, String key2, String value2, String key3, String value3,
+            String key4, String value4 )
+    {
+        assertThat( pairs, Matchers.hasSize( 4 ) );
+        validatePair( pairs.get( 0 ), key1, value1 );
+        validatePair( pairs.get( 1 ), key2, value2 );
+        validatePair( pairs.get( 2 ), key3, value3 );
+        validatePair( pairs.get( 3 ), key4, value4 );
+    }
+
+    private void validatePair( Pair<String,Value> pair, String key, String value )
+    {
+        assertEquals( key, pair.key() );
+        assertEquals( value, pair.value().asString() );
+    }
+
+    private URI boltURI()
+    {
+        ConnectorPortRegister connectorPortRegister = ((GraphDatabaseAPI) db).getDependencyResolver().resolveDependency( ConnectorPortRegister.class );
+        HostnamePort boltHostNamePort = connectorPortRegister.getLocalAddress( "bolt" );
+        return URI.create( "bolt://" + boltHostNamePort.getHost() + ":" + boltHostNamePort.getPort() );
+    }
+
+}

--- a/integrationtests/src/test/java/org/neo4j/bolt/BoltSnapshotQueryExecutionIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/BoltSnapshotQueryExecutionIT.java
@@ -74,28 +74,22 @@ public class BoltSnapshotQueryExecutionIT
     @Test
     public void executeQueryWithSnapshotEngine()
     {
-        db = new EnterpriseGraphDatabaseFactory()
-                .newEmbeddedDatabaseBuilder( testDirectory.directory("withSnapshotEngine") )
-                .setConfig( new BoltConnector( "bolt" ).type, "BOLT" )
-                .setConfig( new BoltConnector( "bolt" ).enabled, "true" )
-                .setConfig( new BoltConnector( "bolt" ).listen_address, "localhost:0" )
-                .setConfig( GraphDatabaseSettings.snapshot_query, Settings.TRUE )
-                .newGraphDatabase();
-        initDatabase();
-        connectDirver();
-        verifyQueryExecution();
+        executeQuery( "withSnapshotEngine", Settings.TRUE );
     }
 
     @Test
     public void executeQueryWithoutSnapshotEngine()
     {
-        db = new EnterpriseGraphDatabaseFactory()
-                .newEmbeddedDatabaseBuilder( testDirectory.directory( "withoutSnapshotEngine" ) )
+        executeQuery( "withoutSnapshotEngine", Settings.FALSE );
+    }
+
+    private void executeQuery( String directory, String useSnapshotEngineSettingValue )
+    {
+        db = new EnterpriseGraphDatabaseFactory().newEmbeddedDatabaseBuilder( testDirectory.directory( directory ) )
                 .setConfig( new BoltConnector( "bolt" ).type, "BOLT" )
                 .setConfig( new BoltConnector( "bolt" ).enabled, "true" )
                 .setConfig( new BoltConnector( "bolt" ).listen_address, "localhost:0" )
-                .setConfig( GraphDatabaseSettings.snapshot_query, Settings.FALSE )
-                .newGraphDatabase();
+                .setConfig( GraphDatabaseSettings.snapshot_query, useSnapshotEngineSettingValue ).newGraphDatabase();
         initDatabase();
         connectDirver();
         verifyQueryExecution();

--- a/integrationtests/src/test/java/org/neo4j/bolt/BoltSnapshotQueryExecutionIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/BoltSnapshotQueryExecutionIT.java
@@ -34,7 +34,6 @@ import org.neo4j.driver.v1.GraphDatabase;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResult;
-import org.neo4j.driver.v1.TransactionWork;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.util.Pair;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -106,7 +105,7 @@ public class BoltSnapshotQueryExecutionIT
     {
         try ( Session session = driver.session() )
         {
-            session.readTransaction( (TransactionWork<Void>) tx ->
+            session.readTransaction( tx ->
             {
                 StatementResult statementResult = tx.run( "MATCH (n) RETURN n.name, n.profession, n.planet, n.city ORDER BY n.name" );
                 List<String> fields = Arrays.asList( "n.name", "n.profession", "n.planet", "n.city" );


### PR DESCRIPTION
Restore possibility of executing snapshot queries over bolt endpoint.
Do not expect results of specific type in TransactionStateMachineSPI.
Introduce interface that marks Result that can supply QueryResult instead.
Add additional rest endpoint integration test for snapshot execution.