### PR TITLE
Change nodeUniqueIndexSeek to use fresh index reader

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
@@ -353,7 +353,7 @@ final class TransactionBoundQueryContext(tc: TransactionalContextWrapper, val re
     JavaConversionSupport.mapToScalaENFXSafe(scan(DefaultIndexReference.general(index.labelId, index.propertyId)))(nodeOps.getByIdIfExists)
 
   override def lockingExactUniqueIndexSearch(index: SchemaTypes.IndexDescriptor, value: Any): Option[Node] = {
-    val nodeId: Long = tc.dataRead.nodeUniqueIndexSeek(DefaultIndexReference.general(index.labelId, index.propertyId),
+    val nodeId: Long = tc.dataRead.lockingNodeUniqueIndexSeek(DefaultIndexReference.general(index.labelId, index.propertyId),
                                                        IndexQuery.exact(index.propertyId, Values.of(value)))
     if (StatementConstants.NO_SUCH_NODE == nodeId) None else Some(nodeOps.getById(nodeId))
   }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundQueryContext.scala
@@ -360,7 +360,7 @@ final class TransactionBoundQueryContext(txContext: TransactionalContextWrapper,
 
   override def lockingUniqueIndexSeek(index: IndexDescriptor, value: Any): Option[Node] = {
     indexSearchMonitor.lockingUniqueIndexSeek(index, value)
-    val nodeId = reads().nodeUniqueIndexSeek(DefaultIndexReference.general(index.labelId, index.propertyId), IndexQuery.exact(index.propertyId, value))
+    val nodeId = reads().lockingNodeUniqueIndexSeek(DefaultIndexReference.general(index.labelId, index.propertyId), IndexQuery.exact(index.propertyId, value))
     if (StatementConstants.NO_SUCH_NODE == nodeId) None else Some(nodeOps.getById(nodeId))
   }
 

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
@@ -301,7 +301,7 @@ sealed class TransactionBoundQueryContext(val transactionalContext: Transactiona
   override def lockingUniqueIndexSeek(indexReference: IndexReference, queries: Seq[IndexQuery.ExactPredicate]): Option[NodeValue] = {
     indexSearchMonitor.lockingUniqueIndexSeek(indexReference, queries)
     val index = DefaultIndexReference.general(indexReference.label(), indexReference.properties():_*)
-    val nodeId = reads().nodeUniqueIndexSeek(index, queries:_*)
+    val nodeId = reads().lockingNodeUniqueIndexSeek(index, queries:_*)
     if (StatementConstants.NO_SUCH_NODE == nodeId) None else Some(nodeOps.getById(nodeId))
   }
 

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Read.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Read.java
@@ -30,6 +30,8 @@ public interface Read
     int ANY_RELATIONSHIP_TYPE = -1;
 
     /**
+     * Seek all nodes matching the provided index query in an index.
+     *
      * @param index {@link IndexReference} referencing index to query.
      * @param cursor the cursor to use for consuming the results.
      * @param indexOrder requested {@link IndexOrder} of result. Must be among the capabilities of
@@ -45,13 +47,17 @@ public interface Read
      * Note that this is a very special method and should be use with caution. It has special locking semantics in
      * order to facilitate unique creation of nodes. If a node is found; a shared lock for the index entry will be
      * held whereas if no node is found we will hold onto an exclusive lock until the close of the transaction.
-     *  @param index {@link IndexReference} referencing index to query.
-     * {@link IndexReference referenced index}, or {@link IndexOrder#NONE}.
+     *
+     * @param index {@link IndexReference} referencing index to query.
+     *              {@link IndexReference referenced index}, or {@link IndexOrder#NONE}.
      * @param predicates Combination of {@link IndexQuery.ExactPredicate index queries} to run against referenced index.
      */
-    long nodeUniqueIndexSeek( IndexReference index, IndexQuery.ExactPredicate... predicates )
+    long lockingNodeUniqueIndexSeek( IndexReference index, IndexQuery.ExactPredicate... predicates )
             throws KernelException;
+
     /**
+     * Scan all values in an index.
+     *
      * @param index {@link IndexReference} referencing index to query.
      * @param cursor the cursor to use for consuming the results.
      * @param indexOrder requested {@link IndexOrder} of result. Must be among the capabilities of
@@ -75,6 +81,11 @@ public interface Read
 
     Scan<NodeLabelIndexCursor> nodeLabelScan( int label );
 
+    /**
+     * Return all nodes in the graph.
+     *
+     * @param cursor Cursor to initialize for scanning.
+     */
     void allNodesScan( NodeCursor cursor );
 
     Scan<NodeCursor> allNodesScan();

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubRead.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubRead.java
@@ -43,7 +43,7 @@ public class StubRead implements Read
     }
 
     @Override
-    public long nodeUniqueIndexSeek( IndexReference index,
+    public long lockingNodeUniqueIndexSeek( IndexReference index,
             IndexQuery.ExactPredicate... predicates ) throws KernelException
     {
         throw new UnsupportedOperationException();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
@@ -246,12 +246,13 @@ public class AllStoreHolder extends Read
     }
 
     @Override
-    IndexReader indexReader( IndexReference index ) throws IndexNotFoundKernelException
+    IndexReader indexReader( IndexReference index, boolean fresh ) throws IndexNotFoundKernelException
     {
         SchemaIndexDescriptor schemaIndexDescriptor = index.isUnique() ?
                                                       SchemaIndexDescriptorFactory.uniqueForLabel( index.label(), index.properties() ) :
                                                       SchemaIndexDescriptorFactory.forLabel( index.label(), index.properties() );
-        return statement.getIndexReader( schemaIndexDescriptor );
+        return fresh ? statement.getFreshIndexReader( schemaIndexDescriptor ) :
+               statement.getIndexReader( schemaIndexDescriptor );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeValueIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeValueIndexCursor.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
+import org.neo4j.graphdb.Resource;
 import org.neo4j.internal.kernel.api.IndexQuery;
 import org.neo4j.internal.kernel.api.NodeCursor;
 import org.neo4j.internal.kernel.api.NodeValueIndexCursor;
@@ -47,6 +48,7 @@ final class DefaultNodeValueIndexCursor extends IndexCursor<IndexProgressor>
         implements NodeValueIndexCursor, NodeValueClient
 {
     private Read read;
+    private Resource resource;
     private long node;
     private IndexQuery[] query;
     private Value[] values;
@@ -142,9 +144,10 @@ final class DefaultNodeValueIndexCursor extends IndexCursor<IndexProgressor>
         }
     }
 
-    public void setRead( Read read )
+    public void setRead( Read read, Resource resource )
     {
         this.read = read;
+        this.resource = resource;
     }
 
     @Override
@@ -196,7 +199,18 @@ final class DefaultNodeValueIndexCursor extends IndexCursor<IndexProgressor>
             this.added = emptyIterator();
             this.removed = PrimitiveLongCollections.emptySet();
 
-            pool.accept( this );
+            try
+            {
+                if ( resource != null )
+                {
+                    resource.close();
+                    resource = null;
+                }
+            }
+            finally
+            {
+                pool.accept( this );
+            }
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
@@ -32,7 +32,6 @@ import org.neo4j.internal.kernel.api.CapableIndexReference;
 import org.neo4j.internal.kernel.api.CursorFactory;
 import org.neo4j.internal.kernel.api.ExplicitIndexRead;
 import org.neo4j.internal.kernel.api.ExplicitIndexWrite;
-import org.neo4j.internal.kernel.api.IndexOrder;
 import org.neo4j.internal.kernel.api.IndexQuery;
 import org.neo4j.internal.kernel.api.IndexReference;
 import org.neo4j.internal.kernel.api.Locks;
@@ -394,8 +393,8 @@ public class Operations implements Write, ExplicitIndexWrite, SchemaWrite
                     indexEntryResourceId( labelId, propertyValues )
             );
 
-            allStoreHolder.nodeIndexSeek( allStoreHolder.indexGetCapability( schemaIndexDescriptor ), valueCursor,
-                    IndexOrder.NONE, propertyValues );
+            allStoreHolder.nodeIndexSeekWithFreshIndexReader(
+                    allStoreHolder.indexGetCapability( schemaIndexDescriptor ), valueCursor, propertyValues );
             if ( valueCursor.next() && valueCursor.nodeReference() != modifiedNode )
             {
                 throw new UniquePropertyValueValidationException( constraint, VALIDATION,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodeGetUniqueFromIndexSeekIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodeGetUniqueFromIndexSeekIT.java
@@ -83,7 +83,7 @@ public class NodeGetUniqueFromIndexSeekIT extends KernelIntegrationTest
         // when looking for it
         Read read = newTransaction().dataRead();
         int propertyId = index.properties()[0];
-        long foundId = read.nodeUniqueIndexSeek( index, exact( propertyId, value ) );
+        long foundId = read.lockingNodeUniqueIndexSeek( index, exact( propertyId, value ) );
         commit();
 
         // then
@@ -100,7 +100,7 @@ public class NodeGetUniqueFromIndexSeekIT extends KernelIntegrationTest
 
         // when looking for it
         Transaction transaction = newTransaction();
-        long foundId = transaction.dataRead().nodeUniqueIndexSeek( index, exact( propertyId1, value ) );
+        long foundId = transaction.dataRead().lockingNodeUniqueIndexSeek( index, exact( propertyId1, value ) );
         commit();
 
         // then
@@ -118,7 +118,7 @@ public class NodeGetUniqueFromIndexSeekIT extends KernelIntegrationTest
 
         // when looking for it
         Transaction transaction = newTransaction();
-        long foundId = transaction.dataRead().nodeUniqueIndexSeek( index,
+        long foundId = transaction.dataRead().lockingNodeUniqueIndexSeek( index,
                 exact( propertyId1, value1 ),
                                                                 exact( propertyId2, value2 ) );
         commit();
@@ -138,7 +138,7 @@ public class NodeGetUniqueFromIndexSeekIT extends KernelIntegrationTest
 
         // when looking for it
         Transaction transaction = newTransaction();
-        long foundId =  transaction.dataRead().nodeUniqueIndexSeek( index,
+        long foundId =  transaction.dataRead().lockingNodeUniqueIndexSeek( index,
                 exact( propertyId1, value1 ),
                                                                 exact( propertyId2, value2 ) );
         commit();
@@ -182,7 +182,7 @@ public class NodeGetUniqueFromIndexSeekIT extends KernelIntegrationTest
             latch.waitForAllToStart();
             try ( Transaction tx = session.beginTransaction() )
             {
-                tx.dataRead().nodeUniqueIndexSeek( index, exact( propertyId1, value ) );
+                tx.dataRead().lockingNodeUniqueIndexSeek( index, exact( propertyId1, value ) );
                 tx.success();
             }
             catch ( KernelException e )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationIT.java
@@ -308,7 +308,7 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         createLabeledNode( transaction, "Item", "id", 2 );
 
         // then I should find the original node
-        assertThat( transaction.dataRead().nodeUniqueIndexSeek( idx, exact( propId, Values.of( 1 ) ) ),
+        assertThat( transaction.dataRead().lockingNodeUniqueIndexSeek( idx, exact( propId, Values.of( 1 ) ) ),
                 equalTo( ourNode ) );
         commit();
     }
@@ -336,7 +336,7 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         createLabeledNode( transaction, "Person", "id", 2 );
 
         // then I should find the original node
-        assertThat( transaction.dataRead().nodeUniqueIndexSeek( idx, exact( propId, Values.of( 1 ) ) ),
+        assertThat( transaction.dataRead().lockingNodeUniqueIndexSeek( idx, exact( propId, Values.of( 1 ) ) ),
                 equalTo( ourNode ) );
         commit();
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/MockStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/MockStore.java
@@ -101,7 +101,7 @@ public class MockStore extends Read implements TestRule
     }
 
     @Override
-    IndexReader indexReader( org.neo4j.internal.kernel.api.IndexReference index )
+    IndexReader indexReader( IndexReference index, boolean fresh )
     {
         throw new UnsupportedOperationException( "not implemented" );
     }


### PR DESCRIPTION
Blind revert of a change in behavior that was introduced when implementing the new Kernel API. Before we used to get a new `IndexReader` on every verification of uniqueness constraints, and on merge verification. For some time the new Kernel API has instead been using the cached IndexReader in storage statement. Even though this has not failed any tests as far as I know, with this PR the behavior is returned to getting a fresh reader for these cases, as that code path seemed very elaborate and likely was there for a reason.

I have been unable to write any test which provokes a problem with the previous impl, but will try some more.