### PR TITLE
Backup rotation fix

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/test/rule/EmbeddedDatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/EmbeddedDatabaseRule.java
@@ -71,7 +71,7 @@ public class EmbeddedDatabaseRule extends DatabaseRule
     @Override
     protected GraphDatabaseBuilder newBuilder( GraphDatabaseFactory factory )
     {
-        return factory.newEmbeddedDatabaseBuilder( testDirectory.graphDbDir() );
+        return factory.newEmbeddedDatabaseBuilder( getStoreDir() );
     }
 
     @Override

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupCopyService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupCopyService.java
@@ -70,6 +70,7 @@ class BackupCopyService
             {
                 moves.next().move( target );
             }
+            oldLocation.toFile().delete();
         }
         catch ( IOException e )
         {

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupStrategyWrapper.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupStrategyWrapper.java
@@ -74,8 +74,7 @@ class BackupStrategyWrapper
         return state;
     }
 
-    private Fallible<BackupStrategyOutcome> performBackupWithoutLifecycle(
-            OnlineBackupContext onlineBackupContext )
+    private Fallible<BackupStrategyOutcome> performBackupWithoutLifecycle( OnlineBackupContext onlineBackupContext )
     {
         Path backupLocation = onlineBackupContext.getResolvedLocationFromName();
         Path userSpecifiedBackupLocation = onlineBackupContext.getResolvedLocationFromName();
@@ -136,8 +135,7 @@ class BackupStrategyWrapper
      * @param onlineBackupContext command line arguments, config etc.
      * @return outcome of full backup
      */
-    private Fallible<BackupStageOutcome> fullBackupWithTemporaryFolderResolutions(
-            OnlineBackupContext onlineBackupContext )
+    private Fallible<BackupStageOutcome> fullBackupWithTemporaryFolderResolutions( OnlineBackupContext onlineBackupContext )
     {
         Path userSpecifiedBackupLocation = onlineBackupContext.getResolvedLocationFromName();
         Path temporaryFullBackupLocation = backupCopyService.findAnAvailableLocationForNewFullBackup( userSpecifiedBackupLocation );
@@ -146,12 +144,12 @@ class BackupStrategyWrapper
         Fallible<BackupStageOutcome> state = backupStrategy.performFullBackup( temporaryFullBackupLocation, config, address );
 
         // NOTE temporaryFullBackupLocation can be equal to desired
-        boolean aBackupAlreadyExisted = userSpecifiedBackupLocation.equals( temporaryFullBackupLocation );
+        boolean backupWasMadeToATemporaryLocation = !userSpecifiedBackupLocation.equals( temporaryFullBackupLocation );
 
         if ( BackupStageOutcome.SUCCESS.equals( state.getState() ) )
         {
             backupRecoveryService.recoverWithDatabase( temporaryFullBackupLocation, pageCache, config );
-            if ( !aBackupAlreadyExisted )
+            if ( backupWasMadeToATemporaryLocation )
             {
                 try
                 {

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupCommandHaIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupCommandHaIT.java
@@ -48,6 +48,8 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
@@ -66,6 +68,7 @@ import static java.lang.String.format;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
@@ -110,6 +113,19 @@ public class OnlineBackupCommandHaIT
         }
     }
 
+    private static void createSpecificNodePair( GraphDatabaseService db, String name )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node left = db.createNode();
+            left.setProperty( "name", name + "Left" );
+            Node right = db.createNode();
+            right.setProperty( "name", name + "Right" );
+            right.createRelationshipTo( left, RelationshipType.withName( "KNOWS" ) );
+            tx.success();
+        }
+    }
+
     @Before
     public void resetTasks()
     {
@@ -143,7 +159,7 @@ public class OnlineBackupCommandHaIT
                         "--cc-report-dir=" + backupDir,
                         "--backup-dir=" + backupDir,
                         "--name=" + backupName ) );
-        assertEquals( getDbRepresentation(), getBackupDbRepresentation( backupName ) );
+        assertEquals( DbRepresentation.of( db ), getBackupDbRepresentation( backupName ) );
         createSomeData( db );
         assertEquals(
                 0,
@@ -151,7 +167,7 @@ public class OnlineBackupCommandHaIT
                         "--cc-report-dir=" + backupDir,
                         "--backup-dir=" + backupDir,
                         "--name=" + backupName ) );
