### PR TITLE
Fix test assertion on platform dependent message

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SemanticErrorAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SemanticErrorAcceptanceTest.scala
@@ -467,7 +467,7 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
   test("should fail nicely when divide integer by zero in runtime") {
     executeAndEnsureErrorForAllRuntimes(
       s"RETURN {t1} / {t2}",
-      "/ by zero",
+      List("/ by zero", "divide by zero"),
       "t1" -> 1, "t2" -> 0
     )
   }
@@ -475,7 +475,7 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
   test("should fail nicely when modulo integer by zero in runtime") {
     executeAndEnsureErrorForAllRuntimes(
       s"RETURN {t1} % {t2}",
-      "/ by zero",
+      List("/ by zero", "divide by zero"),
       "t1" -> 1, "t2" -> 0
     )
   }
@@ -487,25 +487,41 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
   }
 
   private def executeAndEnsureErrorForAllRuntimes(query: String, expected: String, params: (String,Any)*): Unit = {
+    executeAndEnsureErrorForAllRuntimes(query, List(expected), params:_*)
+  }
+
+  private def executeAndEnsureErrorForAllRuntimes(query: String, expected: Seq[String], params: (String,Any)*): Unit = {
     val runtimes = List(CompiledRuntimeName.name, SlottedRuntimeName.name, InterpretedRuntimeName.name) // Non-experimental runtimes that support arithmetics
     runtimes.foreach( r => executeAndEnsureError(s"CYPHER runtime=$r $query", expected, params: _*) )
   }
 
-  private def executeAndEnsureError(query: String, expected: String, params: (String,Any)*) {
+  private def executeAndEnsureError(query: String, expected: String, params: (String,Any)*): Unit = {
+    executeAndEnsureError(query, List(expected), params: _*)
+  }
+
+  private def executeAndEnsureError(query: String, expected: Seq[String], params: (String,Any)*) {
     import org.neo4j.cypher.internal.frontend.v3_4.helpers.StringHelper._
 
     import scala.collection.JavaConverters._
+
+    val expectedErrorString = expected.map(e => s"'$e'").mkString(" or ")
 
     try {
       val jParams = new util.HashMap[String, Object]()
       params.foreach(kv => jParams.put(kv._1, kv._2.asInstanceOf[AnyRef]))
 
       graph.execute(query.fixNewLines, jParams).asScala.size
-      fail(s"Did not get the expected syntax error, expected: $expected")
+      fail(s"Did not get the expected error, expected: $expectedErrorString")
     } catch {
       case x: QueryExecutionException =>
         val actual = x.getMessage.lines.next().trim
-        actual should equal(expected)
+        if (!correctError(actual, expected)) {
+          fail(s"Did not get the expected error, expected: $expectedErrorString actual: '$actual'")
+        }
     }
+  }
+
+  private def correctError(actualError: String, possibleErrors: Seq[String]): Boolean = {
+    possibleErrors == Seq.empty || (actualError != null && possibleErrors.exists(s => actualError.replaceAll("\\r", "").contains(s.replaceAll("\\r", ""))))
   }
 }

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/CypherReductionSupportTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/CypherReductionSupportTest.scala
@@ -69,7 +69,7 @@ class CypherReductionSupportTest extends CypherFunSuite with CypherReductionSupp
     val reduced = reduceQuery(query, Some(setup)) { (tryResults: Try[InternalExecutionResult]) =>
       tryResults match {
         case Failure(e:ArithmeticException) =>
-          if(e.getMessage == "/ by zero")
+          if(e.getMessage == "/ by zero" || e.getMessage == "divide by zero")
             Reproduced
           else
             NotReproduced
@@ -85,7 +85,7 @@ class CypherReductionSupportTest extends CypherFunSuite with CypherReductionSupp
     val reduced = reduceQuery(query, Some(setup), enterprise = true) { (tryResults: Try[InternalExecutionResult]) =>
       tryResults match {
         case Failure(e:ArithmeticException) =>
-          if(e.getMessage == "/ by zero")
+          if(e.getMessage == "/ by zero" || e.getMessage == "divide by zero")
             Reproduced
           else
             NotReproduced


### PR DESCRIPTION
Arithmetic exceptions can be "/ by zero" or "divide by zero",
depending on the JDK.
(This is a test-only fix rather than actually making the error
message that comes out platform independent)