### PR TITLE
Precompute inputs to map

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/FieldSignature.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/FieldSignature.java
@@ -48,9 +48,16 @@ public class FieldSignature
     {
         return new FieldSignature( name, type, null, false )
         {
+            @Override
             public Object map( Object input )
             {
                 return mapper.map( input );
+            }
+
+            @Override
+            public boolean needsMapping()
+            {
+                return true;
             }
         };
     }
@@ -59,9 +66,16 @@ public class FieldSignature
     {
         return new FieldSignature( name, type, requireNonNull( defaultValue, "defaultValue" ), false )
         {
+            @Override
             public Object map( Object input )
             {
                 return mapper.map( input );
+            }
+
+            @Override
+            public boolean needsMapping()
+            {
+                return true;
             }
         };
     }
@@ -96,6 +110,11 @@ public class FieldSignature
                         type.toString(), defaultValue.neo4jType().toString() ) );
             }
         }
+    }
+
+    public boolean needsMapping()
+    {
+        return false;
     }
 
     /** Fields that are not supported full stack (ie. by Cypher) need to be mapped from Cypher to internal types */

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/UserFunctionSignature.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/UserFunctionSignature.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.api.proc;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
@@ -848,6 +848,8 @@ class ReflectiveProcedureCompiler
                 inject( ctx, cls );
                 Object aggregator = creator.invoke( cls );
 
+                List<FieldSignature> inputSignature = signature.inputSignature();
+                int expectedNumberOfInputs = inputSignature.size();
                 return new Aggregator()
                 {
                     @Override
@@ -855,13 +857,12 @@ class ReflectiveProcedureCompiler
                     {
                         try
                         {
-                            List<FieldSignature> inputSignature = signature.inputSignature();
-                            if ( inputSignature.size() != input.length )
+                            if ( expectedNumberOfInputs != input.length )
                             {
                                 throw new ProcedureException( Status.Procedure.ProcedureCallFailed,
                                         "Function `%s` takes %d arguments but %d was provided.",
                                         signature.name(),
-                                        inputSignature.size(), input.length );
+                                        expectedNumberOfInputs, input.length );
                             }
                             // Some input fields are not supported by Cypher and need to be mapped
                             for ( int indexToMap : indexesToMap )


### PR DESCRIPTION
Recently when adding support for byte arrays in procedures et al we
introduced a mapping of the input to the procedure so that we can
to byte arrays as necessary. However this means that we will attempt
to map all inputs, byte arrays or not which introduced a regression.
This PR precomputes the inputs that needs mapping and updates only
those.