### PR TITLE
Backup no longer shows errors on success

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/test/ProcessStreamHandler.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ProcessStreamHandler.java
@@ -54,16 +54,15 @@ public class ProcessStreamHandler
         this( process, quiet, "", quiet ? IGNORE_FAILURES : PRINT_FAILURES );
     }
 
-    public ProcessStreamHandler( Process process, boolean quiet, String prefix,
-            StreamExceptionHandler failureHandler )
+    public ProcessStreamHandler( Process process, boolean quiet, String prefix, StreamExceptionHandler failureHandler )
     {
         this( process, quiet, prefix, failureHandler, System.out, System.err );
     }
 
-    public ProcessStreamHandler( Process process, boolean quiet, String prefix,
-            StreamExceptionHandler failureHandler, PrintStream out, PrintStream err )
+    public ProcessStreamHandler( Process process, boolean quiet, String prefix, StreamExceptionHandler failureHandler, PrintStream out, PrintStream err )
     {
         this.process = process;
+
         this.out = new Thread( new StreamConsumer( process.getInputStream(), out, quiet, prefix, failureHandler ) );
         this.err = new Thread( new StreamConsumer( process.getErrorStream(), err, quiet, prefix, failureHandler ) );
     }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/CausalClusteringBackupStrategy.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/CausalClusteringBackupStrategy.java
@@ -63,7 +63,7 @@ class CausalClusteringBackupStrategy extends LifecycleAdapter implements BackupS
 
         try
         {
-            backupDelegator.copy( fromAddress,storeId, desiredBackupLocation );
+            backupDelegator.copy( fromAddress, storeId, desiredBackupLocation );
             return new Fallible<>( BackupStageOutcome.SUCCESS, null );
         }
         catch ( StoreCopyFailedException e )

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/OnlineBackupCommandBuilder.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/OnlineBackupCommandBuilder.java
@@ -64,6 +64,13 @@ public class OnlineBackupCommandBuilder
     private Boolean consistencyCheckLabel;
     private Boolean consistencyCheckOwners;
     private OutputStream output;
+    private Optional<String[]> rawArgs = Optional.empty();
+
+    public OnlineBackupCommandBuilder withRawArgs( String... args )
+    {
+        rawArgs = Optional.of( args );
+        return this;
+    }
 
     public OnlineBackupCommandBuilder withHost( String host )
     {
@@ -147,13 +154,20 @@ public class OnlineBackupCommandBuilder
     {
         File targetLocation = new File( neo4jHome, backupName );
         String[] args;
-        try
+        if ( rawArgs.isPresent() )
         {
-            args = resolveArgs( targetLocation );
+            args = rawArgs.get();
         }
-        catch ( IOException e )
+        else
         {
-            throw new CommandFailed( "Failed to resolve arguments", e );
+            try
+            {
+                args = resolveArgs( targetLocation );
+            }
+            catch ( IOException e )
+            {
+                throw new CommandFailed( "Failed to resolve arguments", e );
+            }
         }
         new OnlineBackupCommandProvider()
                 .create( neo4jHome.toPath(),

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/OnlineBackupCommandProvider.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/OnlineBackupCommandProvider.java
@@ -30,6 +30,7 @@ import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.commandline.arguments.Arguments;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.FormattedLogProvider;
+import org.neo4j.logging.Level;
 import org.neo4j.logging.LogProvider;
 
 import static java.lang.String.format;
@@ -81,7 +82,8 @@ public class OnlineBackupCommandProvider extends AdminCommand.Provider
     @Nonnull
     public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
     {
-        LogProvider logProvider = FormattedLogProvider.toOutputStream( outsideWorld.outStream() );
+        boolean debug = System.getenv().get( "NEO4J_DEBUG") != null;
+        LogProvider logProvider = FormattedLogProvider.withDefaultLogLevel( debug ? Level.DEBUG : Level.NONE ).toOutputStream( outsideWorld.outStream() );
         Monitors monitors = new Monitors();
 
         OnlineBackupContextBuilder contextBuilder = new OnlineBackupContextBuilder( homeDir, configDir );


### PR DESCRIPTION
Tests added that prove errors are not being displayed on successful backup.
Server logs are suppressed from backup output. This behaviour can be overridden with NEO4J_DEBUG 