### PR TITLE
ClusterRule fixes

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/ClusterBinder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/ClusterBinder.java
@@ -168,11 +168,11 @@ public class ClusterBinder implements Supplier<Optional<ClusterId>>
         boolean success = topologyService.setClusterId( localClusterId, dbName );
         if ( !success )
         {
-            throw new BindingException( "Failed to publish: " + localClusterId );
+            throw new BindingException( format( "Failed to publish %s for database name %s", localClusterId, dbName ) );
         }
         else
         {
-            log.info( "Published: " + localClusterId );
+            log.info( "Published %s for database name %s", localClusterId, dbName );
         }
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryCoreClient.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryCoreClient.java
@@ -79,7 +79,8 @@ class SharedDiscoveryCoreClient extends AbstractTopologyService implements CoreT
     @Override
     public boolean setClusterId( ClusterId clusterId, String dbName )
     {
-        return sharedDiscoveryService.casClusterId( clusterId, dbName );
+        log.debug( "Attempting to set %s for database name %s", clusterId, dbName );
+        return sharedDiscoveryService.casClusterId( clusterId, dbName, log );
     }
 
     @Override

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryService.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryService.java
@@ -34,6 +34,7 @@ import java.util.stream.Stream;
 import org.neo4j.causalclustering.core.consensus.LeaderInfo;
 import org.neo4j.causalclustering.identity.ClusterId;
 import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.logging.Log;
 
 public final class SharedDiscoveryService
 {
@@ -142,12 +143,15 @@ public final class SharedDiscoveryService
         }
     }
 
-    boolean casClusterId( ClusterId clusterId, String dbName )
+    boolean casClusterId( ClusterId clusterId, String dbName, Log log )
     {
+        log.debug( "Current state of ClusterIdDBNames map: %s", clusterIdDbNames );
         ClusterId previousId = clusterIdDbNames.putIfAbsent( dbName, clusterId );
 
+        log.debug( "Return from putIfAbsent: %s", previousId );
         boolean success = previousId == null || previousId.equals( clusterId );
 
+        log.debug( "Update of cluster id for database name %s to %s was a success? %s", dbName, clusterId, success );
         if ( success )
         {
             notifyCoreClients();

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/MultiClusterRoutingIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/MultiClusterRoutingIT.java
@@ -39,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.neo4j.causalclustering.core.CoreGraphDatabase;
@@ -85,8 +86,8 @@ public class MultiClusterRoutingIT
                         { "[hazelcast discovery, 6 core hosts, 2 databases]", 6, 0, DB_NAMES_1, HAZELCAST },
                         { "[shared discovery, 5 core hosts, 1 database]", 5, 0, DB_NAMES_2, SHARED },
                         { "[hazelcast discovery, 5 core hosts, 1 database]", 5, 0, DB_NAMES_2, HAZELCAST },
-                        { "[hazelcast discovery, 6 core hosts, 3 read replicas, 3 databases]", 9, 3, DB_NAMES_3, HAZELCAST },
-                        { "[shared discovery, 6 core hosts, 3 read replicas, 3 databases]", 8, 2, DB_NAMES_3, SHARED }
+                        { "[hazelcast discovery, 9 core hosts, 3 read replicas, 3 databases]", 9, 3, DB_NAMES_3, HAZELCAST },
+                        { "[shared discovery, 8 core hosts, 2 read replicas, 3 databases]", 8, 2, DB_NAMES_3, SHARED }
                 }
         );
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/test/causalclustering/ClusterRule.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/test/causalclustering/ClusterRule.java
@@ -40,6 +40,7 @@ import org.neo4j.causalclustering.helpers.CausalClusteringTestHelpers;
 import org.neo4j.causalclustering.scenarios.DiscoveryServiceType;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.kernel.impl.store.format.standard.Standard;
+import org.neo4j.management.CausalClustering;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.VerboseTimeout;
 
@@ -171,6 +172,7 @@ public class ClusterRule extends ExternalResource
 
         withInstanceCoreParam( CausalClusteringSettings.database, coreDBMap::get );
         withInstanceCoreParam( CausalClusteringSettings.minimum_core_cluster_size_at_formation, minCoresSettingsMap::get );
+        withInstanceCoreParam( CausalClusteringSettings.minimum_core_cluster_size_at_runtime, minCoresSettingsMap::get );
         withInstanceReadReplicaParam( CausalClusteringSettings.database, rrDBMap::get );
         return this;
     }


### PR DESCRIPTION
`ClusterRule` was not setting the maximum runtime cluster size for each sub cluster, only the formation size. This is potentially causing some of the observed flakiness in `MultiClusterRoutingIT`. I have also added some low impact logging to help route out other sources of flakiness in the `SharedDiscoveryService`.