### PR TITLE
Stabilize udc tests

### DIFF
--- a/integrationtests/src/test/java/org/neo4j/ext/udc/impl/UdcExtensionImplIT.java
+++ b/integrationtests/src/test/java/org/neo4j/ext/udc/impl/UdcExtensionImplIT.java
@@ -114,7 +114,7 @@ public class UdcExtensionImplIT extends LocalServerTestBase
         String serverAddress = serviceHostName + ":" + servicePort;
 
         config = new HashMap<>();
-        config.put( UdcSettings.first_delay.name(), "100" );
+        config.put( UdcSettings.first_delay.name(), "1000" );
         config.put( UdcSettings.udc_host.name(), serverAddress );
         config.put( OnlineBackupSettings.online_backup_enabled.name(), Settings.FALSE );
 
@@ -475,7 +475,7 @@ public class UdcExtensionImplIT extends LocalServerTestBase
 
     private void assertGotPingWithRetry( Map<String,Integer> counts, Condition<Integer> condition ) throws Exception
     {
-        for ( int i = 0; i < 50; i++ )
+        for ( int i = 0; i < 100; i++ )
         {
             Thread.sleep( 200 );
             Collection<Integer> countValues = counts.values();


### PR DESCRIPTION
These tests rely on the db loading and the test getting to the wait-point
within 100ms of the udc extension loading. That time is now increased to
1000ms