### PR TITLE
Migrate tests from old kernel API

### DIFF
--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/SecurityContext.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/SecurityContext.java
@@ -94,30 +94,32 @@ public class SecurityContext implements LoginContext
     }
 
     /** Allows all operations. */
-    public static final SecurityContext AUTH_DISABLED = authDisabled( AccessMode.Static.FULL );
+    @SuppressWarnings( "StaticInitializerReferencesSubClass" )
+    public static final SecurityContext AUTH_DISABLED = new AuthDisabled( AccessMode.Static.FULL );
 
-    private static SecurityContext authDisabled( AccessMode mode )
+    private static class AuthDisabled extends SecurityContext
     {
-        return new SecurityContext( AuthSubject.AUTH_DISABLED, mode )
+        private AuthDisabled( AccessMode mode )
         {
+            super( AuthSubject.AUTH_DISABLED, mode );
+        }
 
-            @Override
-            public SecurityContext withMode( AccessMode mode )
-            {
-                return authDisabled( mode );
-            }
+        @Override
+        public SecurityContext withMode( AccessMode mode )
+        {
+            return new AuthDisabled( mode );
+        }
 
-            @Override
-            public String description()
-            {
-                return "AUTH_DISABLED with " + mode().name();
-            }
+        @Override
+        public String description()
+        {
+            return "AUTH_DISABLED with " + mode().name();
+        }
 
-            @Override
-            public String toString()
-            {
-                return defaultString( "auth-disabled" );
-            }
-        };
+        @Override
+        public String toString()
+        {
+            return defaultString( "auth-disabled" );
+        }
     }
 }

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/SchemaReadWriteTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/SchemaReadWriteTestBase.java
@@ -81,6 +81,16 @@ public abstract class SchemaReadWriteTestBase<G extends KernelAPIWriteTestSuppor
     }
 
     @Test
