### PR TITLE
Provide backup client feedback via Monitors

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/monitoring/Monitors.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/monitoring/Monitors.java
@@ -32,6 +32,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.logging.NullLogProvider;
 
 import static org.neo4j.helpers.collection.Iterables.append;
 import static org.neo4j.helpers.collection.Iterables.asArray;
@@ -56,6 +59,18 @@ import static org.neo4j.helpers.collection.Iterables.asArray;
  */
 public class Monitors
 {
+    private final Log log;
+
+    public Monitors()
+    {
+        this( NullLogProvider.getInstance() );
+    }
+
+    public Monitors( LogProvider logProvider )
+    {
+        this.log = logProvider.getLog( Monitors.class );
+    }
+
     private static final AtomicBoolean FALSE = new AtomicBoolean( false );
 
     // Concurrency: Mutation of these data structures is always guarded by the monitor lock on this Monitors instance,
@@ -289,7 +304,8 @@ public class Monitors
                     }
                     catch ( Throwable e )
                     {
-                        // TODO: something?! Ignore, rethrow etc.
+                        String message = String.format( "Encountered exception while handling listener for monitor method %s", method.getName() );
+                        log.warn( message, e );
                     }
                 }
             }

--- a/community/kernel/src/test/java/org/neo4j/kernel/monitoring/MonitorsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/monitoring/MonitorsTest.java
@@ -19,10 +19,19 @@
  */
 package org.neo4j.kernel.monitoring;
 
+import org.junit.Assert;
 import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+import org.neo4j.logging.FormattedLogProvider;
+import org.neo4j.logging.LogProvider;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -137,5 +146,31 @@ public class MonitorsTest
 
         // Then
         assertFalse( monitors.hasListeners( MyMonitor.class ) );
+    }
+
+    @Test
+    public void exceptionsInHandlersAreLogged()
+    {
+        // given
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        OutputStream outputStream = new PrintStream( byteArrayOutputStream );
+        LogProvider logProvider = FormattedLogProvider.toOutputStream( outputStream );
+        Monitors monitors = new Monitors( logProvider );
+
+        // and
+        MyMonitor listener = mock( MyMonitor.class );
+        RuntimeException runtimeException = new RuntimeException( "Exception message" );
+        doThrow( runtimeException ).when( listener ).aVoid();
+        monitors.addMonitorListener( listener );
+
+        // when
+        MyMonitor monitor = monitors.newMonitor( MyMonitor.class );
+        monitor.aVoid();
+
+        // then
+        String logOutput = byteArrayOutputStream.toString();
+        assertTrue( logOutput.contains( "RuntimeException: Exception message" ) );
+        assertTrue( logOutput.contains( this.getClass().getName() ) );
+        assertTrue( logOutput.contains( "Encountered exception while handling listener for monitor method aVoid" ) );
     }
 }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupOutputMonitor.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupOutputMonitor.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.backup.impl;
