### PR TITLE
Remove unnecessary synchronization

### DIFF
--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryService.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryService.java
@@ -169,7 +169,7 @@ public final class SharedDiscoveryService
         return coreMembers.keySet().stream().collect( Collectors.toMap( Function.identity(), roleMapper ) );
     }
 
-    private synchronized void notifyCoreClients()
+    private void notifyCoreClients()
     {
         listeningClients.forEach( c -> {
             c.onCoreTopologyChange( getCoreTopology( c ) );


### PR DESCRIPTION
This could cause deadlocks between the discovery and raft.

A better long-term solution would be for the notifiers to
run on threads of their own.