### PR TITLE
Flip IndexProxy to failed if population fails while applying last batch

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexStoreView.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexStoreView.java
@@ -96,7 +96,9 @@ public interface IndexStoreView extends PropertyAccessor, PropertyLoader
         }
     };
 
-    IndexStoreView EMPTY = new IndexStoreView()
+    IndexStoreView EMPTY = new Adaptor();
+
+    class Adaptor implements IndexStoreView
     {
         @Override
         public void loadProperties( long nodeId, PrimitiveIntSet propertyIds, PropertyLoadSink sink )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.index;
+
+import org.junit.Test;
+
+import java.util.function.IntPredicate;
+
+import org.neo4j.helpers.collection.Visitor;
+import org.neo4j.internal.kernel.api.IndexCapability;
+import org.neo4j.kernel.api.exceptions.index.ExceptionDuringFlipKernelException;
+import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
+import org.neo4j.kernel.api.index.IndexAccessor;
+import org.neo4j.kernel.api.index.IndexEntryUpdate;
+import org.neo4j.kernel.api.index.IndexPopulator;
+import org.neo4j.kernel.api.index.IndexUpdater;
+import org.neo4j.kernel.api.index.PropertyAccessor;
+import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
+import org.neo4j.kernel.api.schema.LabelSchemaDescriptor;
+import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
+import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
+import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptorFactory;
+import org.neo4j.logging.NullLogProvider;
+import org.neo4j.storageengine.api.schema.PopulationProgress;
+import org.neo4j.values.storable.Values;
+
+import static org.junit.Assert.assertTrue;
+
+public class IndexPopulationTest
+{
+    @Test
+    public void mustFlipToFailedIfFailureToApplyLastBatchWhileFlipping() throws Exception
+    {
+        // given
+        NullLogProvider logProvider = NullLogProvider.getInstance();
+        IndexStoreView storeView = emptyIndexStoreViewThatProcessUpdates();
+        IndexPopulator.Adapter populator = emptyPopulatorWithThrowingUpdater();
+        SchemaIndexDescriptor failedDescriptor = SchemaIndexDescriptorFactory.forLabel( 0, 0 );
+        FailedIndexProxy failedProxy = failedIndexProxy( storeView, populator, failedDescriptor );
+        OnlineIndexProxy onlineProxy = onlineIndexProxy( storeView );
+        FlippableIndexProxy flipper = new FlippableIndexProxy();
+        flipper.setFlipTarget( () -> onlineProxy );
+        MultipleIndexPopulator multipleIndexPopulator = new MultipleIndexPopulator( storeView, logProvider );
+        MultipleIndexPopulator.IndexPopulation indexPopulation =
+                multipleIndexPopulator.addPopulator( populator, 0, dummyMeta(), flipper, t -> failedProxy, "userDescription" );
+        multipleIndexPopulator.queue( someUpdate() );
+        multipleIndexPopulator.indexAllNodes().run();
+
+        // when
+        try
+        {
+            indexPopulation.flip();
+        }
+        catch ( ExceptionDuringFlipKernelException e )
+        {
+            // good
+        }
+
+        // then
+        assertTrue( "flipper should have flipped to failing proxy", flipper.getDescriptor() == failedDescriptor );
+    }
+
+    private OnlineIndexProxy onlineIndexProxy( IndexStoreView storeView )
+    {
+        return new OnlineIndexProxy( 0, dummyMeta(), IndexAccessor.EMPTY, storeView, false );
+    }
+
+    private FailedIndexProxy failedIndexProxy( IndexStoreView storeView, IndexPopulator.Adapter populator, SchemaIndexDescriptor failedDescriptor )
+    {
+        return new FailedIndexProxy( dummyMeta( failedDescriptor ), "userDescription", populator, IndexPopulationFailure
+                .failure( "failure" ), new IndexCountsRemover( storeView, 0 ), NullLogProvider.getInstance() );
+    }
+
+    private IndexPopulator.Adapter emptyPopulatorWithThrowingUpdater()
+    {
+        return new IndexPopulator.Adapter()
+        {
+            @Override
+            public IndexUpdater newPopulatingUpdater( PropertyAccessor accessor )
+            {
+                return new IndexUpdater()
+                {
+                    @Override
+                    public void process( IndexEntryUpdate<?> update ) throws IndexEntryConflictException
+                    {
+                        throw new IndexEntryConflictException( 0, 1, Values.numberValue( 0 ) );
+                    }
+
+                    @Override
+                    public void close()
+                    {
+                    }
+                };
+            }
+        };
+    }
+
+    private IndexStoreView.Adaptor emptyIndexStoreViewThatProcessUpdates()
+    {
+        return new IndexStoreView.Adaptor()
+        {
+            @Override
+            public <FAILURE extends Exception> StoreScan<FAILURE> visitNodes( int[] labelIds, IntPredicate propertyKeyIdFilter,
+                    Visitor<NodeUpdates,FAILURE> propertyUpdateVisitor, Visitor<NodeLabelUpdate,FAILURE> labelUpdateVisitor, boolean forceStoreScan )
+            {
+                //noinspection unchecked
+                return new StoreScan()
+                {
+
+                    @Override
+                    public void run()
+                    {
+                    }
+
+                    @Override
+                    public void stop()
+                    {
+                    }
+
+                    @Override
+                    public PopulationProgress getProgress()
+                    {
+                        return null;
+                    }
+
+                    @Override
+                    public void acceptUpdate( MultipleIndexPopulator.MultipleIndexUpdater updater, IndexEntryUpdate update, long currentlyIndexedNodeId )
+                    {
+                        updater.process( update );
+                    }
+                };
+            }
+        };
+    }
+
+    private IndexMeta dummyMeta()
+    {
+        return dummyMeta( SchemaIndexDescriptorFactory.forLabel( 0, 0 ) );
+    }
+
+    private IndexMeta dummyMeta( SchemaIndexDescriptor schemaIndexDescriptor )
+    {
+        return new IndexMeta( 0, schemaIndexDescriptor,
+                TestIndexProviderDescriptor.PROVIDER_DESCRIPTOR, IndexCapability.NO_CAPABILITY );
+    }
+
+    private IndexEntryUpdate<LabelSchemaDescriptor> someUpdate()
+    {
+        return IndexEntryUpdate.add( 0, SchemaDescriptorFactory.forLabel( 0, 0 ), Values.numberValue( 0 ) );
+    }
+}


### PR DESCRIPTION
If the last batch of index entry updates, being applied to index while flipping index proxy
to online, violate constraint then index proxy should instead flip to failed.

Before, the MultipleIndexUpdater would fail IndexPopulation and thus flipping IndexProxy to
failed. However, because this was done inside of flip it would then incorrecly flip back to online.
Symptom 1: Index will be online even though it has constraint violations.
or
Symptom 2: During shutdown we cannot close PageCache because it still has files that are mapped. This
happens because we fail half way through while opening an IndexAccessor because the underlying index
has been marked as failed. This in turn leave some mapped native index files hanging without anyone
taking care of them and thus not closing them properly.

Now the flip action returns false to indicate that flip was not successful.