### PR TITLE
Add missing tests for sparse nodes

### DIFF
--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/NodesTest.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/NodesTest.java
@@ -29,10 +29,9 @@ import static org.neo4j.internal.kernel.api.helpers.Nodes.countOutgoing;
 
 public class NodesTest
 {
-    private static final StubNodeCursor NODE = new StubNodeCursor();
 
     @Test
-    public void shouldCountOutgoing()
+    public void shouldCountOutgoingDense()
     {
         // Given
         StubGroupCursor groupCursor = new StubGroupCursor(
@@ -45,14 +44,35 @@ public class NodesTest
         StubCursorFactory cursors = new StubCursorFactory().withGroupCursors( groupCursor );
 
         // When
-        int count = countOutgoing( NODE, cursors );
+        int count = countOutgoing( new StubNodeCursor( true ), cursors );
 
         // Then
         assertThat( count, equalTo( 24 ) );
     }
 
     @Test
-    public void shouldCountIncoming()
+    public void shouldCountOutgoingSparse()
+    {
+        // Given
+        StubRelationshipCursor relationshipCursor = new StubRelationshipCursor(
+                new TestRelationshipChain( 11 )
+                        .outgoing( 55, 0, 1 )
+                        .incoming( 56, 0, 1 )
+                        .outgoing( 57, 0, 1 )
+                        .loop( 58, 0 ) );
+        StubCursorFactory cursors = new StubCursorFactory().withRelationshipTraversalCursors( relationshipCursor );
+
+        // When
+        StubNodeCursor nodeCursor = new StubNodeCursor( false ).withNode( 11 );
+        nodeCursor.next();
+        int count = countOutgoing( nodeCursor, cursors );
+
+        // Then
+        assertThat( count, equalTo( 3 ) );
+    }
+
+    @Test
+    public void shouldCountIncomingDense()
     {
         // Given
         StubGroupCursor groupCursor = new StubGroupCursor(
@@ -65,14 +85,36 @@ public class NodesTest
         StubCursorFactory cursors = new StubCursorFactory().withGroupCursors( groupCursor );
 
         // When
-        int count = countIncoming( new StubNodeCursor(), cursors );
+        int count = countIncoming( new StubNodeCursor( true ), cursors );
 
         // Then
         assertThat( count, equalTo( 17 ) );
     }
 
     @Test
-    public void shouldCountAll()
+    public void shouldCountIncomingSparse()
+    {
+        // Given
+        StubRelationshipCursor relationshipCursor = new StubRelationshipCursor(
+                new TestRelationshipChain( 11 )
+                        .outgoing( 55, 0, 1 )
+                        .incoming( 56, 0, 1 )
+                        .outgoing( 57, 0, 1 )
+                        .loop( 58, 0 ) );
+        StubCursorFactory cursors = new StubCursorFactory().withRelationshipTraversalCursors( relationshipCursor );
+
+        StubNodeCursor nodeCursor = new StubNodeCursor( false ).withNode( 11 );
+        nodeCursor.next();
+
+        // When
+        int count = countIncoming( nodeCursor, cursors );
+
+        // Then
+        assertThat( count, equalTo( 2 ) );
+    }
+
+    @Test
+    public void shouldCountAllDense()
     {
         // Given
         StubGroupCursor groupCursor = new StubGroupCursor(
@@ -85,29 +127,36 @@ public class NodesTest
         StubCursorFactory cursors = new StubCursorFactory().withGroupCursors( groupCursor );
 
         // When
-        int count = countAll( new StubNodeCursor(), cursors );
+        int count = countAll( new StubNodeCursor( true ), cursors );
 
         // Then
         assertThat( count, equalTo( 29 ) );
     }
 
     @Test
-    public void shouldCountOutgoingWithType()
+    public void shouldCountAllSparse()
     {
         // Given
-        StubGroupCursor groupCursor = new StubGroupCursor(
-                group( 1 ).withOutCount( 1 ).withInCount( 1 ).withLoopCount( 5 ),
-                group( 2 ).withOutCount( 1 ).withInCount( 1 ).withLoopCount( 3 )
-        );
-        StubCursorFactory cursors = new StubCursorFactory().withGroupCursors( groupCursor, groupCursor );
+        StubRelationshipCursor relationshipCursor = new StubRelationshipCursor(
+                new TestRelationshipChain( 11 )
+                        .outgoing( 55, 0, 1 )
+                        .incoming( 56, 0, 1 )
+                        .outgoing( 57, 0, 1 )
+                        .loop( 58, 0 ) );
+        StubCursorFactory cursors = new StubCursorFactory().withRelationshipTraversalCursors( relationshipCursor );
+
+        StubNodeCursor nodeCursor = new StubNodeCursor( false ).withNode( 11 );
+        nodeCursor.next();
+
+        // When
+        int count = countAll( nodeCursor, cursors );
 
         // Then
-        assertThat( countOutgoing( new StubNodeCursor(), cursors, 1 ), equalTo( 6 ) );
-        assertThat( countOutgoing( new StubNodeCursor(), cursors, 2 ), equalTo( 4 ) );
+        assertThat( count, equalTo( 4 ) );
     }
 
     @Test
-    public void shouldCountIncomingWithType()
+    public void shouldCountOutgoingDenseWithType()
     {
         // Given
         StubGroupCursor groupCursor = new StubGroupCursor(
@@ -117,12 +166,34 @@ public class NodesTest
         StubCursorFactory cursors = new StubCursorFactory().withGroupCursors( groupCursor, groupCursor );
 
         // Then
-        assertThat( countIncoming( new StubNodeCursor(), cursors, 1 ), equalTo( 6 ) );
-        assertThat( countIncoming( new StubNodeCursor(), cursors, 2 ), equalTo( 4 ) );
+        assertThat( countOutgoing( new StubNodeCursor( true ), cursors, 1 ), equalTo( 6 ) );
+        assertThat( countOutgoing( new StubNodeCursor( true ), cursors, 2 ), equalTo( 4 ) );
     }
 
     @Test
-    public void shouldCountAllWithType()
+    public void shouldCountOutgoingSparseWithType()
+    {
+        // Given
+        StubRelationshipCursor relationshipCursor = new StubRelationshipCursor(
+                new TestRelationshipChain( 11 )
+                        .outgoing( 55, 0, 1 )
+                        .incoming( 56, 0, 1 )
+                        .outgoing( 57, 0, 1 )
+                        .loop( 58, 2 ) );
+        StubCursorFactory cursors = new StubCursorFactory( true )
+                .withRelationshipTraversalCursors( relationshipCursor );
+
+        // Then
+        StubNodeCursor nodeCursor = new StubNodeCursor( false ).withNode( 11 );
+        nodeCursor.next();
+        assertThat( countOutgoing( nodeCursor, cursors, 1 ), equalTo( 2 ) );
+        nodeCursor = new StubNodeCursor( false ).withNode( 11 );
+        nodeCursor.next();
+        assertThat( countOutgoing( nodeCursor, cursors, 2 ), equalTo( 1 ) );
+    }
+
+    @Test
+    public void shouldCountIncomingWithTypeDense()
     {
         // Given
         StubGroupCursor groupCursor = new StubGroupCursor(
@@ -132,8 +203,64 @@ public class NodesTest
         StubCursorFactory cursors = new StubCursorFactory().withGroupCursors( groupCursor, groupCursor );
 
         // Then
-        assertThat( countAll( new StubNodeCursor(), cursors, 1 ), equalTo( 7 ) );
-        assertThat( countAll( new StubNodeCursor(), cursors, 2 ), equalTo( 5 ) );
+        assertThat( countIncoming( new StubNodeCursor( true ), cursors, 1 ), equalTo( 6 ) );
+        assertThat( countIncoming( new StubNodeCursor( true ), cursors, 2 ), equalTo( 4 ) );
+    }
+    @Test
+    public void shouldCountIncomingWithTypeSparse()
+    {
+        // Given
+        StubRelationshipCursor relationshipCursor = new StubRelationshipCursor(
+                new TestRelationshipChain( 11 )
+                        .outgoing( 55, 0, 1 )
+                        .incoming( 56, 0, 1 )
+                        .outgoing( 57, 0, 1 )
+                        .loop( 58, 2 ) );
+        StubCursorFactory cursors = new StubCursorFactory( true )
+                .withRelationshipTraversalCursors( relationshipCursor );
+
+        // Then
+        StubNodeCursor nodeCursor = new StubNodeCursor( false ).withNode( 11 );
+        nodeCursor.next();
+        assertThat( countIncoming( nodeCursor, cursors, 1 ), equalTo( 1 ) );
+        nodeCursor = new StubNodeCursor( false ).withNode( 11 );
+        nodeCursor.next();
+        assertThat( countIncoming( nodeCursor, cursors, 2 ), equalTo( 1 ) );
+    }
+
+    @Test
+    public void shouldCountAllWithTypeDense()
+    {
+        // Given
+        StubGroupCursor groupCursor = new StubGroupCursor(
+                group( 1 ).withOutCount( 1 ).withInCount( 1 ).withLoopCount( 5 ),
+                group( 2 ).withOutCount( 1 ).withInCount( 1 ).withLoopCount( 3 )
+        );
+        StubCursorFactory cursors = new StubCursorFactory().withGroupCursors( groupCursor, groupCursor );
+
+        // Then
+        assertThat( countAll( new StubNodeCursor( true ), cursors, 1 ), equalTo( 7 ) );
+        assertThat( countAll( new StubNodeCursor( true ), cursors, 2 ), equalTo( 5 ) );
+    }
+
+    @Test
+    public void shouldCountAllWithTypeSparse()
+    {
+        // Given
+        StubRelationshipCursor relationshipCursor = new StubRelationshipCursor(
+                new TestRelationshipChain( 11 )
+                        .outgoing( 55, 0, 1 )
+                        .incoming( 56, 0, 1 )
+                        .outgoing( 57, 0, 1 )
+                        .loop( 58, 2 ) );
+        StubCursorFactory cursors = new StubCursorFactory( true )
+                .withRelationshipTraversalCursors( relationshipCursor );
+
+        // Then
+        StubNodeCursor nodeCursor = new StubNodeCursor( false ).withNode( 11 );
+        nodeCursor.next();
+        assertThat( countAll( nodeCursor, cursors, 1 ), equalTo( 3 ) );
+        assertThat( countAll( nodeCursor, cursors, 2 ), equalTo( 1) );
     }
 
     private StubGroupCursor.GroupData group()


### PR DESCRIPTION
Analysis shows that tests are missing that tests `Nodes` for sparse nodes. This PR adds such tests.