### PR TITLE
Close signal on inactive or exception in the pipeline.

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpResponseHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpResponseHandler.java
@@ -51,4 +51,8 @@ public interface CatchUpResponseHandler
     void onCoreSnapshot( CoreSnapshot coreSnapshot );
 
     void onStoreListingResponse( PrepareStoreCopyResponse storeListingRequest );
+
+    void onChannelInactive();
+
+    void onException( Throwable cause );
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileChunkHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileChunkHandler.java
@@ -22,6 +22,8 @@ package org.neo4j.causalclustering.catchup.storecopy;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 
+import java.io.IOException;
+
 import org.neo4j.causalclustering.catchup.CatchUpResponseHandler;
 import org.neo4j.causalclustering.catchup.CatchupClientProtocol;
 
@@ -37,7 +39,7 @@ public class FileChunkHandler extends SimpleChannelInboundHandler<FileChunk>
     }
 
     @Override
-    protected void channelRead0( ChannelHandlerContext ctx, FileChunk fileChunk ) throws Exception
+    protected void channelRead0( ChannelHandlerContext ctx, FileChunk fileChunk ) throws IOException
     {
         if ( handler.onFileContent( fileChunk ) )
         {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyProcess.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyProcess.java
@@ -57,6 +57,6 @@ public class StoreCopyProcess
             copiedStoreRecovery.recoverCopiedStore( tempStore.storeDir() );
             localDatabase.replaceWith( tempStore.storeDir() );
         }
-        log.info( "Replaced store with one downloaded from %s", addressProvider );
+        log.info( "Replaced store" );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/TrackingResponseHandlerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/TrackingResponseHandlerTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.catchup;
+
+import org.junit.Test;
+
+import java.time.Clock;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class TrackingResponseHandlerTest
+{
+    @Test
+    public void shouldCompleteSignalExceptionallyOnInactive()
+    {
+        // given
+        TrackingResponseHandler trackingResponseHandler = new TrackingResponseHandler( new CatchUpResponseAdaptor(), Clock.systemUTC() );
+        CompletableFuture<Object> future = new CompletableFuture<>();
+        trackingResponseHandler.setResponseHandler( new CatchUpResponseAdaptor(), future );
+
+        // when
+        trackingResponseHandler.onChannelInactive();
+
+        // then
+        assertTrue( future.isCompletedExceptionally() );
+        Throwable cause = null;
+        try
+        {
+            future.get();
+        }
+        catch ( InterruptedException e )
+        {
+            fail();
+        }
+        catch ( ExecutionException e )
+        {
+            cause = e.getCause();
+        }
+        assertNotNull( cause );
+        assertEquals( IllegalStateException.class, cause.getClass() );
+        assertEquals( "Channel inactive", cause.getMessage() );
+    }
+
+    @Test
+    public void shouldCompleteSignalExceptionallyOnException()
+    {
+        // given
+        TrackingResponseHandler trackingResponseHandler = new TrackingResponseHandler( new CatchUpResponseAdaptor(), Clock.systemUTC() );
+        CompletableFuture<Object> future = new CompletableFuture<>();
+        trackingResponseHandler.setResponseHandler( new CatchUpResponseAdaptor(), future );
+
+        IllegalArgumentException error = new IllegalArgumentException( "error" );
+
+        // when
+        trackingResponseHandler.onException( error );
+
+        // then
+        assertTrue( future.isCompletedExceptionally() );
+        Throwable cause = null;
+        try
+        {
+            future.get();
+        }
+        catch ( InterruptedException e )
+        {
+            fail();
+        }
+        catch ( ExecutionException e )
+        {
+            cause = e.getCause();
+        }
+        assertNotNull( cause );
+        assertEquals( error, cause );
+    }
+}


### PR DESCRIPTION
This makes sure the signal is completed exceptionally if either
channel inactive is called or an exception is thrown in the pipeline.
Before the request would always wait for the 20 s timeout to complete.