### PR TITLE
Move timeout to after cluster has started.

### DIFF
--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreToCoreCopySnapshotIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreToCoreCopySnapshotIT.java
@@ -135,10 +135,10 @@ public class CoreToCoreCopySnapshotIT
         coreParams.put( raft_log_pruning_frequency.name(), "100ms" );
         coreParams.put( state_machine_flush_window_size.name(), "64" );
         int numberOfTransactions = 100;
-        Timeout timeout = new Timeout( Clocks.systemClock(), 120, SECONDS );
 
         // start the cluster
         Cluster cluster = clusterRule.withSharedCoreParams( coreParams ).startCluster();
+        Timeout timeout = new Timeout( Clocks.systemClock(), 120, SECONDS );
 
         // accumulate some log files
         int firstServerLogFileCount;


### PR DESCRIPTION
At rare occasion the cluster may take up to 120 s to start. This
initiate the timeout after the cluster has started.

This fixes flaky test CoreToCoreCopySnapshotIT.shouldBeAbleToDownloadToRejoinedInstanceAfterPruning