### PR TITLE
3.4 Renamed Multicluster routing procedures

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
@@ -80,13 +80,13 @@ import org.neo4j.causalclustering.protocol.handshake.HandshakeClientInitializer;
 import org.neo4j.causalclustering.protocol.handshake.ModifierProtocolRepository;
 import org.neo4j.causalclustering.protocol.handshake.ModifierSupportedProtocols;
 import org.neo4j.causalclustering.protocol.handshake.ProtocolStack;
+import org.neo4j.causalclustering.routing.multi_cluster.procedure.GetRoutersForAllDatabasesProcedure;
+import org.neo4j.causalclustering.routing.multi_cluster.procedure.GetRoutersForDatabaseProcedure;
 import org.neo4j.causalclustering.upstream.NoOpUpstreamDatabaseStrategiesLoader;
 import org.neo4j.causalclustering.upstream.UpstreamDatabaseSelectionStrategy;
 import org.neo4j.causalclustering.upstream.UpstreamDatabaseStrategiesLoader;
 import org.neo4j.causalclustering.upstream.UpstreamDatabaseStrategySelector;
 import org.neo4j.causalclustering.upstream.strategies.TypicallyConnectToRandomReadReplicaStrategy;
-import org.neo4j.causalclustering.routing.multi_cluster.procedure.GetSubClusterRoutersProcedure;
-import org.neo4j.causalclustering.routing.multi_cluster.procedure.GetSuperClusterRoutersProcedure;
 import org.neo4j.com.storecopy.StoreUtil;
 import org.neo4j.function.Predicates;
 import org.neo4j.graphdb.DependencyResolver;
@@ -187,8 +187,8 @@ public class EnterpriseCoreEditionModule extends EditionModule
                     config, logProvider ) );
         }
 
-        procedures.register( new GetSuperClusterRoutersProcedure( topologyService, config ) );
-        procedures.register( new GetSubClusterRoutersProcedure( topologyService, config ) );
+        procedures.register( new GetRoutersForAllDatabasesProcedure( topologyService, config ) );
+        procedures.register( new GetRoutersForDatabaseProcedure( topologyService, config ) );
         procedures.register( new ClusterOverviewProcedure( topologyService, logProvider ) );
         procedures.register( new CoreRoleProcedure( consensusModule.raftMachine() ) );
         procedures.register( new InstalledProtocolsProcedure( clientInstalledProtocols, serverInstalledProtocols ) );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/MultiClusterRoutingResult.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/MultiClusterRoutingResult.java
