### PR TITLE
Small spatial bugfixes

### DIFF
--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/ToString.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/functions/ToString.scala
@@ -32,6 +32,7 @@ case object ToString extends Function with TypeSignatures {
     TypeSignature(argumentTypes = Vector(CTTime), outputType = CTString),
     TypeSignature(argumentTypes = Vector(CTDateTime), outputType = CTString),
     TypeSignature(argumentTypes = Vector(CTLocalTime), outputType = CTString),
-    TypeSignature(argumentTypes = Vector(CTLocalDateTime), outputType = CTString)
+    TypeSignature(argumentTypes = Vector(CTLocalDateTime), outputType = CTString),
+    TypeSignature(argumentTypes = Vector(CTPoint), outputType = CTString)
   )
 }

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/ToStringTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/functions/ToStringTest.scala
@@ -33,15 +33,16 @@ class ToStringTest extends FunctionTestBase("toString")  {
     testValidTypes(CTLocalTime)(CTString)
     testValidTypes(CTLocalDateTime)(CTString)
     testValidTypes(CTDateTime)(CTString)
+    testValidTypes(CTPoint)(CTString)
   }
 
   test("should fail type check for incompatible arguments") {
     testInvalidApplication(CTRelationship)(
-      "Type mismatch: expected Boolean, Float, Integer, String, Duration, Date, Time, LocalTime, LocalDateTime or DateTime but was Relationship"
+      "Type mismatch: expected Boolean, Float, Integer, Point, String, Duration, Date, Time, LocalTime, LocalDateTime or DateTime but was Relationship"
     )
 
     testInvalidApplication(CTNode)(
-      "Type mismatch: expected Boolean, Float, Integer, String, Duration, Date, Time, LocalTime, LocalDateTime or DateTime but was Node"
+      "Type mismatch: expected Boolean, Float, Integer, Point, String, Duration, Date, Time, LocalTime, LocalDateTime or DateTime but was Node"
     )
   }
 

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/StringFunctions.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/StringFunctions.scala
@@ -62,6 +62,7 @@ case class ToStringFunction(argument: Expression) extends StringFunction(argumen
     case v: BooleanValue => Values.stringValue(v.booleanValue().toString)
     case v: TemporalValue[_,_] => Values.stringValue(v.toString)
     case v: DurationValue => Values.stringValue(v.toString)
+    case v: PointValue => Values.stringValue(v.toString)
     case v =>
       throw new ParameterWrongTypeException("Expected a String, Number, Boolean, Temporal or Duration, got: " + v.toString)
   }

