### PR TITLE
Spatial/Temporal indexes stores failures in FailureStorage

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/impl/index/storage/FailureStorage.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/impl/index/storage/FailureStorage.java
@@ -26,7 +26,6 @@ import java.nio.ByteBuffer;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.OpenMode;
 import org.neo4j.io.fs.StoreChannel;
-import org.neo4j.kernel.api.impl.index.storage.layout.FolderLayout;
 import org.neo4j.string.UTF8;
 
 /**
@@ -39,23 +38,23 @@ public class FailureStorage
     public static final String DEFAULT_FAILURE_FILE_NAME = "failure-message";
 
     private final FileSystemAbstraction fs;
-    private final FolderLayout folderLayout;
+    private final File folder;
     private final String failureFileName;
 
     /**
      * @param failureFileName name of failure files to be created
-     * @param folderLayout describing where failure files should be stored
+     * @param folder describing where failure files should be stored
      */
-    public FailureStorage( FileSystemAbstraction fs, FolderLayout folderLayout, String failureFileName )
+    public FailureStorage( FileSystemAbstraction fs, File folder, String failureFileName )
     {
         this.fs = fs;
-        this.folderLayout = folderLayout;
+        this.folder = folder;
         this.failureFileName = failureFileName;
     }
 
-    public FailureStorage( FileSystemAbstraction fs, FolderLayout folderLayout )
+    public FailureStorage( FileSystemAbstraction fs, File folder )
     {
-        this( fs, folderLayout, DEFAULT_FAILURE_FILE_NAME );
+        this( fs, folder, DEFAULT_FAILURE_FILE_NAME );
     }
 
     /**
@@ -67,7 +66,7 @@ public class FailureStorage
      */
     public synchronized void reserveForIndex() throws IOException
     {
-        fs.mkdirs( folderLayout.getIndexFolder() );
+        fs.mkdirs( folder );
         File failureFile = failureFile();
         try ( StoreChannel channel = fs.create( failureFile ) )
         {
@@ -78,7 +77,6 @@ public class FailureStorage
 
     /**
      * Delete failure file for the given index id
-     *
      */
     public synchronized void clearForIndex()
     {
@@ -130,7 +128,6 @@ public class FailureStorage
 
     File failureFile()
     {
-        File folder = folderLayout.getIndexFolder();
         return new File( folder, failureFileName );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexCache.java
@@ -90,6 +90,9 @@ class SpatialIndexCache<T> implements Iterable<T>
         }
     }
 
+    /**
+     * Must be called while owning the instantiateCloseLock lock
+     */
     protected void assertOpen()
     {
         if ( closed )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexFiles.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexFiles.java
@@ -46,7 +46,7 @@ class SpatialIndexFiles
     {
         this.fs = fs;
         this.settingsFactory = settingsFactory;
-        indexDirectory = directoryStructure.directoryForIndex( indexId );
+        this.indexDirectory = directoryStructure.directoryForIndex( indexId );
     }
 
     Iterable<SpatialFileLayout> existing()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexCache.java
@@ -163,6 +163,9 @@ class TemporalIndexCache<T> implements Iterable<T>
         return cachedValue != null ? function.apply( cachedValue ) : orElse;
     }
 
+    /**
+     * Must be called while owning the instantiateCloseLock lock
+     */
     private void assertOpen()
     {
         if ( closed )

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/impl/index/storage/FailureStorageTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/impl/index/storage/FailureStorageTest.java
@@ -25,12 +25,10 @@ import org.junit.Test;
 
 import java.io.File;
 
-import org.neo4j.kernel.api.impl.index.storage.layout.IndexFolderLayout;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
-import static org.hamcrest.CoreMatchers.containsString;
-
 import static java.lang.String.format;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -40,21 +38,21 @@ public class FailureStorageTest
 {
     @Rule
     public final EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
-    private IndexFolderLayout indexFolderLayout;
+    private File indexFolder;
 
     @Before
     public void before()
     {
         File rootDirectory = new File( "dir" );
         fs.get().mkdirs( rootDirectory );
-        indexFolderLayout = new IndexFolderLayout( rootDirectory );
+        indexFolder = rootDirectory;
     }
 
     @Test
     public void shouldReserveFailureFile() throws Exception
     {
         // GIVEN
-        FailureStorage storage = new FailureStorage( fs.get(), indexFolderLayout );
+        FailureStorage storage = new FailureStorage( fs.get(), indexFolder );
 
         // WHEN
         storage.reserveForIndex();
@@ -69,7 +67,7 @@ public class FailureStorageTest
     public void shouldStoreFailure() throws Exception
     {
         // GIVEN
-        FailureStorage storage = new FailureStorage( fs.get(), indexFolderLayout );
+        FailureStorage storage = new FailureStorage( fs.get(), indexFolder );
         storage.reserveForIndex();
         String failure = format( "A failure message%nspanning%nmultiple lines." );
 
@@ -87,7 +85,7 @@ public class FailureStorageTest
     public void shouldClearFailure() throws Exception
     {
         // GIVEN
-        FailureStorage storage = new FailureStorage( fs.get(), indexFolderLayout );
+        FailureStorage storage = new FailureStorage( fs.get(), indexFolder );
         storage.reserveForIndex();
         String failure = format( "A failure message%nspanning%nmultiple lines." );
         storage.storeIndexFailure( failure );
@@ -106,7 +104,7 @@ public class FailureStorageTest
     public void shouldAppendFailureIfAlreadyExists() throws Exception
     {
         // GIVEN
-        FailureStorage storage = new FailureStorage( fs.get(), indexFolderLayout );
+        FailureStorage storage = new FailureStorage( fs.get(), indexFolder );
         storage.reserveForIndex();
         String failure1 = "Once upon a time there was a first failure";
         String failure2 = "Then there was another";

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/SimpleIndexPopulatorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/SimpleIndexPopulatorCompatibility.java
@@ -107,6 +107,7 @@ public class SimpleIndexPopulatorCompatibility extends IndexProviderCompatibilit
         // GIVEN
         IndexSamplingConfig indexSamplingConfig = new IndexSamplingConfig( Config.defaults() );
         final IndexPopulator p = indexProvider.getPopulator( 17, descriptor, indexSamplingConfig );
+        p.create();
         p.close( false );
 
         // WHEN

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/PartitionedIndexStorage.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/PartitionedIndexStorage.java
@@ -60,7 +60,7 @@ public class PartitionedIndexStorage
         this.fileSystem = fileSystem;
         this.folderLayout = new IndexFolderLayout( rootFolder );
         this.directoryFactory = directoryFactory;
-        this.failureStorage = new FailureStorage( fileSystem, folderLayout );
+        this.failureStorage = new FailureStorage( fileSystem, folderLayout.getIndexFolder() );
     }
 
     /**


### PR DESCRIPTION
instead of opening, and keeping open, one of the parts for
the sole purpose of potentially storing a failure in it.
This reduces number of open files and file handles per index.