@@ -27,7 +27,7 @@ import org.neo4j.causalclustering.routing.RoutingResult;
 import org.neo4j.causalclustering.routing.Endpoint;
 
 /**
- * Simple struct containing the the result of Get*ClusterRouting procedure execution.
+ * Simple struct containing the the result of multi-cluster routing procedure execution.
  */
 public class MultiClusterRoutingResult implements RoutingResult
 {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/GetRoutersForAllDatabasesProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/GetRoutersForAllDatabasesProcedure.java
@@ -39,19 +39,19 @@ import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.Context;
 import org.neo4j.kernel.configuration.Config;
 
-import static org.neo4j.causalclustering.routing.multi_cluster.procedure.ProcedureNames.GET_SUPER_CLUSTER_ROUTERS;
+import static org.neo4j.causalclustering.routing.multi_cluster.procedure.ProcedureNames.GET_ROUTERS_FOR_ALL_DATABASES;
 import static org.neo4j.causalclustering.routing.multi_cluster.procedure.ParameterNames.ROUTERS;
 import static org.neo4j.causalclustering.routing.multi_cluster.procedure.ParameterNames.TTL;
 import static org.neo4j.internal.kernel.api.procs.ProcedureSignature.procedureSignature;
 import static org.neo4j.causalclustering.routing.Util.extractBoltAddress;
 
-public class GetSuperClusterRoutersProcedure implements CallableProcedure
+public class GetRoutersForAllDatabasesProcedure implements CallableProcedure
 {
 
-    private static final String DESCRIPTION = "Returns router capable endpoints for each database name in a multicluster.";
+    private static final String DESCRIPTION = "Returns router capable endpoints for each database name in a multi-cluster.";
 
     private final ProcedureSignature procedureSignature =
-            procedureSignature( GET_SUPER_CLUSTER_ROUTERS.fullyQualifiedProcedureName() )
+            procedureSignature( GET_ROUTERS_FOR_ALL_DATABASES.fullyQualifiedProcedureName() )
                     .out( TTL.parameterName(), Neo4jTypes.NTInteger )
                     .out( ROUTERS.parameterName(), Neo4jTypes.NTList( Neo4jTypes.NTMap ) )
                     .description( DESCRIPTION )
@@ -60,7 +60,7 @@ public class GetSuperClusterRoutersProcedure implements CallableProcedure
     private final TopologyService topologyService;
     private final long timeToLiveMillis;
 
-    public GetSuperClusterRoutersProcedure( TopologyService topologyService, Config config )
+    public GetRoutersForAllDatabasesProcedure( TopologyService topologyService, Config config )
     {
         this.topologyService = topologyService;
         this.timeToLiveMillis = config.get( CausalClusteringSettings.cluster_routing_ttl ).toMillis();

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/GetRoutersForDatabaseProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/GetRoutersForDatabaseProcedure.java
@@ -39,19 +39,19 @@ import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.Context;
 import org.neo4j.kernel.configuration.Config;
 
-import static org.neo4j.causalclustering.routing.multi_cluster.procedure.ProcedureNames.GET_SUB_CLUSTER_ROUTERS;
+import static org.neo4j.causalclustering.routing.multi_cluster.procedure.ProcedureNames.GET_ROUTERS_FOR_DATABASE;
 import static org.neo4j.causalclustering.routing.multi_cluster.procedure.ParameterNames.DATABASE;
 import static org.neo4j.causalclustering.routing.multi_cluster.procedure.ParameterNames.ROUTERS;
 import static org.neo4j.causalclustering.routing.multi_cluster.procedure.ParameterNames.TTL;
 import static org.neo4j.causalclustering.routing.Util.extractBoltAddress;
 import static org.neo4j.internal.kernel.api.procs.ProcedureSignature.procedureSignature;
 
-public class GetSubClusterRoutersProcedure implements CallableProcedure
+public class GetRoutersForDatabaseProcedure implements CallableProcedure
 {
-    private static final String DESCRIPTION = "Returns router capable endpoints for a specific database in a multicluster.";
+    private static final String DESCRIPTION = "Returns router capable endpoints for a specific database in a multi-cluster.";
 
     private final ProcedureSignature procedureSignature =
-            procedureSignature( GET_SUB_CLUSTER_ROUTERS.fullyQualifiedProcedureName() )
+            procedureSignature( GET_ROUTERS_FOR_DATABASE.fullyQualifiedProcedureName() )
                     .in( DATABASE.parameterName(), Neo4jTypes.NTString )
                     .out( TTL.parameterName(), Neo4jTypes.NTInteger )
                     .out( ROUTERS.parameterName(), Neo4jTypes.NTList( Neo4jTypes.NTMap ) )
@@ -61,7 +61,7 @@ public class GetSubClusterRoutersProcedure implements CallableProcedure
     private final TopologyService topologyService;
     private final long timeToLiveMillis;
 
-    public GetSubClusterRoutersProcedure( TopologyService topologyService, Config config )
+    public GetRoutersForDatabaseProcedure( TopologyService topologyService, Config config )
     {
         this.topologyService = topologyService;
         this.timeToLiveMillis = config.get( CausalClusteringSettings.cluster_routing_ttl ).toMillis();

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/MultiClusterRoutingResultFormat.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/MultiClusterRoutingResultFormat.java
@@ -34,8 +34,8 @@ import static org.neo4j.causalclustering.routing.procedure.RoutingResultFormatHe
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
- * The result format of {@link GetSubClusterRoutersProcedure} and
- * {@link GetSuperClusterRoutersProcedure} procedures.
+ * The result format of {@link GetRoutersForDatabaseProcedure} and
+ * {@link GetRoutersForAllDatabasesProcedure} procedures.
  */
 public class MultiClusterRoutingResultFormat
 {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/ParameterNames.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/ParameterNames.java
@@ -20,14 +20,14 @@
 package org.neo4j.causalclustering.routing.multi_cluster.procedure;
 
 /**
- * Enumerates the parameter names used for the Get*ClusterRoutersProcedures
+ * Enumerates the parameter names used for the multi-cluster routing procedures
  */
 public enum ParameterNames
 {
     /**
      * Type: IN
      *
-     * An string specifying the database in the multicluster for which to provide routers.
+     * An string specifying the database in the multi-cluster for which to provide routers.
      */
     DATABASE( "database" ),
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/ProcedureNames.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/ProcedureNames.java
@@ -19,11 +19,7 @@
  */
 package org.neo4j.causalclustering.routing.multi_cluster.procedure;
 
-import java.util.Arrays;
 import org.neo4j.causalclustering.routing.procedure.ProcedureNamesEnum;
-
-import static java.lang.String.join;
-
 
 /**
  * This is part of the cluster / driver interface specification and
@@ -37,8 +33,8 @@ import static java.lang.String.join;
  */
 public enum ProcedureNames implements ProcedureNamesEnum
 {
-    GET_SUB_CLUSTER_ROUTERS( "getSubClusterRoutingTable" ),
-    GET_SUPER_CLUSTER_ROUTERS( "getSuperClusterRoutingTable" );
+    GET_ROUTERS_FOR_DATABASE( "getRoutersForDatabase" ),
+    GET_ROUTERS_FOR_ALL_DATABASES( "getRoutersForAllDatabases" );
 
     private static final String[] nameSpace = new String[]{"dbms", "cluster", "routing"};
     private final String name;

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/MultiClusterRoutingProcedureTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/multi_cluster/procedure/MultiClusterRoutingProcedureTest.java
@@ -38,7 +38,7 @@ public class MultiClusterRoutingProcedureTest
     @Test
     public void subClusterRoutingProcedureShouldHaveCorrectSignature()
     {
-        GetSubClusterRoutersProcedure proc = new GetSubClusterRoutersProcedure( null, Config.defaults() );
+        GetRoutersForDatabaseProcedure proc = new GetRoutersForDatabaseProcedure( null, Config.defaults() );
 
         ProcedureSignature procSig = proc.signature();
 
@@ -47,15 +47,15 @@ public class MultiClusterRoutingProcedureTest
                 FieldSignature.outputField( "ttl", Neo4jTypes.NTInteger ),
                 FieldSignature.outputField( "routers", Neo4jTypes.NTList( Neo4jTypes.NTMap ) ) );
 
-        assertEquals( "The input signature of the GetSubClusterRoutersProcedure should not change.", procSig.inputSignature(), input );
+        assertEquals( "The input signature of the GetRoutersForDatabaseProcedure should not change.", procSig.inputSignature(), input );
 
-        assertEquals( "The output signature of the GetSubClusterRoutersProcedure should not change.", procSig.outputSignature(), output );
+        assertEquals( "The output signature of the GetRoutersForDatabaseProcedure should not change.", procSig.outputSignature(), output );
     }
 
     @Test
     public void superClusterRoutingProcedureShouldHaveCorrectSignature()
     {
-        GetSuperClusterRoutersProcedure proc = new GetSuperClusterRoutersProcedure( null, Config.defaults() );
+        GetRoutersForAllDatabasesProcedure proc = new GetRoutersForAllDatabasesProcedure( null, Config.defaults() );
 
         ProcedureSignature procSig = proc.signature();
 
@@ -63,6 +63,6 @@ public class MultiClusterRoutingProcedureTest
                 FieldSignature.outputField( "ttl", Neo4jTypes.NTInteger ),
                 FieldSignature.outputField( "routers", Neo4jTypes.NTList( Neo4jTypes.NTMap ) ) );
 
-        assertEquals( "The output signature of the GetSuperClusterRoutersProcedure should not change.", procSig.outputSignature(), output );
+        assertEquals( "The output signature of the GetRoutersForAllDatabasesProcedure should not change.", procSig.outputSignature(), output );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/MultiClusterRoutingIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/MultiClusterRoutingIT.java
@@ -64,8 +64,8 @@ import static org.junit.Assert.assertEquals;
 import static org.neo4j.causalclustering.routing.multi_cluster.procedure.ParameterNames.DATABASE;
 import static org.neo4j.causalclustering.scenarios.DiscoveryServiceType.SHARED;
 import static org.neo4j.causalclustering.scenarios.DiscoveryServiceType.HAZELCAST;
-import static org.neo4j.causalclustering.routing.multi_cluster.procedure.ProcedureNames.GET_SUB_CLUSTER_ROUTERS;
-import static org.neo4j.causalclustering.routing.multi_cluster.procedure.ProcedureNames.GET_SUPER_CLUSTER_ROUTERS;
+import static org.neo4j.causalclustering.routing.multi_cluster.procedure.ProcedureNames.GET_ROUTERS_FOR_DATABASE;
+import static org.neo4j.causalclustering.routing.multi_cluster.procedure.ProcedureNames.GET_ROUTERS_FOR_ALL_DATABASES;
 import static org.neo4j.test.assertion.Assert.assertEventually;
 
 @RunWith( Parameterized.class )
@@ -136,7 +136,7 @@ public class MultiClusterRoutingIT
                 .map( n -> cluster.getDbWithAnyRole( n, Role.FOLLOWER, Role.LEADER ).database() ).collect( Collectors.toList() );
 
         Stream<Optional<MultiClusterRoutingResult>> optResults = dbs.stream()
-                .map( db -> callProcedure( db, GET_SUPER_CLUSTER_ROUTERS, Collections.emptyMap() ) );
+                .map( db -> callProcedure( db, GET_ROUTERS_FOR_ALL_DATABASES, Collections.emptyMap() ) );
 
         List<MultiClusterRoutingResult> results = optResults.filter( Optional::isPresent ).map( Optional::get ).collect( Collectors.toList() );
         assertEquals("There should be a result for each database against which the procedure is executed.",  dbNames.size(), results.size() );
@@ -157,7 +157,7 @@ public class MultiClusterRoutingIT
 
         Map<String,Object> params = new HashMap<>();
         params.put( DATABASE.parameterName(), dbName );
-        Stream<Optional<MultiClusterRoutingResult>> optResults = members.map( db -> callProcedure( db, GET_SUB_CLUSTER_ROUTERS, params ) );
+        Stream<Optional<MultiClusterRoutingResult>> optResults = members.map( db -> callProcedure( db, GET_ROUTERS_FOR_DATABASE, params ) );
         List<MultiClusterRoutingResult> results = optResults.filter( Optional::isPresent ).map( Optional::get ).collect( Collectors.toList() );
 
         boolean consistentResults = results.stream().distinct().count() == 1;
@@ -185,7 +185,7 @@ public class MultiClusterRoutingIT
 
         Function<CoreGraphDatabase, Set<Endpoint>> getResult = database ->
         {
-            Optional<MultiClusterRoutingResult> optResult = callProcedure( database, GET_SUPER_CLUSTER_ROUTERS, Collections.emptyMap() );
+            Optional<MultiClusterRoutingResult> optResult = callProcedure( database, GET_ROUTERS_FOR_ALL_DATABASES, Collections.emptyMap() );
 
             return optResult.map( r ->
                     r.routers().values().stream()


### PR DESCRIPTION
Simply changes the name of the multi-cluster routing procedures from `getSuperClusterRoutingTable` and `getSubClusterRoutingTable` to `getRoutersForAllDatabases` and `getRoutersForDatabase` respectively at the request of PM.