### PR TITLE
Breaks a deadlock in the test discovery service

### DIFF
--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryService.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryService.java
@@ -126,19 +126,22 @@ public final class SharedDiscoveryService
         notifyCoreClients();
     }
 
-    synchronized void casLeaders( LeaderInfo leaderInfo, String dbName )
+    void casLeaders( LeaderInfo leaderInfo, String dbName )
     {
-        Optional<LeaderInfo> current = Optional.ofNullable( leaderMap.get( dbName ) );
-
-        boolean noUpdate = current.map( LeaderInfo::memberId ).equals( Optional.ofNullable( leaderInfo.memberId() ) );
-
-        boolean greaterOrEqualTermExists =  current.map(l -> l.term() >= leaderInfo.term() ).orElse( false );
-
-        boolean success = !( greaterOrEqualTermExists || noUpdate );
-
-        if ( success )
+        synchronized ( leaderMap )
         {
-            leaderMap.put( dbName, leaderInfo );
+            Optional<LeaderInfo> current = Optional.ofNullable( leaderMap.get( dbName ) );
+
+            boolean noUpdate = current.map( LeaderInfo::memberId ).equals( Optional.ofNullable( leaderInfo.memberId() ) );
+
+            boolean greaterOrEqualTermExists = current.map( l -> l.term() >= leaderInfo.term() ).orElse( false );
+
+            boolean success = !(greaterOrEqualTermExists || noUpdate);
+
+            if ( success )
+            {
+                leaderMap.put( dbName, leaderInfo );
+            }
         }
     }
 


### PR DESCRIPTION
This is just a quick-fix breaking the potential for a deadlock
between Raft and the discovery service, where the Raft is notified
of updates through notifyCoreClients() and Discovery is notified
of leader updates through casLeaders(). There is much room for
improvement here in the future.

By performing the "transactional update" of the leaderMap using
a lock only over the leaderMap itself, there is only one point
of synchronization left for the whole of the discovery service.

Note that the synchronization for the notifyCoreClients() can not
be removed since the order of notifications would not be guaranteed
and a lost update phenomena could occur, e.g. ->{1,2}->{1,2,3} could
be observed in the order {1,2,3},{1,2} hence ending up with a
member thinking that the final topology is {1,2}.

A longer term revamp of this component should probably decouple
the discovery services of different members and not have them
call into each other, as happens today. This is a fundamental
design flaw I believe. This is also the reason why this only
is an issue for this test discovery service, and not the
regular discovery service based around hazelcast.