### PR TITLE
Do not hit node store on index scans and no unnecessary wrapping.

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
@@ -349,8 +349,17 @@ final class TransactionBoundQueryContext(tc: TransactionalContextWrapper, val re
       }.getOrElse(Iterator.empty)
   }
 
-  def indexScan(index: SchemaTypes.IndexDescriptor) =
-    JavaConversionSupport.mapToScalaENFXSafe(scan(DefaultIndexReference.general(index.labelId, index.propertyId)))(nodeOps.getByIdIfExists)
+  def indexScan(index: SchemaTypes.IndexDescriptor) = {
+    val cursor = allocateAndTraceNodeValueIndexCursor()
+    reads().nodeIndexScan(DefaultIndexReference.general(index.labelId, index.propertyId), cursor, IndexOrder.NONE)
+    new CursorIterator[Node] {
+      override protected def fetchNext(): Node = {
+        if (cursor.next()) proxySpi.newNodeProxy(cursor.nodeReference())
+        else null
+      }
+      override protected def close(): Unit = cursor.close()
+    }
+  }
 
   override def lockingExactUniqueIndexSearch(index: SchemaTypes.IndexDescriptor, value: Any): Option[Node] = {
     val nodeId: Long = tc.dataRead.nodeUniqueIndexSeek(DefaultIndexReference.general(index.labelId, index.propertyId),


### PR DESCRIPTION
This solves a regression on interpreted index scans, where an additional node existence check had been added by accident.

Improves performance locally from 374.072±3.892  to  282.457±15.388 ms/op.