### PR TITLE
Stress test temporal and spatial index population

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingConfig.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingConfig.java
@@ -30,9 +30,16 @@ public class IndexSamplingConfig
 
     public IndexSamplingConfig( Config config )
     {
-        this.sampleSizeLimit = config.get( GraphDatabaseSettings.index_sample_size_limit );
-        this.updateRatio = ((double) config.get( GraphDatabaseSettings.index_sampling_update_percentage )) / 100.0d;
-        this.backgroundSampling = config.get( GraphDatabaseSettings.index_background_sampling_enabled );
+        this( config.get( GraphDatabaseSettings.index_sample_size_limit ),
+                          config.get( GraphDatabaseSettings.index_sampling_update_percentage ) / 100.0d,
+                          config.get( GraphDatabaseSettings.index_background_sampling_enabled ) );
+    }
+
+    public IndexSamplingConfig( int sampleSizeLimit, double updateRatio, boolean backgroundSampling )
+    {
+        this.sampleSizeLimit = sampleSizeLimit;
+        this.updateRatio = updateRatio;
+        this.backgroundSampling = backgroundSampling;
     }
 
     public int sampleSizeLimit()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/IndexPopulationStressTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/IndexPopulationStressTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.neo4j.kernel.api.index.IndexDirectoryStructure;
