### PR TITLE
Improve logging and exception handling

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/ReconnectingChannel.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/ReconnectingChannel.java
@@ -23,7 +23,6 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.EventLoop;
-import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.Promise;
 
@@ -95,7 +94,9 @@ public class ReconnectingChannel implements Channel
         {
             if ( !f.isSuccess() )
             {
-                f.channel().eventLoop().schedule( this::tryConnect, connectionBackoff.getMillis(), MILLISECONDS );
+                long millis = connectionBackoff.getMillis();
+                log.warn( "Failed to connect to: %s. Retrying in %d ms", destination.socketAddress(), millis );
+                f.channel().eventLoop().schedule( this::tryConnect, millis, MILLISECONDS );
                 connectionBackoff.increment();
             }
             else

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/net/Server.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/net/Server.java
@@ -109,8 +109,8 @@ public class Server extends LifecycleAdapter
                 String message = serverName + ": address is already bound: " + listenAddress;
                 userLog.error( message );
                 debugLog.error( message, e );
-                throw e;
             }
+            throw e;
         }
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/net/Server.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/net/Server.java
@@ -99,6 +99,7 @@ public class Server extends LifecycleAdapter
         try
         {
             channel = bootstrap.bind().syncUninterruptibly().channel();
+            debugLog.info( serverName + ": bound to " + listenAddress );
         }
         catch ( Exception e )
         {


### PR DESCRIPTION
Ensure we always re-throw exception when server fails to bind.

Add logging when server has bound.

Add logging when reconnecting channel fails to connect.

Failed request during store copy are now info and not error since they are expected to happen every now and then.