### PR TITLE
Allow nodes with arbitrary properties when passing them to PointFunction

### DIFF
--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/PointFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/PointFunction.scala
@@ -27,14 +27,27 @@ import org.neo4j.cypher.internal.runtime.interpreted.IsMap
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.QueryState
 import org.neo4j.values.AnyValue
 import org.neo4j.values.storable.{PointValue, Values}
-import org.neo4j.values.virtual.MapValue
+import org.neo4j.values.virtual.{MapValue, VirtualNodeValue, VirtualRelationshipValue, VirtualValues}
+
+import scala.collection.JavaConverters._
 
 case class PointFunction(data: Expression) extends NullInNullOutExpression(data) {
   override def compute(value: AnyValue, ctx: ExecutionContext, state: QueryState): AnyValue = value match {
     case IsMap(mapCreator) =>
       val map = mapCreator(state.query)
-      if (containsNull(map)) Values.NO_VALUE
-      else PointValue.fromMap(map)
+      if (containsNull(map)) {
+        Values.NO_VALUE
+      } else {
+        if (value.isInstanceOf[VirtualNodeValue] || value.isInstanceOf[VirtualRelationshipValue]) {
+          // We need to filter out any non-spatial properties from the map, otherwise PointValue.fromMap will throw
+          val allowedKeys = PointValue.ALLOWED_KEYS
+          val filteredMap = VirtualValues.map(map.getMapCopy.asScala.filterKeys( k => allowedKeys.exists( _.equalsIgnoreCase(k) )).asJava)
+          PointValue.fromMap(filteredMap)
+        }
+        else {
+          PointValue.fromMap(map)
+        }
+      }
     case x => throw new CypherTypeException(s"Expected a map but got $x")
   }
 

--- a/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
@@ -38,6 +38,8 @@ import static java.util.Collections.singletonList;
 
 public class PointValue extends ScalarValue implements Point, Comparable<PointValue>
 {
+    public static String[] ALLOWED_KEYS = new String[]{"crs", "x", "y", "z", "longitude", "latitude", "height", "srid"};
+
     private CoordinateReferenceSystem crs;
     private double[] coordinate;
 


### PR DESCRIPTION
Allow any properties when treating a node/relationship as a map
and passing it to the PointFunction. Simply ignore other properties.