### PR TITLE
Avoid indirectory relying on commons-lang3.

### DIFF
--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ProfileRefCounts.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ProfileRefCounts.java
@@ -19,14 +19,27 @@
  */
 package org.neo4j.kernel.impl.pagecache;
 
-import org.apache.commons.lang3.mutable.MutableInt;
-
 import java.util.HashMap;
 import java.util.Map;
 
 class ProfileRefCounts
 {
-    private final Map<Profile,MutableInt> bag;
+    private static class Counter
+    {
+        private int count;
+
+        void increment()
+        {
+            count++;
+        }
+
+        int decrementAndGet()
+        {
+            return --count;
+        }
+    }
+
+    private final Map<Profile,Counter> bag;
 
     ProfileRefCounts()
     {
@@ -37,7 +50,7 @@ class ProfileRefCounts
     {
         for ( Profile profile : profiles )
         {
-            bag.computeIfAbsent( profile, p -> new MutableInt() ).increment();
+            bag.computeIfAbsent( profile, p -> new Counter() ).increment();
         }
     }
 


### PR DESCRIPTION
Not all versions of `MutableInt` have the `decrementAndGet` method.
Using it can thus lead to `NoSuchMethodError` at runtime.
To work around this, we just create our own very minimal Counter class,
which has just the two methods that we actually need, and nothing more.