### PR TITLE
Adds --db to neo4j-admin memrec

### DIFF
--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/Arguments.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/Arguments.java
@@ -67,6 +67,11 @@ public class Arguments
         return withArgument( new Database() );
     }
 
+    public Arguments withDatabase( String description )
+    {
+        return withArgument( new Database( description ) );
+    }
+
     public Arguments withAdditionalConfig()
     {
         return withArgument( new OptionalCanonicalPath( "additional-config", "config-file-path", "",

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/Database.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/Database.java
@@ -27,9 +27,16 @@ import org.neo4j.helpers.Args;
 
 public class Database extends OptionalNamedArg
 {
+    public static final String ARG_DATABASE = "database";
+
     public Database()
     {
-        super( "database", "name", "graph.db", "Name of database." );
+        this( "Name of database." );
+    }
+
+    public Database( String description )
+    {
+        super( ARG_DATABASE, "name", "graph.db", description );
     }
 
     private static String validate( String dbName )

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
@@ -33,6 +33,7 @@ import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.commandline.arguments.Arguments;
 import org.neo4j.commandline.arguments.OptionalBooleanArg;
+import org.neo4j.commandline.arguments.common.Database;
 import org.neo4j.commandline.arguments.common.OptionalCanonicalPath;
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
 import org.neo4j.consistency.checking.full.ConsistencyFlags;
@@ -50,6 +51,7 @@ import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.FormattedLogProvider;
 
 import static java.lang.String.format;
+import static org.neo4j.commandline.arguments.common.Database.ARG_DATABASE;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.database_path;
 
 public class CheckConsistencyCommand implements AdminCommand
@@ -111,7 +113,7 @@ public class CheckConsistencyCommand implements AdminCommand
 
         try
         {
-            database = arguments.parse( args ).get( "database" );
+            database = arguments.parse( args ).get( ARG_DATABASE );
             backupPath = arguments.getOptionalPath( "backup" );
             verbose = arguments.getBoolean( "verbose" );
             additionalConfigFile = arguments.getOptionalPath( "additional-config" );
@@ -125,9 +127,9 @@ public class CheckConsistencyCommand implements AdminCommand
 
         if ( backupPath.isPresent() )
         {
-            if ( arguments.has( "database" ) )
+            if ( arguments.has( ARG_DATABASE ) )
             {
-                throw new IncorrectUsage( "Only one of '--database' and '--backup' can be specified." );
+                throw new IncorrectUsage( "Only one of '--" + ARG_DATABASE + "' and '--backup' can be specified." );
             }
             if ( !backupPath.get().toFile().isDirectory() )
             {

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
@@ -32,6 +32,7 @@ import org.neo4j.commandline.admin.AdminCommand;
 import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.arguments.Arguments;
+import org.neo4j.commandline.arguments.common.Database;
 import org.neo4j.dbms.archive.Dumper;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.StoreLockException;
@@ -41,6 +42,7 @@ import org.neo4j.kernel.internal.locker.StoreLocker;
 
 import static java.lang.String.format;
 import static org.neo4j.commandline.Util.canonicalPath;
+import static org.neo4j.commandline.arguments.common.Database.ARG_DATABASE;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.database_path;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.logical_logs_location;
 
@@ -65,7 +67,7 @@ public class DumpCommand implements AdminCommand
     @Override
     public void execute( String[] args ) throws IncorrectUsage, CommandFailed
     {
-        String database = arguments.parse( args ).get( "database" );
+        String database = arguments.parse( args ).get( ARG_DATABASE );
         Path archive = calculateArchive( database, arguments.getMandatoryPath( "to" ) );
 
         Config config = buildConfig( database );

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
@@ -35,12 +35,14 @@ import org.neo4j.commandline.arguments.MandatoryNamedArg;
 import org.neo4j.commandline.arguments.OptionalBooleanArg;
 import org.neo4j.commandline.arguments.OptionalNamedArg;
 import org.neo4j.commandline.arguments.OptionalNamedArgWithMetadata;
+import org.neo4j.commandline.arguments.common.Database;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.util.Validators;
 
+import static org.neo4j.commandline.arguments.common.Database.ARG_DATABASE;
 import static org.neo4j.csv.reader.Configuration.DEFAULT;
 import static org.neo4j.tooling.ImportTool.parseFileArgumentList;
 import static org.neo4j.unsafe.impl.batchimport.Configuration.DEFAULT_MAX_MEMORY_PERCENT;
@@ -220,7 +222,7 @@ public class ImportCommand implements AdminCommand
             {
                 allArguments.parse( parseFileArgumentList( fileArgument.get().toFile() ) );
             }
-            database = allArguments.get( "database" );
+            database = allArguments.get( ARG_DATABASE );
             additionalConfigFile = allArguments.getOptionalPath( "additional-config" );
         }
         catch ( IllegalArgumentException e )

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/LoadCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/LoadCommand.java
@@ -31,6 +31,7 @@ import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.arguments.Arguments;
 import org.neo4j.commandline.arguments.OptionalBooleanArg;
+import org.neo4j.commandline.arguments.common.Database;
 import org.neo4j.commandline.arguments.common.MandatoryCanonicalPath;
 import org.neo4j.dbms.archive.IncorrectFormat;
 import org.neo4j.dbms.archive.Loader;
@@ -43,6 +44,7 @@ import static org.neo4j.commandline.Util.canonicalPath;
 import static org.neo4j.commandline.Util.checkLock;
 import static org.neo4j.commandline.Util.isSameOrChildPath;
 import static org.neo4j.commandline.Util.wrapIOException;
+import static org.neo4j.commandline.arguments.common.Database.ARG_DATABASE;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.database_path;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.logical_logs_location;
 
@@ -73,7 +75,7 @@ public class LoadCommand implements AdminCommand
     {
         arguments.parse( args );
         Path archive = arguments.getMandatoryPath( "from" );
-        String database = arguments.get( "database" );
+        String database = arguments.get( ARG_DATABASE );
         boolean force = arguments.getBoolean( "force" );
 
         Config config = buildConfig( database );

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommand.java
@@ -32,12 +32,14 @@ import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.commandline.arguments.Arguments;
 import org.neo4j.commandline.arguments.OptionalBooleanArg;
 import org.neo4j.commandline.arguments.OptionalNamedArg;
+import org.neo4j.commandline.arguments.common.Database;
 import org.neo4j.io.os.OsBeanUtil;
 import org.neo4j.kernel.api.impl.index.storage.FailureStorage;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.store.StoreType;
 
 import static java.lang.String.format;
+import static org.neo4j.commandline.arguments.common.Database.ARG_DATABASE;
 import static org.neo4j.configuration.ExternalSettings.initialHeapSize;
 import static org.neo4j.configuration.ExternalSettings.maxHeapSize;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.database_path;
@@ -76,7 +78,6 @@ public class MemoryRecommendationsCommand implements AdminCommand
             new Bracket( 1024.0, 30, 31 ),
     };
     private static final String ARG_MEMORY = "memory";
-    private static final String ARG_DB = "db";
     private final Path homeDir;
     private final OutsideWorld outsideWorld;
     private final Path configDir;
@@ -132,11 +133,11 @@ public class MemoryRecommendationsCommand implements AdminCommand
                 .withArgument( new OptionalNamedArg( ARG_MEMORY, memory, memory,
                         "Recommend memory settings with respect to the given amount of memory, " +
                         "instead of the total memory of the system running the command." ) )
-                .withArgument( new OptionalBooleanArg( ARG_DB, false,
-                        "Specific database to calculate page cache memory requirement for. " +
+                .withDatabase(
+                        "Name of specific database to calculate page cache memory requirement for. " +
                         "The generic calculation is still a good generic recommendation for this machine, " +
                         "but there will be an additional calculation for minimal required page cache memory " +
-                        "for mapping all store and index files that are managed by the page cache." ) );
+                        "for mapping all store and index files that are managed by the page cache." );
     }
 
     static String bytesToString( double bytes )
@@ -220,7 +221,7 @@ public class MemoryRecommendationsCommand implements AdminCommand
         print( maxHeapSize.name() + "=" + heap );
         print( pagecache_memory.name() + "=" + pagecache );
 
-        boolean db = arguments.getBoolean( ARG_DB );
+        boolean db = arguments.getBoolean( ARG_DATABASE );
         if ( !db )
         {
             return;

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommandProvider.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommandProvider.java
@@ -75,6 +75,6 @@ public class MemoryRecommendationsCommandProvider extends AdminCommand.Provider
     @Override
     public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
     {
-        return new MemoryRecommendationsCommand( outsideWorld );
+        return new MemoryRecommendationsCommand( homeDir, configDir, outsideWorld );
     }
 }

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommandTest.java
@@ -19,16 +19,44 @@
  */
 package org.neo4j.commandline.dbms;
 
+import org.apache.commons.lang3.mutable.MutableLong;
 import org.hamcrest.Matcher;
+import org.junit.Rule;
 import org.junit.Test;
 
+import java.io.File;
+import java.io.IOException;
 import java.io.StringReader;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Clock;
+import java.time.Duration;
 import java.util.Map;
 
 import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.commandline.admin.RealOutsideWorld;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.kernel.api.impl.index.storage.FailureStorage;
+import org.neo4j.kernel.api.index.IndexDirectoryStructure;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.store.StoreType;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.values.storable.CoordinateReferenceSystem;
+import org.neo4j.values.storable.DateTimeValue;
+import org.neo4j.values.storable.DateValue;
+import org.neo4j.values.storable.DurationValue;
+import org.neo4j.values.storable.LocalDateTimeValue;
+import org.neo4j.values.storable.LocalTimeValue;
+import org.neo4j.values.storable.TimeValue;
+import org.neo4j.values.storable.Values;
 
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.greaterThan;
@@ -43,16 +71,26 @@ import static org.neo4j.commandline.dbms.MemoryRecommendationsCommand.recommendO
 import static org.neo4j.commandline.dbms.MemoryRecommendationsCommand.recommendPageCacheMemory;
 import static org.neo4j.configuration.ExternalSettings.initialHeapSize;
 import static org.neo4j.configuration.ExternalSettings.maxHeapSize;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.data_directory;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.database_path;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
+import static org.neo4j.helpers.ArrayUtil.array;
+import static org.neo4j.helpers.collection.MapUtil.store;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.io.ByteUnit.exbiBytes;
 import static org.neo4j.io.ByteUnit.gibiBytes;
 import static org.neo4j.io.ByteUnit.mebiBytes;
 import static org.neo4j.io.ByteUnit.tebiBytes;
+import static org.neo4j.kernel.configuration.Config.DEFAULT_CONFIG_FILE_NAME;
 import static org.neo4j.kernel.configuration.Settings.BYTES;
 import static org.neo4j.kernel.configuration.Settings.buildSetting;
+import static org.neo4j.test.TestLabels.LABEL_ONE;
 
 public class MemoryRecommendationsCommandTest
 {
+    @Rule
+    public final TestDirectory directory = TestDirectory.testDirectory();
+
     @Test
     public void mustRecommendOSMemory()
     {
@@ -114,6 +152,8 @@ public class MemoryRecommendationsCommandTest
     public void mustPrintRecommendationsAsConfigReadableOutput() throws Exception
     {
         StringBuilder output = new StringBuilder();
+        Path homeDir = Paths.get( "home" );
+        Path configDir = Paths.get( "home", "config" );
         OutsideWorld outsideWorld = new RealOutsideWorld()
         {
             @Override
@@ -122,7 +162,7 @@ public class MemoryRecommendationsCommandTest
                 output.append( text ).append( System.lineSeparator() );
             }
         };
-        MemoryRecommendationsCommand command = new MemoryRecommendationsCommand( outsideWorld );
+        MemoryRecommendationsCommand command = new MemoryRecommendationsCommand( homeDir, configDir, outsideWorld );
         String heap = bytesToString( recommendHeapMemory( gibiBytes( 8 ) ) );
         String pagecache = bytesToString( recommendPageCacheMemory( gibiBytes( 8 ) ) );
 
@@ -132,5 +172,122 @@ public class MemoryRecommendationsCommandTest
         assertThat( stringMap.get( initialHeapSize.name() ), is( heap ) );
         assertThat( stringMap.get( maxHeapSize.name() ), is( heap ) );
         assertThat( stringMap.get( pagecache_memory.name() ), is( pagecache ) );
+    }
+
+    @Test
+    public void mustPrintMinimalPageCacheMemorySettingForConfiguredDb() throws Exception
+    {
+        // given
+        StringBuilder output = new StringBuilder();
+        Path homeDir = directory.directory().toPath();
+        Path configDir = homeDir.resolve( "conf" );
+        configDir.toFile().mkdirs();
+        Path configFile = configDir.resolve( DEFAULT_CONFIG_FILE_NAME );
+        store( stringMap( data_directory.name(), homeDir.toString() ), configFile.toFile() );
+        File storeDir = Config.fromFile( configFile ).withHome( homeDir ).build().get( database_path );
+        createDatabaseWithNativeIndexes( storeDir );
+        OutsideWorld outsideWorld = new RealOutsideWorld()
+        {
+            @Override
+            public void stdOutLine( String text )
+            {
+                output.append( text ).append( System.lineSeparator() );
+            }
+        };
+        MemoryRecommendationsCommand command = new MemoryRecommendationsCommand( homeDir, configDir, outsideWorld );
+
+        // when
+        command.execute( array( "--db" ) );
+
+        // then
+        Map<String,String> stringMap = MapUtil.load( new StringReader( output.toString() ) );
+        long expectedSize = calculatePageCacheFileSize( storeDir );
+        assertThat( stringMap.get( pagecache_memory.name() ), is( bytesToString( expectedSize ) ) );
+    }
+
+    private long calculatePageCacheFileSize( File storeDir ) throws IOException
+    {
+        MutableLong total = new MutableLong();
+        for ( StoreType storeType : StoreType.values() )
+        {
+            if ( storeType.isRecordStore() )
+            {
+                File file = new File( storeDir, storeType.getStoreFile().storeFileName() );
+                long length = file.length();
+                total.add( length );
+            }
+        }
+
+        Files.walkFileTree( IndexDirectoryStructure.baseSchemaIndexFolder( storeDir ).toPath(), new SimpleFileVisitor<Path>()
+        {
+            @Override
+            public FileVisitResult visitFile( Path path, BasicFileAttributes attrs ) throws IOException
+            {
+                File file = path.toFile();
+                Path name = path.getName( path.getNameCount() - 3 );
+                boolean isLuceneFile = path.getNameCount() >= 3 && name.toString().startsWith( "lucene-" );
+                if ( !FailureStorage.DEFAULT_FAILURE_FILE_NAME.equals( file.getName() ) && !isLuceneFile )
+                {
+                    total.add( file.length() );
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        } );
+        return total.longValue();
+    }
+
+    private void createDatabaseWithNativeIndexes( File storeDir )
+    {
+        GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( storeDir );
+        try
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+                db.schema().indexFor( LABEL_ONE ).on( "key" ).create();
+                tx.success();
+            }
+
+            try ( Transaction tx = db.beginTx() )
+            {
+                for ( int i = 0; i < 1_000; i++ )
+                {
+                    db.createNode( LABEL_ONE ).setProperty( "key", randomIndexValue( i ) );
+                }
+                tx.success();
+            }
+        }
+        finally
+        {
+            db.shutdown();
+        }
+    }
+
+    private Object randomIndexValue( int i )
+    {
+        switch ( i % 10 )
+        {
+        case 0:
+            return i;
+        case 1:
+            return String.valueOf( i );
+        case 2:
+            return DateValue.now( Clock.systemUTC() );
+        case 3:
+            return DateTimeValue.now( Clock.systemUTC() );
+        case 4:
+            return LocalDateTimeValue.now( Clock.systemUTC() );
+        case 5:
+            return DurationValue.duration( Duration.ofSeconds( 10 ) );
+        case 6:
+            return TimeValue.now( Clock.systemUTC() );
+        case 7:
+            return LocalTimeValue.now( Clock.systemUTC() );
+        case 8:
+            return Values.pointValue( CoordinateReferenceSystem.Cartesian, 1, 2 );
+        case 9:
+            return Values.pointValue( CoordinateReferenceSystem.Cartesian_3D, 1, 2, 3 );
+        default:
+            throw new UnsupportedOperationException( "Unexpected" );
+        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexDirectoryStructure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexDirectoryStructure.java
@@ -76,7 +76,7 @@ public abstract class IndexDirectoryStructure
      * @param databaseStoreDir database store directory, i.e. {@code db} in the example above, where e.g. {@code nodestore} lives.
      * @return the base directory of schema indexing.
      */
-    static File baseSchemaIndexFolder( File databaseStoreDir )
+    public static File baseSchemaIndexFolder( File databaseStoreDir )
     {
         return path( databaseStoreDir, "schema", "index" );
     }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/FailureStorage.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/FailureStorage.java
@@ -36,7 +36,7 @@ import org.neo4j.string.UTF8;
 public class FailureStorage
 {
     private static final int MAX_FAILURE_SIZE = 16384;
-    private static final String DEFAULT_FAILURE_FILE_NAME = "failure-message";
+    public static final String DEFAULT_FAILURE_FILE_NAME = "failure-message";
 
     private final FileSystemAbstraction fs;
     private final FolderLayout folderLayout;

--- a/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCli.java
+++ b/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCli.java
@@ -29,10 +29,13 @@ import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.arguments.Arguments;
 import org.neo4j.commandline.arguments.MandatoryNamedArg;
 import org.neo4j.commandline.arguments.OptionalBooleanArg;
+import org.neo4j.commandline.arguments.common.Database;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
+
+import static org.neo4j.commandline.arguments.common.Database.ARG_DATABASE;
 
 public class RestoreDatabaseCli implements AdminCommand
 {
@@ -66,7 +69,7 @@ public class RestoreDatabaseCli implements AdminCommand
 
         try
         {
-            databaseName = arguments.parse( incomingArguments ).get( "database" );
+            databaseName = arguments.parse( incomingArguments ).get( ARG_DATABASE );
             fromPath = arguments.get( "from" );
             forceOverwrite = arguments.getBoolean( "force" );
         }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/commandline/dbms/UnbindFromClusterCommand.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/commandline/dbms/UnbindFromClusterCommand.java
@@ -31,12 +31,14 @@ import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.commandline.arguments.Arguments;
+import org.neo4j.commandline.arguments.common.Database;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.StoreLockException;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.util.Validators;
 
+import static org.neo4j.commandline.arguments.common.Database.ARG_DATABASE;
 import static org.neo4j.kernel.configuration.Config.fromFile;
 
 public class UnbindFromClusterCommand implements AdminCommand
@@ -70,7 +72,7 @@ public class UnbindFromClusterCommand implements AdminCommand
     {
         try
         {
-            Config config = loadNeo4jConfig( homeDir, configDir, arguments.parse( args ).get( "database" ) );
+            Config config = loadNeo4jConfig( homeDir, configDir, arguments.parse( args ).get( ARG_DATABASE ) );
             File dataDirectory = config.get( GraphDatabaseSettings.data_directory );
             Path pathToSpecificDatabase = config.get( GraphDatabaseSettings.database_path ).toPath();
 


### PR DESCRIPTION
Which will print a minimal page cache memory setting for the
selected database in addition to the generic memory distribution
based on the machine specs