### PR TITLE
Fail state machine after marked failure is handled

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
@@ -23,7 +23,6 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.time.Clock;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -62,7 +61,7 @@ import static org.neo4j.values.storable.Values.stringArray;
  */
 public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
 {
-    private final String id = UUID.randomUUID().toString();
+    private final String id;
     private final BoltChannel boltChannel;
     private final Clock clock;
     private final Log log;
@@ -74,6 +73,7 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
 
     public BoltStateMachine( SPI spi, BoltChannel boltChannel, Clock clock, LogService logService )
     {
+        this.id = boltChannel.id();
         this.spi = spi;
         this.ctx = new MutableConnectionState( spi, clock );
         this.boltChannel = boltChannel;
@@ -273,6 +273,7 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
     public void markFailed( Neo4jError error )
     {
         fail( this, error );
+        state = State.FAILED;
     }
 
     private boolean hasPendingError()


### PR DESCRIPTION
This PR addresses a bug that `BoltStateMachine#markFailed(Neo4jError)` call does not change `BoltStateMachine`'s state to `FAILED`. 

The client, after receiving `FAILURE` message tries to acknowledge the failure via `ACK_FAILURE` but `BoltStateMachine` responds back with `"ACK_FAILURE cannot be handled by a session in the READY state.` failure.

With the new behaviour, `BoltStateMachine` transitions to `FAILED` state as soon as `#markFailed` method is invoked.