-        assertEquals( getDbRepresentation(), getBackupDbRepresentation( backupName ) );
+        assertEquals( DbRepresentation.of( db ), getBackupDbRepresentation( backupName ) );
     }
 
     @Test
@@ -289,6 +305,48 @@ public class OnlineBackupCommandHaIT
         assertFalse( output.contains( "Finished receiving index snapshots" ) );
     }
 
+    @Test
+    public void backupRenamesWork() throws Exception
+    {
+        // given a prexisting backup from a different store
+        String backupName = "preexistingBackup_" + recordFormat;
+        int firstBackupPort = PortAuthority.allocatePort();
+        startDb( firstBackupPort );
+        createSpecificNodePair( db, "first" );
+
+        assertEquals( 0, runSameJvm( backupDir, backupName,
+                "--from", "127.0.0.1:" + firstBackupPort,
+                "--cc-report-dir=" + backupDir,
+                "--protocol=common",
+                "--backup-dir=" + backupDir,
+                "--name=" + backupName ) );
+        DbRepresentation firstDatabaseRepresentation = DbRepresentation.of( db );
+
+        // and a different database
+        int secondBackupPort = PortAuthority.allocatePort();
+        GraphDatabaseService db2 = createDb2( secondBackupPort );
+        createSpecificNodePair( db2, "second" );
+        DbRepresentation secondDatabaseRepresentation = DbRepresentation.of( db2 );
+
+        // when backup is performed
+        assertEquals( 0, runSameJvm(backupDir, backupName,
+                "--from", "127.0.0.1:" + secondBackupPort,
+                "--cc-report-dir=" + backupDir,
+                "--backup-dir=" + backupDir,
+                "--protocol=common",
+                "--name=" + backupName ) );
+
+        // then the new backup has the correct name
+        assertEquals( secondDatabaseRepresentation, getBackupDbRepresentation( backupName ) );
+
+        // and the old backup is in a renamed location
+        assertEquals( firstDatabaseRepresentation, getBackupDbRepresentation( backupName + ".err.0" ) );
+
+        // and the data isn't equal (sanity check)
+        assertNotEquals( firstDatabaseRepresentation, secondDatabaseRepresentation );
+        db2.shutdown();
+    }
+
     private void repeatedlyPopulateDatabase( GraphDatabaseService db, AtomicBoolean continueFlagReference )
     {
         while ( continueFlagReference.get() )
@@ -313,7 +371,21 @@ public class OnlineBackupCommandHaIT
         }
     }
 
+    private GraphDatabaseService createDb2( Integer backupPort )
+    {
+        File storeDir = testDirectory.directory("graph-db-2");
+        GraphDatabaseFactory factory = new GraphDatabaseFactory();
+        GraphDatabaseBuilder builder = factory.newEmbeddedDatabaseBuilder( storeDir );
+        builder.setConfig( OnlineBackupSettings.online_backup_server, "0.0.0.0:" + backupPort );
+        return builder.newGraphDatabase();
+    }
+
     private void startDb( Integer backupPort )
+    {
+        startDb( db, backupPort );
+    }
+
+    private void startDb( EmbeddedDatabaseRule db, Integer backupPort )
     {
         db.setConfig( GraphDatabaseSettings.record_format, recordFormat );
         db.setConfig( OnlineBackupSettings.online_backup_enabled, Settings.TRUE );
@@ -333,9 +405,18 @@ public class OnlineBackupCommandHaIT
         return runBackupToolFromOtherJvmToGetExitCode( neo4jHome, args );
     }
 
-    private DbRepresentation getDbRepresentation()
+    private static int runSameJvm( File home, String name, String... args )
     {
-        return DbRepresentation.of( db );
+        try
+        {
+            new OnlineBackupCommandBuilder().withRawArgs( args ).backup( home, name );
+            return 0;
+        }
+        catch ( Exception e )
+        {
+            e.printStackTrace();
+            return 1;
+        }
     }
 
     private DbRepresentation getBackupDbRepresentation( String name )

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/FileMoveAction.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/FileMoveAction.java
@@ -74,6 +74,7 @@ public interface FileMoveAction
                 Path resolvedPath = toDir.toPath().resolve( relativePath );
                 Files.createDirectories( resolvedPath.getParent() );
                 Files.copy( originalPath, resolvedPath, copyOptions );