--- a/community/values/src/main/java/org/neo4j/values/storable/CSVHeaderInformation.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/CSVHeaderInformation.java
@@ -27,5 +27,5 @@ package org.neo4j.values.storable;
  */
 public interface CSVHeaderInformation
 {
-    void assign( String key, String value );
+    void assign( String key, Object value );
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
@@ -220,7 +220,9 @@ public class PointValue extends ScalarValue implements Point, Comparable<PointVa
     @Override
     public String toString()
     {
-        return format( "Point{%s, %s}", getCoordinateReferenceSystem().getName(), Arrays.toString( coordinate ) );
+        String coordString = coordinate.length == 2 ? format( "x: %s, y: %s", coordinate[0], coordinate[1] ) :
+                             format( "x: %s, y: %s, z: %s", coordinate[0], coordinate[1], coordinate[2] );
+        return format( "point({%s, crs: '%s'})", coordString, getCoordinateReferenceSystem().getName() );
     }
 
     /**

--- a/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
@@ -22,6 +22,7 @@ package org.neo4j.values.storable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.neo4j.graphdb.spatial.CRS;
@@ -276,7 +277,7 @@ public class PointValue extends ScalarValue implements Point, Comparable<PointVa
 
     public static PointValue fromMap( MapValue map )
     {
-        PointCSVHeaderInformation fields = new PointCSVHeaderInformation();
+        PointBuilder fields = new PointBuilder();
         for ( Map.Entry<String,AnyValue> entry : map.entrySet() )
         {
             fields.assign( entry.getKey().toLowerCase(), entry.getValue() );
@@ -299,27 +300,27 @@ public class PointValue extends ScalarValue implements Point, Comparable<PointVa
      */
     public static PointValue parse( CharSequence text, CSVHeaderInformation fieldsFromHeader )
     {
-        PointCSVHeaderInformation fieldsFromData = parseHeaderInformation( text );
+        PointBuilder fieldsFromData = parseHeaderInformation( text );
         if ( fieldsFromHeader != null )
         {
             // Merge InputFields: Data fields override header fields
-            if ( !(fieldsFromHeader instanceof PointCSVHeaderInformation) )
+            if ( !(fieldsFromHeader instanceof PointBuilder) )
             {
                 throw new IllegalStateException( "Wrong header information type: " + fieldsFromHeader );
             }
-            fieldsFromData.mergeWithHeader( (PointCSVHeaderInformation) fieldsFromHeader );
+            fieldsFromData.mergeWithHeader( (PointBuilder) fieldsFromHeader );
         }
         return fromInputFields( fieldsFromData );
     }
 
-    public static PointCSVHeaderInformation parseHeaderInformation( CharSequence text )
+    public static PointBuilder parseHeaderInformation( CharSequence text )
     {
-        PointCSVHeaderInformation fields = new PointCSVHeaderInformation();
+        PointBuilder fields = new PointBuilder();
         Value.parseHeaderInformation( text, "point", fields );
         return fields;
     }
 
-    private static CoordinateReferenceSystem findSpecifiedCRS( PointCSVHeaderInformation fields )
+    private static CoordinateReferenceSystem findSpecifiedCRS( PointBuilder fields )
     {
         String crsValue = fields.crs;
         int sridValue = fields.srid;
@@ -344,7 +345,7 @@ public class PointValue extends ScalarValue implements Point, Comparable<PointVa
     /**
      * This contains the logic to decide the default coordinate reference system based on the input fields
      */
-    private static PointValue fromInputFields( PointCSVHeaderInformation fields )
+    private static PointValue fromInputFields( PointBuilder fields )
     {
         CoordinateReferenceSystem crs = findSpecifiedCRS( fields );
         double[] coordinates;
@@ -455,7 +456,7 @@ public class PointValue extends ScalarValue implements Point, Comparable<PointVa
         }
     }
 
-    private static class PointCSVHeaderInformation implements CSVHeaderInformation
+    private static class PointBuilder implements CSVHeaderInformation
     {
         private String crs;
         private Double x;
@@ -466,135 +467,52 @@ public class PointValue extends ScalarValue implements Point, Comparable<PointVa
         private Double height;
         private int srid = -1;
 
-        private void checkUnassigned( Object key, String fieldName )
-        {
-            if ( key != null )
-            {
-                throw new InvalidValuesArgumentException( String.format( "Duplicate field '%s' is not allowed." , fieldName ) );
-            }
-        }
-
-        public void assign( String key, AnyValue value )
-        {
-            if ( value instanceof IntegralValue )
-            {
-                assignIntegral( key, ((IntegralValue) value).longValue() );
-            }
-            else if ( value instanceof FloatingPointValue )
-            {
-                assignFloatingPoint( key, ((FloatingPointValue) value).doubleValue() );
-            }
-            else if ( value instanceof TextValue )
-            {
-                assignTextValue( key, ((TextValue) value).stringValue() );
-            }
-            else
-            {
-                throw new InvalidValuesArgumentException( String.format( "Cannot assign %s to field %s", value, key ) );
-            }
-        }
-
-        private void assignTextValue( String key, String value )
-        {
-            String lowercaseKey = key.toLowerCase();
-            switch ( lowercaseKey )
-            {
-            case "crs":
-                checkUnassigned( crs, lowercaseKey );
-                crs = quotesPattern.matcher( value ).replaceAll( "" );
-                break;
-            default:
-                throwOnUnrecognizedKey( key );
-            }
-        }
-
-        private void assignFloatingPoint( String key, double value )
-        {
-            String lowercaseKey = key.toLowerCase();
-            switch ( lowercaseKey )
-            {
-            case "x":
-                checkUnassigned( x, lowercaseKey );
-                x = value;
-                break;
-            case "y":
-                checkUnassigned( y, lowercaseKey );
-                y = value;
-                break;
-            case "z":
-                checkUnassigned( z, lowercaseKey );
-                z = value;
-                break;
-            case "longitude":
-                checkUnassigned( longitude, lowercaseKey );
-                longitude = value;
-                break;
-            case "latitude":
-                checkUnassigned( latitude, lowercaseKey );
-                latitude = value;
-                break;
-            case "height":
-                checkUnassigned( height, lowercaseKey );
-                height = value;
-                break;
-            default:
-                throwOnUnrecognizedKey( key );
-            }
-        }
-
-        private void assignIntegral( String key, long value )
+        @Override
+        public void assign( String key, Object value )
         {
             switch ( key.toLowerCase() )
             {
+            case "crs":
+                checkUnassigned( crs, key );
+                assignTextValue( key, value, str -> crs = quotesPattern.matcher( str ).replaceAll( "" ) );
+                break;
             case "x":
+                checkUnassigned( x, key );
+                assignFloatingPoint( key, value, i -> x = i );
+                break;
             case "y":
+                checkUnassigned( y, key );
+                assignFloatingPoint( key, value, i -> y = i );
+                break;
             case "z":
+                checkUnassigned( z, key );
+                assignFloatingPoint( key, value, i -> z = i );
+                break;
             case "longitude":
+                checkUnassigned( longitude, key );
+                assignFloatingPoint( key, value, i -> longitude = i );
+                break;
             case "latitude":
+                checkUnassigned( latitude, key );
+                assignFloatingPoint( key, value, i -> latitude = i );
+                break;
             case "height":
-                assignFloatingPoint( key, (double) value );
+                checkUnassigned( height, key );
+                assignFloatingPoint( key, value, i -> height = i );
                 break;
             case "srid":
                 if ( srid != -1 )
                 {
-                    throw new InvalidValuesArgumentException( "Duplicate field 'srid' is not allowed." );
+                    throw new InvalidValuesArgumentException( String.format( "Duplicate field '%s' is not allowed.", key ) );
                 }
-                srid = (int) value;
+                assignIntegral( key, value, i -> srid = i );
                 break;
             default:
                 throwOnUnrecognizedKey( key );
             }
         }
 
-        public void assign( String key, String value )
-        {
-            switch ( key.toLowerCase() )
-            {
-            case "crs":
-                assignTextValue( key, value );
-                break;
-            case "x":
-            case "y":
-            case "z":
-            case "longitude":
-            case "latitude":
-            case "height":
-                assignFloatingPoint( key, assertConvertible( () -> Double.parseDouble( value ) ) );
-                break;
-            case "srid":
-                assignIntegral( key, assertConvertible( () -> Integer.parseInt( value ) ) );
-                break;
-            default:
-                throwOnUnrecognizedKey( key );
-            }
-        }
-
-        private void throwOnUnrecognizedKey( String key )
-        {
-            throw new InvalidValuesArgumentException( String.format( "Unknown key '%s' for creating new point", key ) );
-        }
-
-        void mergeWithHeader( PointCSVHeaderInformation header )
+        void mergeWithHeader( PointBuilder header )
         {
             this.crs = this.crs == null ? header.crs : this.crs;
             this.x = this.x == null ? header.x : this.x;
@@ -605,17 +523,82 @@ public class PointValue extends ScalarValue implements Point, Comparable<PointVa
             this.height = this.height == null ? header.height : this.height;
             this.srid = this.srid == -1 ? header.srid : this.srid;
         }
-    }
 
-    private static <T extends Number> T assertConvertible( Supplier<T> func )
-    {
-        try
+        private void assignTextValue( String key, Object value, Consumer<String> assigner )
         {
-            return func.get();
+            if ( value instanceof String )
+            {
+                assigner.accept( (String) value );
+            }
+            else if ( value instanceof TextValue )
+            {
+                assigner.accept( ((TextValue) value).stringValue() );
+            }
+            else
+            {
+                throw new InvalidValuesArgumentException( String.format( "Cannot assign %s to field %s", value, key ) );
+            }
         }
-        catch ( NumberFormatException e )
+
+        private void assignFloatingPoint( String key, Object value, Consumer<Double> assigner )
         {
-            throw new InvalidValuesArgumentException( e.getMessage(), e );
+            if ( value instanceof String )
+            {
+                assigner.accept( assertConvertible( () -> Double.parseDouble( (String) value ) ) );
+            }
+            else if ( value instanceof IntegralValue )
+            {
+                assigner.accept( ((IntegralValue) value).doubleValue() );
+            }
+            else if ( value instanceof FloatingPointValue )
+            {
+                assigner.accept( ((FloatingPointValue) value).doubleValue() );
+            }
+            else
+            {
+                throw new InvalidValuesArgumentException( String.format( "Cannot assign %s to field %s", value, key ) );
+            }
+        }
+
+        private void assignIntegral( String key, Object value, Consumer<Integer> assigner )
+        {
+            if ( value instanceof String )
+            {
+                assigner.accept( assertConvertible( () -> Integer.parseInt( (String) value ) ) );
+            }
+            else if ( value instanceof IntegralValue )
+            {
+                assigner.accept( (int) ((IntegralValue) value).longValue() );
+            }
+            else
+            {
+                throw new InvalidValuesArgumentException( String.format( "Cannot assign %s to field %s", value, key ) );
+            }
+        }
+
+        private void throwOnUnrecognizedKey( String key )
+        {
+            throw new InvalidValuesArgumentException( String.format( "Unknown key '%s' for creating new point", key ) );
+        }
+
+        private <T extends Number> T assertConvertible( Supplier<T> func )
+        {
+            try
+            {
+                return func.get();
+            }
+            catch ( NumberFormatException e )
+            {
+                throw new InvalidValuesArgumentException( e.getMessage(), e );
+            }
+        }
+
+        private void checkUnassigned( Object key, String fieldName )
+        {
+            if ( key != null )
+            {
+                throw new InvalidValuesArgumentException( String.format( "Duplicate field '%s' is not allowed.", fieldName ) );
+            }
         }
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/TemporalValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TemporalValue.java
@@ -1515,8 +1515,13 @@ public abstract class TemporalValue<T extends Temporal, V extends TemporalValue<
         String timezone;
 
         @Override
-        public void assign( String key, String value )
+        public void assign( String key, Object valueObj )
         {
+            if ( !(valueObj instanceof String) )
+            {
+                throw new InvalidValuesArgumentException( String.format( "Cannot assign %s to field %s", valueObj, key ) );
+            }
+            String value = (String) valueObj;
             if ( "timezone".equals( key.toLowerCase() ) )
             {
                 if ( timezone == null )

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SemanticErrorAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SemanticErrorAcceptanceTest.scala
@@ -127,7 +127,7 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
   test("cant use toString() on nodes") {
     executeAndEnsureError(
       "MATCH (n) RETURN toString(n)",
-      "Type mismatch: expected Boolean, Float, Integer, String, Duration, Date, Time, LocalTime, LocalDateTime or DateTime but was Node (line 1, column 27 (offset: 26))"
+      "Type mismatch: expected Boolean, Float, Integer, Point, String, Duration, Date, Time, LocalTime, LocalDateTime or DateTime but was Node (line 1, column 27 (offset: 26))"
     )
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
@@ -163,6 +163,16 @@ class SpatialFunctionsAcceptanceTest extends ExecutionEngineFunSuite with Cypher
     result.toList should equal(List(Map("point" -> Values.pointValue(CoordinateReferenceSystem.Cartesian, 2.3, 4.5))))
   }
 
+  test("point function with invalid coordinate types should give reasonable error") {
+    failWithError(pointConfig + Configs.Procs,
+      "return point({x: 'apa', y: 0, crs: 'cartesian'})", List("String is not a valid coordinate type.", "Cannot assign"))
+  }
+
+  test("point function with invalid crs types should give reasonable error") {
+    failWithError(pointConfig + Configs.Procs,
+      "return point({x: 0, y: 0, crs: 5})", List("java.lang.Long cannot be cast to java.lang.String", "Cannot assign"))
+  }
+
   test("should default to WGS84 if missing geographic CRS") {
     val result = executeWith(pointConfig, "RETURN point({longitude: 2.3, latitude: 4.5}) as point",
       planComparisonStrategy = ComparePlansWithAssertion(_ should useOperatorWithText("Projection", "point"),

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
@@ -30,6 +30,11 @@ class SpatialFunctionsAcceptanceTest extends ExecutionEngineFunSuite with Cypher
   val equalityConfig = Configs.Interpreted - Configs.OldAndRule
   val latestPointConfig = Configs.Interpreted - Configs.BackwardsCompatibility - Configs.AllRulePlanners
 
+  test("toString on points") {
+    val result = executeWith(latestPointConfig,  "RETURN toString(point({x:1, y:2})) AS s")
+    result.toList should equal(List(Map("s" -> "Point{cartesian, [1.0, 2.0]}")))
+  }
+
   test("point function should work with literal map") {
     val result = executeWith(pointConfig, "RETURN point({latitude: 12.78, longitude: 56.7}) as point",
       planComparisonStrategy = ComparePlansWithAssertion(_ should useOperatorWithText("Projection", "point"),

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
@@ -31,8 +31,8 @@ class SpatialFunctionsAcceptanceTest extends ExecutionEngineFunSuite with Cypher
   val latestPointConfig = Configs.Interpreted - Configs.BackwardsCompatibility - Configs.AllRulePlanners
 
   test("toString on points") {
-    val result = executeWith(latestPointConfig,  "RETURN toString(point({x:1, y:2})) AS s")
-    result.toList should equal(List(Map("s" -> "Point{cartesian, [1.0, 2.0]}")))
+    executeWith(latestPointConfig, "RETURN toString(point({x:1, y:2})) AS s").toList should equal(List(Map("s" -> "point({x: 1.0, y: 2.0, crs: 'cartesian'})")))
+    executeWith(latestPointConfig, "RETURN toString(point({longitude:1, latitude:2, height:3})) AS s").toList should equal(List(Map("s" -> "point({x: 1.0, y: 2.0, z: 3.0, crs: 'wgs-84-3d'})")))
   }
 
   test("point function should work with literal map") {


### PR DESCRIPTION
Includes 2 fixes:
* Correct error message when a value in the map passed to the point function has the wrong type.
* Allow `toString(point)`