### PR TITLE
Coordinates instantiate/close in spatial/temporal indexes 

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexAccessor.java
@@ -106,6 +106,7 @@ class SpatialIndexAccessor extends SpatialIndexCache<SpatialIndexAccessor.PartAc
     @Override
     public void close() throws IOException
     {
+        shutInstantiateCloseLock();
         forAll( NativeSchemaIndexAccessor::close, this );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexAccessor.java
@@ -106,7 +106,7 @@ class SpatialIndexAccessor extends SpatialIndexCache<SpatialIndexAccessor.PartAc
     @Override
     public void close() throws IOException
     {
-        shutInstantiateCloseLock();
+        closeInstantiateCloseLock();
         forAll( NativeSchemaIndexAccessor::close, this );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPopulator.java
@@ -115,7 +115,7 @@ class SpatialIndexPopulator extends SpatialIndexCache<SpatialIndexPopulator.Part
     @Override
     public synchronized void close( boolean populationCompletedSuccessfully ) throws IOException
     {
-        shutInstantiateCloseLock();
+        closeInstantiateCloseLock();
         for ( NativeSchemaIndexPopulator part : this )
         {
             part.close( populationCompletedSuccessfully );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPopulator.java
@@ -24,8 +24,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
-import java.util.stream.StreamSupport;
 import java.util.Map;
+import java.util.stream.StreamSupport;
 
 import org.neo4j.gis.spatial.index.curves.SpaceFillingCurveConfiguration;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -115,6 +115,7 @@ class SpatialIndexPopulator extends SpatialIndexCache<SpatialIndexPopulator.Part
     @Override
     public synchronized void close( boolean populationCompletedSuccessfully ) throws IOException
     {
+        shutInstantiateCloseLock();
         for ( NativeSchemaIndexPopulator part : this )
         {
             part.close( populationCompletedSuccessfully );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexAccessor.java
@@ -96,6 +96,7 @@ class TemporalIndexAccessor extends TemporalIndexCache<TemporalIndexAccessor.Par
     @Override
     public void close() throws IOException
     {
+        shutInstantiateCloseLock();
         forAll( NativeSchemaIndexAccessor::close, this );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulator.java
@@ -24,9 +24,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
-import java.util.stream.StreamSupport;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.StreamSupport;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
@@ -110,6 +109,7 @@ class TemporalIndexPopulator extends TemporalIndexCache<TemporalIndexPopulator.P
     @Override
     public synchronized void close( boolean populationCompletedSuccessfully ) throws IOException
     {
+        shutInstantiateCloseLock();
         for ( NativeSchemaIndexPopulator part : this )
         {
             part.close( populationCompletedSuccessfully );

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
@@ -147,6 +147,11 @@ public abstract class IndexProviderCompatibilityTestSuite
 
         void withPopulator( IndexPopulator populator, ThrowingConsumer<IndexPopulator,Exception> runWithPopulator ) throws Exception
         {
+            withPopulator( populator, runWithPopulator, true );
+        }
+
+        void withPopulator( IndexPopulator populator, ThrowingConsumer<IndexPopulator,Exception> runWithPopulator, boolean closeSuccessfully ) throws Exception
+        {
             try
             {
                 populator.create();
@@ -154,20 +159,7 @@ public abstract class IndexProviderCompatibilityTestSuite
             }
             finally
             {
-                try
-                {
-                    populator.close( true );
-                }
-                catch ( Exception e )
-                {
-                    try
-                    {
-                        populator.close( false );
-                    }
-                    catch ( Exception inner )
-                    {   // ignore
-                    }
-                }
+                populator.close( closeSuccessfully );
             }
         }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/SimpleIndexPopulatorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/SimpleIndexPopulatorCompatibility.java
@@ -79,7 +79,7 @@ public class SimpleIndexPopulatorCompatibility extends IndexProviderCompatibilit
         String failure = "The contrived failure";
         IndexSamplingConfig indexSamplingConfig = new IndexSamplingConfig( Config.defaults() );
         // WHEN (this will attempt to call close)
-        withPopulator( indexProvider.getPopulator( 17, descriptor, indexSamplingConfig ), p -> p.markAsFailed( failure ) );
+        withPopulator( indexProvider.getPopulator( 17, descriptor, indexSamplingConfig ), p -> p.markAsFailed( failure ), false );
         // THEN
         assertThat( indexProvider.getPopulationFailure( 17, descriptor ), containsString( failure ) );
     }
@@ -98,7 +98,7 @@ public class SimpleIndexPopulatorCompatibility extends IndexProviderCompatibilit
 
             // THEN
             assertEquals( FAILED, indexProvider.getInitialState( 17, descriptor ) );
-        } );
+        }, false );
     }
 
     @Test
@@ -144,7 +144,6 @@ public class SimpleIndexPopulatorCompatibility extends IndexProviderCompatibilit
                 PrimitiveLongIterator nodes = reader.query( IndexQuery.exact( propertyKeyId, propertyValue ) );
                 assertEquals( asSet( 1L ), PrimitiveLongCollections.toSet( nodes ) );
             }
-            accessor.close();
         }
     }
 
