### PR TITLE
Introduces EnterpriseDbStructureTool

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureTool.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureTool.java
@@ -31,12 +31,16 @@ import static java.lang.String.format;
 
 public class DbStructureTool
 {
-    private DbStructureTool()
+    protected DbStructureTool()
     {
-        throw new IllegalStateException( "Should not be instantiated" );
     }
 
     public static void main( String[] args ) throws IOException
+    {
+        new DbStructureTool().run( args );
+    }
+
+    protected void run( String[] args ) throws IOException
     {
         if ( args.length != 2 && args.length != 3 )
         {
@@ -53,11 +57,11 @@ public class DbStructureTool
         String generatedClassName = parsedGenerated.other();
 
         String generator = format( "%s %s [<output source root>] <db-dir>",
-                DbStructureTool.class.getCanonicalName(),
+                getClass().getCanonicalName(),
                 generatedClassWithPackage
         );
 
-        GraphDatabaseService graph = new GraphDatabaseFactory().newEmbeddedDatabase( new File( dbDir ) );
+        GraphDatabaseService graph = instantiateGraphDatabase( dbDir );
         try
         {
             if ( writeToFile )
@@ -83,7 +87,12 @@ public class DbStructureTool
         }
     }
 
-    private static void traceDb( String generator,
+    protected GraphDatabaseService instantiateGraphDatabase( String dbDir )
+    {
+        return new GraphDatabaseFactory().newEmbeddedDatabase( new File( dbDir ) );
+    }
+
+    private void traceDb( String generator,
                                  String generatedClazzPackage, String generatedClazzName,
                                  GraphDatabaseService graph,
                                  Appendable output )
@@ -104,7 +113,7 @@ public class DbStructureTool
         tracer.close();
     }
 
-    private static Pair<String, String> parseClassNameWithPackage( String classNameWithPackage )
+    private Pair<String, String> parseClassNameWithPackage( String classNameWithPackage )
     {
         if ( classNameWithPackage.contains( "%" ) )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/GraphDbStructureGuide.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/GraphDbStructureGuide.java
@@ -35,6 +35,7 @@ import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.schema.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema.constaints.NodeExistenceConstraintDescriptor;
+import org.neo4j.kernel.api.schema.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema.constaints.RelExistenceConstraintDescriptor;
 import org.neo4j.kernel.api.schema.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
@@ -164,6 +165,11 @@ public class GraphDbStructureGuide implements Visitable<DbStructureVisitor>
             {
                 RelExistenceConstraintDescriptor existenceConstraint = (RelExistenceConstraintDescriptor) constraint;
                 visitor.visitRelationshipPropertyExistenceConstraint( existenceConstraint, userDescription );
+            }
+            else if ( constraint instanceof NodeKeyConstraintDescriptor )
+            {
+                NodeKeyConstraintDescriptor nodeKeyConstraint = (NodeKeyConstraintDescriptor) constraint;
+                visitor.visitNodeKeyConstraint( nodeKeyConstraint, userDescription );
             }
             else
             {

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/EnterpriseDbStructureTool.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/EnterpriseDbStructureTool.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util.dbstructure;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.factory.EnterpriseGraphDatabaseFactory;
+
+public class EnterpriseDbStructureTool extends DbStructureTool
+{
+    private EnterpriseDbStructureTool()
+    {
+    }
+
+    public static void main( String[] args ) throws IOException
+    {
+        new EnterpriseDbStructureTool().run( args );
+    }
+
+    @Override
+    protected GraphDatabaseService instantiateGraphDatabase( String dbDir )
+    {
+        return new EnterpriseGraphDatabaseFactory().newEmbeddedDatabase( new File( dbDir ) );
+    }
+}


### PR DESCRIPTION
The original DbStructureTool doesn't work with databases that have
 NodeKey constraints, since it instantiates a community database
 service. This simple extension adds support for that through a
 subclass in the enterprise kernel module.