### PR TITLE
3.4 Fix Cluster Overview edge-cases

### DIFF
--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupCommandCcIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupCommandCcIT.java
@@ -140,7 +140,7 @@ public class OnlineBackupCommandCcIT
         Cluster cluster = startCluster( recordFormat );
 
         // and the database has indexes
-        ClusterHelper.createIndexes( cluster.getDbWithAnyRole( Role.LEADER ).database() );
+        ClusterHelper.createIndexes( cluster.getMemberWithAnyRole( Role.LEADER ).database() );
 
         // and the database is being populated
         AtomicBoolean populateDatabaseFlag = new AtomicBoolean( true );
@@ -229,7 +229,7 @@ public class OnlineBackupCommandCcIT
     {
         // given
         Cluster cluster = startCluster( recordFormat );
-        ClusterHelper.createIndexes( cluster.getDbWithAnyRole( Role.LEADER ).database() );
+        ClusterHelper.createIndexes( cluster.getMemberWithAnyRole( Role.LEADER ).database() );
         String customAddress = CausalClusteringTestHelpers.backupAddress( clusterLeader( cluster ).database() );
 
         // and
@@ -356,7 +356,7 @@ public class OnlineBackupCommandCcIT
 
     private static CoreClusterMember clusterLeader( Cluster cluster )
     {
-        return cluster.getDbWithRole( Role.LEADER );
+        return cluster.getMemberWithRole( Role.LEADER );
     }
 
     public static DbRepresentation getBackupDbRepresentation( String name, File backupDir )

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/BackupCoreIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/BackupCoreIT.java
@@ -102,7 +102,7 @@ public class BackupCoreIT
 
     static String backupAddress( Cluster cluster )
     {
-        return cluster.getDbWithRole( Role.LEADER ).settingValue( "causal_clustering.transaction_listen_address" );
+        return cluster.getMemberWithRole( Role.LEADER ).settingValue( "causal_clustering.transaction_listen_address" );
     }
 
     static String[] backupArguments( String from, File backupsDir, String name )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderInfo.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderInfo.java
@@ -32,11 +32,23 @@ public class LeaderInfo implements Serializable
 
     private final MemberId memberId;
     private final long term;
+    private boolean isStepDown;
 
     public LeaderInfo( MemberId memberId, long term )
     {
         this.memberId = memberId;
         this.term = term;
+        this.isStepDown = false;
+    }
+
+    public void stepDown()
+    {
+        this.isStepDown = true;
+    }
+
+    public boolean isStepDown()
+    {
+        return isStepDown;
     }
 
     public MemberId memberId()

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderInfo.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderInfo.java
@@ -32,23 +32,23 @@ public class LeaderInfo implements Serializable
 
     private final MemberId memberId;
     private final long term;
-    private boolean isStepDown;
+    private boolean isSteppingDown;
 
     public LeaderInfo( MemberId memberId, long term )
     {
+        this( memberId, term, false );
+    }
+
+    public LeaderInfo( MemberId memberId, long term, boolean isSteppingDown )
+    {
         this.memberId = memberId;
         this.term = term;
-        this.isStepDown = false;
+        this.isSteppingDown = isSteppingDown;
     }
 
-    public void stepDown()
+    public boolean isSteppingDown()
     {
-        this.isStepDown = true;
-    }
-
-    public boolean isStepDown()
-    {
-        return isStepDown;
+        return isSteppingDown;
     }
 
     public MemberId memberId()

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderListener.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderListener.java
@@ -22,4 +22,7 @@ package org.neo4j.causalclustering.core.consensus;
 public interface LeaderListener
 {
     void onLeaderSwitch( LeaderInfo leaderInfo );
+    default void onLeaderStepDown( LeaderInfo leaderInfo )
+    {
+    }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMachine.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMachine.java
@@ -213,17 +213,11 @@ public class RaftMachine implements LeaderLocator, CoreMetaData
 
     private void notifyLeaderChanges( Outcome outcome )
     {
-        LeaderInfo leaderInfo = new LeaderInfo( outcome.getLeader(), outcome.getTerm() );
-        boolean isStepDown = outcome.isSteppingDown();
-
-        if ( isStepDown )
-        {
-            leaderInfo.stepDown();
-        }
+        LeaderInfo leaderInfo = new LeaderInfo( outcome.getLeader(), outcome.getTerm(), outcome.isSteppingDown() );
 
         for ( LeaderListener listener : leaderListeners )
         {
-            if ( isStepDown )
+            if ( outcome.isSteppingDown() )
             {
                 listener.onLeaderStepDown( leaderInfo );
             }
@@ -251,10 +245,7 @@ public class RaftMachine implements LeaderLocator, CoreMetaData
 
     private boolean leaderChanged( Outcome outcome, MemberId oldLeader )
     {
-        Optional<MemberId> oldLeaderOpt = Optional.ofNullable( oldLeader );
-        Optional<MemberId> outcomeLeaderOpt = Optional.ofNullable( outcome.getLeader() );
-
-        return !oldLeaderOpt.equals( outcomeLeaderOpt );
+        return !Objects.equals( oldLeader, outcome.getLeader() );
     }
 
     public synchronized ConsensusOutcome handle( RaftMessages.RaftMessage incomingMessage ) throws IOException

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMachine.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMachine.java
@@ -24,6 +24,7 @@ import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
@@ -213,8 +214,19 @@ public class RaftMachine implements LeaderLocator, CoreMetaData
     private void notifyLeaderChanges( Outcome outcome )
     {
         LeaderInfo leaderInfo = new LeaderInfo( outcome.getLeader(), outcome.getTerm() );
+        boolean isStepDown = outcome.isSteppingDown();
+
+        if ( isStepDown )
+        {
+            leaderInfo.stepDown();
+        }
+
         for ( LeaderListener listener : leaderListeners )
         {
+            if ( isStepDown )
+            {
+                listener.onLeaderStepDown( leaderInfo );
+            }
             listener.onLeaderSwitch( leaderInfo );
         }
     }
@@ -239,18 +251,10 @@ public class RaftMachine implements LeaderLocator, CoreMetaData
 
     private boolean leaderChanged( Outcome outcome, MemberId oldLeader )
     {
-        if ( oldLeader == null && outcome.getLeader() != null )
-        {
-            return true;
-        }
-        else if ( oldLeader != null && !oldLeader.equals( outcome.getLeader() ) )
-        {
-            return true;
-        }
+        Optional<MemberId> oldLeaderOpt = Optional.ofNullable( oldLeader );
+        Optional<MemberId> outcomeLeaderOpt = Optional.ofNullable( outcome.getLeader() );
 
-        //TODO: Add logic for handling leader step-down with no replacement
-
-        return false;
+        return !oldLeaderOpt.equals( outcomeLeaderOpt );
     }
 
     public synchronized ConsensusOutcome handle( RaftMessages.RaftMessage incomingMessage ) throws IOException

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyService.java
@@ -56,10 +56,10 @@ public interface CoreTopologyService extends TopologyService
      * Set the leader memberId to null for a given database (i.e. Raft consensus group).
      * This is intended to trigger state cleanup for informational procedures like {@link ClusterOverviewProcedure}
      *
-     * @param leaderInfo
-     * @param dbName
+     * @param stepDownLeaderInfo Information about the stepdown event, including term
+     * @param dbName The database for which this topology member should handle a stepdown
      */
-    void handleStepDown( LeaderInfo leaderInfo, String dbName );
+    void handleStepDown( LeaderInfo stepDownLeaderInfo, String dbName );
 
     interface Listener
     {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyService.java
@@ -52,6 +52,15 @@ public interface CoreTopologyService extends TopologyService
      */
     void setLeader( LeaderInfo leaderInfo, String dbName );
 
+    /**
+     * Set the leader memberId to null for a given database (i.e. Raft consensus group).
+     * This is intended to trigger state cleanup for informational procedures like {@link ClusterOverviewProcedure}
+     *
+     * @param leaderInfo
+     * @param dbName
+     */
+    void handleStepDown( LeaderInfo leaderInfo, String dbName );
+
     interface Listener
     {
         void onCoreTopologyChange( CoreTopology coreTopology );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClusterTopology.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClusterTopology.java
@@ -222,7 +222,7 @@ public final class HazelcastClusterTopology
 
         boolean greaterOrEqualTermExists = Optional.ofNullable( expected ).map(l -> l.term() >= leaderInfo.term() ).orElse( false );
 
-        if ( greaterOrEqualTermExists || noUpdate )
+        if ( (greaterOrEqualTermExists || noUpdate) && !leaderInfo.isStepDown() )
         {
             return;
         }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClusterTopology.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClusterTopology.java
@@ -216,18 +216,25 @@ public final class HazelcastClusterTopology
     {
         IAtomicReference<LeaderInfo> leaderRef = hazelcastInstance.getAtomicReference( DB_NAME_LEADER_TERM_PREFIX + dbName );
 
-        LeaderInfo expected = leaderRef.get();
+        LeaderInfo current = leaderRef.get();
+        Optional<LeaderInfo> currentOpt = Optional.ofNullable( current );
 
-        boolean noUpdate = Optional.ofNullable( expected ).map( LeaderInfo::memberId ).equals( Optional.ofNullable( leaderInfo.memberId() ) );
+        boolean noUpdate =  currentOpt.map( LeaderInfo::memberId ).equals( Optional.ofNullable( leaderInfo.memberId() ) );
 
-        boolean greaterOrEqualTermExists = Optional.ofNullable( expected ).map(l -> l.term() >= leaderInfo.term() ).orElse( false );
+        int termComparison =  currentOpt.map( l -> Long.compare( l.term(), leaderInfo.term() ) ).orElse( -1 );
 
-        if ( (greaterOrEqualTermExists || noUpdate) && !leaderInfo.isStepDown() )
+        boolean greaterTermExists = termComparison > 0;
+
+        boolean invalidTerm = greaterTermExists || ( termComparison == 0 && !leaderInfo.isSteppingDown() );
+
+        boolean success = !( invalidTerm || noUpdate);
+
+        if ( !success )
         {
             return;
         }
 
-        leaderRef.compareAndSet( expected, leaderInfo );
+        leaderRef.compareAndSet( current, leaderInfo );
     }
 
     private static Optional<LeaderInfo> getLeaderForDBName( HazelcastInstance hazelcastInstance, String dbName )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
@@ -71,6 +71,7 @@ public class HazelcastCoreTopologyService extends AbstractTopologyService implem
     private static final long HAZELCAST_IS_HEALTHY_TIMEOUT_MS = TimeUnit.MINUTES.toMillis( 10 );
     private static final int HAZELCAST_MIN_CLUSTER = 2;
 
+    private final int minimumConsensusSize;
     private final Config config;
     private final MemberId myself;
     private final Log log;
@@ -100,6 +101,7 @@ public class HazelcastCoreTopologyService extends AbstractTopologyService implem
             TopologyServiceRetryStrategy topologyServiceRetryStrategy )
     {
         this.config = config;
+        this.minimumConsensusSize = config.get( CausalClusteringSettings.minimum_core_cluster_size_at_runtime );
         this.myself = myself;
         this.listenerService = new CoreTopologyListenerService();
         this.log = logProvider.getLog( getClass() );
@@ -137,6 +139,16 @@ public class HazelcastCoreTopologyService extends AbstractTopologyService implem
         if ( this.leaderInfo.term() < leaderInfo.term() )
         {
             this.leaderInfo = leaderInfo;
+        }
+    }
+
+    @Override
+    public void handleStepDown( LeaderInfo leaderInfo, String dbName )
+    {
+        boolean wasPreviousLeader = myself.equals( this.leaderInfo.memberId() );
+        if ( wasPreviousLeader )
+        {
+            HazelcastClusterTopology.casLeaders( hazelcastInstance, leaderInfo, dbName );
         }
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
@@ -71,7 +71,6 @@ public class HazelcastCoreTopologyService extends AbstractTopologyService implem
     private static final long HAZELCAST_IS_HEALTHY_TIMEOUT_MS = TimeUnit.MINUTES.toMillis( 10 );
     private static final int HAZELCAST_MIN_CLUSTER = 2;
 
-    private final int minimumConsensusSize;
     private final Config config;
     private final MemberId myself;
     private final Log log;
@@ -101,7 +100,6 @@ public class HazelcastCoreTopologyService extends AbstractTopologyService implem
             TopologyServiceRetryStrategy topologyServiceRetryStrategy )
     {
         this.config = config;
-        this.minimumConsensusSize = config.get( CausalClusteringSettings.minimum_core_cluster_size_at_runtime );
         this.myself = myself;
         this.listenerService = new CoreTopologyListenerService();
         this.log = logProvider.getLog( getClass() );
@@ -143,12 +141,12 @@ public class HazelcastCoreTopologyService extends AbstractTopologyService implem
     }
 
     @Override
-    public void handleStepDown( LeaderInfo leaderInfo, String dbName )
+    public void handleStepDown( LeaderInfo stepDownLeaderInfo, String dbName )
     {
         boolean wasPreviousLeader = myself.equals( this.leaderInfo.memberId() );
         if ( wasPreviousLeader )
         {
-            HazelcastClusterTopology.casLeaders( hazelcastInstance, leaderInfo, dbName );
+            HazelcastClusterTopology.casLeaders( hazelcastInstance, stepDownLeaderInfo, dbName );
         }
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RaftCoreTopologyConnector.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RaftCoreTopologyConnector.java
@@ -64,6 +64,12 @@ public class RaftCoreTopologyConnector extends LifecycleAdapter implements CoreT
     }
 
     @Override
+    public void onLeaderStepDown( LeaderInfo leaderInfo )
+    {
+        coreTopologyService.handleStepDown( leaderInfo, dbName );
+    }
+
+    @Override
     public String dbName()
     {
         return this.dbName;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedure.java
@@ -80,9 +80,8 @@ public class ClusterOverviewProcedure extends CallableProcedure.BasicProcedure
     public RawIterator<Object[],ProcedureException> apply(
             Context ctx, Object[] input, ResourceTracker resourceTracker )
     {
-        Map<MemberId,RoleInfo> roleMap = emptyMap();
+        Map<MemberId,RoleInfo> roleMap = topologyService.allCoreRoles();
         List<ReadWriteEndPoint> endpoints = new ArrayList<>();
-        roleMap = topologyService.allCoreRoles();
 
         CoreTopology coreTopology = topologyService.allCoreServers();
         Set<MemberId> coreMembers = coreTopology.members().keySet();

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
@@ -395,7 +395,9 @@ public class Cluster
         Set<Role> roleSet = Arrays.stream( roles ).collect( toSet() );
 
         return coreMembers.values().stream()
-                .filter( m -> m.database() != null && m.dbName().equals( dbName ) &&  roleSet.contains( m.database().getRole() ) )
+                .filter( m -> m.database() != null )
+                .filter( m -> m.dbName().equals( dbName ) )
+                .filter( m -> roleSet.contains( m.database().getRole() ) )
                 .collect( Collectors.toList() );
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
@@ -352,31 +352,51 @@ public class Cluster
         }
     }
 
-    public CoreClusterMember getDbWithRole( Role role )
+    public CoreClusterMember getMemberWithRole( Role role )
     {
-        return getDbWithAnyRole( role );
+        return getMemberWithAnyRole( role );
     }
 
-    public CoreClusterMember getDbWithRole( String dbName, Role role )
+    public List<CoreClusterMember> getAllMembersWithRole( Role role )
     {
-        return getDbWithAnyRole( dbName, role );
+        return getAllMembersWithAnyRole( role );
     }
 
-    public CoreClusterMember getDbWithAnyRole( Role... roles )
+    public CoreClusterMember getMemberWithRole( String dbName, Role role )
+    {
+        return getMemberWithAnyRole( dbName, role );
+    }
+
+    public List<CoreClusterMember> getAllMembersWithRole( String dbName, Role role )
+    {
+        return getAllMembersWithAnyRole( dbName, role );
+    }
+
+    public CoreClusterMember getMemberWithAnyRole( Role... roles )
     {
         String dbName = CausalClusteringSettings.database.getDefaultValue();
-        return getDbWithAnyRole( dbName, roles );
+        return getMemberWithAnyRole( dbName, roles );
     }
 
-    public CoreClusterMember getDbWithAnyRole( String dbName, Role... roles )
+    public List<CoreClusterMember> getAllMembersWithAnyRole( Role... roles )
+    {
+        String dbName = CausalClusteringSettings.database.getDefaultValue();
+        return getAllMembersWithAnyRole( dbName, roles );
+    }
+
+    public CoreClusterMember getMemberWithAnyRole( String dbName, Role... roles )
+    {
+        return getAllMembersWithAnyRole( dbName, roles ).stream().findFirst().orElse( null );
+    }
+
+    public List<CoreClusterMember> getAllMembersWithAnyRole( String dbName, Role... roles )
     {
         ensureDBName( dbName );
         Set<Role> roleSet = Arrays.stream( roles ).collect( toSet() );
 
-        Optional<CoreClusterMember> firstAppropriate = coreMembers.values().stream().filter( m ->
-            m.database() != null && m.dbName().equals( dbName ) &&  roleSet.contains( m.database().getRole() ) ).findFirst();
-
-        return firstAppropriate.orElse( null );
+        return coreMembers.values().stream()
+                .filter( m -> m.database() != null && m.dbName().equals( dbName ) &&  roleSet.contains( m.database().getRole() ) )
+                .collect( Collectors.toList() );
     }
 
     public CoreClusterMember awaitLeader() throws TimeoutException
@@ -401,12 +421,12 @@ public class Cluster
 
     public CoreClusterMember awaitCoreMemberWithRole( Role role, long timeout, TimeUnit timeUnit ) throws TimeoutException
     {
-        return await( () -> getDbWithRole( role ), notNull(), timeout, timeUnit );
+        return await( () -> getMemberWithRole( role ), notNull(), timeout, timeUnit );
     }
 
     public CoreClusterMember awaitCoreMemberWithRole( String dbName, Role role, long timeout, TimeUnit timeUnit ) throws TimeoutException
     {
-        return await( () -> getDbWithRole( dbName, role ), notNull(), timeout, timeUnit );
+        return await( () -> getMemberWithRole( dbName, role ), notNull(), timeout, timeUnit );
     }
 
     public int numberOfCoreMembersReportedByTopology()

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryCoreClient.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryCoreClient.java
@@ -91,7 +91,7 @@ class SharedDiscoveryCoreClient extends AbstractTopologyService implements CoreT
     @Override
     public void setLeader( LeaderInfo newLeader, String dbName )
     {
-        if ( this.leaderInfo.term() < newLeader.term() )
+        if ( this.leaderInfo.term() < newLeader.term() && newLeader.memberId() != null )
         {
             this.leaderInfo = newLeader;
             sharedDiscoveryService.casLeaders( newLeader, localDBName );
@@ -143,12 +143,12 @@ class SharedDiscoveryCoreClient extends AbstractTopologyService implements CoreT
     }
 
     @Override
-    public void handleStepDown( LeaderInfo leaderInfo, String dbName )
+    public void handleStepDown( LeaderInfo stepDownLeaderInfo, String dbName )
     {
         boolean wasPreviousLeader = myself.equals( this.leaderInfo.memberId() );
         if ( wasPreviousLeader )
         {
-            sharedDiscoveryService.casLeaders( leaderInfo, dbName );
+            sharedDiscoveryService.casLeaders( stepDownLeaderInfo, dbName );
         }
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryCoreClient.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryCoreClient.java
@@ -91,7 +91,7 @@ class SharedDiscoveryCoreClient extends AbstractTopologyService implements CoreT
     @Override
     public void setLeader( LeaderInfo newLeader, String dbName )
     {
-        if ( this.leaderInfo.term() < newLeader.term() && newLeader.memberId() != null )
+        if ( this.leaderInfo.term() < newLeader.term() )
         {
             this.leaderInfo = newLeader;
             sharedDiscoveryService.casLeaders( newLeader, localDBName );
@@ -140,6 +140,16 @@ class SharedDiscoveryCoreClient extends AbstractTopologyService implements CoreT
         // for the database local to the host upon which this method is called.
         // TODO: evaluate returning clusterId = null for global Topologies returned by allCoreServers()
         return this.coreTopology;
+    }
+
+    @Override
+    public void handleStepDown( LeaderInfo leaderInfo, String dbName )
+    {
+        boolean wasPreviousLeader = myself.equals( this.leaderInfo.memberId() );
+        if ( wasPreviousLeader )
+        {
+            sharedDiscoveryService.casLeaders( leaderInfo, dbName );
+        }
     }
 
     @Override

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryService.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryService.java
@@ -136,7 +136,7 @@ public final class SharedDiscoveryService
 
             boolean greaterOrEqualTermExists = current.map( l -> l.term() >= leaderInfo.term() ).orElse( false );
 
-            boolean success = !(greaterOrEqualTermExists || noUpdate);
+            boolean success = !(greaterOrEqualTermExists || noUpdate) || leaderInfo.isStepDown();
 
             if ( success )
             {

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryService.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryService.java
@@ -134,9 +134,13 @@ public final class SharedDiscoveryService
 
             boolean noUpdate = current.map( LeaderInfo::memberId ).equals( Optional.ofNullable( leaderInfo.memberId() ) );
 
-            boolean greaterOrEqualTermExists = current.map( l -> l.term() >= leaderInfo.term() ).orElse( false );
+            int termComparison = current.map( l -> Long.compare( l.term(), leaderInfo.term() ) ).orElse( -1 );
 
-            boolean success = !(greaterOrEqualTermExists || noUpdate) || leaderInfo.isStepDown();
+            boolean greaterTermExists = termComparison > 0;
+
+            boolean invalidTerm = greaterTermExists || ( termComparison == 0 && !leaderInfo.isSteppingDown() );
+
+            boolean success = !( invalidTerm || noUpdate);
 
             if ( success )
             {

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterFormationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterFormationIT.java
@@ -120,7 +120,7 @@ public class ClusterFormationIT
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         executorService.submit( () ->
         {
-            CoreGraphDatabase leader = cluster.getDbWithRole( Role.LEADER ).database();
+            CoreGraphDatabase leader = cluster.getMemberWithRole( Role.LEADER ).database();
             try ( Transaction tx = leader.beginTx() )
             {
                 leader.createNode();

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterOverviewIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterOverviewIT.java
@@ -277,7 +277,6 @@ public class ClusterOverviewIT
         clusterRule.withNumberOfCoreMembers( 2 );
 
         Cluster cluster = clusterRule.startCluster();
-        //TODO: address proliferation of Role enums
         List<CoreClusterMember> followers = cluster.getAllMembersWithRole( Role.FOLLOWER );
         CoreClusterMember leader = cluster.getMemberWithRole( Role.LEADER );
         followers.forEach( CoreClusterMember::shutdown );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterOverviewIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterOverviewIT.java
@@ -23,6 +23,7 @@ import org.hamcrest.Description;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,8 +42,10 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
+import org.neo4j.causalclustering.core.consensus.roles.Role;
 import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.ClusterMember;
+import org.neo4j.causalclustering.discovery.CoreClusterMember;
 import org.neo4j.causalclustering.discovery.RoleInfo;
 import org.neo4j.causalclustering.discovery.procedures.ClusterOverviewProcedure;
 import org.neo4j.collection.RawIterator;
@@ -62,6 +65,7 @@ import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.neo4j.causalclustering.discovery.RoleInfo.FOLLOWER;
 import static org.neo4j.causalclustering.discovery.RoleInfo.LEADER;
 import static org.neo4j.causalclustering.discovery.RoleInfo.READ_REPLICA;
@@ -264,6 +268,21 @@ public class ClusterOverviewIT
             assertEventualOverview( cluster, allOf( containsRole( LEADER, 1 ), containsRole( FOLLOWER, coreMembers - 1 - 2 ) ),
                     coreServerId );
         }
+    }
+
+    @Test
+    public void shouldHaveNoLeaderIfMajorityCoreMembersDead() throws Exception
+    {
+        clusterRule.withNumberOfCoreMembers( 3 );
+        clusterRule.withNumberOfCoreMembers( 2 );
+
+        Cluster cluster = clusterRule.startCluster();
+        //TODO: address proliferation of Role enums
+        List<CoreClusterMember> followers = cluster.getAllMembersWithRole( Role.FOLLOWER );
+        CoreClusterMember leader = cluster.getMemberWithRole( Role.LEADER );
+        followers.forEach( CoreClusterMember::shutdown );
+
+        assertEventualOverview( cluster, containsRole( LEADER, 0 ), leader.serverId() );
     }
 
     private void assertEventualOverview( Cluster cluster, Matcher<List<MemberInfo>> expected, int coreServerId )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ConsensusGroupSettingsIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ConsensusGroupSettingsIT.java
@@ -61,7 +61,7 @@ public class ConsensusGroupSettingsIT
         // when
         for ( int i = 0; i < numberOfCoreSeversToRemove; i++ )
         {
-            cluster.removeCoreMember( cluster.getDbWithRole( Role.LEADER ) );
+            cluster.removeCoreMember( cluster.getMemberWithRole( Role.LEADER ) );
             cluster.awaitLeader( 30, SECONDS );
         }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreReplicationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreReplicationIT.java
@@ -94,7 +94,7 @@ public class CoreReplicationIT
         // given
         cluster.awaitLeader();
 
-        CoreGraphDatabase follower = cluster.getDbWithRole( Role.FOLLOWER ).database();
+        CoreGraphDatabase follower = cluster.getMemberWithRole( Role.FOLLOWER ).database();
 
         // when
         try ( Transaction tx = follower.beginTx() )
@@ -156,7 +156,7 @@ public class CoreReplicationIT
         // given
         cluster.awaitLeader();
 
-        CoreGraphDatabase follower = cluster.getDbWithRole( Role.FOLLOWER ).database();
+        CoreGraphDatabase follower = cluster.getMemberWithRole( Role.FOLLOWER ).database();
 
         // when
         try ( Transaction tx = follower.beginTx() )
@@ -185,7 +185,7 @@ public class CoreReplicationIT
         awaitForDataToBeApplied( leader );
         dataMatchesEventually( leader, cluster.coreMembers() );
 
-        CoreGraphDatabase follower = cluster.getDbWithRole( Role.FOLLOWER ).database();
+        CoreGraphDatabase follower = cluster.getMemberWithRole( Role.FOLLOWER ).database();
 
         // when
         try ( Transaction tx = follower.beginTx() )
@@ -334,8 +334,8 @@ public class CoreReplicationIT
                     db.createNode();
                     tx.success();
 
-                    cluster.removeCoreMember( cluster.getDbWithAnyRole( Role.FOLLOWER, Role.CANDIDATE ) );
-                    cluster.removeCoreMember( cluster.getDbWithAnyRole( Role.FOLLOWER, Role.CANDIDATE ) );
+                    cluster.removeCoreMember( cluster.getMemberWithAnyRole( Role.FOLLOWER, Role.CANDIDATE ) );
+                    cluster.removeCoreMember( cluster.getMemberWithAnyRole( Role.FOLLOWER, Role.CANDIDATE ) );
                     latch.countDown();
                 } );
                 fail( "Should have thrown" );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/MultiClusterRoutingIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/MultiClusterRoutingIT.java
@@ -133,7 +133,7 @@ public class MultiClusterRoutingIT
     public void superCallShouldReturnAllRouters()
     {
         List<CoreGraphDatabase> dbs = dbNames.stream()
-                .map( n -> cluster.getDbWithAnyRole( n, Role.FOLLOWER, Role.LEADER ).database() ).collect( Collectors.toList() );
+                .map( n -> cluster.getMemberWithAnyRole( n, Role.FOLLOWER, Role.LEADER ).database() ).collect( Collectors.toList() );
 
         Stream<Optional<MultiClusterRoutingResult>> optResults = dbs.stream()
                 .map( db -> callProcedure( db, GET_SUPER_CLUSTER_ROUTERS, Collections.emptyMap() ) );
@@ -153,7 +153,7 @@ public class MultiClusterRoutingIT
     public void subCallShouldReturnLocalRouters()
     {
         String dbName = getFirstDbName( dbNames );
-        Stream<CoreGraphDatabase> members = dbNames.stream().map( n -> cluster.getDbWithAnyRole( n, Role.FOLLOWER, Role.LEADER ).database() );
+        Stream<CoreGraphDatabase> members = dbNames.stream().map( n -> cluster.getMemberWithAnyRole( n, Role.FOLLOWER, Role.LEADER ).database() );
 
         Map<String,Object> params = new HashMap<>();
         params.put( DATABASE.parameterName(), dbName );
@@ -176,12 +176,12 @@ public class MultiClusterRoutingIT
     public void procedureCallsShouldReflectMembershipChanges() throws Exception
     {
         String dbName = getFirstDbName( dbNames );
-        CoreClusterMember follower = cluster.getDbWithAnyRole( dbName, Role.FOLLOWER );
+        CoreClusterMember follower = cluster.getMemberWithAnyRole( dbName, Role.FOLLOWER );
         int followerId = follower.serverId();
 
         cluster.removeCoreMemberWithServerId( followerId );
 
-        CoreGraphDatabase db = cluster.getDbWithAnyRole( dbName, Role.FOLLOWER, Role.LEADER ).database();
+        CoreGraphDatabase db = cluster.getMemberWithAnyRole( dbName, Role.FOLLOWER, Role.LEADER ).database();
 
         Function<CoreGraphDatabase, Set<Endpoint>> getResult = database ->
         {

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/MultiClusteringIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/MultiClusteringIT.java
@@ -186,7 +186,7 @@ public class MultiClusteringIT
     public void rejoiningFollowerShouldDownloadSnapshotFromCorrectDatabase() throws Exception
     {
         String dbName = getFirstDbName( dbNames );
-        int followerId = cluster.getDbWithAnyRole( dbName, Role.FOLLOWER ).serverId();
+        int followerId = cluster.getMemberWithAnyRole( dbName, Role.FOLLOWER ).serverId();
         cluster.removeCoreMemberWithServerId( followerId );
 
         for ( int  i = 0; i < 100; i++ )

--- a/integrationtests/src/test/java/org/neo4j/causalclustering/scenarios/BoltCausalClusteringIT.java
+++ b/integrationtests/src/test/java/org/neo4j/causalclustering/scenarios/BoltCausalClusteringIT.java
@@ -113,7 +113,7 @@ public class BoltCausalClusteringIT
         } );
 
         // when
-        int count = executeWriteAndReadThroughBolt( cluster.getDbWithRole( Role.FOLLOWER ) );
+        int count = executeWriteAndReadThroughBolt( cluster.getMemberWithRole( Role.FOLLOWER ) );
 
         // then
         assertEquals( 1, count );


### PR DESCRIPTION
Fixes a bug reported by team drivers where if a a cluster goes read-only then the cluster overview is never updated and still reflects the last known leader. This is because previously, changes to the state which the Overview depends upon in the discovery service were only allowed by the current leader. This has now been changed so that if there are no leaders an update can be made regardless.