### PR TITLE
Extra cast to fix compilation error

### DIFF
--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedMethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedMethodStructure.scala
@@ -41,7 +41,7 @@ import org.neo4j.cypher.internal.util.v3_4.attribution.Id
 import org.neo4j.cypher.internal.util.v3_4.symbols.{CTInteger, CTNode, CTRelationship, ListType}
 import org.neo4j.cypher.internal.util.v3_4.{ParameterNotFoundException, symbols}
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection
-import org.neo4j.graphdb.{Direction, Node, Relationship}
+import org.neo4j.graphdb.Direction
 import org.neo4j.internal.kernel.api._
 import org.neo4j.internal.kernel.api.helpers.RelationshipSelectionCursor
 import org.neo4j.kernel.impl.util.ValueUtils
@@ -287,7 +287,7 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
   // NOTE: This method assumes that code for converting from null to NoValue for nullable expressions has already been generated outside it
   private def toAnyValue(expression: Expression, codeGenType: CodeGenType, materializeEntities: Boolean): Expression = codeGenType match {
     case CypherCodeGenType(_, _: AnyValueType) =>
-      expression // Already an AnyValue
+      cast(typeRef[AnyValue], expression) // Already an AnyValue
 
     // == Node ==
     case CodeGenType.primitiveNode =>


### PR DESCRIPTION
When running queries with `CYPHER debug=...` ((DebugPrinterTest)[https://github.com/neo4j/neo4j/blob/3.4/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/DebugToStringTest.scala]) from within intellij byte code verification fails. This change fixes this. 