### PR TITLE
Dump internal and user logs on test failure to diagnose the problem

### DIFF
--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/ServerControls.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/ServerControls.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.harness;
 
+import java.io.PrintStream;
 import java.net.URI;
 import java.util.Optional;
 
@@ -51,4 +52,7 @@ public interface ServerControls extends AutoCloseable
 
     /** Returns the server's configuration */
     Configuration config();
+
+    /** Prints logs to the specified print stream if log is available */
+    void printLogs( PrintStream out );
 }

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/AbstractInProcessServerBuilder.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/AbstractInProcessServerBuilder.java
@@ -33,6 +33,7 @@ import java.util.function.Function;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.config.Setting;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.harness.ServerControls;
 import org.neo4j.harness.TestServerBuilder;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
@@ -127,10 +128,13 @@ public abstract class AbstractInProcessServerBuilder implements TestServerBuilde
     {
         try ( FileSystemAbstraction fileSystem = new DefaultFileSystemAbstraction() )
         {
+            File userLogFile = new File( serverFolder, "neo4j.log" );
+            File internalLogFile = new File( serverFolder, "debug.log" );
+
             final OutputStream logOutputStream;
             try
             {
-                logOutputStream = createOrOpenAsOutputStream( fileSystem, new File( serverFolder, "neo4j.log" ), true );
+                logOutputStream = createOrOpenAsOutputStream( fileSystem, userLogFile, true );
             }
             catch ( IOException e )
             {
@@ -138,6 +142,7 @@ public abstract class AbstractInProcessServerBuilder implements TestServerBuilde
             }
 
             config.put( ServerSettings.third_party_packages.name(), toStringForThirdPartyPackageProperty( extensions.toList() ) );
+            config.put( GraphDatabaseSettings.store_internal_log_path.name(), internalLogFile.getAbsolutePath() );
 
             final FormattedLogProvider userLogProvider = FormattedLogProvider.toOutputStream( logOutputStream );
             GraphDatabaseDependencies dependencies = GraphDatabaseDependencies.newDependencies();
@@ -146,7 +151,7 @@ public abstract class AbstractInProcessServerBuilder implements TestServerBuilde
             dependencies = dependencies.kernelExtensions( kernelExtensions ).userLogProvider( userLogProvider );
 
             AbstractNeoServer neoServer = createNeoServer( config, dependencies, userLogProvider );
-            InProcessServerControls controls = new InProcessServerControls( serverFolder, neoServer, logOutputStream );
+            InProcessServerControls controls = new InProcessServerControls( serverFolder, userLogFile, internalLogFile, neoServer, logOutputStream );
             controls.start();
 
             try

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/junit/Neo4jRule.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/junit/Neo4jRule.java
@@ -24,6 +24,7 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 import java.io.File;
+import java.io.PrintStream;
 import java.net.URI;
 import java.util.function.Function;
 
@@ -46,32 +47,21 @@ public class Neo4jRule implements TestRule, TestServerBuilder
 {
     private TestServerBuilder builder;
     private ServerControls controls;
-    private boolean dumpLogsOnFailure;
+    private PrintStream dumpLogsOnFailureTarget;
 
-    Neo4jRule( TestServerBuilder builder, boolean dumpLogsOnFailure )
+    Neo4jRule( TestServerBuilder builder )
     {
         this.builder = builder;
-        this.dumpLogsOnFailure = dumpLogsOnFailure;
     }
 
-    public Neo4jRule()
+    public Neo4jRule( )
     {
-        this( false );
-    }
-
-    public Neo4jRule( boolean dumpLogsOnFailure )
-    {
-        this( TestServerBuilders.newInProcessBuilder(), dumpLogsOnFailure );
+        this( TestServerBuilders.newInProcessBuilder() );
     }
 
     public Neo4jRule( File workingDirectory )
     {
-        this( workingDirectory, false );
-    }
-
-    public Neo4jRule( File workingDirectory, boolean dumpLogsOnFailure )
-    {
-        this( TestServerBuilders.newInProcessBuilder( workingDirectory ), dumpLogsOnFailure );
+        this( TestServerBuilders.newInProcessBuilder( workingDirectory ) );
     }
 
     @Override
@@ -90,9 +80,9 @@ public class Neo4jRule implements TestRule, TestServerBuilder
                     }
                     catch ( Throwable t )
                     {
-                        if ( dumpLogsOnFailure )
+                        if ( dumpLogsOnFailureTarget != null )
                         {
-                            sc.printLogs( System.out );
+                            sc.printLogs( dumpLogsOnFailureTarget );
                         }
 
                         throw t;
@@ -182,6 +172,12 @@ public class Neo4jRule implements TestRule, TestServerBuilder
     public Neo4jRule withAggregationFunction( Class<?> functionClass )
     {
         builder = builder.withAggregationFunction( functionClass );
+        return this;
+    }
+
+    public Neo4jRule dumpLogsOnFailure( PrintStream out )
+    {
+        dumpLogsOnFailureTarget = out;
         return this;
     }
 

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/junit/Neo4jRule.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/junit/Neo4jRule.java
@@ -46,20 +46,32 @@ public class Neo4jRule implements TestRule, TestServerBuilder
 {
     private TestServerBuilder builder;
     private ServerControls controls;
+    private boolean dumpLogsOnFailure;
 
-    Neo4jRule( TestServerBuilder builder )
+    Neo4jRule( TestServerBuilder builder, boolean dumpLogsOnFailure )
     {
         this.builder = builder;
+        this.dumpLogsOnFailure = dumpLogsOnFailure;
     }
 
     public Neo4jRule()
     {
-        this( TestServerBuilders.newInProcessBuilder() );
+        this( false );
+    }
+
+    public Neo4jRule( boolean dumpLogsOnFailure )
+    {
+        this( TestServerBuilders.newInProcessBuilder(), dumpLogsOnFailure );
     }
 
     public Neo4jRule( File workingDirectory )
     {
-        this( TestServerBuilders.newInProcessBuilder( workingDirectory ) );
+        this( workingDirectory, false );
+    }
+
+    public Neo4jRule( File workingDirectory, boolean dumpLogsOnFailure )
+    {
+        this( TestServerBuilders.newInProcessBuilder( workingDirectory ), dumpLogsOnFailure );
     }
 
     @Override
@@ -72,7 +84,19 @@ public class Neo4jRule implements TestRule, TestServerBuilder
             {
                 try ( ServerControls sc = controls = builder.newServer() )
                 {
-                    base.evaluate();
+                    try
+                    {
+                        base.evaluate();
+                    }
+                    catch ( Throwable t )
+                    {
+                        if ( dumpLogsOnFailure )
+                        {
+                            sc.printLogs( System.out );
+                        }
+
+                        throw t;
+                    }
                 }
             }
         };

--- a/enterprise/neo4j-harness-enterprise/src/main/java/org/neo4j/harness/junit/EnterpriseNeo4jRule.java
+++ b/enterprise/neo4j-harness-enterprise/src/main/java/org/neo4j/harness/junit/EnterpriseNeo4jRule.java
@@ -27,21 +27,11 @@ public class EnterpriseNeo4jRule extends Neo4jRule
 {
     public EnterpriseNeo4jRule()
     {
-        this( false );
-    }
-
-    public EnterpriseNeo4jRule( boolean dumpLogsOnFailure )
-    {
-        super( EnterpriseTestServerBuilders.newInProcessBuilder(), dumpLogsOnFailure );
+        super( EnterpriseTestServerBuilders.newInProcessBuilder() );
     }
 
     public EnterpriseNeo4jRule( File workingDirectory )
     {
-        this( workingDirectory, false );
-    }
-
-    public EnterpriseNeo4jRule( File workingDirectory, boolean dumpLogsOnFailure )
-    {
-        super( EnterpriseTestServerBuilders.newInProcessBuilder( workingDirectory ), dumpLogsOnFailure );
+        super( EnterpriseTestServerBuilders.newInProcessBuilder( workingDirectory ) );
     }
 }

--- a/enterprise/neo4j-harness-enterprise/src/main/java/org/neo4j/harness/junit/EnterpriseNeo4jRule.java
+++ b/enterprise/neo4j-harness-enterprise/src/main/java/org/neo4j/harness/junit/EnterpriseNeo4jRule.java
@@ -27,11 +27,21 @@ public class EnterpriseNeo4jRule extends Neo4jRule
 {
     public EnterpriseNeo4jRule()
     {
-        super( EnterpriseTestServerBuilders.newInProcessBuilder() );
+        this( false );
+    }
+
+    public EnterpriseNeo4jRule( boolean dumpLogsOnFailure )
+    {
+        super( EnterpriseTestServerBuilders.newInProcessBuilder(), dumpLogsOnFailure );
     }
 
     public EnterpriseNeo4jRule( File workingDirectory )
     {
-        super( EnterpriseTestServerBuilders.newInProcessBuilder( workingDirectory ) );
+        this( workingDirectory, false );
+    }
+
+    public EnterpriseNeo4jRule( File workingDirectory, boolean dumpLogsOnFailure )
+    {
+        super( EnterpriseTestServerBuilders.newInProcessBuilder( workingDirectory ), dumpLogsOnFailure );
     }
 }

--- a/integrationtests/src/test/java/org/neo4j/bolt/SessionResetIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/SessionResetIT.java
@@ -106,7 +106,7 @@ public class SessionResetIT
     private static final String[] STRESS_IT_QUERIES = {SHORT_QUERY_1, SHORT_QUERY_2, LONG_QUERY};
 
     private final VerboseTimeout timeout = VerboseTimeout.builder().withTimeout( 6, MINUTES ).build();
-    private final Neo4jRule db = new EnterpriseNeo4jRule()
+    private final Neo4jRule db = new EnterpriseNeo4jRule( true )
             .withConfig( GraphDatabaseSettings.load_csv_file_url_root, "import" )
             .withConfig( OnlineBackupSettings.online_backup_enabled, Settings.FALSE )
             .withConfig( ServerSettings.script_enabled, Settings.TRUE );

--- a/integrationtests/src/test/java/org/neo4j/bolt/SessionResetIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/SessionResetIT.java
@@ -106,10 +106,11 @@ public class SessionResetIT
     private static final String[] STRESS_IT_QUERIES = {SHORT_QUERY_1, SHORT_QUERY_2, LONG_QUERY};
 
     private final VerboseTimeout timeout = VerboseTimeout.builder().withTimeout( 6, MINUTES ).build();
-    private final Neo4jRule db = new EnterpriseNeo4jRule( true )
+    private final Neo4jRule db = new EnterpriseNeo4jRule()
             .withConfig( GraphDatabaseSettings.load_csv_file_url_root, "import" )
             .withConfig( OnlineBackupSettings.online_backup_enabled, Settings.FALSE )
-            .withConfig( ServerSettings.script_enabled, Settings.TRUE );
+            .withConfig( ServerSettings.script_enabled, Settings.TRUE )
+            .dumpLogsOnFailure( System.out );
 
     @Rule
     public final RuleChain ruleChain = RuleChain.outerRule( timeout ).around( db );


### PR DESCRIPTION
We have come across a couple of tests that need access to server logs in order to get an insight about what was happening. This PR adds a capability of dumping user and internal logs to standard output on test failures to `EnterpriseNeo4jRule`.