### PR TITLE
Add Unwind, StartsWith and EndWith support in Prettifier and ExpressionStringifier

### DIFF
--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/prettifier/ExpressionStringifier.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/prettifier/ExpressionStringifier.scala
@@ -40,7 +40,12 @@ case class ExpressionStringifier(extender: Expression => String = e => throw new
       case l: Literal =>
         l.asCanonicalStringVal
       case e: BinaryOperatorExpression =>
-        s"${parens(e, e.lhs)} ${e.canonicalOperatorSymbol} ${parens(e, e.rhs)}"
+        val op = e match {
+          case _: StartsWith => "STARTS WITH"
+          case _: EndsWith => "ENDS WITH"
+          case _ => e.canonicalOperatorSymbol
+        }
+        s"${parens(e, e.lhs)} ${op} ${parens(e, e.rhs)}"
       case Variable(v) =>
         backtick(v)
       case ListLiteral(expressions) =>

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/prettifier/Prettifier.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/prettifier/Prettifier.scala
@@ -30,6 +30,7 @@ case class Prettifier(mkStringOf: ExpressionStringifier) {
     case m: Match => asString(m)
     case w: With => asString(w)
     case c: Create => asString(c)
+    case u: Unwind => asString(u)
     case _ => clause.asCanonicalStringVal // TODO
   }
 
@@ -88,6 +89,8 @@ case class Prettifier(mkStringOf: ExpressionStringifier) {
     val wh = w.where.map(w => NL + "  WHERE " + mkStringOf(w.expression)).getOrElse("")
     s"WITH$d $i$o$s$l$wh"
   }
+
+  private def asString(u:Unwind) = s"UNWIND ${mkStringOf(u.expression)} AS ${mkStringOf(u.variable)}"
 
   private def asString(c: Create): String = {
     val p = c.pattern.patternParts.map(p => asString(p)).mkString(", ")

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/prettifier/ExpressionStringifierTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/prettifier/ExpressionStringifierTest.scala
@@ -72,7 +72,9 @@ class ExpressionStringifierTest
       "not(((1) = (2)) and ((3) = (4)))" -> "not (1 = 2 AND 3 = 4)",
       "reduce(totalAge = 0, n IN nodes(p)| totalAge + n.age)" ->
         "reduce(totalAge = 0, n IN nodes(p) | totalAge + n.age)",
-      "$param1+{param2}" -> "$param1 + $param2"
+      "$param1+{param2}" -> "$param1 + $param2",
+      "p.name starts with 'Keanu'" -> """p.name STARTS WITH "Keanu"""",
+      "p.name ends with 'Reeves'" -> """p.name ENDS WITH "Reeves""""
     )
 
   tests foreach {

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/prettifier/PrettifierTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/prettifier/PrettifierTest.scala
@@ -58,7 +58,23 @@ class PrettifierTest extends CypherFunSuite {
 
       "create (a)--(b) RETURN a" ->
         """CREATE (a)--(b)
-          |RETURN a""".stripMargin
+          |RETURN a""".stripMargin,
+
+      "unwind [1,2] as a return a"->
+        """
+          |
+        """.stripMargin,
+
+      "match(p:Person) where p.name starts with 'Keanu' return p"->
+        """
+          |
+        """.stripMargin,
+
+      "match(p:Person) where p.name ends with 'Reeves' return p"->
+        """
+          |
+        """.stripMargin
+
     )
 
   tests foreach {

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/prettifier/PrettifierTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/prettifier/PrettifierTest.scala
@@ -61,19 +61,18 @@ class PrettifierTest extends CypherFunSuite {
           |RETURN a""".stripMargin,
 
       "unwind [1,2] as a return a"->
-        """
-          |
-        """.stripMargin,
+        """UNWIND [1, 2] AS a
+          |RETURN a""".stripMargin,
 
       "match(p:Person) where p.name starts with 'Keanu' return p"->
-        """
-          |
-        """.stripMargin,
+        """MATCH (p:Person)
+          |  WHERE p.name STARTS WITH "Keanu"
+          |RETURN p""".stripMargin,
 
       "match(p:Person) where p.name ends with 'Reeves' return p"->
-        """
-          |
-        """.stripMargin
+        """MATCH (p:Person)
+          |  WHERE p.name ENDS WITH "Reeves"
+          |RETURN p""".stripMargin
 
     )
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialIndexCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialIndexCacheTest.java
@@ -71,7 +71,7 @@ public class SpatialIndexCacheTest
     }
 
     private static final CoordinateReferenceSystem[] coordinateReferenceSystems =
-            Iterators.stream( CoordinateReferenceSystem.all() ).toArray( CoordinateReferenceSystem[]::new );
+            Iterators.stream( CoordinateReferenceSystem.all().iterator() ).toArray( CoordinateReferenceSystem[]::new );
 
     static class CacheStresser implements Runnable
     {


### PR DESCRIPTION
_UNWIND_, _STARTS WITH_ and _ENDS WITH_ are not handled properly by `Prettifier` and `ExpressionStringifier`

Consider the following code for example

```
import org.neo4j.cypher.internal.frontend.v3_4.parser.CypherParser
import org.neo4j.cypher.internal.frontend.v3_4.prettifier.{ExpressionStringifier, Prettifier}

object Experiments extends App {
  val query =
    """unwind ['Keanu'] as firstName
      |unwind ['Reeves'] as lastName
      |match (p:Person) where p.name starts with firstName and p.name ends with lastName and p.born=1964
      |return p""".stripMargin
  val parsed = new CypherParser().parse(query, Option.empty)
  val stringifier: Prettifier = Prettifier(ExpressionStringifier())
  val pretty = stringifier.asString(parsed)

  println(pretty)
}
```

With the current version, it produces the following ouptu
```
Unwind(ListLiteral(List(StringLiteral(Keanu))),Variable(firstName))
Unwind(ListLiteral(List(StringLiteral(Reeves))),Variable(lastName))
MATCH (p:Person)
  WHERE (p.name STARTSWITH firstName AND p.name ENDSWITH lastName) AND p.born = 1964
RETURN p
```
Which is not a valid cypher query. Look at `Unwind`, `STARTSWITH` and `ENDSWITH`

With the changes in this pull request, we will get the following output instead

```
UNWIND ["Keanu"] AS firstName
UNWIND ["Reeves"] AS lastName
MATCH (p:Person)
  WHERE (p.name STARTS WITH firstName AND p.name ENDS WITH lastName) AND p.born = 1964
RETURN p
```