### PR TITLE
Spatial and Temporal don't assume file existence

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexProvider.java
@@ -140,10 +140,6 @@ public class SpatialIndexProvider extends IndexProvider
         SpatialIndexFiles spatialIndexFiles = new SpatialIndexFiles( directoryStructure(), indexId, fs, settingsFactory );
 
         final Iterable<SpatialIndexFiles.SpatialFileLayout> existing = spatialIndexFiles.existing();
-        if ( !existing.iterator().hasNext() )
-        {
-            return InternalIndexState.ONLINE;
-        }
         InternalIndexState state = InternalIndexState.ONLINE;
         for ( SpatialIndexFiles.SpatialFileLayout subIndex : existing )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexProvider.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.impl.index.schema;
 
 import java.io.IOException;
-import java.nio.file.NoSuchFileException;
 
 import org.neo4j.gis.spatial.index.curves.PartialOverlapConfiguration;
 import org.neo4j.gis.spatial.index.curves.SpaceFillingCurveConfiguration;
@@ -43,7 +42,6 @@ import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.kernel.impl.index.schema.config.SpaceFillingCurveSettingsFactory;
 import org.neo4j.kernel.impl.index.schema.config.SpatialIndexSettings;
 import org.neo4j.kernel.impl.storemigration.StoreMigrationParticipant;
-import org.neo4j.values.storable.CoordinateReferenceSystem;
 import org.neo4j.values.storable.ValueCategory;
 
 public class SpatialIndexProvider extends IndexProvider
@@ -144,9 +142,7 @@ public class SpatialIndexProvider extends IndexProvider
         final Iterable<SpatialIndexFiles.SpatialFileLayout> existing = spatialIndexFiles.existing();
         if ( !existing.iterator().hasNext() )
         {
-            monitor.failedToOpenIndex( indexId, descriptor, "Requesting re-population.",
-                    new NoSuchFileException( spatialIndexFiles.forCrs( CoordinateReferenceSystem.WGS84 ).indexFile.getAbsolutePath() ) );
-            return InternalIndexState.POPULATING;
+            return InternalIndexState.ONLINE;
         }
         InternalIndexState state = InternalIndexState.ONLINE;
         for ( SpatialIndexFiles.SpatialFileLayout subIndex : existing )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexProvider.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.impl.index.schema;
 
 import java.io.IOException;
-import java.nio.file.NoSuchFileException;
 
 import org.neo4j.index.internal.gbptree.MetadataMismatchException;
 import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
@@ -112,9 +111,7 @@ public class TemporalIndexProvider extends IndexProvider
         final Iterable<TemporalIndexFiles.FileLayout> existing = temporalIndexFiles.existing();
         if ( !existing.iterator().hasNext() )
         {
-            monitor.failedToOpenIndex( indexId, descriptor, "Requesting re-population.",
-                    new NoSuchFileException( temporalIndexFiles.date().indexFile.getAbsolutePath() ) );
-            return InternalIndexState.POPULATING;
+            return InternalIndexState.ONLINE;
         }
         InternalIndexState state = InternalIndexState.ONLINE;
         for ( TemporalIndexFiles.FileLayout subIndex : existing )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexProvider.java
@@ -109,10 +109,6 @@ public class TemporalIndexProvider extends IndexProvider
         TemporalIndexFiles temporalIndexFiles = new TemporalIndexFiles( directoryStructure(), indexId, descriptor, fs );
 
         final Iterable<TemporalIndexFiles.FileLayout> existing = temporalIndexFiles.existing();
-        if ( !existing.iterator().hasNext() )
-        {
-            return InternalIndexState.ONLINE;
-        }
         InternalIndexState state = InternalIndexState.ONLINE;
         for ( TemporalIndexFiles.FileLayout subIndex : existing )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberIndexProviderTest.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.index.schema;
 
 import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
