### PR TITLE
Multiclustering static database name 

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
@@ -88,7 +88,12 @@ public class CausalClusteringSettings implements LoadableConfig
     public static final Setting<Boolean> refuse_to_be_leader =
             setting( "causal_clustering.refuse_to_be_leader", BOOLEAN, FALSE );
 
-    @Description( "The name of the database hosted by this server instance" )
+    @Description( "The name of the database being hosted by this server instance. This configuration setting may be safely ignored " +
+            "unless deploying a multicluster. Instances may be allocated to distinct sub-clusters by assigning them distinct database " +
+            "names using this setting. For instance if you had 6 instances you could form 2 sub-clusters by assigning half " +
+            "the database name \"foo\", half the name \"bar\". The setting value must match exactly between members of the same sub-cluster. " +
+            "This setting is a one-off: once an instance is configured with a database name it may not be changed in future without using " +
+            "neo4j-admin unbind." )
     public static final Setting<String> database =
             setting( "causal_clustering.database", STRING, "default" );
 
@@ -133,7 +138,9 @@ public class CausalClusteringSettings implements LoadableConfig
             "setting alone. If you have 5 machines then you can survive failures down to 3 remaining, e.g. with 2 dead members. The three remaining can " +
             "still vote another replacement member in successfully up to a total of 6 (2 of which are still dead) and then after this, one of the " +
             "superfluous dead members will be immediately and automatically voted out (so you are left with 5 members in the consensus group, 1 of which " +
