### PR TITLE
Reduce number of batches in test

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/ForkedProcessorStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/ForkedProcessorStepTest.java
@@ -303,7 +303,7 @@ public class ForkedProcessorStepTest
     private void shouldBeAbleToProgressUnderStressfulProcessorChanges( int orderingGuarantees ) throws Exception
     {
         // given
-        int batches = 1_000;
+        int batches = 100;
         int processors = Runtime.getRuntime().availableProcessors() * 10;
         Configuration config = new Configuration.Overridden( Configuration.DEFAULT )
         {


### PR DESCRIPTION
This has already been done in 3.4.
This will keep test run time, even schedually challenged runs, timely