+    public void shouldNotFindNonExistentIndex() throws Exception
+    {
+        try ( Transaction transaction = session.beginTransaction() )
+        {
+            SchemaRead schemaRead = transaction.schemaRead();
+            assertThat( schemaRead.index( label, prop1 ), equalTo( CapableIndexReference.NO_INDEX ) );
+        }
+    }
+
+    @Test
     public void shouldCreateIndex() throws Exception
     {
         IndexReference index;
@@ -107,6 +117,18 @@ public abstract class SchemaReadWriteTestBase<G extends KernelAPIWriteTestSuppor
 
             assertThat( index.providerKey(), equalTo( "Undecided" ));
             assertThat( index.providerVersion(), equalTo( "0" ));
+        }
+    }
+
+    @Test
+    public void createdIndexShouldPopulateInTx() throws Exception
+    {
+        IndexReference index;
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            index = tx.schemaWrite().indexCreate( labelDescriptor( label, prop1 ) );
+            assertThat( tx.schemaRead().indexGetState( index ), equalTo( InternalIndexState.POPULATING ) );
+            tx.success();
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
@@ -23,6 +23,7 @@ import org.neo4j.internal.kernel.api.NodeCursor;
 import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.RelationshipScanCursor;
 import org.neo4j.internal.kernel.api.Transaction;
+import org.neo4j.internal.kernel.api.security.AuthSubject;
 import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.api.ClockContext;
@@ -101,6 +102,11 @@ public interface KernelTransaction extends Transaction, AssertOpen
      * @return the security context this transaction is currently executing in.
      */
     SecurityContext securityContext();
+
+    /**
+     * @return the subject executing this transaction.
+     */
+    AuthSubject subject();
 
     /**
      * @return The timestamp of the last transaction that was committed to the store when this transaction started.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransactionHandle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransactionHandle.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.AuthSubject;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.query.ExecutingQuery;
 import org.neo4j.kernel.impl.api.TransactionExecutionStatistic;
@@ -84,7 +84,7 @@ public interface KernelTransactionHandle
      *
      * @return underlying transaction security context
      */
-    SecurityContext securityContext();
+    AuthSubject subject();
 
     /**
      * Metadata of underlying transaction that transaction has when handle was created.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -54,6 +54,7 @@ import org.neo4j.internal.kernel.api.Write;
 import org.neo4j.internal.kernel.api.exceptions.InvalidTransactionTypeKernelException;
 import org.neo4j.internal.kernel.api.exceptions.schema.ConstraintValidationException;
 import org.neo4j.internal.kernel.api.security.AccessMode;
+import org.neo4j.internal.kernel.api.security.AuthSubject;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer;
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier;
@@ -366,7 +367,16 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     @Override
     public SecurityContext securityContext()
     {
+        if ( securityContext == null )
+        {
+            throw new NotInTransactionException();
+        }
         return securityContext;
+    }
+
+    public AuthSubject subject()
+    {
+        return securityContext == null ? AuthSubject.ANONYMOUS : securityContext.subject();
     }
 
     public void setMetaData( Map<String, Object> data )
@@ -828,6 +838,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
 
     public StatementLocks statementLocks()
     {
+        assertOpen();
         return statementLocks;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandle.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.neo4j.internal.kernel.api.security.AuthSubject;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.KernelTransactionHandle;
@@ -48,7 +49,7 @@ class KernelTransactionImplementationHandle implements KernelTransactionHandle
     private final long timeoutMillis;
     private final KernelTransactionImplementation tx;
     private final SystemNanoClock clock;
-    private final SecurityContext securityContext;
+    private final AuthSubject subject;
     private final Optional<Status> terminationReason;
     private final ExecutingQueryList executingQueries;
     private final Map<String,Object> metaData;
@@ -61,7 +62,7 @@ class KernelTransactionImplementationHandle implements KernelTransactionHandle
         this.lastTransactionTimestampWhenStarted = tx.lastTransactionTimestampWhenStarted();
         this.startTime = tx.startTime();
         this.timeoutMillis = tx.timeout();
-        this.securityContext = tx.securityContext();
+        this.subject = tx.subject();
         this.terminationReason = tx.getReasonIfTerminated();
         this.executingQueries = tx.executingQueries();
         this.metaData = tx.getMetaData();
@@ -107,9 +108,9 @@ class KernelTransactionImplementationHandle implements KernelTransactionHandle
     }
 
     @Override
-    public SecurityContext securityContext()
+    public AuthSubject subject()
     {
-        return securityContext;
+        return subject;
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/StubKernelTransaction.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/StubKernelTransaction.java
@@ -37,6 +37,7 @@ import org.neo4j.internal.kernel.api.Token;
 import org.neo4j.internal.kernel.api.TokenRead;
 import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.Write;
+import org.neo4j.internal.kernel.api.security.AuthSubject;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
@@ -172,6 +173,12 @@ public class StubKernelTransaction implements KernelTransaction
 
     @Override
     public SecurityContext securityContext()
+    {
+        throw new UnsupportedOperationException( "not implemented" );
+    }
+
+    @Override
+    public AuthSubject subject()
     {
         throw new UnsupportedOperationException( "not implemented" );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionAssertOpenTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionAssertOpenTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.neo4j.graphdb.NotInTransactionException;
+import org.neo4j.graphdb.TransactionTerminatedException;
+import org.neo4j.internal.kernel.api.Read;
+import org.neo4j.internal.kernel.api.SchemaRead;
+import org.neo4j.internal.kernel.api.Write;
+import org.neo4j.internal.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.api.security.AnonymousContext;
+import org.neo4j.values.storable.Values;
+
+@RunWith( Parameterized.class )
+public class KernelTransactionAssertOpenTest extends KernelTransactionTestBase
+{
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Parameterized.Parameter( 0 )
+    public String name;
+
+    @Parameterized.Parameter( 1 )
+    public Operation transactionOperation;
+
+    @Parameterized.Parameters( name = "{0}" )
+    public static Collection<Object[]> parameters()
+    {
+        // Some samples of operations that should react to transaction killing. Not exhaustive.
+        return Arrays.asList(
+                operation( "nodeExists", ( read, write, schema ) -> read.nodeExists( 0 ) ),
+                operation( "singleRelationship", ( read, write, schema ) -> read.singleRelationship( 0, null ) ),
+                operation( "nodeCreate", ( read, write, schema ) -> write.nodeCreate() ),
+                operation( "relationshipSetProperty", ( read, write, schema ) -> write.relationshipSetProperty( 0, 2, Values.longValue( 42 ) ) ),
+                operation( "indexesGetAll", ( read, write, schema ) -> schema.indexesGetAll() ) );
+    }
+
+    private static Object[] operation( String name, Operation op )
+    {
+        return new Object[]{name, op};
+    }
+
+    @Test( expected = TransactionTerminatedException.class )
+    public void shouldThrowTerminateExceptionWhenTransactionTerminated() throws KernelException
+    {
+        KernelTransaction transaction = newTransaction( AnonymousContext.write() );
+
+        transaction.success();
+        transaction.markForTermination( Status.General.UnknownError );
+
+        transactionOperation.operate( transaction.dataRead(), transaction.dataWrite(), transaction.schemaRead() );
+    }
+
+    @Test( expected = NotInTransactionException.class )
+    public void shouldThrowNotInTransactionWhenTransactionClosedAndAccessingOperations() throws KernelException
+    {
+        KernelTransaction transaction = newTransaction( AnonymousContext.write() );
+
+        transaction.success();
+        transaction.close();
+
+        transactionOperation.operate( transaction.dataRead(), transaction.dataWrite(), transaction.schemaRead() );
+    }
+
+    @Test( expected = NotInTransactionException.class )
+    public void shouldThrowNotInTransactionWhenTransactionClosedAndAttemptingOperations() throws KernelException
+    {
+        KernelTransaction transaction = newTransaction( AnonymousContext.write() );
+
+        Read read = transaction.dataRead();
+        Write write = transaction.dataWrite();
+        SchemaRead schemaRead = transaction.schemaRead();
+
+        transaction.success();
+        transaction.close();
+
+        transactionOperation.operate( read, write, schemaRead );
+    }
+
+    interface Operation
+    {
+        void operate( Read read, Write write, SchemaRead schemaRead ) throws KernelException;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TestKernelTransactionHandle.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TestKernelTransactionHandle.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.AuthSubject;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.KernelTransactionHandle;
 import org.neo4j.kernel.api.exceptions.Status;
@@ -83,9 +83,9 @@ public class TestKernelTransactionHandle implements KernelTransactionHandle
     }
 
     @Override
-    public SecurityContext securityContext()
+    public AuthSubject subject()
     {
-        return tx.securityContext();
+        return tx.subject();
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeLabelIndexCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeLabelIndexCursorTest.java
@@ -21,11 +21,11 @@ package org.neo4j.kernel.impl.newapi;
 
 import org.neo4j.internal.kernel.api.NodeLabelIndexCursorTestBase;
 
-public class NodeLabelIndexCursorTest extends NodeLabelIndexCursorTestBase<ReadTestSupport>
+public class NodeLabelIndexCursorTest extends NodeLabelIndexCursorTestBase<WriteTestSupport>
 {
     @Override
-    public ReadTestSupport newTestSupport()
+    public WriteTestSupport newTestSupport()
     {
-        return new ReadTestSupport();
+        return new WriteTestSupport();
     }
 }

--- a/community/neo4j/src/test/java/org/neo4j/locking/QueryExecutionLocksIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/locking/QueryExecutionLocksIT.java
@@ -53,6 +53,7 @@ import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.Write;
 import org.neo4j.internal.kernel.api.exceptions.InvalidTransactionTypeKernelException;
 import org.neo4j.internal.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.internal.kernel.api.security.AuthSubject;
 import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.GraphDatabaseQueryService;
@@ -693,6 +694,12 @@ public class QueryExecutionLocksIT
         public SecurityContext securityContext()
         {
             return internal.securityContext();
+        }
+
+        @Override
+        public AuthSubject subject()
+        {
+            return internal.subject();
         }
 
         @Override

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
@@ -310,7 +310,7 @@ public class EnterpriseBuiltInDbmsProcedures
         try
         {
             Set<KernelTransactionHandle> handles = getKernelTransactions().activeTransactions().stream()
-                    .filter( transaction -> isAdminOrSelf( transaction.securityContext().subject().username() ) )
+                    .filter( transaction -> isAdminOrSelf( transaction.subject().username() ) )
                     .collect( toSet() );
 
             Map<KernelTransactionHandle,List<QuerySnapshot>> handleQuerySnapshotsMap = handles.stream()
@@ -475,7 +475,7 @@ public class EnterpriseBuiltInDbmsProcedures
     {
         long terminatedCount = getActiveTransactions( dependencyResolver )
             .stream()
-            .filter( tx -> tx.securityContext().subject().hasUsername( username ) &&
+            .filter( tx -> tx.subject().hasUsername( username ) &&
                             !tx.isUnderlyingTransaction( currentTx ) )
             .map( tx -> tx.markForTermination( Status.Transaction.Terminated ) )
             .filter( marked -> marked )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/TransactionStatusResult.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/TransactionStatusResult.java
@@ -71,7 +71,7 @@ public class TransactionStatusResult
             Map<KernelTransactionHandle,List<QuerySnapshot>> handleSnapshotsMap, ZoneId zoneId ) throws InvalidArgumentsException
     {
         this.transactionId = transaction.getUserTransactionName();
-        this.username = transaction.securityContext().subject().username();
+        this.username = transaction.subject().username();
         this.startTime = ProceduresTimeFormatHelper.formatTime( transaction.startTime(), zoneId );
         Optional<Status> terminationReason = transaction.terminationReason();
         this.activeLockCount = transaction.activeLocks().count();

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/StubKernelTransaction.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/StubKernelTransaction.java
@@ -39,6 +39,7 @@ import org.neo4j.internal.kernel.api.Token;
 import org.neo4j.internal.kernel.api.TokenRead;
 import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.Write;
+import org.neo4j.internal.kernel.api.security.AuthSubject;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
@@ -174,6 +175,14 @@ class StubKernelTransaction implements KernelTransaction
         SecurityContext securityContext = mock( SecurityContext.class, Answers.RETURNS_DEEP_STUBS );
         when( securityContext.subject().username() ).thenReturn( "testUser" );
         return securityContext;
+    }
+
+    @Override
+    public AuthSubject subject()
+    {
+        AuthSubject subject = mock( AuthSubject.class );
+        when( subject.username() ).thenReturn( "testUser" );
+        return subject;
     }
 
     @Override

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/AuthProceduresBase.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/AuthProceduresBase.java
@@ -76,7 +76,7 @@ public class AuthProceduresBase
         getActiveTransactions()
                 .stream()
                 .filter( tx ->
-                     tx.securityContext().subject().hasUsername( username ) &&
+                     tx.subject().hasUsername( username ) &&
                     !tx.isUnderlyingTransaction( currentTx )
                 ).forEach( tx -> tx.markForTermination( Status.Transaction.Terminated ) );
     }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
@@ -583,7 +583,7 @@ public abstract class ProcedureInteractionTestBase<S>
                         neo.getLocalGraph().getDependencyResolver()
                 ).stream()
                         .filter( tx -> !tx.terminationReason().isPresent() )
-                        .map( tx -> tx.securityContext().subject().username() )
+                        .map( tx -> tx.subject().username() )
         ).collect( Collectors.toMap( r -> r.username, r -> r.activeTransactions ) );
     }
 


### PR DESCRIPTION
When attempting to remove the old Kernel API, we would a bunch of tests that had not been migrated to the new API yet. Some of those are added in this PR, to better allow for a parallel migration process. 

Tracking of the tests should still happen in https://github.com/neo4j/neo4j/pull/11455.