### PR TITLE
Exit on OOM errors during tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <java9.exports/>
     <test.runner.jvm/>
     <test.runner.jvm.settings.additional/>
-    <test.runner.jvm.settings>-Xmx2G -XX:+UseG1GC -XX:-OmitStackTraceInFastThrow -XX:+HeapDumpOnOutOfMemoryError
+    <test.runner.jvm.settings>-Xmx2G -XX:+UseG1GC -XX:-OmitStackTraceInFastThrow -XX:+HeapDumpOnOutOfMemoryError -XX:+ExitOnOutOfMemoryError
       -XX:HeapDumpPath=target/test-data -Dorg.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.DIRTY_MEMORY=true
       -Dorg.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.CHECK_NATIVE_ACCESS=true
       -Dorg.neo4j.io.pagecache.impl.muninn.usePreciseCursorErrorStackTraces=true


### PR DESCRIPTION
Exit on OOM during test execution to avoid cases when test can survive
and hide that OOM.