### PR TITLE
 Update available configuration options and default values

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
@@ -154,7 +154,7 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
         BoltSchedulerProvider boltSchedulerProvider =
                 life.add( new ExecutorBoltSchedulerProvider( config, new CachedThreadPoolExecutorFactory( log ), scheduler, logService ) );
         BoltConnectionFactory boltConnectionFactory =
-                createConnectionFactory( boltFactory, boltSchedulerProvider, throttleGroup, dependencies, logService, clock );
+                createConnectionFactory( config, boltFactory, boltSchedulerProvider, throttleGroup, dependencies, logService, clock );
         ConnectorPortRegister connectionRegister = dependencies.connectionRegister();
 
         BoltProtocolPipelineInstallerFactory handlerFactory = createHandlerFactory( boltConnectionFactory, throttleGroup, logService );
@@ -171,12 +171,14 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
         return life;
     }
 
-    private BoltConnectionFactory createConnectionFactory( BoltFactory boltFactory, BoltSchedulerProvider schedulerProvider,
+    private BoltConnectionFactory createConnectionFactory( Config config, BoltFactory boltFactory, BoltSchedulerProvider schedulerProvider,
             TransportThrottleGroup throttleGroup,
             Dependencies dependencies, LogService logService, Clock clock )
     {
         return new DefaultBoltConnectionFactory( boltFactory, schedulerProvider, throttleGroup, logService, clock,
-                new BoltConnectionReadLimiter( logService.getInternalLog( BoltConnectionReadLimiter.class ) ), dependencies.monitors() );
+                new BoltConnectionReadLimiter( logService.getInternalLog( BoltConnectionReadLimiter.class ),
+                        config.get( GraphDatabaseSettings.bolt_inbound_message_throttle_low_water_mark ),
+                        config.get( GraphDatabaseSettings.bolt_inbound_message_throttle_high_water_mark ) ), dependencies.monitors() );
     }
 
     private Map<BoltConnector,ProtocolInitializer> createConnectors( Config config, SslPolicyLoader sslPolicyFactory, LogService logService, Log log,

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/BoltConnectionReadLimiter.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/BoltConnectionReadLimiter.java
@@ -27,23 +27,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.neo4j.bolt.v1.runtime.Job;
 import org.neo4j.logging.Log;
-import org.neo4j.util.FeatureToggles;
 
 public class BoltConnectionReadLimiter implements BoltConnectionQueueMonitor
 {
-    protected static final String LOW_WATERMARK_NAME = "low_watermark";
-    protected static final String HIGH_WATERMARK_NAME = "high_watermark";
-
     private final ConcurrentHashMap<String, AtomicInteger> counters = new ConcurrentHashMap<>();
     private final Log log;
     private final int lowWatermark;
     private final int highWatermark;
-
-    public BoltConnectionReadLimiter( Log log )
-    {
-        this( log, FeatureToggles.getInteger( BoltConnectionReadLimiter.class, LOW_WATERMARK_NAME, 100 ),
-                FeatureToggles.getInteger( BoltConnectionReadLimiter.class, HIGH_WATERMARK_NAME, 300 ) );
-    }
 
     public BoltConnectionReadLimiter( Log log, int lowWatermark, int highWatermark )
     {

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/CachedThreadPoolExecutorFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/CachedThreadPoolExecutorFactory.java
@@ -54,9 +54,14 @@ public class CachedThreadPoolExecutorFactory implements ExecutorFactory
     }
 
     @Override
-    public ExecutorService create( int corePoolSize, int maxPoolSize, Duration keepAlive, int queueSize, ThreadFactory threadFactory )
+    public ExecutorService create( int corePoolSize, int maxPoolSize, Duration keepAlive, int queueSize, boolean startCoreThreads, ThreadFactory threadFactory )
     {
         ThreadPool result = new ThreadPool( corePoolSize, maxPoolSize, keepAlive, createTaskQueue( queueSize ), threadFactory, rejectionHandler );
+
+        if ( startCoreThreads )
+        {
+            result.prestartAllCoreThreads();
+        }
 
         return result;
     }

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/DefaultBoltConnection.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/DefaultBoltConnection.java
@@ -254,7 +254,7 @@ public class DefaultBoltConnection implements BoltConnection
         {
             error = Neo4jError.from( Status.Request.NoThreadsAvailable, Status.Request.NoThreadsAvailable.code().description() );
             message = String.format( "Unable to schedule bolt session '%s' for execution since there are no available threads to " +
-                    "serve it at the moment. You can retry at a later time or consider increasing max pool / queue size for bolt connector(s).", id() );
+                    "serve it at the moment. You can retry at a later time or consider increasing max thread pool size for bolt connector(s).", id() );
         }
         else
         {

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/ExecutorBoltScheduler.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/ExecutorBoltScheduler.java
@@ -83,7 +83,7 @@ public class ExecutorBoltScheduler implements BoltScheduler, BoltConnectionLifet
     @Override
     public void start()
     {
-        threadPool = executorFactory.create( corePoolSize, maxPoolSize, keepAlive, queueSize,
+        threadPool = executorFactory.create( corePoolSize, maxPoolSize, keepAlive, queueSize, true,
                 new NameAppendingThreadFactory( connector, scheduler.threadFactory( JobScheduler.Groups.boltWorker ) ) );
     }
 

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/ExecutorBoltSchedulerProvider.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/ExecutorBoltSchedulerProvider.java
@@ -58,7 +58,7 @@ public class ExecutorBoltSchedulerProvider extends LifecycleAdapter implements B
         config.enabledBoltConnectors().forEach( connector ->
         {
             BoltScheduler boltScheduler =
-                    new ExecutorBoltScheduler( connector.key(), executorFactory, scheduler, logService, config.get( connector.thread_pool_core_size ),
+                    new ExecutorBoltScheduler( connector.key(), executorFactory, scheduler, logService, config.get( connector.thread_pool_min_size ),
                             config.get( connector.thread_pool_max_size ), config.get( connector.thread_pool_keep_alive ),
                             config.get( connector.unsupported_thread_pool_queue_size ), forkJoinThreadPool );
             boltScheduler.start();

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/ExecutorBoltSchedulerProvider.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/ExecutorBoltSchedulerProvider.java
@@ -60,7 +60,7 @@ public class ExecutorBoltSchedulerProvider extends LifecycleAdapter implements B
             BoltScheduler boltScheduler =
                     new ExecutorBoltScheduler( connector.key(), executorFactory, scheduler, logService, config.get( connector.thread_pool_core_size ),
                             config.get( connector.thread_pool_max_size ), config.get( connector.thread_pool_keep_alive ),
-                            config.get( connector.thread_pool_queue_size ), forkJoinThreadPool );
+                            config.get( connector.unsupported_thread_pool_queue_size ), forkJoinThreadPool );
             boltScheduler.start();
             boltSchedulers.put( connector.key(), boltScheduler );
         } );

--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/ExecutorFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/ExecutorFactory.java
@@ -26,6 +26,6 @@ import java.util.concurrent.ThreadFactory;
 public interface ExecutorFactory
 {
 
-    ExecutorService create( int corePoolSize, int maxPoolSize, Duration keepAlive, int queueSize, ThreadFactory threadFactory );
+    ExecutorService create( int corePoolSize, int maxPoolSize, Duration keepAlive, int queueSize, boolean startCoreThreads, ThreadFactory threadFactory );
 
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportThrottleGroup.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportThrottleGroup.java
@@ -65,11 +65,11 @@ public class TransportThrottleGroup
 
     private static TransportThrottle createWriteThrottle( Config config, Clock clock )
     {
-        if ( config.get( GraphDatabaseSettings.bolt_write_throttle ) )
+        if ( config.get( GraphDatabaseSettings.bolt_outbound_buffer_throttle) )
         {
-            return new TransportWriteThrottle( config.get( GraphDatabaseSettings.bolt_write_buffer_low_water_mark ),
-                    config.get( GraphDatabaseSettings.bolt_write_buffer_high_water_mark ), clock,
-                    config.get( GraphDatabaseSettings.bolt_write_throttle_max_duration ) );
+            return new TransportWriteThrottle( config.get( GraphDatabaseSettings.bolt_outbound_buffer_throttle_low_water_mark ),
+                    config.get( GraphDatabaseSettings.bolt_outbound_buffer_throttle_high_water_mark ), clock,
+                    config.get( GraphDatabaseSettings.bolt_outbound_buffer_throttle_max_duration ) );
         }
 
         return NoOpTransportThrottle.INSTANCE;

--- a/community/bolt/src/test/java/org/neo4j/bolt/runtime/BoltConnectionReadLimiterTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/runtime/BoltConnectionReadLimiterTest.java
@@ -28,9 +28,7 @@ import java.util.Arrays;
 
 import org.neo4j.bolt.v1.runtime.Job;
 import org.neo4j.logging.Log;
-import org.neo4j.util.FeatureToggles;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -68,26 +66,6 @@ public class BoltConnectionReadLimiterTest
     public void cleanup()
     {
         channel.finishAndReleaseAll();
-    }
-
-    @Test
-    public void shouldUseWatermarksFromSystemProperties()
-    {
-        FeatureToggles.set( BoltConnectionReadLimiter.class, BoltConnectionReadLimiter.LOW_WATERMARK_NAME, 5 );
-        FeatureToggles.set( BoltConnectionReadLimiter.class, BoltConnectionReadLimiter.HIGH_WATERMARK_NAME, 10 );
-
-        try
-        {
-           BoltConnectionReadLimiter limiter = newLimiterWithDefaults();
-
-           assertThat( limiter.getLowWatermark(), is( 5 ) );
-           assertThat( limiter.getHighWatermark(), is( 10 ) );
-        }
-        finally
-        {
-            FeatureToggles.clear( BoltConnectionReadLimiter.class, BoltConnectionReadLimiter.LOW_WATERMARK_NAME );
-            FeatureToggles.clear( BoltConnectionReadLimiter.class, BoltConnectionReadLimiter.HIGH_WATERMARK_NAME );
-        }
     }
 
     @Test
@@ -243,10 +221,4 @@ public class BoltConnectionReadLimiterTest
     {
         return new BoltConnectionReadLimiter( log, low, high );
     }
-
-    private BoltConnectionReadLimiter newLimiterWithDefaults()
-    {
-        return new BoltConnectionReadLimiter( log );
-    }
-
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/runtime/ExecutorBoltSchedulerTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/runtime/ExecutorBoltSchedulerTest.java
@@ -56,6 +56,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -93,7 +94,7 @@ public class ExecutorBoltSchedulerTest
     public void initShouldCreateThreadPool() throws Throwable
     {
         ExecutorFactory mockExecutorFactory = mock( ExecutorFactory.class );
-        when( mockExecutorFactory.create( anyInt(), anyInt(), any(), anyInt(), any() ) ).thenReturn( Executors.newCachedThreadPool() );
+        when( mockExecutorFactory.create( anyInt(), anyInt(), any(), anyInt(), anyBoolean(), any() ) ).thenReturn( Executors.newCachedThreadPool() );
         ExecutorBoltScheduler scheduler =
                 new ExecutorBoltScheduler( CONNECTOR_KEY, mockExecutorFactory, jobScheduler, logService, 0, 10, Duration.ofMinutes( 1 ), 0,
                         ForkJoinPool.commonPool() );
@@ -101,7 +102,7 @@ public class ExecutorBoltSchedulerTest
         scheduler.start();
 
         verify( jobScheduler ).threadFactory( JobScheduler.Groups.boltWorker );
-        verify( mockExecutorFactory, times( 1 ) ).create( anyInt(), anyInt(), any( Duration.class ), anyInt(), any( ThreadFactory.class ) );
+        verify( mockExecutorFactory, times( 1 ) ).create( anyInt(), anyInt(), any( Duration.class ), anyInt(), anyBoolean(), any( ThreadFactory.class ) );
     }
 
     @Test
@@ -109,7 +110,7 @@ public class ExecutorBoltSchedulerTest
     {
         ExecutorService cachedThreadPool = Executors.newCachedThreadPool();
         ExecutorFactory mockExecutorFactory = mock( ExecutorFactory.class );
-        when( mockExecutorFactory.create( anyInt(), anyInt(), any(), anyInt(), any() ) ).thenReturn( cachedThreadPool );
+        when( mockExecutorFactory.create( anyInt(), anyInt(), any(), anyInt(), anyBoolean(), any() ) ).thenReturn( cachedThreadPool );
         ExecutorBoltScheduler scheduler =
                 new ExecutorBoltScheduler( CONNECTOR_KEY, mockExecutorFactory, jobScheduler, logService, 0, 10, Duration.ofMinutes( 1 ), 0,
                         ForkJoinPool.commonPool() );
@@ -234,7 +235,8 @@ public class ExecutorBoltSchedulerTest
         String id = UUID.randomUUID().toString();
         BoltConnection connection = newConnection( id );
         AtomicBoolean exitCondition = new AtomicBoolean();
-        when( connection.processNextBatch() ).thenAnswer( inv -> {
+        when( connection.processNextBatch() ).thenAnswer( inv ->
+        {
             processNextBatchCount.incrementAndGet();
             return awaitExit( exitCondition );
         } );
@@ -324,5 +326,4 @@ public class ExecutorBoltSchedulerTest
         Predicates.awaitForever( () -> Thread.currentThread().isInterrupted() || exitCondition.get(), 500, MILLISECONDS );
         return true;
     }
-
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/runtime/integration/BoltSchedulerShouldReportFailureWhenBusyIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/runtime/integration/BoltSchedulerShouldReportFailureWhenBusyIT.java
@@ -86,7 +86,7 @@ public class BoltSchedulerShouldReportFailureWhenBusyIT extends AbstractBoltTran
             settings.put( new BoltConnector( DEFAULT_CONNECTOR_KEY ).enabled.name(), "TRUE" );
             settings.put( new BoltConnector( DEFAULT_CONNECTOR_KEY ).listen_address.name(), "localhost:0" );
             settings.put( new BoltConnector( DEFAULT_CONNECTOR_KEY ).type.name(), BoltConnector.ConnectorType.BOLT.name() );
-            settings.put( new BoltConnector( DEFAULT_CONNECTOR_KEY ).thread_pool_core_size.name(), "0" );
+            settings.put( new BoltConnector( DEFAULT_CONNECTOR_KEY ).thread_pool_min_size.name(), "0" );
             settings.put( new BoltConnector( DEFAULT_CONNECTOR_KEY ).thread_pool_max_size.name(), "2" );
         };
     }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/ResetFuzzTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/ResetFuzzTest.java
@@ -215,7 +215,7 @@ public class ResetFuzzTest
         configProps.put( new BoltConnector( CONNECTOR ).enabled.name(), "TRUE" );
         configProps.put( new BoltConnector( CONNECTOR ).listen_address.name(), "localhost:0" );
         configProps.put( new BoltConnector( CONNECTOR ).type.name(), BoltConnector.ConnectorType.BOLT.name() );
-        configProps.put( new BoltConnector( CONNECTOR ).thread_pool_core_size.name(), "5" );
+        configProps.put( new BoltConnector( CONNECTOR ).thread_pool_min_size.name(), "5" );
         configProps.put( new BoltConnector( CONNECTOR ).thread_pool_max_size.name(), "10" );
 
         return Config.fromSettings( configProps ).build();

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/BoltThrottleMaxDurationIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/BoltThrottleMaxDurationIT.java
@@ -107,7 +107,7 @@ public class BoltThrottleMaxDurationIT
         return settings ->
         {
             settings.put( GraphDatabaseSettings.auth_enabled.name(), "false" );
-            settings.put( GraphDatabaseSettings.bolt_write_throttle_max_duration.name(), "30s" );
+            settings.put( GraphDatabaseSettings.bolt_outbound_buffer_throttle_max_duration.name(), "30s" );
         };
     }
 

--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -108,7 +108,7 @@ public interface Status
                 "The client made a request but did not consume outgoing buffers in a timely fashion." ),
         NoThreadsAvailable( TransientError,  // TODO: see above
                 "There are no available threads to serve this request at the moment. You can retry at a later time " +
-                        "or consider increasing max pool / queue size for bolt connector(s)." );
+                        "or consider increasing max thread pool size for bolt connector(s)." );
         private final Code code;
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -836,15 +836,16 @@ public class GraphDatabaseSettings implements LoadableConfig
     public static final Setting<Boolean> bolt_write_throttle = setting( "unsupported.dbms.bolt.write_throttle", BOOLEAN, TRUE );
 
     @Description( "When the size (in bytes) of write buffers, used by bolt's network layer, " +
-            "grows beyond this value bolt channel will advertise itself as unwritable and bolt worker " +
-            "threads will block until it becomes writable again." )
+            "grows beyond this value bolt channel will advertise itself as unwritable and will block " +
+            "related processing thread until it becomes writable again." )
     @Internal
     public static final Setting<Integer> bolt_write_buffer_high_water_mark =
             buildSetting( "unsupported.dbms.bolt.write_throttle.high_watermark", INTEGER, String.valueOf( ByteUnit.kibiBytes( 512 ) ) ).constraint(
                     range( (int) ByteUnit.kibiBytes( 64 ), Integer.MAX_VALUE ) ).build();
 
     @Description( "When the size (in bytes) of write buffers, previously advertised as unwritable, " +
-            "gets below this value bolt channel will re-advertise itself as writable and blocked bolt worker " + "threads will resume execution." )
+            "gets below this value bolt channel will re-advertise itself as writable and blocked processing " +
+            "thread will resume execution." )
     @Internal
     public static final Setting<Integer> bolt_write_buffer_low_water_mark =
             buildSetting( "unsupported.dbms.bolt.write_throttle.low_watermark", INTEGER, String.valueOf( ByteUnit.kibiBytes( 128 ) ) ).constraint(

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -831,32 +831,49 @@ public class GraphDatabaseSettings implements LoadableConfig
     public static final Setting<File> bolt_log_filename = derivedSetting( "unsupported.dbms.logs.bolt.path",
             GraphDatabaseSettings.logs_directory, logsDir -> new File( logsDir, "bolt.log" ), PATH );
 
-    @Description( "Whether to apply network level write throttling" )
+    @Description( "Whether to apply network level outbound network buffer based throttling" )
     @Internal
-    public static final Setting<Boolean> bolt_write_throttle = setting( "unsupported.dbms.bolt.write_throttle", BOOLEAN, TRUE );
+    public static final Setting<Boolean> bolt_outbound_buffer_throttle = setting( "unsupported.dbms.bolt.outbound_buffer_throttle", BOOLEAN, TRUE );
 
-    @Description( "When the size (in bytes) of write buffers, used by bolt's network layer, " +
+    @Description( "When the size (in bytes) of outbound network buffers, used by bolt's network layer, " +
             "grows beyond this value bolt channel will advertise itself as unwritable and will block " +
             "related processing thread until it becomes writable again." )
     @Internal
-    public static final Setting<Integer> bolt_write_buffer_high_water_mark =
-            buildSetting( "unsupported.dbms.bolt.write_throttle.high_watermark", INTEGER, String.valueOf( ByteUnit.kibiBytes( 512 ) ) ).constraint(
+    public static final Setting<Integer> bolt_outbound_buffer_throttle_high_water_mark =
+            buildSetting( "unsupported.dbms.bolt.outbound_buffer_throttle.high_watermark", INTEGER, String.valueOf( ByteUnit.kibiBytes( 512 ) ) ).constraint(
                     range( (int) ByteUnit.kibiBytes( 64 ), Integer.MAX_VALUE ) ).build();
 
-    @Description( "When the size (in bytes) of write buffers, previously advertised as unwritable, " +
+    @Description( "When the size (in bytes) of outbound network buffers, previously advertised as unwritable, " +
             "gets below this value bolt channel will re-advertise itself as writable and blocked processing " +
             "thread will resume execution." )
     @Internal
-    public static final Setting<Integer> bolt_write_buffer_low_water_mark =
-            buildSetting( "unsupported.dbms.bolt.write_throttle.low_watermark", INTEGER, String.valueOf( ByteUnit.kibiBytes( 128 ) ) ).constraint(
+    public static final Setting<Integer> bolt_outbound_buffer_throttle_low_water_mark =
+            buildSetting( "unsupported.dbms.bolt.outbound_buffer_throttle.low_watermark", INTEGER, String.valueOf( ByteUnit.kibiBytes( 128 ) ) ).constraint(
                     range( (int) ByteUnit.kibiBytes( 16 ), Integer.MAX_VALUE ) ).build();
 
-    @Description( "When the total time write throttle lock is held exceeds this value, the corresponding bolt channel will be aborted. Setting "
-            + " this to 0 will disable this behaviour." )
+    @Description( "When the total time outbound network buffer based throttle lock is held exceeds this value, " +
+            "the corresponding bolt channel will be aborted. Setting " +
+            "this to 0 will disable this behaviour." )
     @Internal
-    public static final Setting<Duration> bolt_write_throttle_max_duration =
-            buildSetting( "unsupported.dbms.bolt.write_throttle.max_duration", DURATION, "15m" ).constraint(
+    public static final Setting<Duration> bolt_outbound_buffer_throttle_max_duration =
+            buildSetting( "unsupported.dbms.bolt.outbound_buffer_throttle.max_duration", DURATION, "15m" ).constraint(
                     min( Duration.ofSeconds( 30 ) ) ).build();
+
+    @Description( "When the number of queued inbound messages grows beyond this value, reading from underlying " +
+            "channel will be paused (no more inbound messages will be available) until queued number of " +
+            "messages drops below the configured low watermark value." )
+    @Internal
+    public static final Setting<Integer> bolt_inbound_message_throttle_high_water_mark =
+            buildSetting( "unsupported.dbms.bolt.inbound_message_throttle.high_watermark", INTEGER, String.valueOf( 300 ) ).constraint(
+                    range( 1, Integer.MAX_VALUE ) ).build();
+
+    @Description( "When the number of queued inbound messages, previously reached configured high watermark value, " +
+            "drops below this value, reading from underlying channel will be enabled and any pending messages " +
+            "will start queuing again." )
+    @Internal
+    public static final Setting<Integer> bolt_inbound_message_throttle_low_water_mark =
+            buildSetting( "unsupported.dbms.bolt.inbound_message_throttle.low_watermark", INTEGER, String.valueOf( 100 ) ).constraint(
+                    range( 1, Integer.MAX_VALUE ) ).build();
 
     @Description( "Create an archive of an index before re-creating it if failing to load on startup." )
     @Internal

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/BoltConnector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/BoltConnector.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.configuration;
 import java.time.Duration;
 
 import org.neo4j.configuration.Description;
+import org.neo4j.configuration.Internal;
 import org.neo4j.configuration.ReplacedBy;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.helpers.AdvertisedSocketAddress;
@@ -66,7 +67,8 @@ public class BoltConnector extends Connector
     public final Setting<Duration> thread_pool_keep_alive;
 
     @Description( "The queue size of the thread pool bound to this connector (-1 for unbounded, 0 for direct handoff, > 0 for bounded)" )
-    public final Setting<Integer> thread_pool_queue_size;
+    @Internal
+    public final Setting<Integer> unsupported_thread_pool_queue_size;
 
     // Used by config doc generator
     public BoltConnector()
@@ -89,7 +91,7 @@ public class BoltConnector extends Connector
         this.thread_pool_core_size = group.scope( setting( "thread_pool_core_size", INTEGER, String.valueOf( 10 ) ) );
         this.thread_pool_max_size = group.scope( setting( "thread_pool_max_size", INTEGER, String.valueOf( 400 ) ) );
         this.thread_pool_keep_alive = group.scope( setting( "thread_pool_keep_alive", DURATION, "5m" ) );
-        this.thread_pool_queue_size = group.scope( setting( "thread_pool_queue_size", INTEGER, String.valueOf( 0 ) ) );
+        this.unsupported_thread_pool_queue_size = group.scope( setting( "unsupported_thread_pool_queue_size", INTEGER, String.valueOf( 0 ) ) );
     }
 
     public enum EncryptionLevel

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/BoltConnector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/BoltConnector.java
@@ -58,7 +58,7 @@ public class BoltConnector extends Connector
     public final Setting<AdvertisedSocketAddress> advertised_address;
 
     @Description( "The number of threads to keep in the thread pool bound to this connector, even if they are idle." )
-    public final Setting<Integer> thread_pool_core_size;
+    public final Setting<Integer> thread_pool_min_size;
 
     @Description( "The maximum number of threads allowed in the thread pool bound to this connector." )
     public final Setting<Integer> thread_pool_max_size;
@@ -88,7 +88,7 @@ public class BoltConnector extends Connector
         this.address = group.scope( legacyAddressSetting );
         this.listen_address = group.scope( listenAddressSetting );
         this.advertised_address = group.scope( advertisedAddress( "advertised_address", listenAddressSetting ) );
-        this.thread_pool_core_size = group.scope( setting( "thread_pool_core_size", INTEGER, String.valueOf( 10 ) ) );
+        this.thread_pool_min_size = group.scope( setting( "thread_pool_min_size", INTEGER, String.valueOf( 5 ) ) );
         this.thread_pool_max_size = group.scope( setting( "thread_pool_max_size", INTEGER, String.valueOf( 400 ) ) );
         this.thread_pool_keep_alive = group.scope( setting( "thread_pool_keep_alive", DURATION, "5m" ) );
         this.unsupported_thread_pool_queue_size = group.scope( setting( "unsupported_thread_pool_queue_size", INTEGER, String.valueOf( 0 ) ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/BoltConnectorValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/BoltConnectorValidator.java
@@ -90,7 +90,7 @@ public class BoltConnectorValidator extends ConnectorValidator
                     listenAddress( settingName, 7687 ) );
             setting.setDescription( "Advertised address for this connector." );
             break;
-        case "thread_pool_core_size":
+        case "thread_pool_min_size":
             setting = (BaseSetting) setting( settingName, INTEGER, NO_DEFAULT );
             setting.setDescription( "The number of threads to keep in the thread pool bound to this connector, even if they are idle." );
             break;
@@ -102,7 +102,7 @@ public class BoltConnectorValidator extends ConnectorValidator
             setting = (BaseSetting) setting( settingName, DURATION, NO_DEFAULT );
             setting.setDescription( "The maximum time an idle thread in the thread pool bound to this connector will wait for new tasks." );
             break;
-        case "thread_pool_queue_size":
+        case "unsupported_thread_pool_queue_size":
             setting = (BaseSetting) setting( settingName, INTEGER, NO_DEFAULT );
             setting.setDescription( "The queue size of the thread pool bound to this connector (-1 for unbounded, 0 for direct handoff, > 0 for bounded)" );
             break;


### PR DESCRIPTION
This PR makes some changes around how configuration keys for bolt server are named.

***Thread pooling***
The new pooled thread architecture being introduced in bolt server makes it possible that idle connections do not eat up server resources. The thread pools are isolated per connector, i.e. you can have multiple bolt connectors defined at different ports with different thread pool characteristics. Currently, any open transaction (be it an explicit transaction or an auto-commit one) will borrow a thread from the thread pool until that transaction is closed. This should be kept in mind while picking values for `thread_pool_min_size` and `thread_pool_max_size`.

1. **dbms.connector.[connector_name].thread_pool_min_size** [Default value is `5`]
This is the minimum number of threads that'll always be up even if they're idle. They're created as part of the server startup process and the value could be customised based on your normal load.

2. **dbms.connector.[connector_name].thread_pool_max_size** [Default value is `400`]
This is the maximum number of threads that'll be created by the thread pool. Any request requiring an additional thread startup will be rejected and a `FAILURE` message will be generated. Consider your peak loads when choosing a value for this configuration option.

3. **dbms.connector.[connector_name].thread_pool_keep_alive** [Default value is `5m`]
This is the amount of time that the thread pool will wait before killing an idle thread from the pool. Beware that the number of threads will not go below `thread_pool_min_size`.

***Outgoing Buffer Throttle***
Outgoing buffer throttle is a network buffer based back pressure mechanism, where the query processing is blocked after outgoing buffer size grows beyond a configured high watermark (`high_watermark` and is resumed when it drops below a configured low watermark (`low_watermark`). If the query processing is blocked more than a configured amount of time (`max_duration`), the connection is terminated with a log entry.

1. **unsupported.dbms.bolt.outbound_buffer_throttle.low_watermark** [Default value is `128KB`]
2. **unsupported.dbms.bolt.outbound_buffer_throttle.high_watermark** [Default value is `512KB`]
3. **unsupported.dbms.bolt.outbound_buffer_throttle.max_duration** [Default value is `15m`]

***Incoming Message Throttle***
Incoming message throttle is a stopper mechanism that kicks in when client's message queue length gets above `high_watermark` and we stop reading from client channel until queue length drops below `low_watermark`.

1. **unsupported.dbms.bolt.inbound_message_throttle.low_watermark** [Default value is `100`]
2. **unsupported.dbms.bolt.inbound_message_throttle.high_watermark** [Default value is `300`]