+import org.neo4j.internal.kernel.api.InternalIndexState;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexDirectoryStructure;
@@ -42,6 +43,12 @@ public class NumberIndexProviderTest extends NativeIndexProviderTest
                                        Monitor monitor, RecoveryCleanupWorkCollector collector )
     {
         return new NumberIndexProvider( pageCache, fs, dir, monitor, collector, true );
+    }
+
+    @Override
+    protected InternalIndexState expectedStateOnNonExistingSubIndex()
+    {
+        return InternalIndexState.POPULATING;
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialIndexProviderTest.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.index.schema;
 
 import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
+import org.neo4j.internal.kernel.api.InternalIndexState;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexDirectoryStructure;
@@ -44,6 +45,12 @@ public class SpatialIndexProviderTest extends NativeIndexProviderTest
                                        Monitor monitor, RecoveryCleanupWorkCollector collector )
     {
         return new SpatialIndexProvider( pageCache, fs, dir, monitor, collector, true, Config.defaults() );
+    }
+
+    @Override
+    protected InternalIndexState expectedStateOnNonExistingSubIndex()
+    {
+        return InternalIndexState.ONLINE;
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/StringIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/StringIndexProviderTest.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.index.schema;
 
 import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
+import org.neo4j.internal.kernel.api.InternalIndexState;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexDirectoryStructure;
@@ -42,6 +43,12 @@ public class StringIndexProviderTest extends NativeIndexProviderTest
                                        Monitor monitor, RecoveryCleanupWorkCollector collector )
     {
         return new StringIndexProvider( pageCache, fs, dir, monitor, collector, true );
+    }
+
+    @Override
+    protected InternalIndexState expectedStateOnNonExistingSubIndex()
+    {
+        return InternalIndexState.POPULATING;
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TemporalIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/TemporalIndexProviderTest.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.index.schema;
 
 import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
+import org.neo4j.internal.kernel.api.InternalIndexState;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexDirectoryStructure;
@@ -42,6 +43,12 @@ public class TemporalIndexProviderTest extends NativeIndexProviderTest
                                        Monitor monitor, RecoveryCleanupWorkCollector collector )
     {
         return new TemporalIndexProvider( pageCache, fs, dir, monitor, collector, true );
+    }
+
+    @Override
+    protected InternalIndexState expectedStateOnNonExistingSubIndex()
+    {
+        return InternalIndexState.ONLINE;
     }
 
     @Override

--- a/community/neo4j/src/test/java/migration/StartOldDbOn3_4AndCreateFusionIndexIT.java
+++ b/community/neo4j/src/test/java/migration/StartOldDbOn3_4AndCreateFusionIndexIT.java
@@ -25,7 +25,9 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -38,6 +40,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.internal.kernel.api.CapableIndexReference;
 import org.neo4j.internal.kernel.api.IndexQuery;
+import org.neo4j.internal.kernel.api.InternalIndexState;
 import org.neo4j.internal.kernel.api.SchemaRead;
 import org.neo4j.internal.kernel.api.TokenRead;
 import org.neo4j.internal.kernel.api.exceptions.TransactionFailureException;
@@ -48,11 +51,14 @@ import org.neo4j.kernel.api.impl.schema.LuceneIndexProviderFactory;
 import org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory10;
 import org.neo4j.kernel.api.impl.schema.NativeLuceneFusionIndexProviderFactory20;
 import org.neo4j.kernel.api.index.IndexProvider;
+import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.api.KernelStatement;
+import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.store.DefaultIndexReference;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.storageengine.api.StorageStatement;
 import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.test.rule.TestDirectory;
