### PR TITLE
Fix flaky test in `ExecutorBoltSchedulerTest`

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/runtime/ExecutorBoltSchedulerTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/runtime/ExecutorBoltSchedulerTest.java
@@ -264,11 +264,11 @@ public class ExecutorBoltSchedulerTest
 
         String id = UUID.randomUUID().toString();
         BoltConnection connection = newConnection( id );
-        when ( connection.hasPendingJobs() ).thenAnswer( inv ->
+        when( connection.hasPendingJobs() ).thenAnswer( inv ->
         {
             executeBatchCompletionCount.incrementAndGet();
             return false;
-        });
+        } );
         when( connection.processNextBatch() ).thenAnswer( inv ->
         {
             poolThread.set( Thread.currentThread() );


### PR DESCRIPTION
Fixed the flaky test in `ExecutorBoltSchedulerTest#createdWorkerThreadsShouldContainConnectorName` due to thread race condition.
The test requires `ExecutorBoltScheduler#executeBatch` to be finished before the test verification code.
While before the test could only ensure `BoltConnection#processNextBatch` finishes.
```
try
{
    return connection.processNextBatch(); // before the test only ensure this line finished
}
finally
{
    currentThread.setName( originalName ); // we need this to be also finished too
}
```