### PR TITLE
Half-deprecate the catchup client timeout

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupClientBuilder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupClientBuilder.java
@@ -57,7 +57,7 @@ public class CatchupClientBuilder
     private NettyPipelineBuilderFactory pipelineBuilder = new NettyPipelineBuilderFactory( VOID_WRAPPER );
     private ApplicationSupportedProtocols catchupProtocols = new ApplicationSupportedProtocols( CATCHUP, emptyList() );
     private Collection<ModifierSupportedProtocols> modifierProtocols = emptyList();
-    private long inactivityTimeoutMillis = SECONDS.toMillis( 20 );
+    private long inactivityTimeoutMillis = SECONDS.toMillis( 3600 );
     private Clock clock = systemClock();
 
     public CatchupClientBuilder()

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
@@ -311,10 +311,11 @@ public class CausalClusteringSettings implements LoadableConfig
     @Description( "Interval of pulling updates from cores." )
     public static final Setting<Duration> pull_interval = setting( "causal_clustering.pull_interval", DURATION, "1s" );
 
+    @Internal
     @Description( "The catch up protocol times out if the given duration elapses with no network activity. " +
             "Every message received by the client from the server extends the time out duration." )
     public static final Setting<Duration> catch_up_client_inactivity_timeout =
-            setting( "causal_clustering.catch_up_client_inactivity_timeout", DURATION, "20s" );
+            setting( "causal_clustering.catch_up_client_inactivity_timeout", DURATION, "3600s" );
 
     @Description( "Maximum retry time per request during store copy. Regular store files and indexes are downloaded in separate requests during store copy." +
             " This configures the maximum time failed requests are allowed to resend. " )


### PR DESCRIPTION
Since 76bacc294171bfd61b02492478218bd3e0fed9ce we longer expect
timeouts to be the means of discovering failed network connections.
This commit does not deprecate the functionality completely, since
it might still come in handy, but sets it at a very high level that
is unlikely to be too eager. A proper deprecation might come with
the next release.