### PR TITLE
Restore ability of BatchingNeoStores to create new store based on already existent

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
@@ -31,13 +31,13 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
 import org.neo4j.internal.kernel.api.TokenNameLookup;
+import org.neo4j.internal.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.internal.kernel.api.exceptions.schema.ConstraintValidationException;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.tracing.cursor.context.VersionContextSupplier;
 import org.neo4j.kernel.api.exceptions.TransactionApplyKernelException;
-import org.neo4j.internal.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.LabelScanWriter;
@@ -420,7 +420,7 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
         labelTokenHolder.setInitialTokens(
                 neoStores.getLabelTokenStore().getTokens( Integer.MAX_VALUE ) );
 
-        neoStores.rebuildCountStoreIfNeeded(); // TODO: move this to counts store lifecycle
+        neoStores.startCountStore(); // TODO: move this to counts store lifecycle
         loadSchemaCache();
         indexingService.start();
         labelScanStore.start();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStores.java
@@ -516,7 +516,7 @@ public class NeoStores implements AutoCloseable
         }
     }
 
-    public void rebuildCountStoreIfNeeded() throws IOException
+    public void startCountStore() throws IOException
     {
         // TODO: move this to LifeCycle
         getCounts().start();

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
@@ -179,6 +179,7 @@ public class BatchingNeoStores implements AutoCloseable, MemoryStatsVisitor.Visi
                 initialIds.lastCommittedTransactionId(), initialIds.lastCommittedTransactionChecksum(),
                 BASE_TX_COMMIT_TIMESTAMP, initialIds.lastCommittedTransactionLogByteOffset(),
                 initialIds.lastCommittedTransactionLogVersion() );
+        neoStores.startCountStore();
     }
 
     public void assertDatabaseIsEmptyOrNonExistent()
@@ -228,11 +229,9 @@ public class BatchingNeoStores implements AutoCloseable, MemoryStatsVisitor.Visi
         life.add( labelScanStore );
     }
 
-    private void instantiateStores() throws IOException
+    private void instantiateStores()
     {
         neoStores = newStoreFactory( DEFAULT_NAME ).openAllNeoStores( true );
-        // TODO why do we need this counts store thing here?
-        neoStores.rebuildCountStoreIfNeeded();
         propertyKeyRepository = new BatchingPropertyKeyTokenRepository(
                 neoStores.getPropertyKeyTokenStore() );
         labelRepository = new BatchingLabelTokenRepository(

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStoresIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStoresIT.java
@@ -19,15 +19,22 @@
  */
 package org.neo4j.unsafe.impl.batchimport.store;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
 
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.factory.EnterpriseGraphDatabaseFactory;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.logging.SimpleLogService;
 import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.metrics.MetricsExtension;
 import org.neo4j.metrics.MetricsSettings;
@@ -36,22 +43,33 @@ import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 import org.neo4j.unsafe.impl.batchimport.AdditionalInitialIds;
 import org.neo4j.unsafe.impl.batchimport.Configuration;
 
+import static org.junit.Assert.assertEquals;
+
 public class BatchingNeoStoresIT
 {
     @Rule
-    public TestDirectory testDirectory = TestDirectory.testDirectory();
+    public final TestDirectory testDirectory = TestDirectory.testDirectory();
     @Rule
-    public DefaultFileSystemRule fileSystemRule = new DefaultFileSystemRule();
+    public final DefaultFileSystemRule fileSystemRule = new DefaultFileSystemRule();
+
+    private FileSystemAbstraction fileSystem;
+    private File storeDir;
+    private AssertableLogProvider provider;
+    private SimpleLogService logService;
+
+    @Before
+    public void setUp()
+    {
+        fileSystem = fileSystemRule.get();
+        storeDir = testDirectory.graphDbDir();
+        provider = new AssertableLogProvider();
+        logService = new SimpleLogService( provider, provider );
+    }
 
     @Test
     public void startBatchingNeoStoreWithMetricsPluginEnabled() throws Exception
     {
-        FileSystemAbstraction fileSystem = fileSystemRule.get();
-        File storeDir = testDirectory.graphDbDir();
         Config config = Config.defaults( MetricsSettings.metricsEnabled, "true"  );
-        AssertableLogProvider provider = new AssertableLogProvider();
-        SimpleLogService logService = new SimpleLogService( provider, provider );
-
         try ( BatchingNeoStores batchingNeoStores = BatchingNeoStores
                 .batchingNeoStores( fileSystem, storeDir, RecordFormatSelector.defaultFormat(), Configuration.DEFAULT,
                         logService, AdditionalInitialIds.EMPTY, config ) )
@@ -59,5 +77,60 @@ public class BatchingNeoStoresIT
             batchingNeoStores.createNew();
         }
         provider.assertNone( AssertableLogProvider.inLog( MetricsExtension.class ).any() );
+    }
+
+    @Test
+    public void createStoreWithNotEmptyInitialIds() throws IOException
+    {
+        try ( BatchingNeoStores batchingNeoStores = BatchingNeoStores
+                .batchingNeoStores( fileSystem, storeDir, RecordFormatSelector.defaultFormat(), Configuration.DEFAULT,
+                        logService, new TestAdditionalInitialIds(), Config.defaults() ) )
+        {
+            batchingNeoStores.createNew();
+        }
+
+        GraphDatabaseService database = new EnterpriseGraphDatabaseFactory().newEmbeddedDatabase( storeDir );
+        try
+        {
+            TransactionIdStore transactionIdStore = getTransactionIdStore( (GraphDatabaseAPI) database );
+            assertEquals( 10, transactionIdStore.getLastCommittedTransactionId() );
+        }
+        finally
+        {
+            database.shutdown();
+        }
+    }
+
+    private static TransactionIdStore getTransactionIdStore( GraphDatabaseAPI database )
+    {
+        DependencyResolver resolver = database.getDependencyResolver();
+        return resolver.resolveDependency( TransactionIdStore.class );
+    }
+
+    private static class TestAdditionalInitialIds implements AdditionalInitialIds
+    {
+        @Override
+        public long lastCommittedTransactionId()
+        {
+            return 10;
+        }
+
+        @Override
+        public long lastCommittedTransactionChecksum()
+        {
+            return 11;
+        }
+
+        @Override
+        public long lastCommittedTransactionLogVersion()
+        {
+            return 12;
+        }
+
+        @Override
+        public long lastCommittedTransactionLogByteOffset()
+        {
+            return 13;
+        }
     }
 }


### PR DESCRIPTION
Because of incorrect place where transaction metadata was set previously
it was impossible to create a new store with non-empty initial ids
since that was blocked by count store rotation process that will wait
for transactions that will never come since we only create an empty store
with some metadata.
This PR restore that ability and adds a test that confirms that's it possible.