### PR TITLE
Exclude guava from org.bitbucket.inkytonik.kiama dependency.

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/LICENSES.txt
+++ b/enterprise/cypher/acceptance-spec-suite/LICENSES.txt
@@ -8,7 +8,6 @@ Apache Software License, Version 2.0
   Caffeine cache
   ConcurrentLinkedHashMap
   FindBugs-jsr305
-  Guava: Google Core Libraries for Java
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core

--- a/enterprise/cypher/acceptance-spec-suite/NOTICE.txt
+++ b/enterprise/cypher/acceptance-spec-suite/NOTICE.txt
@@ -30,7 +30,6 @@ Apache Software License, Version 2.0
   Caffeine cache
   ConcurrentLinkedHashMap
   FindBugs-jsr305
-  Guava: Google Core Libraries for Java
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core

--- a/enterprise/cypher/compatibility-spec-suite/LICENSES.txt
+++ b/enterprise/cypher/compatibility-spec-suite/LICENSES.txt
@@ -8,7 +8,6 @@ Apache Software License, Version 2.0
   Caffeine cache
   ConcurrentLinkedHashMap
   FindBugs-jsr305
-  Guava: Google Core Libraries for Java
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core

--- a/enterprise/cypher/compatibility-spec-suite/NOTICE.txt
+++ b/enterprise/cypher/compatibility-spec-suite/NOTICE.txt
@@ -30,7 +30,6 @@ Apache Software License, Version 2.0
   Caffeine cache
   ConcurrentLinkedHashMap
   FindBugs-jsr305
-  Guava: Google Core Libraries for Java
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core

--- a/enterprise/cypher/cypher/LICENSES.txt
+++ b/enterprise/cypher/cypher/LICENSES.txt
@@ -8,7 +8,6 @@ Apache Software License, Version 2.0
   Caffeine cache
   ConcurrentLinkedHashMap
   FindBugs-jsr305
-  Guava: Google Core Libraries for Java
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core

--- a/enterprise/cypher/cypher/NOTICE.txt
+++ b/enterprise/cypher/cypher/NOTICE.txt
@@ -30,7 +30,6 @@ Apache Software License, Version 2.0
   Caffeine cache
   ConcurrentLinkedHashMap
   FindBugs-jsr305
-  Guava: Google Core Libraries for Java
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core

--- a/enterprise/cypher/cypher/pom.xml
+++ b/enterprise/cypher/cypher/pom.xml
@@ -269,6 +269,10 @@
           <groupId>org.bitbucket.inkytonik.dsprofile</groupId>
           <artifactId>dsprofile_2.11</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/enterprise/neo4j-harness-enterprise/LICENSES.txt
+++ b/enterprise/neo4j-harness-enterprise/LICENSES.txt
@@ -27,7 +27,6 @@ Apache Software License, Version 2.0
   Data Mapper for Jackson
   FindBugs-jsr305
   Graphite Integration for Metrics
-  Guava: Google Core Libraries for Java
   hazelcast-all
   Jackson
   JAX-RS provider for JSON content type

--- a/enterprise/neo4j-harness-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-harness-enterprise/NOTICE.txt
@@ -49,7 +49,6 @@ Apache Software License, Version 2.0
   Data Mapper for Jackson
   FindBugs-jsr305
   Graphite Integration for Metrics
-  Guava: Google Core Libraries for Java
   hazelcast-all
   Jackson
   JAX-RS provider for JSON content type

--- a/enterprise/server-enterprise/LICENSES.txt
+++ b/enterprise/server-enterprise/LICENSES.txt
@@ -27,7 +27,6 @@ Apache Software License, Version 2.0
   Data Mapper for Jackson
   FindBugs-jsr305
   Graphite Integration for Metrics
-  Guava: Google Core Libraries for Java
   hazelcast-all
   Jackson
   JAX-RS provider for JSON content type

--- a/enterprise/server-enterprise/NOTICE.txt
+++ b/enterprise/server-enterprise/NOTICE.txt
@@ -49,7 +49,6 @@ Apache Software License, Version 2.0
   Data Mapper for Jackson
   FindBugs-jsr305
   Graphite Integration for Metrics
-  Guava: Google Core Libraries for Java
   hazelcast-all
   Jackson
   JAX-RS provider for JSON content type


### PR DESCRIPTION
We verified using `mvn dependency:tree` that guava is now excluded. 