### PR TITLE
Add file separators after each name part to construct correct Windows file names

### DIFF
--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
@@ -500,7 +500,8 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
         }
         for ( String pathItem : pathItems )
         {
-            file = file == null ? new File( pathItem ) : new File( file, pathItem );
+            String pathItemName = pathItem + File.separator;
+            file = file == null ? new File( pathItemName ) : new File( file, pathItemName );
         }
         return file;
     }


### PR DESCRIPTION
As part of https://bugs.openjdk.java.net/browse/JDK-8153250 corrections
where made to how windows handle paths like "C:" and that brakes our paths
concatenations assumptions.
Now we will always insert File.separator after each name part to force
correct name resolution always.