+import org.neo4j.kernel.api.index.IndexEntryUpdate;
+import org.neo4j.kernel.api.index.IndexPopulator;
+import org.neo4j.kernel.api.index.IndexProvider;
+import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
+import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptorFactory;
+import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
+import org.neo4j.test.Race;
+import org.neo4j.test.rule.PageCacheAndDependenciesRule;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+import org.neo4j.values.storable.Value;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.fail;
+import static org.neo4j.kernel.api.index.IndexDirectoryStructure.directoriesByProvider;
+import static org.neo4j.kernel.api.index.IndexDirectoryStructure.directoriesBySubProvider;
+
+public abstract class IndexPopulationStressTest
+{
+    @Rule
+    public PageCacheAndDependenciesRule rules = new PageCacheAndDependenciesRule( DefaultFileSystemRule::new, IndexPopulationStressTest.class );
+
+    protected final SchemaIndexDescriptor descriptor = SchemaIndexDescriptorFactory.forLabel( 0, 0 );
+
+    private IndexPopulator populator;
+
+    /**
+     * Create the provider to stress.
+     */
+    abstract IndexProvider newProvider( IndexDirectoryStructure.Factory directory );
+
+    /**
+     * Generate a random value to populate the index with.
+     */
+    abstract Value randomValue( Random random );
+
+    @Before
+    public void setup() throws IOException
+    {
+        File storeDir = rules.directory().graphDbDir();
+        IndexDirectoryStructure.Factory directory =
+                directoriesBySubProvider( directoriesByProvider( storeDir ).forProvider( new IndexProvider.Descriptor( "provider", "1.0" ) ) );
+
+        IndexProvider indexProvider = newProvider( directory );
+
+        rules.fileSystem().mkdirs( indexProvider.directoryStructure().rootDirectory() );
+
+        populator = indexProvider.getPopulator( 0, descriptor, new IndexSamplingConfig( 1000, 0.2, true ) );
+    }
+
+    @After
+    public void teardown() throws IOException
+    {
+        populator.close( true );
+    }
+
+    @Test
+    public void stressIt() throws Throwable
+    {
+        Race race = new Race();
+        final int threads = 50;
+        final AtomicBoolean end = new AtomicBoolean();
+
+        populator.create();
+
+        for ( int i = 0; i < threads; i++ )
+        {
+            race.addContestant( Race.throwing( () ->
+            {
+                ThreadLocalRandom random = ThreadLocalRandom.current();
+                while ( !end.get() )
+                {
+                    populator.add( randomAdds( random ) );
+                }
+            } ) );
+        }
+
+        try
+        {
+            race.go( 5, SECONDS );
+            fail( "Race should have timed out." );
+        }
+        catch ( TimeoutException t )
+        {
+            // great, nothing else failed!
+            end.set( true );
+        }
+    }
+
+    private Collection<? extends IndexEntryUpdate<?>> randomAdds( Random random )
+    {
+        int n = random.nextInt( 100 ) + 1;
+        List<IndexEntryUpdate<?>> updates = new ArrayList<>( n );
+        for ( int i = 0; i < n; i++ )
+        {
+            Value value = randomValue( random );
+            updates.add( IndexEntryUpdate.add( i, descriptor, value ) );
+        }
+        return updates;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPopulationStressTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPopulationStressTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema;
+
+import java.util.Random;
+
+import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
+import org.neo4j.kernel.api.index.IndexDirectoryStructure;
+import org.neo4j.kernel.api.index.IndexProvider;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.values.storable.Value;
+
+import static org.neo4j.values.storable.CoordinateReferenceSystem.Cartesian;
+import static org.neo4j.values.storable.CoordinateReferenceSystem.Cartesian_3D;
+import static org.neo4j.values.storable.CoordinateReferenceSystem.WGS84;
+import static org.neo4j.values.storable.CoordinateReferenceSystem.WGS84_3D;
+import static org.neo4j.values.storable.Values.pointValue;
+
+public class SpatialIndexPopulationStressTest extends IndexPopulationStressTest
+{
+    @Override
+    IndexProvider newProvider( IndexDirectoryStructure.Factory directory )
+    {
+        return new SpatialIndexProvider( rules.pageCache(),
+                                          rules.fileSystem(),
+                                          directory,
+                                          IndexProvider.Monitor.EMPTY,
+                                          RecoveryCleanupWorkCollector.IMMEDIATE,
+                                          false,
+                                          Config.defaults() );
+    }
+
+    @Override
+    Value randomValue( Random random )
+    {
+        switch ( random.nextInt( 4 ) )
+        {
+        case 0:
+            return pointValue( Cartesian, random.nextDouble(), random.nextDouble() );
+
+            case 1:
+            return pointValue( Cartesian_3D, random.nextDouble(), random.nextDouble(), random.nextDouble() );
+
+        case 2:
+            return pointValue( WGS84, random.nextDouble(), random.nextDouble() );
+
+        case 3:
+            return pointValue( WGS84_3D, random.nextDouble(), random.nextDouble(), random.nextDouble() );
+
+            default:
+                throw new IllegalStateException( "Broke java.util.Random." );
+        }
+
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulationStressTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulationStressTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema;
+
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Random;
+
+import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
+import org.neo4j.kernel.api.index.IndexDirectoryStructure;
+import org.neo4j.kernel.api.index.IndexProvider;
+import org.neo4j.values.storable.DateTimeValue;
+import org.neo4j.values.storable.DateValue;
+import org.neo4j.values.storable.DurationValue;
+import org.neo4j.values.storable.LocalDateTimeValue;
+import org.neo4j.values.storable.LocalTimeValue;
+import org.neo4j.values.storable.TimeValue;
+import org.neo4j.values.storable.Value;
+
+public class TemporalIndexPopulationStressTest extends IndexPopulationStressTest
+{
+    private static final ZoneId[] zoneIds = ZoneId.getAvailableZoneIds().stream().map( ZoneId::of ).toArray( ZoneId[]::new );
+    private static final int MAX_OFFSET = ZoneOffset.MAX.getTotalSeconds();
+    private static final int MIN_OFFSET = ZoneOffset.MIN.getTotalSeconds();
+
+    @Override
+    IndexProvider newProvider( IndexDirectoryStructure.Factory directory )
+    {
+        return new TemporalIndexProvider( rules.pageCache(),
+                                          rules.fileSystem(),
+                                          directory,
+                                          IndexProvider.Monitor.EMPTY,
+                                          RecoveryCleanupWorkCollector.IMMEDIATE,
+                                          false );
+    }
+
+    @Override
+    Value randomValue( Random random )
+    {
+        switch ( random.nextInt( 6 ) )
+        {
+        case 0:
+            return DateValue.epochDate( random.nextInt( 1_000_000 ) );
+
+        case 1:
+            return LocalDateTimeValue.localDateTime( epochSecond( random ), nanosOfSecond( random ) );
+
+        case 2:
+            ZoneId zone = random.nextBoolean() ? randomZoneOffset( random ) : randomZoneId( random );
+            return DateTimeValue.datetime( epochSecond( random ), nanosOfSecond( random ), zone );
+
+        case 3:
+            return LocalTimeValue.localTime( secondsOfDay( random ) );
+
+        case 4:
+            return TimeValue.time( secondsOfDay( random ), randomZoneOffset( random ) );
+
+        case 5:
+            return DurationValue.duration( random.nextInt( 1_000_000 ), random.nextInt( 1_000 ), random.nextInt( 1_000 ), random.nextInt( 1_000 ) );
+
+        default:
+            throw new IllegalStateException( "Managed to break java.util.Random" );
+        }
+    }
+
+    private int secondsOfDay( Random random )
+    {
+        return random.nextInt( 1_000_000_000 );
+    }
+
+    private int epochSecond( Random random )
+    {
+        return random.nextInt( 1_000_000_000 );
+    }
+
+    private ZoneOffset randomZoneOffset( Random random )
+    {
+        return ZoneOffset.ofTotalSeconds( random.nextInt( MAX_OFFSET - MIN_OFFSET ) + MIN_OFFSET );
+    }
+
+    private ZoneId randomZoneId( Random random )
+    {
+        return zoneIds[random.nextInt( zoneIds.length )];
+    }
+
+    private long nanosOfSecond( Random random )
+    {
+        return random.nextInt( 1_000_000_000 );
+    }
+}


### PR DESCRIPTION
As the `BatchingMultipleIndexPopulator` uses an Executor to populate indexes, index populators need to be thread safe. The indexes were already modified for thread safety, but these tests should help detect if we mess it up again.

Not in this PR: asserts on the index contents after stressing.