### PR TITLE
Corrects FailedIndexProxy behaviour for updates

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FailedIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FailedIndexProxy.java
@@ -95,7 +95,6 @@ public class FailedIndexProxy extends AbstractSwallowingIndexProxy
     @Override
     public void validateBeforeCommit( Value[] tuple )
     {
-        throw new IllegalStateException( "Shouldn't be called on a failed index proxy. Cause:" + getPopulationFailure().asString() );
     }
 
     @Override

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/PropertyConstraintsStressIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/PropertyConstraintsStressIT.java
@@ -142,7 +142,7 @@ public class PropertyConstraintsStressIT
         List<Object[]> data = new ArrayList<>();
         for ( IntFunction<?> values : array( STRING_VALUE_GENERATOR, NUMBER_VALUE_GENERATOR ) )
         {
-            for ( ConstraintOperations operations : array( UNIQUE_PROPERTY_CONSTRAINT_OPS, UNIQUE_PROPERTY_CONSTRAINT_OPS,
+            for ( ConstraintOperations operations : array( UNIQUE_PROPERTY_CONSTRAINT_OPS,
                     NODE_PROPERTY_EXISTENCE_CONSTRAINT_OPS, REL_PROPERTY_EXISTENCE_CONSTRAINT_OPS ) )
             {
                 data.add( array( operations, values ) );


### PR DESCRIPTION
The newly introduced `validateBeforeCommit` method in IndexProxy
was implemented incorrectly in FailedIndexProxy. It threw exception
instead of just ignore that call, just like `newUpdater` did.
This caused unexpected temporary failures for transactions touching
the same label/key combination as an attempted uniqueness constraint
creation did, one that failed due to constraint violations.