+                Files.delete( originalPath );
             }
 
             @Override

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/FileMoveProvider.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/FileMoveProvider.java
@@ -126,7 +126,7 @@ public class FileMoveProvider
         File base = basePath; // Capture effectively-final base path snapshot.
         Stream<File> files = listing.stream().filter( this::isFile );
         Stream<File> dirs = listing.stream().filter( this::isDirectory );
-        Stream<FileMoveAction> moveFiles = files.map( f -> copyFileCorrectly( f, base ) );
+        Stream<FileMoveAction> moveFiles = files.map( f -> moveFileCorrectly( f, base ) );
         Stream<FileMoveAction> traverseDirectories = dirs.flatMap( d -> traverseForMoving( d, base ) );
         return Stream.concat( moveFiles, traverseDirectories );
     }
@@ -171,7 +171,7 @@ public class FileMoveProvider
      * contains the logic for handling files between
      * the 2 systems
      */
-    private FileMoveAction copyFileCorrectly( File fileToMove, File basePath )
+    private FileMoveAction moveFileCorrectly( File fileToMove, File basePath )
     {
         if ( fileMoveActionInformer.shouldBeManagedByPageCache( fileToMove.getName() ) )
         {

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/FileMoveActionTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/FileMoveActionTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j Enterprise Edition. The included source
+ * code can be redistributed and/or modified under the terms of the
+ * GNU AFFERO GENERAL PUBLIC LICENSE Version 3
+ * (http://www.fsf.org/licensing/licenses/agpl-3.0.html) with the
+ * Commons Clause, as found in the associated LICENSE.txt file.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * Neo4j object code can be licensed independently from the source
+ * under separate terms from the AGPL. Inquiries can be directed to:
+ * licensing@neo4j.com
+ *
+ * More information is also available at:
+ * https://neo4j.com/licensing/
+ */
+package org.neo4j.com.storecopy;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.StandardOpenOption;
+
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.pagecache.ConfigurableStandalonePageCacheFactory;
+import org.neo4j.test.rule.TestDirectory;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FileMoveActionTest
+{
+    @Rule
+    public final TestDirectory testDirectory = TestDirectory.testDirectory();
+
+    private FileSystemAbstraction fileSystemAbstraction = new DefaultFileSystemAbstraction();
+    private Config config = Config.defaults();
+
+    @Test
+    public void pageCacheFilesMovedDoNotLeaveOriginal() throws IOException
+    {
+        // given
+        PageCache pageCache = aPageCache();
+
+        // and
+        File pageCacheFile = new File( "page-cache-file" );
+        pageCache.map( pageCacheFile, 100, StandardOpenOption.CREATE );
+
+        // when
+        File targetRename = new File( "target" );
+        FileMoveAction.copyViaPageCache( pageCacheFile, pageCache ).move( targetRename );
+
+        // then
+        assertFalse( pageCacheFile.exists() );
+        assertTrue( targetRename.exists() );
+    }
+
+    @Test
+    public void nonPageCacheFilesMovedDoNotLeaveOriginal() throws IOException
+    {
+        // given
+        File baseDirectory = testDirectory.directory();
+        File sourceDirectory = new File( baseDirectory, "source" );
+        File targetDirectory = new File( baseDirectory, "target" );
+        File sourceFile = new File( sourceDirectory, "theFileName" );
+        File targetFile = new File( targetDirectory, "theFileName" );
+        sourceFile.getParentFile().mkdirs();
+        targetDirectory.mkdirs();
+
+        // and sanity check
+        assertTrue( sourceFile.createNewFile() );
+        assertTrue( sourceFile.exists() );
+        assertFalse( targetFile.exists() );
+
+        // when
+        FileMoveAction.copyViaFileSystem( sourceFile, sourceDirectory ).move( targetDirectory );
+
+        // then
+        assertTrue( targetFile.exists() );
+        assertFalse( sourceFile.exists() );
+    }
+
+    private PageCache aPageCache()
+    {
+        return ConfigurableStandalonePageCacheFactory.createPageCache( fileSystemAbstraction, config );
+    }
+}

--- a/enterprise/kernel/src/test/java/org/neo4j/util/TestHelpers.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/util/TestHelpers.java
@@ -107,6 +107,5 @@ public class TestHelpers
 
         return hostnamePort.toString();
     }
-
 }
 


### PR DESCRIPTION
FileMoveActions on non page cache files are copied. This is evident when backups are made to a temporary directory and then renamed when successful.

This change fixes file move actions to always move and not copy.