+
+import org.neo4j.com.storecopy.StoreCopyClientMonitor;
+import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.logging.FormattedLogProvider;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+/**
+ * Monitor for events that should be displayed to neo4j-admin backup stdout
+ */
+class BackupOutputMonitor implements StoreCopyClientMonitor
+{
+    private final Log log;
+
+    BackupOutputMonitor( OutsideWorld outsideWorld )
+    {
+        LogProvider stdOutLogProvider = FormattedLogProvider.toOutputStream( outsideWorld.outStream() );
+        log = stdOutLogProvider.getLog( BackupOutputMonitor.class );
+    }
+
+    @Override
+    public void startReceivingStoreFiles()
+    {
+        log.info( "Start receiving store files" );
+    }
+
+    @Override
+    public void finishReceivingStoreFiles()
+    {
+        log.info( "Finish receiving store files" );
+    }
+
+    @Override
+    public void startReceivingStoreFile( String file )
+    {
+        log.info( "Start receiving store file %s", file );
+    }
+
+    @Override
+    public void finishReceivingStoreFile( String file )
+    {
+        log.info( "Finish receiving store file %s", file );
+    }
+
+    @Override
+    public void startReceivingTransactions( long startTxId )
+    {
+        log.info( "Start receiving transactions from %d", startTxId );
+    }
+
+    @Override
+    public void finishReceivingTransactions( long endTxId )
+    {
+        log.info( "Finish receiving transactions at %d", endTxId );
+    }
+
+    @Override
+    public void startRecoveringStore()
+    {
+        log.info( "Start recovering store" );
+    }
+
+    @Override
+    public void finishRecoveringStore()
+    {
+        log.info( "Finish recovering store" );
+    }
+
+    @Override
+    public void startReceivingIndexSnapshots()
+    {
+        log.info( "Start receiving index snapshots" );
+    }
+
+    @Override
+    public void startReceivingIndexSnapshot( long indexId )
+    {
+        log.info( "Start receiving index snapshot id %d", indexId );
+    }
+
+    @Override
+    public void finishReceivingIndexSnapshot( long indexId )
+    {
+        log.info( "Finished receiving index snapshot id %d", indexId );
+    }
+
+    @Override
+    public void finishReceivingIndexSnapshots()
+    {
+        log.info( "Finished receiving index snapshots" );
+    }
+}

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupStrategyCoordinatorFactory.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupStrategyCoordinatorFactory.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.backup.impl;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.neo4j.com.storecopy.FileMoveProvider;

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/CausalClusteringBackupStrategy.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/CausalClusteringBackupStrategy.java
@@ -55,6 +55,7 @@ class CausalClusteringBackupStrategy extends LifecycleAdapter implements BackupS
         try
         {
             storeId = backupDelegator.fetchStoreId( fromAddress );
+            log.info( "Remote store id is " + storeId );
         }
         catch ( StoreIdDownloadFailedException e )
         {
@@ -82,6 +83,7 @@ class CausalClusteringBackupStrategy extends LifecycleAdapter implements BackupS
         try
         {
             storeId = backupDelegator.fetchStoreId( fromAddress );
+            log.info( "Remote store id is " + storeId );
         }
         catch ( StoreIdDownloadFailedException e )
         {

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/OnlineBackupCommandBuilder.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/OnlineBackupCommandBuilder.java
@@ -30,7 +30,6 @@ import java.io.Writer;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -56,7 +55,7 @@ public class OnlineBackupCommandBuilder
     private Boolean fallbackToFull;
     private Long timeout;
     private Boolean checkConsistency;
-    private File  consistencyReportLocation;
+    private File consistencyReportLocation;
     private Config additionalConfig;
     private SelectedBackupProtocol selectedBackupProtocol;
     private Boolean consistencyCheckGraph;

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupOutputMonitorTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupOutputMonitorTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.backup.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.neo4j.com.storecopy.StoreCopyClientMonitor;
+import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.commandline.admin.ParameterisedOutsideWorld;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.kernel.monitoring.Monitors;
+
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.backup.impl.OnlineBackupCommandCcIT.wrapWithNormalOutput;
+
+public class BackupOutputMonitorTest
+{
+    Monitors monitors = new Monitors();
+    OutsideWorld outsideWorld;
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    PrintStream outputStream = wrapWithNormalOutput( System.out, new PrintStream( byteArrayOutputStream ) );
+
+    ByteArrayOutputStream byteArrayErrorStream = new ByteArrayOutputStream();
+    PrintStream errorStream = wrapWithNormalOutput( System.err, new PrintStream( byteArrayErrorStream ) );
+
+    @Before
+    public void setup()
+    {
+        outsideWorld = new ParameterisedOutsideWorld( System.console(), outputStream, errorStream, System.in, new DefaultFileSystemAbstraction() );
+    }
+
+    @Test
+    public void receivingStoreFilesMessageCorrect()
+    {
+        // given
+        monitors.addMonitorListener( new BackupOutputMonitor( outsideWorld ) );
+
+        // when
+        StoreCopyClientMonitor storeCopyClientMonitor = monitors.newMonitor( StoreCopyClientMonitor.class );
+        storeCopyClientMonitor.startReceivingStoreFiles();
+
+        // then
+        assertTrue( byteArrayOutputStream.toString().contains( "Start receiving store files" ) );
+    }
+}

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupStrategyWrapperTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupStrategyWrapperTest.java
@@ -27,7 +27,6 @@ import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.consistency.checking.full.ConsistencyFlags;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
@@ -89,6 +89,7 @@ import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.internal.DatabaseHealth;
 import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.scheduler.JobScheduler;
 
@@ -256,7 +257,7 @@ public class CoreServerModule
                 new ExponentialBackoffStrategy( 1, config.get( CausalClusteringSettings.store_copy_backoff_max_wait ).toMillis(), TimeUnit.MILLISECONDS );
 
         RemoteStore remoteStore = new RemoteStore( logProvider, platformModule.fileSystem, platformModule.pageCache,
-                new StoreCopyClient( catchUpClient, logProvider, storeCopyBackoffStrategy ),
+                new StoreCopyClient( catchUpClient, platformModule.monitors, logProvider, storeCopyBackoffStrategy ),
                 new TxPullClient( catchUpClient, platformModule.monitors ), new TransactionLogCatchUpFactory(), config, platformModule.monitors );
 
         CopiedStoreRecovery copiedStoreRecovery = platformModule.life.add(

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
@@ -36,8 +36,6 @@ import org.neo4j.causalclustering.catchup.CatchUpClient;
 import org.neo4j.causalclustering.catchup.CatchUpResponseHandler;
 import org.neo4j.causalclustering.catchup.CatchupProtocolClientInstaller;
 import org.neo4j.causalclustering.catchup.CatchupServerBuilder;
-import org.neo4j.causalclustering.catchup.CatchupServerHandler;
-import org.neo4j.causalclustering.catchup.CatchupServerProtocol;
 import org.neo4j.causalclustering.catchup.CheckpointerSupplier;
 import org.neo4j.causalclustering.catchup.RegularCatchupServerHandler;
 import org.neo4j.causalclustering.catchup.storecopy.CopiedStoreRecovery;
@@ -279,7 +277,7 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
                 new ExponentialBackoffStrategy( 1, config.get( CausalClusteringSettings.store_copy_backoff_max_wait ).toMillis(), TimeUnit.MILLISECONDS );
 
         RemoteStore remoteStore = new RemoteStore( platformModule.logging.getInternalLogProvider(), fileSystem, platformModule.pageCache,
-                new StoreCopyClient( catchUpClient, logProvider, storeCopyBackoffStrategy ),
+                new StoreCopyClient( catchUpClient, platformModule.monitors, logProvider, storeCopyBackoffStrategy ),
                 new TxPullClient( catchUpClient, platformModule.monitors ),
                 new TransactionLogCatchUpFactory(), config, platformModule.monitors );
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStoreTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStoreTest.java
@@ -71,7 +71,7 @@ public class RemoteStoreTest
         remoteStore.copy( catchupAddressProvider, storeId, new File( "destination" ) );
 
         // then
-        verify( storeCopyClient ).copyStoreFiles( eq( catchupAddressProvider ), eq( storeId ), any( StoreFileStreamProvider.class ), any() );
+        verify( storeCopyClient ).copyStoreFiles( eq( catchupAddressProvider ), eq( storeId ), any( StoreFileStreamProvider.class ), any(), any() );
         verify( txPullClient ).pullTransactions( eq( localhost ), eq( storeId ), anyLong(), isNull() );
     }
 
@@ -85,7 +85,7 @@ public class RemoteStoreTest
         CatchupAddressProvider catchupAddressProvider = CatchupAddressProvider.fromSingleAddress( localhost );
 
         StoreCopyClient storeCopyClient = mock( StoreCopyClient.class );
-        when( storeCopyClient.copyStoreFiles( eq( catchupAddressProvider ), eq( wantedStoreId ), any( StoreFileStreamProvider.class ), any() ) )
+        when( storeCopyClient.copyStoreFiles( eq( catchupAddressProvider ), eq( wantedStoreId ), any( StoreFileStreamProvider.class ), any(), any() ) )
                 .thenReturn( lastFlushedTxId );
 
         TxPullClient txPullClient = mock( TxPullClient.class );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helpers/CausalClusteringTestHelpers.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helpers/CausalClusteringTestHelpers.java
@@ -28,7 +28,9 @@ import java.util.stream.IntStream;
 
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.helpers.AdvertisedSocketAddress;
+import org.neo4j.helpers.HostnamePort;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.enterprise.configuration.OnlineBackupSettings;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 
 public class CausalClusteringTestHelpers
@@ -40,6 +42,15 @@ public class CausalClusteringTestHelpers
                 .resolveDependency( Config.class )
                 .get( CausalClusteringSettings.transaction_advertised_address );
         return String.format( "%s:%s", hostnamePort.getHostname(), hostnamePort.getPort() );
+    }
+
+    public static String backupAddress( GraphDatabaseFacade graphDatabaseFacade )
+    {
+        HostnamePort backupAddress = graphDatabaseFacade
+                .getDependencyResolver()
+                .resolveDependency( Config.class )
+                .get( OnlineBackupSettings.online_backup_server );
+        return String.format( "%s:%s", backupAddress.getHost(), backupAddress.getPort() );
     }
 
     public static Map<Integer, String> distributeDatabaseNamesToHostNums( int nHosts, Set<String> databaseNames )

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
@@ -69,67 +69,6 @@ import static org.neo4j.kernel.impl.transaction.log.entry.LogHeaderWriter.writeL
  */
 public class StoreCopyClient
 {
-    public interface Monitor
-    {
-        void startReceivingStoreFiles();
-
-        void finishReceivingStoreFiles();
-
-        void startReceivingStoreFile( File file );
-
-        void finishReceivingStoreFile( File file );
-
-        void startReceivingTransactions( long startTxId );
-
-        void finishReceivingTransactions( long endTxId );
-
-        void startRecoveringStore();
-
-        void finishRecoveringStore();
-
-        class Adapter implements Monitor
-        {
-            @Override
-            public void startReceivingStoreFiles()
-            {   // empty
-            }
-
-            @Override
-            public void finishReceivingStoreFiles()
-            {   // empty
-            }
-
-            @Override
-            public void startReceivingStoreFile( File file )
-            {   // empty
-            }
-
-            @Override
-            public void finishReceivingStoreFile( File file )
-            {   // empty
-            }
-
-            @Override
-            public void startReceivingTransactions( long startTxId )
-            {   // empty
-            }
-
-            @Override
-            public void finishReceivingTransactions( long endTxId )
-            {   // empty
-            }
-
-            @Override
-            public void startRecoveringStore()
-            {   // empty
-            }
-
-            @Override
-            public void finishRecoveringStore()
-            {   // empty
-            }
-        }
-    }
 
     /**
      * This is built as a pluggable interface to allow backup and HA to use this code independently of each other,
@@ -148,19 +87,19 @@ public class StoreCopyClient
     private final Log log;
     private final FileSystemAbstraction fs;
     private final PageCache pageCache;
-    private final Monitor monitor;
+    private final StoreCopyClientMonitor monitor;
     private final boolean forensics;
     private final FileMoveProvider fileMoveProvider;
 
     public StoreCopyClient( File storeDir, Config config, Iterable<KernelExtensionFactory<?>> kernelExtensions, LogProvider logProvider,
-            FileSystemAbstraction fs, PageCache pageCache, Monitor monitor, boolean forensics )
+            FileSystemAbstraction fs, PageCache pageCache, StoreCopyClientMonitor monitor, boolean forensics )
     {
         this( storeDir, config, kernelExtensions, logProvider, fs, pageCache, monitor, forensics, new FileMoveProvider( pageCache,
                 fs ) );
     }
 
     public StoreCopyClient( File storeDir, Config config, Iterable<KernelExtensionFactory<?>> kernelExtensions, LogProvider logProvider,
-            FileSystemAbstraction fs, PageCache pageCache, Monitor monitor, boolean forensics, FileMoveProvider fileMoveProvider )
+            FileSystemAbstraction fs, PageCache pageCache, StoreCopyClientMonitor monitor, boolean forensics, FileMoveProvider fileMoveProvider )
     {
         this.storeDir = storeDir;
         this.config = config;

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClientMonitor.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClientMonitor.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.com.storecopy;
+
+public interface StoreCopyClientMonitor
+{
+    void startReceivingStoreFiles();
+
+    void finishReceivingStoreFiles();
+
+    void startReceivingStoreFile( String file );
+
+    void finishReceivingStoreFile( String file );
+
+    void startReceivingTransactions( long startTxId );
+
+    void finishReceivingTransactions( long endTxId );
+
+    void startRecoveringStore();
+
+    void finishRecoveringStore();
+
+    void startReceivingIndexSnapshots();
+
+    void startReceivingIndexSnapshot( long indexId );
+
+    void finishReceivingIndexSnapshot( long indexId );
+
+    void finishReceivingIndexSnapshots();
+
+    class Adapter implements StoreCopyClientMonitor
+    {
+        @Override
+        public void startReceivingStoreFiles()
+        {   // empty
+        }
+
+        @Override
+        public void finishReceivingStoreFiles()
+        {   // empty
+        }
+
+        @Override
+        public void startReceivingStoreFile( String file )
+        {   // empty
+        }
+
+        @Override
+        public void finishReceivingStoreFile( String file )
+        {   // empty
+        }
+
+        @Override
+        public void startReceivingTransactions( long startTxId )
+        {   // empty
+        }
+
+        @Override
+        public void finishReceivingTransactions( long endTxId )
+        {   // empty
+        }
+
+        @Override
+        public void startRecoveringStore()
+        {   // empty
+        }
+
+        @Override
+        public void finishRecoveringStore()
+        {   // empty
+        }
+
+        @Override
+        public void startReceivingIndexSnapshots()
+        {   // empty
+        }
+
+        @Override
+        public void startReceivingIndexSnapshot( long indexId )
+        {   // empty
+        }
+
+        @Override
+        public void finishReceivingIndexSnapshot( long indexId )
+        {   // empty
+        }
+
+        @Override
+        public void finishReceivingIndexSnapshots()
+        {   // empty
+        }
+    }
+}

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
@@ -123,7 +123,7 @@ public class StoreCopyClientTest
         final File originalDir = new File( directory.directory(), "original" );
 
         final AtomicBoolean cancelStoreCopy = new AtomicBoolean( false );
-        StoreCopyClient.Monitor storeCopyMonitor = new StoreCopyClient.Monitor.Adapter()
+        StoreCopyClientMonitor storeCopyMonitor = new StoreCopyClientMonitor.Adapter()
         {
             @Override
             public void finishRecoveringStore()
@@ -184,7 +184,7 @@ public class StoreCopyClientTest
         Config config = Config.defaults( logical_logs_location, copyCustomLogFilesLocation.getName() );
         StoreCopyClient copier = new StoreCopyClient(
                 copyDir, config, loadKernelExtensions(), NullLogProvider.getInstance(), fileSystem, pageCache,
-                new StoreCopyClient.Monitor.Adapter(), false );
+                new StoreCopyClientMonitor.Adapter(), false );
 
         GraphDatabaseAPI original = (GraphDatabaseAPI) new TestGraphDatabaseFactory()
                 .newEmbeddedDatabaseBuilder( originalDir )
@@ -236,7 +236,7 @@ public class StoreCopyClientTest
         final File originalDir = new File( directory.directory(), "original" );
 
         final AtomicBoolean cancelStoreCopy = new AtomicBoolean( false );
-        StoreCopyClient.Monitor storeCopyMonitor = new StoreCopyClient.Monitor.Adapter()
+        StoreCopyClientMonitor storeCopyMonitor = new StoreCopyClientMonitor.Adapter()
         {
             @Override
             public void finishReceivingStoreFiles()
@@ -297,7 +297,7 @@ public class StoreCopyClientTest
 
         StoreCopyClient copier =
                 new StoreCopyClient( backupStore, Config.defaults(), loadKernelExtensions(), NullLogProvider
-                        .getInstance(), fileSystem, pageCache, new StoreCopyClient.Monitor.Adapter(), false );
+                        .getInstance(), fileSystem, pageCache, new StoreCopyClientMonitor.Adapter(), false );
         CancellationRequest falseCancellationRequest = () -> false;
         StoreCopyClient.StoreCopyRequester storeCopyRequest =
                 requestFactory.create( (GraphDatabaseAPI) initialDatabase, initialStore, fileSystem, false );
@@ -325,7 +325,7 @@ public class StoreCopyClientTest
         GraphDatabaseService initialDatabase = createInitialDatabase( initialStore );
         StoreCopyClient copier =
                 new StoreCopyClient( backupStore, Config.defaults(), loadKernelExtensions(), NullLogProvider
-                        .getInstance(), fileSystem, pageCache, new StoreCopyClient.Monitor.Adapter(), false );
+                        .getInstance(), fileSystem, pageCache, new StoreCopyClientMonitor.Adapter(), false );
         CancellationRequest falseCancellationRequest = () -> false;
 
         RuntimeException exception = new RuntimeException( "Boom!" );
@@ -362,7 +362,7 @@ public class StoreCopyClientTest
         Config config = Config.defaults( record_format, recordFormatsName );
         StoreCopyClient copier = new StoreCopyClient(
                 copyDir, config, loadKernelExtensions(), NullLogProvider.getInstance(), fileSystem, pageCache,
-                new StoreCopyClient.Monitor.Adapter(), false );
+                new StoreCopyClientMonitor.Adapter(), false );
 
         final GraphDatabaseAPI original = (GraphDatabaseAPI) startDatabase( originalDir, recordFormatsName );
         StoreCopyClient.StoreCopyRequester storeCopyRequest = requestFactory.create( original, originalDir,

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveBranchThenCopy.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveBranchThenCopy.java
@@ -27,6 +27,7 @@ import java.util.function.Supplier;
 
 import org.neo4j.cluster.member.ClusterMemberAvailability;
 import org.neo4j.com.storecopy.StoreCopyClient;
+import org.neo4j.com.storecopy.StoreCopyClientMonitor;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.helpers.CancellationRequest;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -74,7 +75,7 @@ public class SwitchToSlaveBranchThenCopy extends SwitchToSlave
                                         Iterable<KernelExtensionFactory<?>> kernelExtensions,
                                         MasterClientResolver masterClientResolver,
                                         SwitchToSlave.Monitor monitor,
-                                        StoreCopyClient.Monitor storeCopyMonitor,
+                                        StoreCopyClientMonitor storeCopyMonitor,
                                         Supplier<NeoStoreDataSource> neoDataSourceSupplier,
                                         Supplier<TransactionIdStore> transactionIdStoreSupplier,
                                         Function<Slave,SlaveServer> slaveServerFactory,

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveCopyThenBranch.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveCopyThenBranch.java
@@ -28,6 +28,7 @@ import java.util.function.Supplier;
 import org.neo4j.cluster.member.ClusterMemberAvailability;
 import org.neo4j.com.storecopy.MoveAfterCopy;
 import org.neo4j.com.storecopy.StoreCopyClient;
+import org.neo4j.com.storecopy.StoreCopyClientMonitor;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.helpers.CancellationRequest;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -77,7 +78,7 @@ public class SwitchToSlaveCopyThenBranch extends SwitchToSlave
                                         Iterable<KernelExtensionFactory<?>> kernelExtensions,
                                         MasterClientResolver masterClientResolver,
                                         SwitchToSlave.Monitor monitor,
-                                        StoreCopyClient.Monitor storeCopyMonitor,
+                                        StoreCopyClientMonitor storeCopyMonitor,
                                         Supplier<NeoStoreDataSource> neoDataSourceSupplier,
                                         Supplier<TransactionIdStore> transactionIdStoreSupplier,
                                         Function<Slave, SlaveServer> slaveServerFactory,

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -49,7 +49,7 @@ import org.neo4j.cluster.protocol.election.ElectionCredentialsProvider;
 import org.neo4j.cluster.protocol.election.NotElectableElectionCredentialsProvider;
 import org.neo4j.com.Server;
 import org.neo4j.com.monitor.RequestMonitor;
-import org.neo4j.com.storecopy.StoreCopyClient;
+import org.neo4j.com.storecopy.StoreCopyClientMonitor;
 import org.neo4j.com.storecopy.StoreUtil;
 import org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker;
 import org.neo4j.function.Factory;
@@ -597,7 +597,7 @@ public class HighlyAvailableEditionModule
                         pullerFactory,
                         platformModule.kernelExtensions.listFactories(), masterClientResolver,
                         monitors.newMonitor( SwitchToSlave.Monitor.class ),
-                        monitors.newMonitor( StoreCopyClient.Monitor.class ),
+                        monitors.newMonitor( StoreCopyClientMonitor.class ),
                         dependencies.provideDependency( NeoStoreDataSource.class ),
                         dependencies.provideDependency( TransactionIdStore.class ),
                         slaveServerFactory, updatePullerProxy, platformModule.pageCache,
@@ -609,7 +609,7 @@ public class HighlyAvailableEditionModule
                         pullerFactory,
                         platformModule.kernelExtensions.listFactories(), masterClientResolver,
                         monitors.newMonitor( SwitchToSlave.Monitor.class ),
-                        monitors.newMonitor( StoreCopyClient.Monitor.class ),
+                        monitors.newMonitor( StoreCopyClientMonitor.class ),
                         dependencies.provideDependency( NeoStoreDataSource.class ),
                         dependencies.provideDependency( TransactionIdStore.class ),
                         slaveServerFactory, updatePullerProxy, platformModule.pageCache,

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
@@ -42,7 +42,7 @@ import org.neo4j.cluster.member.ClusterMemberListener;
 import org.neo4j.cluster.protocol.election.Election;
 import org.neo4j.com.ResourceReleaser;
 import org.neo4j.com.Response;
-import org.neo4j.com.storecopy.StoreCopyClient;
+import org.neo4j.com.storecopy.StoreCopyClientMonitor;
 import org.neo4j.function.Suppliers;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.helpers.collection.Iterables;
@@ -562,7 +562,7 @@ public class HighAvailabilityMemberStateMachineTest
                 mock( PullerFactory.class, RETURNS_MOCKS ),
                 Iterables.empty(), masterClientResolver,
                 monitor,
-                new StoreCopyClient.Monitor.Adapter(),
+                new StoreCopyClientMonitor.Adapter(),
                 Suppliers.singleton( dataSource ),
                 Suppliers.singleton( transactionIdStoreMock ),
                 slave ->


### PR DESCRIPTION
Instead of relying on logs for backup progress, we now use Monitors that log to output at the correct step. This is not reflected in server logs as they are kept separate.