@@ -110,12 +116,16 @@ public class StartOldDbOn3_4AndCreateFusionIndexIT
     {
         // given
         File storeDir = unzip( getClass(), ZIP_FILE_3_2, directory.absolutePath() );
-        GraphDatabaseAPI db = (GraphDatabaseAPI) new GraphDatabaseFactory()
-                .newEmbeddedDatabaseBuilder( storeDir )
-                .setConfig( GraphDatabaseSettings.allow_upgrade, Settings.TRUE )
-                .newGraphDatabase();
+        IndexRecoveryTracker indexRecoveryTracker = new IndexRecoveryTracker();
+
+        // when
+        GraphDatabaseAPI db = setupDb( storeDir, indexRecoveryTracker );
+
+        // then
+        verifyInitialState( indexRecoveryTracker, 2, InternalIndexState.ONLINE );
         try
         {
+            // then
             verifyIndexes( db, LABEL_LUCENE_10 );
 
             // when
@@ -143,12 +153,16 @@ public class StartOldDbOn3_4AndCreateFusionIndexIT
     {
         // given
         File storeDir = unzip( getClass(), ZIP_FILE_3_3, directory.absolutePath() );
-        GraphDatabaseAPI db = (GraphDatabaseAPI) new GraphDatabaseFactory()
-                .newEmbeddedDatabaseBuilder( storeDir )
-                .setConfig( GraphDatabaseSettings.allow_upgrade, Settings.TRUE )
-                .newGraphDatabase();
+        IndexRecoveryTracker indexRecoveryTracker = new IndexRecoveryTracker();
+
+        // when
+        GraphDatabaseAPI db = setupDb( storeDir, indexRecoveryTracker );
+
+        // then
+        verifyInitialState( indexRecoveryTracker, 4, InternalIndexState.ONLINE );
         try
         {
+            // then
             verifyIndexes( db, LABEL_LUCENE_10 );
             verifyIndexes( db, LABEL_FUSION_10 );
 
@@ -176,6 +190,26 @@ public class StartOldDbOn3_4AndCreateFusionIndexIT
         finally
         {
             db.shutdown();
+        }
+    }
+
+    private GraphDatabaseAPI setupDb( File storeDir, IndexRecoveryTracker indexRecoveryTracker )
+    {
+        Monitors monitors = new Monitors();
+        monitors.addMonitorListener( indexRecoveryTracker );
+        return (GraphDatabaseAPI) new GraphDatabaseFactory()
+                .setMonitors( monitors )
+                .newEmbeddedDatabaseBuilder( storeDir )
+                .setConfig( GraphDatabaseSettings.allow_upgrade, Settings.TRUE )
+                .newGraphDatabase();
+    }
+
+    private void verifyInitialState( IndexRecoveryTracker indexRecoveryTracker, int expectedNumberOfIndexes, InternalIndexState expectedInitialState )
+    {
+        assertEquals( "exactly " + expectedNumberOfIndexes + " legacy indexes ", expectedNumberOfIndexes, indexRecoveryTracker.initialStateMap.size() );
+        for ( InternalIndexState actualInitialState : indexRecoveryTracker.initialStateMap.values() )
+        {
+            assertEquals( "initial state is online, don't do recovery", expectedInitialState, actualInitialState );
         }
     }
 
@@ -305,7 +339,7 @@ public class StartOldDbOn3_4AndCreateFusionIndexIT
                 CapableIndexReference index = ktx.schemaRead().index( labelId, propertyKeyIds );
 
                 // wait for index to come online
-                db.schema().awaitIndexesOnline(5, TimeUnit.SECONDS );
+                db.schema().awaitIndexesOnline( 5, TimeUnit.SECONDS );
 
                 int count;
                 StorageStatement storeStatement = ((KernelStatement) statement).getStoreStatement();
@@ -338,5 +372,16 @@ public class StartOldDbOn3_4AndCreateFusionIndexIT
             tx.success();
         }
         return false;
+    }
+
+    private class IndexRecoveryTracker extends IndexingService.MonitorAdapter
+    {
+        Map<SchemaIndexDescriptor,InternalIndexState> initialStateMap = new HashMap<>();
+
+        @Override
+        public void initialState( SchemaIndexDescriptor descriptor, InternalIndexState state )
+        {
+            initialStateMap.put( descriptor, state );
+        }
     }
 }


### PR DESCRIPTION
Removing assumption in Spatial and Temporal index that they will at least
have some file during startup.

When starting a 3.3 store with neo4j-3.4 (with or without doing migration)
all legacy schema indexes would report initial state to be POPULATING
because Spatial and Temporal indexes assumed their files to exist on
startup which is not the case when opening store on 3.4 for the first time.
This caused all indexes to be rebuilt exactly as they where even if they
did not need recovery.

The file existence assumpion in Spatial and Temporal was meant to guard for
if files where deleted but as they both create their subindex files lazily
anyway, this guard did not cover many cases.

Also improve index migration test to verify that no recovery is done for
the old 3.3 indexes during startup.