### PR TITLE
Don't fail building semantic error message with invalid numeric literal

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/HelpfulErrorMessagesTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/HelpfulErrorMessagesTest.scala
@@ -80,4 +80,10 @@ class HelpfulErrorMessagesTest extends ExecutionEngineFunSuite with NewPlannerTe
       exception.getMessage should include("A single relationship type must be specified for MERGE")
     }
   }
+
+  test("should give correct error message with invalid number literal in a subtract") {
+    a[SyntaxException] shouldBe thrownBy {
+      innerExecute("with [1a-1] as list return list")
+    }
+  }
 }

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/ast/ArithmeticFunctions.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/ast/ArithmeticFunctions.scala
@@ -37,7 +37,7 @@ case class Add(lhs: Expression, rhs: Expression)(val position: InputPosition)
 
   private def checkBoundary(lhs: Expression, rhs: Expression): SemanticCheck = (lhs, rhs) match {
     case (l:IntegerLiteral, r:IntegerLiteral) if Try(Math.addExact(l.value, r.value)).isFailure =>
-      SemanticError(s"result of ${l.value} + ${r.value} cannot be represented as an integer", position)
+      SemanticError(s"result of ${l.stringVal} + ${r.stringVal} cannot be represented as an integer", position)
     case _ => SemanticCheckResult.success
   }
 
@@ -144,7 +144,7 @@ case class Subtract(lhs: Expression, rhs: Expression)(val position: InputPositio
 
   private def checkBoundary(lhs: Expression, rhs: Expression): SemanticCheck = (lhs, rhs) match {
     case (l:IntegerLiteral, r:IntegerLiteral) if Try(Math.subtractExact(l.value, r.value)).isFailure =>
-      SemanticError(s"result of ${l.value} - ${r.value} cannot be represented as an integer", position)
+      SemanticError(s"result of ${l.stringVal} - ${r.stringVal} cannot be represented as an integer", position)
     case _ => SemanticCheckResult.success
   }
 
@@ -180,7 +180,7 @@ case class Multiply(lhs: Expression, rhs: Expression)(val position: InputPositio
 
   private def checkBoundary(lhs: Expression, rhs: Expression): SemanticCheck = (lhs, rhs) match {
     case (l:IntegerLiteral, r:IntegerLiteral) if Try(Math.multiplyExact(l.value, r.value)).isFailure =>
-      SemanticError(s"result of ${l.value} * ${r.value} cannot be represented as an integer", position)
+      SemanticError(s"result of ${l.stringVal} * ${r.stringVal} cannot be represented as an integer", position)
     case _ => SemanticCheckResult.success
   }
 


### PR DESCRIPTION
Having an invalid numeric literal (e.g. `1a`) would produce the correct
error, except if it was used in arithmetic, e.g. `1a-1`.  This case
is now solved.

Fixes #11408