### PR TITLE
Do not scan node store for high id on each loop iteration in consistency checker.

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/CacheTask.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/CacheTask.java
@@ -107,11 +107,11 @@ public abstract class CacheTask extends ConsistencyCheckerTask
         {
             RecordStore<NodeRecord> nodeStore = storeAccess.getNodeStore();
             CacheAccess.Client client = cacheAccess.client();
-            for ( long nodeId = 0; nodeId < nodeStore.getHighId(); nodeId++ )
+            long highId = nodeStore.getHighId();
+            for ( long nodeId = 0; nodeId < highId; nodeId++ )
             {
                 if ( client.getFromCache( nodeId, CacheSlots.NextRelationship.SLOT_FIRST_IN_TARGET ) == 0 )
                 {
-                    // TODO reuse record instances?
                     NodeRecord node = nodeStore.getRecord( nodeId, nodeStore.newRecord(), FORCE );
                     if ( node.inUse() && !node.isDense() )
                     {

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/cache/CheckNextRelTaskTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/cache/CheckNextRelTaskTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.consistency.checking.cache;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import org.neo4j.consistency.checking.full.Stage;
+import org.neo4j.consistency.checking.full.StoreProcessor;
+import org.neo4j.consistency.statistics.Counts;
+import org.neo4j.kernel.impl.store.NeoStores;
+import org.neo4j.kernel.impl.store.NodeStore;
+import org.neo4j.kernel.impl.store.StoreAccess;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.kernel.impl.store.record.RecordLoad;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CheckNextRelTaskTest
+{
+
+    @Test
+    public void scanForHighIdOnlyOnceWhenProcessCache()
+    {
+        NeoStores neoStores = mock( NeoStores.class, Mockito.RETURNS_MOCKS );
+        NodeStore nodeStore = mock( NodeStore.class );
+        NodeRecord nodeRecord = mock( NodeRecord.class );
+        StoreProcessor storeProcessor = mock( StoreProcessor.class );
+
+        when( neoStores.getNodeStore() ).thenReturn( nodeStore );
+        when( nodeStore.getHighId() ).thenReturn( 10L );
+        when( nodeStore.getRecord( anyLong(), any( NodeRecord.class ), any( RecordLoad.class ) ) ).thenReturn( nodeRecord );
+        when( nodeStore.newRecord() ).thenReturn( nodeRecord );
+
+        StoreAccess storeAccess = new StoreAccess( neoStores );
+        storeAccess.initialize();
+
+        CacheTask.CheckNextRel cacheTask = new CacheTask.CheckNextRel( Stage.SEQUENTIAL_FORWARD, new DefaultCacheAccess( Counts.NONE, 1 ),
+                storeAccess, storeProcessor );
+
+        cacheTask.processCache();
+
+        verify( nodeStore, times( 1 ) ).getHighId();
+    }
+}


### PR DESCRIPTION
Since id generators are not initialized each call to get high id
will result in store scan for high id and there is no reason to check
that on each iteration.