@@ -206,7 +205,6 @@ public class SimpleIndexPopulatorCompatibility extends IndexProviderCompatibilit
                     assertEquals( entry.nodeId, single( nodes, NO_SUCH_NODE ) );
                 }
             }
-            accessor.close();
         }
     }
 
@@ -236,7 +234,6 @@ public class SimpleIndexPopulatorCompatibility extends IndexProviderCompatibilit
                     assertEquals( entry.nodeId, single( nodes, NO_SUCH_NODE ) );
                 }
             }
-            accessor.close();
         }
     }
 
@@ -272,7 +269,6 @@ public class SimpleIndexPopulatorCompatibility extends IndexProviderCompatibilit
                         assertEquals( asSet( entry.nodeId, entry.nodeId + offset ), PrimitiveLongCollections.toSet( nodes ) );
                     }
                 }
-                accessor.close();
             }
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationTest.java
@@ -42,6 +42,7 @@ import org.neo4j.storageengine.api.schema.PopulationProgress;
 import org.neo4j.values.storable.Values;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class IndexPopulationTest
 {
@@ -63,17 +64,10 @@ public class IndexPopulationTest
         multipleIndexPopulator.indexAllNodes().run();
 
         // when
-        try
-        {
-            indexPopulation.flip();
-        }
-        catch ( ExceptionDuringFlipKernelException e )
-        {
-            // good
-        }
+        indexPopulation.flip();
 
         // then
-        assertTrue(  "flipper should have flipped to failing proxy", flipper.getState() == InternalIndexState.FAILED );
+        assertTrue( "flipper should have flipped to failing proxy", flipper.getState() == InternalIndexState.FAILED );
     }
 
     private OnlineIndexProxy onlineIndexProxy( IndexStoreView storeView )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialIndexCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialIndexCacheTest.java
@@ -19,11 +19,15 @@
  */
 package org.neo4j.kernel.impl.index.schema;
 
+import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.apache.commons.lang3.mutable.MutableInt;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.HashSet;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -32,11 +36,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.neo4j.helpers.collection.Iterators;
+import org.neo4j.test.Race;
 import org.neo4j.values.storable.CoordinateReferenceSystem;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.neo4j.helpers.collection.Iterables.count;
 
 public class SpatialIndexCacheTest
 {
-
     @SuppressWarnings( "Duplicates" )
     @Test
     public void stressCache() throws Exception
@@ -68,6 +76,48 @@ public class SpatialIndexCacheTest
         {
             pool.shutdown();
         }
+    }
+
+    @Test
+    public void stressInstantiationWithClose() throws Throwable
+    {
+        // given
+        StringFactory factory = new StringFactory();
+        SpatialIndexCache<String> cache = new SpatialIndexCache<>( factory );
+        Race race = new Race().withRandomStartDelays();
+        MutableInt instantiatedAtClose = new MutableInt();
+        race.addContestant( () ->
+        {
+            try
+            {
+                cache.uncheckedSelect( CoordinateReferenceSystem.WGS84 );
+                cache.uncheckedSelect( CoordinateReferenceSystem.Cartesian_3D );
+            }
+            catch ( IllegalStateException e )
+            {
+                // This exception is OK since it may have been closed
+            }
+        }, 1 );
+        race.addContestant( () ->
+        {
+            cache.shutInstantiateCloseLock();
+            instantiatedAtClose.setValue( count( cache ) );
+        }, 1 );
+
+        // when
+        race.go();
+
+        // then
+        try
+        {
+            cache.uncheckedSelect( CoordinateReferenceSystem.Cartesian );
+            fail( "No instantiation after closed" );
+        }
+        catch ( IllegalStateException e )
+        {
+            // good
+        }
+        assertEquals( instantiatedAtClose.intValue(), count( cache ) );
     }
 
     private static final CoordinateReferenceSystem[] coordinateReferenceSystems =

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialIndexCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SpatialIndexCacheTest.java
@@ -19,15 +19,12 @@
  */
 package org.neo4j.kernel.impl.index.schema;
 
-import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.HashSet;
 import java.util.Random;
-import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -100,7 +97,7 @@ public class SpatialIndexCacheTest
         }, 1 );
         race.addContestant( () ->
         {
-            cache.shutInstantiateCloseLock();
+            cache.closeInstantiateCloseLock();
             instantiatedAtClose.setValue( count( cache ) );
         }, 1 );
 


### PR DESCRIPTION
With one-to-one native indexes like number or string,
updates or interactions after call to close() is prohibited
and coordinated inside GBPTree. With the spatial/temporal index
structure, which has lazy instantiation of sub-indexes
there was no such coordination. This meant that a call to close()
could race with an instantiation of one or more sub-indexes.
This in turn would result in opened sub-indexes (GBPTree instances)
that would never get closed.

Contractually this is very good to tighten up so that they all
behave the same. Practically this was found in a population scenario
where an index population was cancelled while running.