### PR TITLE
 Pre-Populate node and rel proxy when using PERIODIC COMMIT over bolt

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineSPI.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineSPI.java
@@ -143,7 +143,7 @@ class TransactionStateMachineSPI implements TransactionStateMachine.SPI
             {
                 try
                 {
-                    Result result = queryExecutionEngine.executeQuery( statement, params, transactionalContext );
+                    Result result = queryExecutionEngine.executeQuery( statement, params, transactionalContext, true );
                     if ( result instanceof QueryResultProvider )
                     {
                         return new CypherAdapterStream( ((QueryResultProvider) result).queryResult(), clock );

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ExecutionEngine.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ExecutionEngine.java
@@ -54,12 +54,12 @@ public class ExecutionEngine implements QueryExecutionEngine
     }
 
     @Override
-    public Result executeQuery( String query, MapValue parameters, TransactionalContext context )
+    public Result executeQuery( String query, MapValue parameters, TransactionalContext context, Boolean prePopulate )
             throws QueryExecutionKernelException
     {
         try
         {
-            return inner.execute( query, parameters, context );
+            return inner.execute( query, parameters, context, prePopulate );
         }
         catch ( CypherException e )
         {
@@ -68,12 +68,12 @@ public class ExecutionEngine implements QueryExecutionEngine
     }
 
     @Override
-    public Result executeQuery( String query, Map<String,Object> parameters, TransactionalContext context )
+    public Result executeQuery( String query, Map<String,Object> parameters, TransactionalContext context, Boolean prePopulate )
             throws QueryExecutionKernelException
     {
         try
         {
-            return inner.execute( query, parameters, context );
+            return inner.execute( query, parameters, context, prePopulate );
         }
         catch ( CypherException e )
         {
@@ -82,12 +82,12 @@ public class ExecutionEngine implements QueryExecutionEngine
     }
 
     @Override
-    public Result profileQuery( String query, Map<String,Object> parameters, TransactionalContext context )
+    public Result profileQuery( String query, Map<String,Object> parameters, TransactionalContext context, Boolean prePopulate )
             throws QueryExecutionKernelException
     {
         try
         {
-            return inner.profile( query, parameters, context );
+            return inner.profile( query, parameters, context, prePopulate );
         }
         catch ( CypherException e )
         {

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/SnapshotExecutionEngine.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/SnapshotExecutionEngine.java
@@ -51,28 +51,28 @@ public class SnapshotExecutionEngine extends ExecutionEngine
     }
 
     @Override
-    public Result executeQuery( String query, MapValue parameters, TransactionalContext context )
+    public Result executeQuery( String query, MapValue parameters, TransactionalContext context, Boolean prePopulate )
             throws QueryExecutionKernelException
     {
-        return executeWithRetries( query, parameters, context, super::executeQuery );
+        return executeWithRetries( query, parameters, context, super::executeQuery, prePopulate );
     }
 
     @Override
-    public Result executeQuery( String query, Map<String,Object> parameters, TransactionalContext context )
+    public Result executeQuery( String query, Map<String,Object> parameters, TransactionalContext context, Boolean prePopulate )
             throws QueryExecutionKernelException
     {
-        return executeWithRetries( query, parameters, context, super::executeQuery );
+        return executeWithRetries( query, parameters, context, super::executeQuery, prePopulate );
     }
 
     @Override
-    public Result profileQuery( String query, Map<String,Object> parameters, TransactionalContext context )
+    public Result profileQuery( String query, Map<String,Object> parameters, TransactionalContext context, Boolean prePopulate )
             throws QueryExecutionKernelException
     {
-        return executeWithRetries( query, parameters, context, super::profileQuery );
+        return executeWithRetries( query, parameters, context, super::profileQuery, prePopulate );
     }
 
     protected <T> Result executeWithRetries( String query, T parameters, TransactionalContext context,
-            ParametrizedQueryExecutor<T> executor ) throws QueryExecutionKernelException
+            ParametrizedQueryExecutor<T> executor, Boolean prePopulate ) throws QueryExecutionKernelException
     {
         VersionContext versionContext = getCursorContext( context );
         EagerResult eagerResult;
@@ -87,7 +87,7 @@ public class SnapshotExecutionEngine extends ExecutionEngine
             }
             attempt++;
             versionContext.initRead();
-            Result result = executor.execute( query, parameters, context );
+            Result result = executor.execute( query, parameters, context, prePopulate );
             eagerResult = new EagerResult( result, versionContext );
             eagerResult.consume();
             dirtySnapshot = versionContext.isDirty();
@@ -115,7 +115,7 @@ public class SnapshotExecutionEngine extends ExecutionEngine
     @FunctionalInterface
     protected interface ParametrizedQueryExecutor<T>
     {
-        Result execute( String query, T parameters, TransactionalContext context ) throws QueryExecutionKernelException;
+        Result execute( String query, T parameters, TransactionalContext context, Boolean prePopulate ) throws QueryExecutionKernelException;
     }
 
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
@@ -82,42 +82,42 @@ class ExecutionEngine(val queryService: GraphDatabaseQueryService,
   private val javaValues = new RuntimeJavaValueConverter(isGraphKernelResultValue)
   private val scalaValues = new RuntimeScalaValueConverter(isGraphKernelResultValue)
 
-  def profile(query: String, scalaParams: Map[String, Any], context: TransactionalContext): Result = {
+  def profile(query: String, scalaParams: Map[String, Any], context: TransactionalContext, prePopulate: Boolean): Result = {
     // we got deep scala parameters => convert to deep java parameters
     val javaParams = javaValues.asDeepJavaMap(scalaParams).asInstanceOf[JavaMap[String, AnyRef]]
-    profile(query, javaParams, context)
+    profile(query, javaParams, context, prePopulate)
   }
 
-  def profile(query: String, javaParams: JavaMap[String, AnyRef], context: TransactionalContext): Result = {
+  def profile(query: String, javaParams: JavaMap[String, AnyRef], context: TransactionalContext, prePopulate: Boolean): Result = {
     // we got deep java parameters => convert to shallow scala parameters for passing into the engine
     val scalaParams: Map[String, Any] = scalaValues.asShallowScalaMap(javaParams)
-    profile(query, ValueConversion.asValues(scalaParams), context)
+    profile(query, ValueConversion.asValues(scalaParams), context, prePopulate)
   }
 
-  def profile(query: String, mapParams: MapValue, context: TransactionalContext): Result = {
+  def profile(query: String, mapParams: MapValue, context: TransactionalContext, prePopulate: Boolean): Result = {
     val (preparedPlanExecution, wrappedContext, queryParamNames) = planQuery(context)
     checkParameters(queryParamNames, mapParams, preparedPlanExecution.extractedParams)
-    preparedPlanExecution.profile(wrappedContext, mapParams)
+    preparedPlanExecution.profile(wrappedContext, mapParams, prePopulate)
   }
 
-  def execute(query: String, scalaParams: Map[String, Any], context: TransactionalContext): Result = {
+  def execute(query: String, scalaParams: Map[String, Any], context: TransactionalContext, prePopulate: Boolean): Result = {
     // we got deep scala parameters => convert to deep java parameters
     val javaParams = javaValues.asDeepJavaMap(scalaParams).asInstanceOf[JavaMap[String, AnyRef]]
-    execute(query, javaParams, context)
+    execute(query, javaParams, context, prePopulate)
   }
 
-  def execute(query: String, javaParams: JavaMap[String, AnyRef], context: TransactionalContext): Result = {
+  def execute(query: String, javaParams: JavaMap[String, AnyRef], context: TransactionalContext, prePopulate: Boolean): Result = {
     // we got deep java parameters => convert to shallow scala parameters for passing into the engine
     val scalaParams = scalaValues.asShallowScalaMap(javaParams)
-   execute(query, ValueConversion.asValues(scalaParams), context)
+   execute(query, ValueConversion.asValues(scalaParams), context, prePopulate)
   }
 
-  def execute(query: String, mapParams: MapValue, context: TransactionalContext): Result = {
+  def execute(query: String, mapParams: MapValue, context: TransactionalContext, prePopulate: Boolean): Result = {
     val (preparedPlanExecution, wrappedContext, queryParamNames) = planQuery(context)
     if (preparedPlanExecution.executionMode.name != "explain") {
       checkParameters(queryParamNames, mapParams, preparedPlanExecution.extractedParams)
     }
-    preparedPlanExecution.execute(wrappedContext, mapParams)
+    preparedPlanExecution.execute(wrappedContext, mapParams, prePopulate)
   }
 
   protected def parseQuery(queryText: String): ParsedQuery =

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionPlan.scala
@@ -30,7 +30,7 @@ final case class TransactionInfo(tx: Transaction, isTopLevelTx: Boolean, stateme
 
 trait ExecutionPlan {
 
-  def run(transactionalContext: TransactionalContextWrapper, executionMode: CypherExecutionMode, params: MapValue): Result
+  def run(transactionalContext: TransactionalContextWrapper, executionMode: CypherExecutionMode, params: MapValue, prePopulate: Boolean): Result
 
   def isPeriodicCommit: Boolean
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/PreparedPlanExecution.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/PreparedPlanExecution.scala
@@ -25,9 +25,9 @@ import org.neo4j.graphdb.Result
 import org.neo4j.values.virtual.{MapValue, VirtualValues}
 
 case class PreparedPlanExecution(plan: ExecutionPlan, executionMode: CypherExecutionMode, extractedParams: Map[String, Any]) {
-  def execute(transactionalContext: TransactionalContextWrapper, params: MapValue): Result =
-    plan.run(transactionalContext, executionMode, VirtualValues.combine(params,ValueConversion.asValues(extractedParams)))
+  def execute(transactionalContext: TransactionalContextWrapper, params: MapValue, prePopulate: Boolean): Result =
+    plan.run(transactionalContext, executionMode, VirtualValues.combine(params,ValueConversion.asValues(extractedParams)), prePopulate)
 
-  def profile(transactionalContext: TransactionalContextWrapper, params: MapValue): Result =
-    plan.run(transactionalContext, CypherExecutionMode.profile, VirtualValues.combine(params,ValueConversion.asValues(extractedParams)))
+  def profile(transactionalContext: TransactionalContextWrapper, params: MapValue, prePopulate: Boolean): Result =
+    plan.run(transactionalContext, CypherExecutionMode.profile, VirtualValues.combine(params,ValueConversion.asValues(extractedParams)), prePopulate)
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/Compatibility.scala
@@ -130,7 +130,7 @@ trait Compatibility {
 
     override val plannerInfo = new PlannerInfo(inner.plannerUsed.name, inner.runtimeUsed.name, emptyList[IndexUsage])
 
-    override def run(transactionalContext: TransactionalContextWrapper, executionMode: CypherExecutionMode, params: MapValue): Result = {
+    override def run(transactionalContext: TransactionalContextWrapper, executionMode: CypherExecutionMode, params: MapValue, prePopulate: Boolean): Result = {
       var map: mutable.Map[String, Any] = mutable.Map[String, Any]()
       params.foreach(new BiConsumer[String, AnyValue] {
         override def accept(t: String, u: AnyValue): Unit = map.put(t, valueHelper.fromValue(u))

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/Compatibility.scala
@@ -134,7 +134,7 @@ trait Compatibility {
 
     override val plannerInfo = new PlannerInfo(inner.plannerUsed.name, inner.runtimeUsed.name, emptyList[IndexUsage])
 
-    override def run(transactionalContext: TransactionalContextWrapperV3_3, executionMode: CypherExecutionMode, params: MapValue): Result = {
+    override def run(transactionalContext: TransactionalContextWrapperV3_3, executionMode: CypherExecutionMode, params: MapValue, prePopulate: Boolean): Result = {
       var map: mutable.Map[String, Any] = mutable.Map[String, Any]()
       params.foreach(new BiConsumer[String, AnyValue] {
         override def accept(t: String, u: AnyValue): Unit = map.put(t, valueHelper.fromValue(u))

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/Compatibility.scala
@@ -177,7 +177,8 @@ class ExecutionPlanWrapper(inner: ExecutionPlan_v3_2,
 
   override def run(transactionalContext: TransactionalContextWrapperV3_3,
                    executionMode: CypherExecutionMode,
-                   params: MapValue): Result = {
+                   params: MapValue,
+                   prePopulate: Boolean): Result = {
     var map: mutable.Map[String, Any] = mutable.Map[String, Any]()
     params.foreach(new BiConsumer[String, AnyValue] {
       override def accept(t: String, u: AnyValue): Unit = map.put(t, valueHelper.fromValue(u))

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/Compatibility.scala
@@ -170,7 +170,7 @@ trait Compatibility[CONTEXT <: CommunityRuntimeContext,
     }
 
     def run(transactionalContext: TransactionalContextWrapper, executionMode: CypherExecutionMode,
-            params: MapValue): Result = {
+            params: MapValue, prePopulate: Boolean): Result = {
       val innerExecutionMode = executionMode match {
         case CypherExecutionMode.explain => ExplainMode
         case CypherExecutionMode.profile => ProfileMode
@@ -180,7 +180,7 @@ trait Compatibility[CONTEXT <: CommunityRuntimeContext,
 
         val context = queryContext(transactionalContext)
 
-        val innerResult: InternalExecutionResult = inner.run(context, innerExecutionMode, params)
+        val innerResult: InternalExecutionResult = inner.run(context, innerExecutionMode, params, prePopulate)
         new ExecutionResult(new ClosingExecutionResult(
           transactionalContext.tc.executingQuery(),
           innerResult.withNotifications(preParsingNotifications.toSeq:_*),

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/DefaultExecutionResultBuilderFactory.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/DefaultExecutionResultBuilderFactory.scala
@@ -45,9 +45,14 @@ case class DefaultExecutionResultBuilderFactory(pipeInfo: PipeInfo,
     private var maybeQueryContext: Option[QueryContext] = None
     private var pipeDecorator: PipeDecorator = NullPipeDecorator
     private var exceptionDecorator: CypherException => CypherException = identity
+    private var prePopulate: Boolean = false
 
     def setQueryContext(context: QueryContext) {
       maybeQueryContext = Some(context)
+    }
+
+    override def setPrePopulate(setFlag: Boolean) = {
+      prePopulate = setFlag
     }
 
     def setLoadCsvPeriodicCommitObserver(batchRowCount: Long) {
@@ -68,7 +73,7 @@ case class DefaultExecutionResultBuilderFactory(pipeInfo: PipeInfo,
               notificationLogger: InternalNotificationLogger, runtimeName: RuntimeName): InternalExecutionResult = {
       taskCloser.addTask(queryContext.transactionalContext.close)
       val state = new QueryState(queryContext, externalResource, params, pipeDecorator,
-                                 triadicState = mutable.Map.empty, repeatableReads = mutable.Map.empty)
+                                 triadicState = mutable.Map.empty, repeatableReads = mutable.Map.empty, prePopulateResult = prePopulate)
       try {
         try {
           createResults(state, planType, notificationLogger, runtimeName)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/ExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/ExecutionPlan.scala
@@ -30,7 +30,7 @@ import org.neo4j.cypher.internal.v3_3.logical.plans.IndexUsage
 import org.neo4j.values.virtual.MapValue
 
 abstract class ExecutionPlan {
-  def run(queryContext: QueryContext, planType: ExecutionMode, params: MapValue): InternalExecutionResult
+  def run(queryContext: QueryContext, planType: ExecutionMode, params: MapValue, prePopulate: Boolean): InternalExecutionResult
   def isPeriodicCommit: Boolean
   def plannerUsed: PlannerName
   def isStale(lastTxId: () => Long, statistics: GraphStatistics): CacheCheckResult

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/ExecutionResultBuilder.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/ExecutionResultBuilder.scala
@@ -30,6 +30,7 @@ import org.neo4j.values.virtual.MapValue
 trait ExecutionResultBuilder {
   def setQueryContext(context: QueryContext)
   def setLoadCsvPeriodicCommitObserver(batchRowCount: Long)
+  def setPrePopulate(setFlag: Boolean)
   def setPipeDecorator(newDecorator: PipeDecorator)
   def setExceptionDecorator(newDecorator: CypherException => CypherException)
   def build(planType: ExecutionMode, params: MapValue,

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/procs/ProcedureCallExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/procs/ProcedureCallExecutionPlan.scala
@@ -70,8 +70,8 @@ case class ProcedureCallExecutionPlan(signature: ProcedureSignature,
   private val argExprCommands: Seq[expressions.Expression] = argExprs.map(converter.toCommandExpression) ++
     signature.inputSignature.drop(argExprs.size).flatMap(_.default).map(o => Literal(o.value))
 
-  override def run(ctx: QueryContext, planType: ExecutionMode, params: MapValue): InternalExecutionResult = {
-    val input = evaluateArguments(ctx, params)
+  override def run(ctx: QueryContext, planType: ExecutionMode, params: MapValue, prePopulate: Boolean): InternalExecutionResult = {
+    val input = evaluateArguments(ctx, params, prePopulate)
 
     val taskCloser = new TaskCloser
     taskCloser.addTask(ctx.transactionalContext.close)
@@ -111,8 +111,8 @@ case class ProcedureCallExecutionPlan(signature: ProcedureSignature,
     }
   }
 
-  private def evaluateArguments(ctx: QueryContext, params: MapValue): Seq[Any] = {
-    val state = new QueryState(ctx, ExternalCSVResource.empty, params)
+  private def evaluateArguments(ctx: QueryContext, params: MapValue, prePopulate: Boolean): Seq[Any] = {
+    val state = new QueryState(ctx, ExternalCSVResource.empty, params, prePopulateResult = prePopulate)
     argExprCommands.map(expr => ctx.asObject(expr.apply(ExecutionContext.empty, state)))
   }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/procs/PureSideEffectExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/procs/PureSideEffectExecutionPlan.scala
@@ -45,7 +45,7 @@ case class PureSideEffectExecutionPlan(name: String, queryType: InternalQueryTyp
   extends ExecutionPlan {
 
   override def run(ctx: QueryContext, planType: ExecutionMode,
-                   params: MapValue): InternalExecutionResult = {
+                   params: MapValue, prePopulate: Boolean): InternalExecutionResult = {
     if (planType == ExplainMode) {
       //close all statements
       ctx.transactionalContext.close(success = true)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/helpers/simpleExpressionEvaluator.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/helpers/simpleExpressionEvaluator.scala
@@ -43,7 +43,8 @@ object simpleExpressionEvaluator extends ExpressionEvaluator {
         params = VirtualValues.EMPTY_MAP,
         decorator = NullPipeDecorator,
         triadicState = mutable.Map.empty,
-        repeatableReads = mutable.Map.empty)
+        repeatableReads = mutable.Map.empty,
+        prePopulateResult = false)
 
     try {
       Some(commandExpr(ExecutionContext.empty, emptyQueryState))

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/QueryState.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/QueryState.scala
@@ -40,7 +40,8 @@ class QueryState(val query: QueryContext,
                  val triadicState: mutable.Map[String, PrimitiveLongSet] = mutable.Map.empty,
                  val repeatableReads: mutable.Map[Pipe, Seq[ExecutionContext]] = mutable.Map.empty,
                  val cachedIn: SingleThreadedLRUCache[Any, InCheckContainer] =
-                   new SingleThreadedLRUCache(maxSize = 16)) {
+                   new SingleThreadedLRUCache(maxSize = 16),
+                 val prePopulateResult: Boolean = false ) {
   private var _pathValueBuilder: PathValueBuilder = _
 
   def createOrGetInitialContext(): ExecutionContext = initialContext.getOrElse(ExecutionContext.empty)
@@ -62,10 +63,10 @@ class QueryState(val query: QueryContext,
   def getStatistics: QueryStatistics = query.getOptStatistics.getOrElse(QueryState.defaultStatistics)
 
   def withDecorator(decorator: PipeDecorator) =
-    new QueryState(query, resources, params, decorator, timeReader, initialContext, triadicState, repeatableReads, cachedIn)
+    new QueryState(query, resources, params, decorator, timeReader, initialContext, triadicState, repeatableReads, cachedIn, prePopulateResult)
 
   def withInitialContext(initialContext: ExecutionContext) =
-    new QueryState(query, resources, params, decorator, timeReader, Some(initialContext), triadicState, repeatableReads, cachedIn)
+    new QueryState(query, resources, params, decorator, timeReader, Some(initialContext), triadicState, repeatableReads, cachedIn, prePopulateResult)
 
   /**
     * When running on the RHS of an Apply, this method will fill an execution context with argument data
@@ -76,7 +77,7 @@ class QueryState(val query: QueryContext,
   def copyArgumentStateTo(ctx: ExecutionContext): Unit = initialContext.foreach(initData => initData.copyTo(ctx))
 
   def withQueryContext(query: QueryContext) =
-    new QueryState(query, resources, params, decorator, timeReader, initialContext, triadicState, repeatableReads, cachedIn)
+    new QueryState(query, resources, params, decorator, timeReader, initialContext, triadicState, repeatableReads, cachedIn, prePopulateResult)
 }
 
 object QueryState {

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/QueryExecutionMonitorTest.scala
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/QueryExecutionMonitorTest.scala
@@ -43,7 +43,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite with GraphIcing with Grap
   private def runQuery(query: String): (ExecutingQuery, Result) = {
     val context = db.transactionalContext(query = query -> Map.empty)
     val executingQuery = context.executingQuery()
-    val executionResult = engine.execute(executingQuery.queryText(), executingQuery.queryParameters(), context)
+    val executionResult = engine.execute(executingQuery.queryText(), executingQuery.queryParameters(), context, false)
     (executingQuery, executionResult)
   }
 
@@ -246,7 +246,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite with GraphIcing with Grap
     val context = db.transactionalContext(query = "CYPHER 2.3 CREATE()" -> Map.empty)
 
     // when
-    val result = engine.execute(context.queryText(), context.queryParameters(), context)
+    val result = engine.execute(context.queryText(), context.queryParameters(), context, false)
 
     // then
     verify(monitor, times(1)).startQueryExecution(context)
@@ -258,7 +258,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite with GraphIcing with Grap
     val context = db.transactionalContext(query = "CYPHER 3.1 RETURN [1, 2, 3, 4, 5]" -> Map.empty)
 
     // when
-    val result = engine.profile(context.queryText(), context.queryParameters(), context)
+    val result = engine.profile(context.queryText(), context.queryParameters(), context, false)
 
     //then
     verify(monitor, times(1)).startQueryExecution(context)

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionEngineTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionEngineTest.java
@@ -73,7 +73,7 @@ public class ExecutionEngineTest
         {
             String query = "RETURN { key : 'Value' , collectionKey: [{ inner: 'Map1' }, { inner: 'Map2' }]}";
             TransactionalContext tc = createTransactionContext( graph, tx, query );
-            result = executionEngine.executeQuery( query, NO_PARAMS, tc );
+            result = executionEngine.executeQuery( query, NO_PARAMS, tc, false );
 
             verifyResult( result );
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineIT.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineIT.scala
@@ -206,9 +206,9 @@ class ExecutionEngineIT extends CypherFunSuite with GraphIcing {
 
   implicit class RichExecutionEngine(engine: ExecutionEngine) {
     def profile(query: String, params: Map[String, Any]): Result =
-      engine.profile(query, params, engine.queryService.transactionalContext(query = query -> params))
+      engine.profile(query, params, engine.queryService.transactionalContext(query = query -> params), false)
 
     def execute(query: String, params: Map[String, Any]): Result =
-      engine.execute(query, params, engine.queryService.transactionalContext(query = query -> params))
+      engine.execute(query, params, engine.queryService.transactionalContext(query = query -> params), false)
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTestSupport.scala
@@ -105,13 +105,13 @@ trait ExecutionEngineHelper {
   def eengine: ExecutionEngine
 
   def execute(q: String, params: (String, Any)*): InternalExecutionResult =
-    RewindableExecutionResult(eengine.execute(q, params.toMap, graph.transactionalContext(query = q -> params.toMap)))
+    RewindableExecutionResult(eengine.execute(q, params.toMap, graph.transactionalContext(query = q -> params.toMap), false))
 
   def profile(q: String, params: (String, Any)*): InternalExecutionResult =
-    RewindableExecutionResult(eengine.profile(q, params.toMap, graph.transactionalContext(query = q -> params.toMap)))
+    RewindableExecutionResult(eengine.profile(q, params.toMap, graph.transactionalContext(query = q -> params.toMap), false))
 
   def executeScalar[T](q: String, params: (String, Any)*): T = {
-    val res = eengine.execute(q, params.toMap, graph.transactionalContext(query = q -> params.toMap))
+    val res = eengine.execute(q, params.toMap, graph.transactionalContext(query = q -> params.toMap), false)
     scalar[T](asScalaResult(res).toList)
   }
 
@@ -132,9 +132,9 @@ trait ExecutionEngineHelper {
 
   implicit class RichExecutionEngine(engine: ExecutionEngine) {
     def profile(query: String, params: Map[String, Any]): Result =
-      engine.profile(query, params, engine.queryService.transactionalContext(query = query -> params))
+      engine.profile(query, params, engine.queryService.transactionalContext(query = query -> params), false)
 
     def execute(query: String, params: Map[String, Any]): Result =
-      engine.execute(query, params, engine.queryService.transactionalContext(query = query -> params))
+      engine.execute(query, params, engine.queryService.transactionalContext(query = query -> params), false)
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/KillQueryTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/KillQueryTest.scala
@@ -110,7 +110,7 @@ class KillQueryTest extends ExecutionEngineFunSuite {
           try {
             val transactionalContext: TransactionalContext = contextFactory.newContext(connectionInfo, tx, query, EMPTY_MAP)
             tcs.put(transactionalContext)
-            val result = engine.execute(query, Map.empty[String, AnyRef], transactionalContext)
+            val result = engine.execute(query, Map.empty[String, AnyRef], transactionalContext, false)
             result.resultAsString()
             tx.success()
           }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/procs/ProcedureCallExecutionPlanTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/procs/ProcedureCallExecutionPlanTest.scala
@@ -44,7 +44,7 @@ class ProcedureCallExecutionPlanTest extends CypherFunSuite {
                                           notifications = Set.empty, converters)
 
     // When
-    val res = proc.run(ctx, NormalMode, EMPTY_MAP)
+    val res = proc.run(ctx, NormalMode, EMPTY_MAP, false)
 
     // Then
     res.toList should equal(List(Map("b" -> 84)))
@@ -57,7 +57,7 @@ class ProcedureCallExecutionPlanTest extends CypherFunSuite {
                                           notifications = Set.empty, converters)
 
     // When
-    proc.run(ctx, NormalMode, EMPTY_MAP)
+    proc.run(ctx, NormalMode, EMPTY_MAP, false)
 
     // Then without touching the result, it should have been spooled out
     iteratorExhausted should equal(true)
@@ -70,7 +70,7 @@ class ProcedureCallExecutionPlanTest extends CypherFunSuite {
                                           notifications = Set.empty, converters)
 
     // When
-    proc.run(ctx, NormalMode, EMPTY_MAP)
+    proc.run(ctx, NormalMode, EMPTY_MAP, false)
 
     // Then without touching the result, the Kernel iterator should not be touched
     iteratorExhausted should equal(false)

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/ClassicCoreSPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/ClassicCoreSPI.java
@@ -77,7 +77,7 @@ class ClassicCoreSPI implements GraphDatabaseFacade.SPI
         try
         {
             availability.assertDatabaseAvailable();
-            return dataSource.queryExecutor.get().executeQuery( query, parameters, transactionalContext );
+            return dataSource.queryExecutor.get().executeQuery( query, parameters, transactionalContext, false );
         }
         catch ( QueryExecutionKernelException e )
         {
@@ -91,7 +91,7 @@ class ClassicCoreSPI implements GraphDatabaseFacade.SPI
         try
         {
             availability.assertDatabaseAvailable();
-            return dataSource.queryExecutor.get().executeQuery( query, parameters, transactionalContext );
+            return dataSource.queryExecutor.get().executeQuery( query, parameters, transactionalContext, false );
         }
         catch ( QueryExecutionKernelException e )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureGDBFacadeSPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureGDBFacadeSPI.java
@@ -126,7 +126,7 @@ class ProcedureGDBFacadeSPI implements GraphDatabaseFacade.SPI
         try
         {
             availability.assertDatabaseAvailable();
-            return sourceModule.queryExecutor.get().executeQuery( query, parameters, tc );
+            return sourceModule.queryExecutor.get().executeQuery( query, parameters, tc, false );
         }
         catch ( QueryExecutionKernelException e )
         {
@@ -140,7 +140,7 @@ class ProcedureGDBFacadeSPI implements GraphDatabaseFacade.SPI
         try
         {
             availability.assertDatabaseAvailable();
-            return sourceModule.queryExecutor.get().executeQuery( query, parameters, tc );
+            return sourceModule.queryExecutor.get().executeQuery( query, parameters, tc, false );
         }
         catch ( QueryExecutionKernelException e )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/NoQueryEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/NoQueryEngine.java
@@ -29,13 +29,13 @@ enum NoQueryEngine implements QueryExecutionEngine
     INSTANCE;
 
     @Override
-    public Result executeQuery( String query, MapValue parameters, TransactionalContext context )
+    public Result executeQuery( String query, MapValue parameters, TransactionalContext context, Boolean prePopulate )
     {
         throw noQueryEngine();
     }
 
     @Override
-    public Result executeQuery( String query, Map<String,Object> parameters, TransactionalContext context )
+    public Result executeQuery( String query, Map<String,Object> parameters, TransactionalContext context, Boolean prePopulate )
     {
         throw noQueryEngine();
     }
@@ -47,7 +47,7 @@ enum NoQueryEngine implements QueryExecutionEngine
     }
 
     @Override
-    public Result profileQuery( String query, Map<String,Object> parameter, TransactionalContext context )
+    public Result profileQuery( String query, Map<String,Object> parameter, TransactionalContext context, Boolean prePopulate )
     {
         throw noQueryEngine();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryExecutionEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryExecutionEngine.java
@@ -26,13 +26,13 @@ import org.neo4j.values.virtual.MapValue;
 
 public interface QueryExecutionEngine
 {
-    Result executeQuery( String query, MapValue parameters, TransactionalContext context )
+    Result executeQuery( String query, MapValue parameters, TransactionalContext context, Boolean prePopulate )
             throws QueryExecutionKernelException;
 
-    Result executeQuery( String query, Map<String,Object> parameters, TransactionalContext context )
+    Result executeQuery( String query, Map<String,Object> parameters, TransactionalContext context, Boolean prePopulate )
             throws QueryExecutionKernelException;
 
-    Result profileQuery( String query, Map<String,Object> parameters, TransactionalContext context )
+    Result profileQuery( String query, Map<String,Object> parameters, TransactionalContext context, Boolean prePopulate )
             throws QueryExecutionKernelException;
 
     boolean isPeriodicCommit( String query );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/NodeProxyWrappingNodeValue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/NodeProxyWrappingNodeValue.java
@@ -73,6 +73,12 @@ public class NodeProxyWrappingNodeValue extends NodeValue
         writer.writeNode( node.getId(), l, p );
     }
 
+    public void populate()
+    {
+        labels();
+        properties();
+    }
+
     @Override
     public TextArray labels()
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/RelationshipProxyWrappingEdgeValue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/RelationshipProxyWrappingEdgeValue.java
@@ -70,6 +70,14 @@ public class RelationshipProxyWrappingEdgeValue extends EdgeValue
         writer.writeEdge( id(), startNode().id(), endNode().id(), type(), p );
     }
 
+    public void populate()
+    {
+        type();
+        properties();
+        startNode();
+        endNode();
+    }
+
     @Override
     public NodeValue startNode()
     {

--- a/community/neo4j/src/test/java/org/neo4j/locking/QueryExecutionLocksIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/locking/QueryExecutionLocksIT.java
@@ -210,7 +210,7 @@ public class QueryExecutionLocksIT
         {
             TransactionalContextWrapper context =
                     new TransactionalContextWrapper( createTransactionContext( graph, tx, query ), listeners );
-            executionEngine.executeQuery( query, Collections.emptyMap(), context );
+            executionEngine.executeQuery( query, Collections.emptyMap(), context, false );
             return new ArrayList<>( context.recordingReadOperationsWrapper.getLockOperationRecords() );
         }
     }

--- a/community/server/src/main/java/org/neo4j/server/rest/management/console/CypherSession.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/console/CypherSession.java
@@ -60,7 +60,7 @@ public class CypherSession implements ScriptSession
         {
             TransactionalContext tc = cypherExecutor.createTransactionContext( script, emptyMap(), request );
             ExecutionEngine engine = cypherExecutor.getExecutionEngine();
-            Result result = engine.executeQuery( script, emptyMap(), tc );
+            Result result = engine.executeQuery( script, emptyMap(), tc, false );
             resultString = result.resultAsString();
         }
         catch ( SyntaxException error )

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandle.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandle.java
@@ -368,7 +368,7 @@ public class TransactionHandle implements TransactionTerminationHandle
     {
         try
         {
-            return engine.executeQuery( statement.statement(), statement.parameters(), tc );
+            return engine.executeQuery( statement.statement(), statement.parameters(), tc, false );
         }
         finally
         {

--- a/community/server/src/main/java/org/neo4j/server/rest/web/CypherService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/CypherService.java
@@ -123,12 +123,12 @@ public class CypherService
             Result result;
             if ( profile )
             {
-                result = executionEngine.profileQuery( query, params, tc );
+                result = executionEngine.profileQuery( query, params, tc, false );
                 includePlan = true;
             }
             else
             {
-                result = executionEngine.executeQuery( query, params, tc );
+                result = executionEngine.executeQuery( query, params, tc, false );
                 includePlan = result.getQueryExecutionType().requestedExecutionPlanDescription();
             }
 

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleTest.java
@@ -81,7 +81,7 @@ public class TransactionHandleTest
         QueryExecutionEngine executionEngine = mock( QueryExecutionEngine.class );
         Result executionResult = mock( Result.class );
         TransactionalContext transactionalContext = prepareKernelWithQuerySession( kernel );
-        when( executionEngine.executeQuery( "query", map(), transactionalContext ) ).thenReturn( executionResult );
+        when( executionEngine.executeQuery( "query", map(), transactionalContext, false ) ).thenReturn( executionResult );
         TransactionRegistry registry = mock( TransactionRegistry.class );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337L );
         TransactionHandle handle = getTransactionHandle( kernel, executionEngine, registry );
@@ -92,7 +92,7 @@ public class TransactionHandleTest
                 mock( HttpServletRequest.class ) );
 
         // then
-        verify( executionEngine ).executeQuery( "query", map(), transactionalContext );
+        verify( executionEngine ).executeQuery( "query", map(), transactionalContext, false );
 
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).transactionCommitUri( uriScheme.txCommitUri( 1337 ) );
@@ -116,7 +116,7 @@ public class TransactionHandleTest
         QueryExecutionEngine executionEngine = mock( QueryExecutionEngine.class );
         TransactionalContext transactionalContext = prepareKernelWithQuerySession( kernel );
         Result executionResult = mock( Result.class );
-        when( executionEngine.executeQuery( "query", map(), transactionalContext) ).thenReturn( executionResult );
+        when( executionEngine.executeQuery( "query", map(), transactionalContext, false) ).thenReturn( executionResult );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337L );
         TransactionHandle handle = getTransactionHandle( kernel, executionEngine, registry );
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
@@ -158,7 +158,7 @@ public class TransactionHandleTest
                 mock( HttpServletRequest.class ) );
         reset( transactionContext, registry, executionEngine, output );
         Result executionResult = mock( Result.class );
-        when( executionEngine.executeQuery( "query", map(), transactionalContext )
+        when( executionEngine.executeQuery( "query", map(), transactionalContext, false )
         ).thenReturn( executionResult );
 
         // when
@@ -168,7 +168,7 @@ public class TransactionHandleTest
         // then
         InOrder order = inOrder( transactionContext, registry, executionEngine );
         order.verify( transactionContext ).resumeSinceTransactionsAreStillThreadBound();
-        order.verify( executionEngine ).executeQuery( "query", map(), transactionalContext );
+        order.verify( executionEngine ).executeQuery( "query", map(), transactionalContext, false );
         order.verify( transactionContext ).suspendSinceTransactionsAreStillThreadBound();
         order.verify( registry ).release( 1337L, handle );
 
@@ -193,7 +193,7 @@ public class TransactionHandleTest
         Result executionResult = mock( Result.class );
         TransactionalContext transactionalContext = prepareKernelWithQuerySession( kernel );
         when( executionEngine.isPeriodicCommit( queryText) ).thenReturn( true );
-        when( executionEngine.executeQuery( eq( queryText ), eq( map() ), eq( transactionalContext ) ) )
+        when( executionEngine.executeQuery( eq( queryText ), eq( map() ), eq( transactionalContext ), false ) )
                 .thenReturn( executionResult );
 
         TransactionRegistry registry = mock( TransactionRegistry.class );
@@ -206,7 +206,7 @@ public class TransactionHandleTest
         handle.commit( statements( statement ), output, mock( HttpServletRequest.class ) );
 
         // then
-        verify( executionEngine ).executeQuery( queryText, map(), transactionalContext );
+        verify( executionEngine ).executeQuery( queryText, map(), transactionalContext, false );
 
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).statementResult( executionResult, false, (ResultDataContent[]) null );
@@ -228,7 +228,7 @@ public class TransactionHandleTest
         QueryExecutionEngine engine = mock( QueryExecutionEngine.class );
         TransactionalContext transactionalContext = prepareKernelWithQuerySession( kernel );
         Result result = mock( Result.class );
-        when( engine.executeQuery( "query", map(), transactionalContext ) ).thenReturn( result );
+        when( engine.executeQuery( "query", map(), transactionalContext, false ) ).thenReturn( result );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337L );
         GraphDatabaseQueryService queryService = mock( GraphDatabaseQueryService.class );
         TransactionHandle handle = new TransactionHandle( kernel, engine, queryService, registry, uriScheme, false,
@@ -294,7 +294,7 @@ public class TransactionHandleTest
         QueryExecutionEngine engine = mock( QueryExecutionEngine.class );
         Result executionResult = mock( Result.class );
         TransactionalContext transactionalContext = prepareKernelWithQuerySession( kernel );
-        when( engine.executeQuery( "query", map(), transactionalContext ) ).thenReturn( executionResult );
+        when( engine.executeQuery( "query", map(), transactionalContext, false ) ).thenReturn( executionResult );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337L );
         GraphDatabaseQueryService queryService = mock( GraphDatabaseQueryService.class );
         TransactionHandle handle = new TransactionHandle( kernel, engine, queryService, registry, uriScheme, true,
@@ -332,7 +332,7 @@ public class TransactionHandleTest
 
         QueryExecutionEngine executionEngine = mock( QueryExecutionEngine.class );
         TransactionalContext transactionalContext = prepareKernelWithQuerySession( kernel );
-        when( executionEngine.executeQuery( "query", map(), transactionalContext ) ).thenThrow( new NullPointerException() );
+        when( executionEngine.executeQuery( "query", map(), transactionalContext, false ) ).thenThrow( new NullPointerException() );
 
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337L );
         TransactionHandle handle = getTransactionHandle( kernel, executionEngine, registry );
@@ -370,7 +370,7 @@ public class TransactionHandleTest
         QueryExecutionEngine engine = mock( QueryExecutionEngine.class );
         Result executionResult = mock( Result.class );
         TransactionalContext transactionalContext = prepareKernelWithQuerySession( kernel );
-        when( engine.executeQuery( "query", map(), transactionalContext ) ).thenReturn( executionResult );
+        when( engine.executeQuery( "query", map(), transactionalContext, false ) ).thenReturn( executionResult );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337L );
         GraphDatabaseQueryService queryService = mock( GraphDatabaseQueryService.class );
         TransactionHandle handle = new TransactionHandle( kernel, engine, queryService, registry, uriScheme, false,
@@ -401,7 +401,7 @@ public class TransactionHandleTest
 
         QueryExecutionEngine executionEngine = mock( QueryExecutionEngine.class );
         TransactionalContext transactionalContext = prepareKernelWithQuerySession( kernel );
-        when( executionEngine.executeQuery( "matsch (n) return n", map(), transactionalContext ) )
+        when( executionEngine.executeQuery( "matsch (n) return n", map(), transactionalContext, false ) )
                 .thenThrow( new QueryExecutionKernelException( new SyntaxException( "did you mean MATCH?" ) ) );
 
         TransactionRegistry registry = mock( TransactionRegistry.class );
@@ -429,7 +429,7 @@ public class TransactionHandleTest
     {
         // given
         QueryExecutionEngine executionEngine = mock( QueryExecutionEngine.class );
-        when( executionEngine.executeQuery( eq( "match (n) return n" ), eq( map() ), any( TransactionalContext.class ) ) ).thenAnswer(
+        when( executionEngine.executeQuery( eq( "match (n) return n" ), eq( map() ), any( TransactionalContext.class ), false ) ).thenAnswer(
                 invocationOnMock ->
                 {
                     throw new Exception( "BOO" );
@@ -484,7 +484,7 @@ public class TransactionHandleTest
     {
         // given
         QueryExecutionEngine executionEngine = mock( QueryExecutionEngine.class );
-        when( executionEngine.executeQuery( anyString(), anyMap(), any( TransactionalContext.class ) ) )
+        when( executionEngine.executeQuery( anyString(), anyMap(), any( TransactionalContext.class ), false ) )
                 .thenThrow( new DeadlockDetectedException( "deadlock" ) );
 
         GraphDatabaseQueryService queryService = mock( GraphDatabaseQueryService.class );

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Start.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Start.java
@@ -121,7 +121,7 @@ public class Start extends TransactionProvidingApp
     {
         Map<String,Object> parameters = getParameters( session );
         TransactionalContext tc = createTransactionContext( query, parameters, session );
-        return getEngine().executeQuery( query, parameters, tc );
+        return getEngine().executeQuery( query, parameters, tc, false );
     }
 
     private String trimQuery( String query )

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
@@ -250,7 +250,7 @@ trait CypherComparisonSupport extends CypherTestSupport {
     innerExecute(queryText, params)
 
   private def innerExecute(queryText: String, params: Map[String, Any]): InternalExecutionResult = {
-    val innerResult: Result = eengine.execute(queryText, params, graph.transactionalContext(query = queryText -> params))
+    val innerResult: Result = eengine.execute(queryText, params, graph.transactionalContext(query = queryText -> params), false)
     RewindableExecutionResult(innerResult)
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherCompilerStringCacheMonitoringAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherCompilerStringCacheMonitoringAcceptanceTest.scala
@@ -123,11 +123,11 @@ class CypherCompilerStringCacheMonitoringAcceptanceTest extends ExecutionEngineF
 
     createLabeledNode("Dog")
     (0 until 50).foreach { _ => createLabeledNode("Person") }
-    engine.execute(query, Map.empty[String, Any], graph.transactionalContext(query = query -> Map.empty)).resultAsString()
+    engine.execute(query, Map.empty[String, Any], graph.transactionalContext(query = query -> Map.empty), false).resultAsString()
 
     // when
     (0 until 1000).foreach { _ => createLabeledNode("Dog") }
-    engine.execute(query, Map.empty[String, Any], graph.transactionalContext(query = query -> Map.empty)).resultAsString()
+    engine.execute(query, Map.empty[String, Any], graph.transactionalContext(query = query -> Map.empty), false).resultAsString()
 
     logProvider.assertAtLeastOnce(
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionResultAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionResultAcceptanceTest.scala
@@ -32,7 +32,7 @@ class ExecutionResultAcceptanceTest extends ExecutionEngineFunSuite{
     Configs.All.scenarios.map(s =>
     s"CYPHER ${s.preparserOptions} $query").foreach(q => {
       val tx = graph.beginTransaction(KernelTransaction.Type.`explicit`, AUTH_DISABLED)
-      val result = eengine.execute(q, Map.empty[String, Object], graph.transactionalContext(query = q -> Map.empty))
+      val result = eengine.execute(q, Map.empty[String, Object], graph.transactionalContext(query = q -> Map.empty), false)
       tx.success()
       result.close()
       tx.close()

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildSlottedExecutionPlan.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildSlottedExecutionPlan.scala
@@ -93,13 +93,13 @@ object BuildSlottedExecutionPlan extends Phase[EnterpriseRuntimeContext, Logical
                                   isPeriodicCommit: Boolean,
                                   plannerUsed: PlannerName,
                                   override val plannedIndexUsage: Seq[IndexUsage],
-                                  runFunction: (QueryContext, ExecutionMode, MapValue) => InternalExecutionResult,
+                                  runFunction: (QueryContext, ExecutionMode, MapValue, Boolean) => InternalExecutionResult,
                                   pipe: Pipe,
                                   config: CypherCompilerConfiguration) extends executionplan.ExecutionPlan {
 
     override def run(queryContext: QueryContext, planType: ExecutionMode,
-                     params: MapValue): InternalExecutionResult =
-      runFunction(queryContext, planType, params)
+                     params: MapValue, prePopulate: Boolean): InternalExecutionResult =
+      runFunction(queryContext, planType, params, prePopulate)
 
     override def isStale(lastTxId: () => Long, statistics: GraphStatistics): CacheCheckResult = fingerprint.isStale(lastTxId, statistics)
 

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/compiled/BuildCompiledExecutionPlan.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/compiled/BuildCompiledExecutionPlan.scala
@@ -103,7 +103,7 @@ object BuildCompiledExecutionPlan extends Phase[EnterpriseRuntimeContext, Logica
                               val notifications: Set[Notification]) extends ExecutionPlan {
 
     override def run(queryContext: QueryContext,
-                     executionMode: ExecutionMode, params: MapValue): InternalExecutionResult = {
+                     executionMode: ExecutionMode, params: MapValue, prePopulate: Boolean): InternalExecutionResult = {
       val taskCloser = new TaskCloser
       taskCloser.addTask(queryContext.transactionalContext.close)
       try {

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/CloseTransactionTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/CloseTransactionTest.scala
@@ -476,10 +476,10 @@ class CloseTransactionTest extends CypherFunSuite with GraphIcing {
 
   implicit class RichExecutionEngine(engine: ExecutionEngine) {
     def profile(query: String, params: Map[String, Any]): Result =
-      engine.profile(query, params, engine.queryService.transactionalContext(query = query -> params))
+      engine.profile(query, params, engine.queryService.transactionalContext(query = query -> params), false)
 
     def execute(query: String, params: Map[String, Any]): Result =
-      engine.execute(query, params, engine.queryService.transactionalContext(query = query -> params))
+      engine.execute(query, params, engine.queryService.transactionalContext(query = query -> params), false)
   }
 
   class AllNodesProcedure extends CallableProcedure {

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineIT.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineIT.scala
@@ -65,10 +65,10 @@ class ExecutionEngineIT extends CypherFunSuite with GraphIcing {
 
   implicit class RichExecutionEngine(engine: ExecutionEngine) {
     def profile(query: String, params: Map[String, Any]): Result =
-      engine.profile(query, params, engine.queryService.transactionalContext(query = query -> params))
+      engine.profile(query, params, engine.queryService.transactionalContext(query = query -> params), false)
 
     def execute(query: String, params: Map[String, Any]): Result =
-      engine.execute(query, params, engine.queryService.transactionalContext(query = query -> params))
+      engine.execute(query, params, engine.queryService.transactionalContext(query = query -> params), false)
   }
 
   class AllNodesProcedure extends CallableProcedure {

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/NewPlannerTestSupport.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/NewPlannerTestSupport.scala
@@ -230,7 +230,7 @@ trait NewPlannerTestSupport extends CypherTestSupport {
   }
 
   protected def innerExecute(queryText: String, params: (String, Any)*): InternalExecutionResult = {
-    val result: Result = eengine.execute(queryText, params.toMap, graph.transactionalContext(query = queryText -> params.toMap))
+    val result: Result = eengine.execute(queryText, params.toMap, graph.transactionalContext(query = queryText -> params.toMap), false)
     rewindableResult(result)
   }
 

--- a/integrationtests/src/test/java/org/neo4j/bolt/CypherOverBoltIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/CypherOverBoltIT.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.neo4j.driver.v1.Config;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.driver.v1.types.Node;
+import org.neo4j.harness.junit.Neo4jRule;
+import org.neo4j.io.fs.FileUtils;
+import org.neo4j.kernel.configuration.Settings;
+import org.neo4j.server.configuration.ServerSettings;
+import org.neo4j.test.rule.SuppressOutput;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CypherOverBoltIT
+{
+    @Rule
+    public final SuppressOutput suppressOutput = SuppressOutput.suppressAll();
+    @Rule
+    public Neo4jRule graphDb = new Neo4jRule().withConfig( ServerSettings.script_enabled, Settings.TRUE );
+
+    private URL url;
+    private final int lineCountInCSV = 3;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        url = prepareTestImportFile( lineCountInCSV );
+    }
+
+    @Test
+    public void mixingPeriodicCommitAndLoadCSVShouldWork()
+    {
+        try ( Driver driver = GraphDatabase.driver( graphDb.boltURI(), configuration() ); Session session = driver.session() )
+        {
+            StatementResult result = session.run( "USING PERIODIC COMMIT 10000\n" + "LOAD CSV FROM \"" + url + "\" as row fieldterminator \" \"\n" +
+                    "merge (currentnode:Label1 {uuid:row[0]})\n" + "return currentnode;" );
+            int countOfNodes = 0;
+            while ( result.hasNext() )
+            {
+                Node node = result.next().get( 0 ).asNode();
+                assertTrue( node.hasLabel( "Label1" ) );
+                assertEquals( String.valueOf(countOfNodes), node.get( "uuid" ).asString());
+                countOfNodes++;
+            }
+            assertEquals( lineCountInCSV, countOfNodes );
+        }
+    }
+
+    @Test
+    public void mixingPeriodicCommitAndLoadCSVShouldWorkWithLists() throws Exception
+    {
+        try ( Driver driver = GraphDatabase.driver( graphDb.boltURI(), configuration() ); Session session = driver.session() )
+        {
+            StatementResult result = session.run( "USING PERIODIC COMMIT 10000\n" + "LOAD CSV FROM \"" + url + "\" as row fieldterminator \" \"\n" +
+                    "merge (currentnode:Label2 {uuid:row[0]})\n" + "RETURN [currentnode];" );
+            int countOfNodes = 0;
+            while ( result.hasNext() )
+            {
+                Iterator<Object> iterator = result.next().get( 0 ).asList().iterator();
+                while ( iterator.hasNext() )
+                {
+                    Node node = (Node) iterator.next();
+                    assertTrue( node.hasLabel( "Label2" ) );
+                    assertEquals( String.valueOf( countOfNodes ), node.get( "uuid" ).asString() );
+                    countOfNodes++;
+                }
+            }
+            assertEquals( lineCountInCSV, countOfNodes );
+        }
+    }
+
+    @Test
+    public void mixingPeriodicCommitAndLoadCSVShouldWorkWithListsOfLists() throws Exception
+    {
+        try ( Driver driver = GraphDatabase.driver( graphDb.boltURI(), configuration() ); Session session = driver.session() )
+        {
+            StatementResult result = session.run( "USING PERIODIC COMMIT 10000\n" + "LOAD CSV FROM \"" + url + "\" as row fieldterminator \" \"\n" +
+                    "merge (currentnode:Label3 {uuid:row[0]})\n" + "RETURN [[currentnode]];" );
+            int countOfNodes = 0;
+            while ( result.hasNext() )
+            {
+                Iterator<Object> iterator = result.next().get( 0 ).asList().iterator();  // iterator over outer list
+                assertTrue( iterator.hasNext() );
+                iterator = ((List<Object>) iterator.next()).iterator();  // iterator over inner list
+                while ( iterator.hasNext() )
+                {
+                    Node node = (Node) iterator.next();
+                    assertTrue( node.hasLabel( "Label3" ) );
+                    assertEquals( String.valueOf( countOfNodes ), node.get( "uuid" ).asString() );
+                    countOfNodes++;
+                }
+            }
+            assertEquals( lineCountInCSV, countOfNodes );
+        }
+    }
+
+    @Test
+    public void mixingPeriodicCommitAndLoadCSVShouldWorkWithMaps() throws Exception
+    {
+        try ( Driver driver = GraphDatabase.driver( graphDb.boltURI(), configuration() ); Session session = driver.session() )
+        {
+            StatementResult result = session.run( "USING PERIODIC COMMIT 10000\n" + "LOAD CSV FROM \"" + url + "\" as row fieldterminator \" \"\n" +
+                    "merge (currentnode:Label4 {uuid:row[0]})\n" + "RETURN {node:currentnode};" );
+            int countOfNodes = 0;
+            while ( result.hasNext() )
+            {
+                Iterator<Map.Entry<String,Object>> iterator = result.next().get( 0 ).asMap().entrySet().iterator();
+                while ( iterator.hasNext() )
+                {
+                    Map.Entry<String,Object> entry = iterator.next();
+                    assertEquals( "node", entry.getKey() );
+                    Node node = (Node) entry.getValue();
+                    assertTrue( node.hasLabel( "Label4" ) );
+                    assertEquals( String.valueOf( countOfNodes ), node.get( "uuid" ).asString() );
+                    countOfNodes++;
+                }
+            }
+            assertEquals( lineCountInCSV, countOfNodes );
+        }
+    }
+
+    @Test
+    public void mixingPeriodicCommitAndLoadCSVShouldWorkWithMapsWithinMaps() throws Exception
+    {
+        try ( Driver driver = GraphDatabase.driver( graphDb.boltURI(), configuration() ); Session session = driver.session() )
+        {
+            StatementResult result = session.run( "USING PERIODIC COMMIT 10000\n" + "LOAD CSV FROM \"" + url + "\" as row fieldterminator \" \"\n" +
+                    "merge (currentnode:Label5 {uuid:row[0]})\n" + "RETURN {outer:{node:currentnode}};" );
+            int countOfNodes = 0;
+            while ( result.hasNext() )
+            {
+                Iterator<Map.Entry<String,Object>> iterator = result.next().get( 0 ).asMap().entrySet().iterator();
+                assertTrue( iterator.hasNext() );
+                iterator = ((Map<String,Object>)iterator.next().getValue()).entrySet().iterator();
+                while ( iterator.hasNext() )
+                {
+                    Map.Entry<String,Object> entry = iterator.next();
+                    assertEquals( "node", entry.getKey() );
+                    Node node = (Node) entry.getValue();
+                    assertTrue( node.hasLabel( "Label5" ) );
+                    assertEquals( String.valueOf( countOfNodes ), node.get( "uuid" ).asString() );
+                    countOfNodes++;
+                }
+            }
+
+            assertEquals( lineCountInCSV, countOfNodes );
+        }
+    }
+
+    @Test
+    public void mixingPeriodicCommitAndLoadCSVShouldWorkWithMapsWithLists() throws Exception
+    {
+        try ( Driver driver = GraphDatabase.driver( graphDb.boltURI(), configuration() ); Session session = driver.session() )
+        {
+            StatementResult result = session.run( "USING PERIODIC COMMIT 10000\n" + "LOAD CSV FROM \"" + url + "\" as row fieldterminator \" \"\n" +
+                    "merge (currentnode:Label6 {uuid:row[0]})\n" + "RETURN {outer:[currentnode]};" );
+            int countOfNodes = 0;
+            while ( result.hasNext() )
+            {
+                Iterator<Map.Entry<String,Object>> mapIterator = result.next().get( 0 ).asMap().entrySet().iterator();
+                assertTrue( mapIterator.hasNext() );
+                Iterator<Object> iterator = ((List<Object>)mapIterator.next().getValue()).iterator();
+                while ( iterator.hasNext() )
+                {
+                    Node node = (Node) iterator.next();
+                    assertTrue( node.hasLabel( "Label6" ) );
+                    assertEquals( String.valueOf( countOfNodes ), node.get( "uuid" ).asString() );
+                    countOfNodes++;
+                }
+            }
+            assertEquals( lineCountInCSV, countOfNodes );
+        }
+    }
+
+    private Config configuration()
+    {
+        return Config.build().withEncryptionLevel( Config.EncryptionLevel.NONE ).toConfig();
+    }
+
+    private URL prepareTestImportFile( int lines ) throws IOException
+    {
+        File tempFile = File.createTempFile( "testImport", ".csv" );
+        try ( PrintWriter writer = FileUtils.newFilePrintWriter( tempFile, StandardCharsets.UTF_8 ) )
+        {
+            for ( int i = 0; i < lines; i++ )
+            {
+                writer.println( i + " " + i + " " + i );
+            }
+        }
+        return tempFile.toURI().toURL();
+    }
+}


### PR DESCRIPTION
Because the transaction was already closed when bolt wanted to serialize the Node/Rel proxy it couldn't get its properties/labels/etc. Now stuff gets populated in the ProduceResultPipe

changelog:
Fixes bug that caused  the ```Unknown value type: STRUCT``` error with queries that use PERIODIC COMMIT over bolt and return whole nodes or relationships