### PR TITLE
Using common code for creation of spatial index range settings

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/IndexPersistenceAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/IndexPersistenceAcceptanceTest.scala
@@ -165,7 +165,7 @@ class IndexPersistenceAcceptanceTest extends IndexingTestSupport {
 
   test("Should not get new index configuration on database settings changes of WGS84 minimum x extent") {
     // remove the entire western hemisphere
-    val wgs84_x_min = Settings.setting("unsupported.dbms.db.spatial.crs.wgs-84.x.min", Settings.DOUBLE, "0")
+    val wgs84_x_min = SpatialIndexSettings.makeCRSRangeSetting(CoordinateReferenceSystem.WGS84, 0, "min")
     testIndexRestartWithSettingsChanges(Map(wgs84_x_min -> "0"))
   }
 


### PR DESCRIPTION
The use of a string in the embedded API call (text code) was working, but considered fragile for future changes to the config system. This cleanup should be more stable.