### PR TITLE
NPE in discovery service

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClusterTopology.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClusterTopology.java
@@ -47,10 +47,11 @@ import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.Log;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
-import static org.neo4j.causalclustering.core.CausalClusteringSettings.refuse_to_be_leader;
 import static java.util.stream.Stream.concat;
 import static java.util.stream.Stream.of;
+import static org.neo4j.causalclustering.core.CausalClusteringSettings.refuse_to_be_leader;
 import static org.neo4j.helpers.SocketAddressParser.socketAddress;
 import static org.neo4j.helpers.collection.Iterables.asSet;
 
@@ -258,24 +259,38 @@ public final class HazelcastClusterTopology
 
         for ( Member member : members )
         {
-            try
-            {
-                MemberId memberId = new MemberId( UUID.fromString( member.getStringAttribute( MEMBER_UUID ) ) );
-                String dbName = member.getStringAttribute( MEMBER_DB_NAME );
+            Collection<String> attrKeys = asList( MEMBER_UUID, RAFT_SERVER, TRANSACTION_SERVER,
+                    CLIENT_CONNECTOR_ADDRESSES, MEMBER_DB_NAME );
 
-                CoreServerInfo coreServerInfo = new CoreServerInfo(
-                        socketAddress( member.getStringAttribute( RAFT_SERVER ), AdvertisedSocketAddress::new ),
-                        socketAddress( member.getStringAttribute( TRANSACTION_SERVER ), AdvertisedSocketAddress::new ),
-                        ClientConnectorAddresses.fromString( member.getStringAttribute( CLIENT_CONNECTOR_ADDRESSES ) ),
-                        asSet( serverGroupsMMap.get( memberId.getUuid().toString() ) ),
-                        dbName );
-
-                coreMembers.put( memberId, coreServerInfo );
-            }
-            catch ( IllegalArgumentException e )
+            Map<String,String> attrMap = new HashMap<>();
+            boolean incomplete = false;
+            for ( String attrKey : attrKeys )
             {
-                log.warn( "Incomplete member attributes supplied from Hazelcast", e );
+                String attrValue = member.getStringAttribute( attrKey );
+                if ( attrValue == null )
+                {
+                    log.warn( "Missing member attribute '%s' for member %s", attrKey, member );
+                    incomplete = true;
+                }
+                else
+                {
+                    attrMap.put( attrKey, attrValue );
+                }
             }
+
+            if ( incomplete )
+            {
+                continue;
+            }
+
+            CoreServerInfo coreServerInfo = new CoreServerInfo(
+                    socketAddress( attrMap.get( RAFT_SERVER ), AdvertisedSocketAddress::new ),
+                    socketAddress( attrMap.get( TRANSACTION_SERVER ), AdvertisedSocketAddress::new ),
+                    ClientConnectorAddresses.fromString( attrMap.get( CLIENT_CONNECTOR_ADDRESSES ) ),
+                    asSet( serverGroupsMMap.get( attrMap.get( MEMBER_UUID ) ) ), attrMap.get( MEMBER_DB_NAME ) );
+
+            MemberId memberId = new MemberId( UUID.fromString( attrMap.get( MEMBER_UUID ) ) );
+            coreMembers.put( memberId, coreServerInfo );
         }
 
         return coreMembers;

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/HazelcastClusterTopologyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/HazelcastClusterTopologyTest.java
@@ -26,7 +26,6 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MultiMap;
 import com.hazelcast.nio.Address;
-import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -51,13 +50,6 @@ import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.kernel.configuration.BoltConnector;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.AssertableLogProvider;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.startsWith;
-import static org.neo4j.causalclustering.discovery.HazelcastClusterTopology.CLUSTER_UUID_DB_NAME_MAP;
-import static org.neo4j.causalclustering.discovery.HazelcastClusterTopology.DB_NAME_LEADER_TERM_PREFIX;
-import static org.neo4j.logging.AssertableLogProvider.inLog;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.NullLog;
 
@@ -67,8 +59,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.neo4j.causalclustering.discovery.HazelcastClusterTopology.CLUSTER_UUID_DB_NAME_MAP;
+import static org.neo4j.causalclustering.discovery.HazelcastClusterTopology.DB_NAME_LEADER_TERM_PREFIX;
 import static org.neo4j.causalclustering.discovery.HazelcastClusterTopology.buildMemberAttributesForCore;
 import static org.neo4j.causalclustering.discovery.HazelcastClusterTopology.toCoreMemberMap;
 import static org.neo4j.helpers.collection.Iterators.asSet;
@@ -228,10 +224,7 @@ public class HazelcastClusterTopologyTest
         // then
         assertThat( map.keySet(), hasItems( coreMembers.get( 0 ), coreMembers.get( 1 ), coreMembers.get( 3 ) ) );
         assertThat( map.keySet(), not( hasItems( coreMembers.get( 2 ) ) ) );
-        logProvider.assertExactly( inLog( this.getClass() )
-                .warn( equalTo("Incomplete member attributes supplied from Hazelcast"),
-                        CoreMatchers.instanceOf( IllegalArgumentException.class )) );
-
+        logProvider.assertContainsMessageContaining( "Missing member attribute" );
     }
 
     @Test


### PR DESCRIPTION
The old logic was a bit odd and relied upon SocketAddress throwing an
IllegalArgumentException during parsing of null, and that was also
the only cases it could handle. This can be refactored into something
much better in the future. This is just a simple quick-fix to make
sure that all attributes are available before populating the
topology map with a CoreServerInfo.