### PR TITLE
Avoid direct use of TEMP environment variable

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/New-Neo4jTempFile.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/New-Neo4jTempFile.ps1
@@ -52,7 +52,7 @@ Function New-Neo4jTempFile
   
   Process {
     Do { 
-      $RandomFileName = Join-Path -Path (Get-Neo4jEnv 'Temp') -ChildPath ($Prefix + [System.IO.Path]::GetRandomFileName())
+      $RandomFileName = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ($Prefix + [System.IO.Path]::GetRandomFileName())
     } 
     Until (-not (Test-Path -Path $RandomFileName))
 


### PR DESCRIPTION
Originally powershell scripts made use of `TEMP` environment variable to generate random files that are being used to check installed java version. When `TEMP` environment variable originally contains `MSDOS 8.3` style path entries, although version check completes successfully, removal of the temporary file fails which causes the startup also to fail.

This PR gets temporary folder through `[System.IO.Path]::GetTempPath()` call which returns a normalized path string that doesn't contain `MSDOS 8.3` path entries.

This resolves #9646 and #11429.