### PR TITLE
Do NOT close system channels as part of outside world close

### DIFF
--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/ParameterisedOutsideWorld.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/ParameterisedOutsideWorld.java
@@ -120,8 +120,5 @@ public class ParameterisedOutsideWorld implements OutsideWorld
     public void close() throws IOException
     {
         fileSystemAbstraction.close();
-        inStream().close();
-        outStream().close();
-        errorStream().close();
     }
 }


### PR DESCRIPTION
Do NOT close system channels.
What if you still think it can be a good idea and what can possibly go wrong?
Here is one example:

Surefire use system channels for communicating across forked VMs
and closing input channel, for example, will trigger forked VM
shutdown without even executing tests that it was already going to execute,
not even mentioning reporting that.