-            "is currently dead). Operationally you can now bring the last machine up by bringing in another replacement or repairing the dead one." )
+            "is currently dead). Operationally you can now bring the last machine up by bringing in another replacement or repairing the dead one. " +
+            "When using multi-clustering (configuring multiple distinct database names across core hosts), this setting is used to define the minimum size " +
+            "of *each* sub-cluster at runtime." )
     public static final Setting<Integer> minimum_core_cluster_size_at_runtime =
             buildSetting( "causal_clustering.minimum_core_cluster_size_at_runtime", INTEGER, "3" ).constraint( min( 2 ) ).build();
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
@@ -101,6 +101,7 @@ public class CoreServerModule
 {
     public static final String CLUSTER_ID_NAME = "cluster-id";
     public static final String LAST_FLUSHED_NAME = "last-flushed";
+    public static final String DB_NAME = "db-name";
 
     public final MembershipWaiterLifecycle membershipWaiterLifecycle;
     private final Server catchupServer;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/storage/SimpleStorage.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/storage/SimpleStorage.java
@@ -21,6 +21,8 @@ package org.neo4j.causalclustering.core.state.storage;
 
 import java.io.IOException;
 
+import org.neo4j.function.ThrowingConsumer;
+
 public interface SimpleStorage<T>
 {
     boolean exists();
@@ -28,4 +30,16 @@ public interface SimpleStorage<T>
     T readState() throws IOException;
 
     void writeState( T state ) throws IOException;
+
+    default <E extends Exception> void writeOrVerify( T state, ThrowingConsumer<T, E> verify ) throws E, IOException
+    {
+        if ( exists() )
+        {
+            verify.accept( readState() );
+        }
+        else
+        {
+            writeState( state );
+        }
+    }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyService.java
@@ -31,6 +31,7 @@ import org.neo4j.kernel.lifecycle.Lifecycle;
  */
 public interface TopologyService extends Lifecycle
 {
+
     String localDBName();
 
     CoreTopology allCoreServers();

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyService.java
@@ -31,7 +31,6 @@ import org.neo4j.kernel.lifecycle.Lifecycle;
  */
 public interface TopologyService extends Lifecycle
 {
-
     String localDBName();
 
     CoreTopology allCoreServers();

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/DatabaseName.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/DatabaseName.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.identity;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
+import org.neo4j.causalclustering.core.state.storage.SafeStateMarshal;
+import org.neo4j.storageengine.api.ReadableChannel;
+import org.neo4j.storageengine.api.WritableChannel;
+import org.neo4j.string.UTF8;
+
+/**
+ * Simple wrapper class for database name strings. These values are provided using the
+ * {@link CausalClusteringSettings#database } setting.
+ */
+public class DatabaseName
+{
+    private final String name;
+
+    public DatabaseName( String name )
+    {
+        this.name = name;
+    }
+
+    public String name()
+    {
+        return name;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        DatabaseName that = (DatabaseName) o;
+        return Objects.equals( name, that.name );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( name );
+    }
+
+    /**
+     * Format:
+     *
+     * nullMarker: 1 byte
+     * nameLength: 1 byte
+     * nameBytes: <= 127 bytes
+     */
+    public static class Marshal extends SafeStateMarshal<DatabaseName>
+    {
+        @Override
+        protected DatabaseName unmarshal0( ReadableChannel channel ) throws IOException
+        {
+            byte nullMarker = channel.get();
+            if ( nullMarker == 0 )
+            {
+                return null;
+            }
+            else
+            {
+                int nameLength = (int) channel.get();
+                byte[] nameBytes = new byte[nameLength];
+                channel.get( nameBytes, nameLength );
+                return new DatabaseName( UTF8.decode( nameBytes ) );
+            }
+        }
+
+        @Override
+        public DatabaseName startState()
+        {
+            return null;
+        }
+
+        @Override
+        public long ordinal( DatabaseName databaseName )
+        {
+            return databaseName == null ? 0 : 1;
+        }
+
+        @Override
+        public void marshal( DatabaseName databaseName, WritableChannel channel ) throws IOException
+        {
+            if ( databaseName == null )
+            {
+                channel.put( (byte) 0 );
+            }
+            else if ( databaseName.name().length() > 127 )
+            {
+                throw new IOException( "The database name is too large to be stored. It must be fewer than 128 UTF-8 characters." );
+            }
+            else
+            {
+                channel.put( (byte) 1 );
+                channel.put( (byte) databaseName.name().length() );
+                channel.put( UTF8.encode( databaseName.name() ), databaseName.name().length() );
+            }
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/MemberId.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/MemberId.java
@@ -21,6 +21,7 @@ package org.neo4j.causalclustering.identity;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.charset.Charset;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -85,6 +86,8 @@ public class MemberId implements Serializable
      */
     public static class Marshal extends SafeStateMarshal<MemberId>
     {
+        private static final Charset UTF8 = Charset.forName("UTF-8");
+
         @Override
         public void marshal( MemberId memberId, WritableChannel channel ) throws IOException
         {

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
@@ -226,28 +226,31 @@ public class Cluster
     {
         try ( ErrorHandler errorHandler = new ErrorHandler( "Error when trying to shutdown cluster" ) )
         {
-            shutdownCoreMembers( errorHandler, coreMembers() );
+            shutdownCoreMembers( coreMembers(), errorHandler );
             shutdownReadReplicas( errorHandler );
         }
     }
 
-    private void shutdownCoreMembers( ErrorHandler errorHandler, Collection<CoreClusterMember> members )
+    private void shutdownCoreMembers( Collection<CoreClusterMember> members, ErrorHandler errorHandler )
     {
         shutdownMembers( members, errorHandler );
     }
 
     public void shutdownCoreMembers()
     {
-        shutdownCoreMembers( coreMembers().toArray( new CoreClusterMember[0] ) );
+        shutdownCoreMembers( coreMembers() );
     }
 
-    public void shutdownCoreMembers( CoreClusterMember... members )
+    public void shutdownCoreMember( CoreClusterMember member )
     {
-        List<CoreClusterMember> membersColl = Arrays.asList( members );
+        shutdownCoreMembers( Collections.singleton( member ) );
+    }
 
+    public void shutdownCoreMembers( Collection<CoreClusterMember> members )
+    {
         try ( ErrorHandler errorHandler = new ErrorHandler( "Error when trying to shutdown core members" ) )
         {
-            shutdownCoreMembers( errorHandler, membersColl );
+            shutdownCoreMembers( members, errorHandler );
         }
     }
 
@@ -593,13 +596,17 @@ public class Cluster
 
     public void startCoreMembers() throws InterruptedException, ExecutionException
     {
-        startCoreMembers( coreMembers.values().toArray( new CoreClusterMember[0] ) );
+        startCoreMembers( coreMembers.values() );
     }
 
-    public void startCoreMembers( CoreClusterMember... members ) throws InterruptedException, ExecutionException
+    public void startCoreMember( CoreClusterMember member ) throws InterruptedException, ExecutionException
     {
-        List<CoreClusterMember> membersColl = Arrays.asList( members );
-        List<Future<CoreGraphDatabase>> futures = invokeAll( "cluster-starter", membersColl, cm ->
+        startCoreMembers( Collections.singleton( member ) );
+    }
+
+    public void startCoreMembers( Collection<CoreClusterMember> members ) throws InterruptedException, ExecutionException
+    {
+        List<Future<CoreGraphDatabase>> futures = invokeAll( "cluster-starter", members, cm ->
         {
             cm.start();
             return cm.database();

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
@@ -226,21 +226,28 @@ public class Cluster
     {
         try ( ErrorHandler errorHandler = new ErrorHandler( "Error when trying to shutdown cluster" ) )
         {
-            shutdownCoreMembers( errorHandler );
+            shutdownCoreMembers( errorHandler, coreMembers() );
             shutdownReadReplicas( errorHandler );
         }
     }
 
-    private void shutdownCoreMembers( ErrorHandler errorHandler )
+    private void shutdownCoreMembers( ErrorHandler errorHandler, Collection<CoreClusterMember> members )
     {
-        shutdownMembers( coreMembers(), errorHandler );
+        shutdownMembers( members, errorHandler );
     }
 
     public void shutdownCoreMembers()
     {
+        shutdownCoreMembers( coreMembers().toArray( new CoreClusterMember[0] ) );
+    }
+
+    public void shutdownCoreMembers( CoreClusterMember... members )
+    {
+        List<CoreClusterMember> membersColl = Arrays.asList( members );
+
         try ( ErrorHandler errorHandler = new ErrorHandler( "Error when trying to shutdown core members" ) )
         {
-            shutdownCoreMembers( errorHandler );
+            shutdownCoreMembers( errorHandler, membersColl );
         }
     }
 
@@ -586,8 +593,13 @@ public class Cluster
 
     public void startCoreMembers() throws InterruptedException, ExecutionException
     {
-        Collection<CoreClusterMember> members = coreMembers.values();
-        List<Future<CoreGraphDatabase>> futures = invokeAll( "cluster-starter", members, cm ->
+        startCoreMembers( coreMembers.values().toArray( new CoreClusterMember[0] ) );
+    }
+
+    public void startCoreMembers( CoreClusterMember... members ) throws InterruptedException, ExecutionException
+    {
+        List<CoreClusterMember> membersColl = Arrays.asList( members );
+        List<Future<CoreGraphDatabase>> futures = invokeAll( "cluster-starter", membersColl, cm ->
         {
             cm.start();
             return cm.database();

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ClusterMember.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ClusterMember.java
@@ -21,6 +21,7 @@ package org.neo4j.causalclustering.discovery;
 
 import java.io.File;
 
+import org.neo4j.graphdb.config.Setting;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.monitoring.Monitors;
@@ -58,4 +59,9 @@ public interface ClusterMember<T extends GraphDatabaseAPI>
     File storeDir();
 
     File homeDir();
+
+    default void updateConfig( Setting<?> setting, String value )
+    {
+        config().augment( setting, value );
+    }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreClusterMember.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreClusterMember.java
@@ -233,6 +233,11 @@ public class CoreClusterMember implements ClusterMember<GraphDatabaseFacade>
         }
     }
 
+    public void updateDbNameConfig( String dbName )
+    {
+        this.memberConfig.augment( CausalClusteringSettings.database, dbName );
+    }
+
     @Override
     public File homeDir()
     {

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreClusterMember.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreClusterMember.java
@@ -33,6 +33,7 @@ import org.neo4j.causalclustering.core.consensus.log.segmented.FileNames;
 import org.neo4j.causalclustering.core.state.ClusterStateDirectory;
 import org.neo4j.causalclustering.core.state.RaftLogPruner;
 import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
@@ -231,11 +232,6 @@ public class CoreClusterMember implements ClusterMember<GraphDatabaseFacade>
         {
             return new FileNames( logFilesDir ).getAllFiles( fileSystem, null );
         }
-    }
-
-    public void updateDbNameConfig( String dbName )
-    {
-        this.memberConfig.augment( CausalClusteringSettings.database, dbName );
     }
 
     @Override

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/identity/ClusterBinderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/identity/ClusterBinderTest.java
@@ -65,8 +65,8 @@ public class ClusterBinderTest
     private ClusterBinder clusterBinder( SimpleStorage<ClusterId> clusterIdStorage,
             CoreTopologyService topologyService )
     {
-        return new ClusterBinder( clusterIdStorage, new StubSimpleStorage<>(), NullLogProvider.getInstance(), clock,
-                () -> clock.forward( 1, TimeUnit.SECONDS ), 3_000, coreBootstrapper, dbName, minCoreHosts, topologyService );
+        return new ClusterBinder( clusterIdStorage, new StubSimpleStorage<>(), topologyService, clock, () -> clock.forward( 1, TimeUnit.SECONDS ), 3_000,
+                coreBootstrapper, dbName, minCoreHosts, NullLogProvider.getInstance() );
     }
 
     @Test

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/MultiClusteringIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/MultiClusteringIT.java
@@ -39,6 +39,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.core.consensus.roles.Role;
 import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.CoreClusterMember;
@@ -233,15 +234,15 @@ public class MultiClusteringIT
     {
         CoreClusterMember member = cluster.coreMembers().stream().findFirst().orElseThrow( IllegalArgumentException::new );
 
-        cluster.shutdownCoreMembers( member );
+        cluster.shutdownCoreMember( member );
 
         //given
-        member.updateDbNameConfig( "new_name" );
+        member.updateConfig( CausalClusteringSettings.database, "new_name" );
 
         try
         {
             //when
-            cluster.startCoreMembers( member );
+            cluster.startCoreMember( member );
             fail( "Cluster member should fail to restart after database name change." );
         }
         catch ( ExecutionException e )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/MultiClusteringIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/MultiClusteringIT.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -49,7 +50,9 @@ import org.neo4j.test.causalclustering.ClusterRule;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.neo4j.causalclustering.TestStoreId.getStoreIds;
 import static org.neo4j.causalclustering.discovery.Cluster.dataMatchesEventually;
 import static org.neo4j.causalclustering.scenarios.DiscoveryServiceType.HAZELCAST;
@@ -181,12 +184,8 @@ public class MultiClusteringIT
     @Test
     public void rejoiningFollowerShouldDownloadSnapshotFromCorrectDatabase() throws Exception
     {
-        String dbName = dbNames.stream()
-                .findFirst()
-                .orElseThrow( () -> new IllegalArgumentException( "The dbNames parameter must not be empty." ) );
-
+        String dbName = getFirstDbName( dbNames );
         int followerId = cluster.getDbWithAnyRole( dbName, Role.FOLLOWER ).serverId();
-
         cluster.removeCoreMemberWithServerId( followerId );
 
         for ( int  i = 0; i < 100; i++ )
@@ -229,6 +228,34 @@ public class MultiClusteringIT
         assertEquals( message, 1, storeIds.size() );
     }
 
+    @Test
+    public void shouldNotBeAbleToChangeClusterMembersDatabaseName() throws Exception
+    {
+        CoreClusterMember member = cluster.coreMembers().stream().findFirst().orElseThrow( IllegalArgumentException::new );
+
+        cluster.shutdownCoreMembers( member );
+
+        //given
+        member.updateDbNameConfig( "new_name" );
+
+        try
+        {
+            //when
+            cluster.startCoreMembers( member );
+            fail( "Cluster member should fail to restart after database name change." );
+        }
+        catch ( ExecutionException e )
+        {
+            //expected
+        }
+    }
+
     //TODO: Test that rejoining followers wait for majority of hosts *for each database* to be available before joining
 
+    private static String getFirstDbName( Set<String> dbNames ) throws Exception
+    {
+        return dbNames.stream()
+                .findFirst()
+                .orElseThrow( () -> new IllegalArgumentException( "The dbNames parameter must not be empty." ) );
+    }
 }


### PR DESCRIPTION
Simply stores a databases name in Simple Storage upon initial startup and then checks for inconsistencies between the stored value and the config value during CoreLife (as part of cluster binding). Errors out in the event of a database name change, which might otherwise lead to undefined behaviour.

A couple of decisions where I would particularly encourage scrutiny: 

* I put the database name check/store logic inside `ClusterBinder#bindTocluster`, because a) the same check/store logic for cluster-id also exists there; and b) the "binding to cluster" phase of the lifecycle seems like a natural place for this check to occur. On the other hand this does rather pollute the `ClusterBinder` class with only tangentially related concerns. Perhaps I should put a `validateName` method in the `TopologyService` and also call that from`CoreLife#start`? 

* I created a super simple `DatabaseName` type to wrap database string names because it provided a place to store the `SafeStateMarshall` instance required for `SimpleFileStorage`. It also provides a location for future validation logic or similar. However I do **not** use this wrapper anywhere except during the new store/check logic, preferring to leave all other references to/usages of database names as unwrapped strings to avoid the potential surface area for new issues this close to freeze. The alternatives are: a) I use update the PR to use `DatabaseName` more pervasively; or b) I do not introduce a new type at all, instead providing a simple `SafeStateMarshall` object for Strings.
