### PR TITLE
Add USING INDEX SEEK hint to Neo4j Cypher

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/AbstractIndexSeekLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/AbstractIndexSeekLeafPlanner.scala
@@ -116,7 +116,7 @@ abstract class AbstractIndexSeekLeafPlanner extends LeafPlanner with LeafPlanFro
       val name = idName.name
       val propertyNames = plannables.map(_.propertyKeyName.name)
       hints.collectFirst {
-        case hint@UsingIndexHint(Variable(`name`), `labelName`, properties)
+        case hint@UsingIndexHint(Variable(`name`), `labelName`, properties, _)
           if properties.map(_.name) == propertyNames => hint
       }
     }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/indexScanLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/indexScanLeafPlanner.scala
@@ -91,8 +91,8 @@ object indexScanLeafPlanner extends LeafPlanner with LeafPlanFromExpression {
          labelId <- labelName.id)
       yield {
         val hint = qg.hints.collectFirst {
-          case hint@UsingIndexHint(Variable(`variableName`), `labelName`, properties)
-            if properties.map(_.name) == Seq(propertyKeyName) => hint
+          case hint@UsingIndexHint(Variable(`variableName`), `labelName`, properties, spec)
+            if spec.fulfilledByScan && properties.map(_.name) == Seq(propertyKeyName) => hint
         }
         val keyToken = PropertyKeyToken(property.propertyKey, property.propertyKey.id.head)
         val labelToken = LabelToken(labelName, labelId)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/uniqueIndexSeekLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/uniqueIndexSeekLeafPlanner.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v3_2.commands.QueryExpression
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.LogicalPlanningContext
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.LogicalPlan
-import org.neo4j.cypher.internal.frontend.v3_2.ast.{Expression, LabelToken, PropertyKeyToken, UsingIndexHint}
+import org.neo4j.cypher.internal.frontend.v3_2.ast._
 import org.neo4j.cypher.internal.ir.v3_2.IdName
 
 object uniqueIndexSeekLeafPlanner extends AbstractIndexSeekLeafPlanner {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/verifyBestPlan.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/verifyBestPlan.scala
@@ -107,7 +107,7 @@ object verifyBestPlan extends PlanTransformer[PlannerQuery] {
   private def findUnfulfillableIndexHints(query: PlannerQuery, planContext: PlanContext): Seq[UsingIndexHint] = {
     query.allHints.flatMap {
       // using index name:label(property1,property2)
-      case UsingIndexHint(_, LabelName(label), properties)
+      case UsingIndexHint(_, LabelName(label), properties, _)
         if planContext.indexGet(label, properties.map(_.name)).isDefined ||
           planContext.uniqueIndexGet(label, properties.map(_.name)).isDefined => None
       // no such index exists

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/Clause.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/Clause.scala
@@ -108,7 +108,7 @@ case class Match(optional: Boolean, pattern: Pattern, hints: Seq[UsingHint], whe
 
   private def checkHints: SemanticCheck = {
     val error: Option[SemanticCheck] = hints.collectFirst {
-      case hint@UsingIndexHint(Variable(variable), LabelName(labelName), properties)
+      case hint@UsingIndexHint(Variable(variable), LabelName(labelName), properties, _)
         if !containsLabelPredicate(variable, labelName) ||
            !containsPropertyPredicates(variable, properties) =>
         SemanticError(

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/Hint.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/Hint.scala
@@ -52,11 +52,22 @@ sealed trait LegacyIndexHint extends UsingHint {
   def variables = NonEmptyList(variable)
 }
 
-case class UsingIndexHint(variable: Variable, label: LabelName, properties: Seq[PropertyKeyName])(val position: InputPosition) extends UsingHint with NodeHint {
+sealed trait UsingIndexHintSpec {
+  def fulfilledByScan: Boolean
+}
+case object SeekOnly extends UsingIndexHintSpec {
+  override def fulfilledByScan: Boolean = false
+}
+case object SeekOrScan extends UsingIndexHintSpec {
+  override def fulfilledByScan: Boolean = true
+}
+
+case class UsingIndexHint(variable: Variable, label: LabelName, properties: Seq[PropertyKeyName],
+                          spec: UsingIndexHintSpec = SeekOrScan)(val position: InputPosition) extends UsingHint with NodeHint {
   def variables = NonEmptyList(variable)
   def semanticCheck = variable.ensureDefined chain variable.expectType(CTNode.covariant)
 
-  override def toString: String = s"USING INDEX ${variable.name}:${label.name}(${properties.map(_.name).mkString(", ")})"
+  override def toString: String = s"USING INDEX ${if(spec == SeekOnly) "SEEK " else ""}${variable.name}:${label.name}(${properties.map(_.name).mkString(", ")})"
 }
 
 case class UsingScanHint(variable: Variable, label: LabelName)(val position: InputPosition) extends UsingHint with NodeHint {

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/parser/Clauses.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/parser/Clauses.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher.internal.frontend.v3_2.parser
 
 import org.neo4j.cypher.internal.frontend.v3_2.ast
+import org.neo4j.cypher.internal.frontend.v3_2.ast.{SeekOnly, SeekOrScan}
 import org.parboiled.scala._
 
 trait Clauses extends Parser
@@ -115,7 +116,8 @@ trait Clauses extends Parser
   )
 
   private def Hint: Rule1[ast.UsingHint] = rule("USING")(
-    group(keyword("USING INDEX") ~~ Variable ~~ NodeLabel ~~ "(" ~~ oneOrMore(PropertyKeyName, separator = CommaSep) ~~ ")") ~~>> (ast.UsingIndexHint(_, _, _))
+    group(keyword("USING INDEX SEEK") ~~ Variable ~~ NodeLabel ~~ "(" ~~ oneOrMore(PropertyKeyName, separator = CommaSep) ~~ ")") ~~>> (ast.UsingIndexHint(_, _, _, SeekOnly))
+      | group(keyword("USING INDEX") ~~ Variable ~~ NodeLabel ~~ "(" ~~ oneOrMore(PropertyKeyName, separator = CommaSep) ~~ ")") ~~>> (ast.UsingIndexHint(_, _, _, SeekOrScan))
       | group(keyword("USING JOIN ON") ~~ oneOrMore(Variable, separator = CommaSep)) ~~>> (ast.UsingJoinHint(_))
       | group(keyword("USING SCAN") ~~ Variable ~~ NodeLabel) ~~>> (ast.UsingScanHint(_, _))
   )


### PR DESCRIPTION
The pre-existing hint `USING INDEX` can be fulfilled by both
index seek and index scan. `USING INDEX SEEK` follows the same syntax,
but is more specific and is only fulfilled by index seek.

This can be used in cases where the planner picks a plan with an
index scan based on lower cost estimation, that turns out to
perform badly in practice.