### PR TITLE
Add update service command to PowerShell scripts

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jPrunsrv.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jPrunsrv.ps1
@@ -31,7 +31,10 @@ An object representing a valid Neo4j Server object
 Retrieve the PrunSrv command line to install a Neo4j Server
 
 .PARAMETER ForServerUninstall
-Retrieve the PrunSrv command line to install a Neo4j Server
+Retrieve the PrunSrv command line to uninstall a Neo4j Server
+
+.PARAMETER ForServerUpdate
+Retrieve the PrunSrv command line to update a Neo4j Server
 
 .PARAMETER ForConsole
 Retrieve the PrunSrv command line to start a Neo4j Server in the console.
@@ -55,6 +58,9 @@ Function Get-Neo4jPrunsrv
 
     ,[Parameter(Mandatory=$true,ValueFromPipeline=$false,ParameterSetName='ServerUninstallInvoke')]
     [switch]$ForServerUninstall
+
+    ,[Parameter(Mandatory=$true,ValueFromPipeline=$false,ParameterSetName='ServerUpdateInvoke')]
+    [switch]$ForServerUpdate
 
     ,[Parameter(Mandatory=$true,ValueFromPipeline=$false,ParameterSetName='ConsoleInvoke')]
     [switch]$ForConsole
@@ -92,8 +98,13 @@ Function Get-Neo4jPrunsrv
 
     # Build the PRUNSRV command line
     switch ($PsCmdlet.ParameterSetName) {
-      "ServerInstallInvoke"   {
+      "ServerInstallInvoke"     {
         $PrunArgs += @("`"//IS//$($Name)`"")
+      }
+      "ServerUpdateInvoke" {
+        $PrunArgs += @("`"//US//$($Name)`"")
+      }
+      {$_ -in @("ServerInstallInvoke", "ServerUpdateInvoke")} {
 
         $JvmOptions = @()
 
@@ -158,10 +169,10 @@ Function Get-Neo4jPrunsrv
         $PrunArgs += @("`"--StopClass=$($serverMainClass)`"",
                        "`"--StartClass=$($serverMainClass)`"")
       }
-      "ServerUninstallInvoke" { $PrunArgs += @("`"//DS//$($Name)`"") }
-      "ConsoleInvoke"         { $PrunArgs += @("`"//TS//$($Name)`"") }
+      "ServerUninstallInvoke"   { $PrunArgs += @("`"//DS//$($Name)`"") }
+      "ConsoleInvoke"           { $PrunArgs += @("`"//TS//$($Name)`"") }
       default {
-        throw "Unknown ParameterSerName $($PsCmdlet.ParameterSetName)"
+        throw "Unknown ParameterSetName $($PsCmdlet.ParameterSetName)"
         return $null
       }
     }

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4j.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4j.ps1
@@ -55,16 +55,16 @@ Function Invoke-Neo4j
     [Parameter(Mandatory=$false,ValueFromPipeline=$false,Position=0)]
     [string]$Command = ''
   )
-  
+
   Begin
   {
   }
-  
+
   Process
   {
-    try 
+    try
     {
-      $HelpText = "Usage: neo4j { console | start | stop | restart | status | install-service | uninstall-service } < -Verbose >"
+      $HelpText = "Usage: neo4j { console | start | stop | restart | status | install-service | uninstall-service | update-service } < -Verbose >"
 
       # Determine the Neo4j Home Directory.  Uses the NEO4J_HOME enironment variable or a parent directory of this script
       $Neo4jHome = Get-Neo4jEnv 'NEO4J_HOME'
@@ -73,7 +73,7 @@ Function Invoke-Neo4j
       }
       if ($Neo4jHome -eq $null) { throw "Could not determine the Neo4j home Directory.  Set the NEO4J_HOME environment variable and retry" }  
       Write-Verbose "Neo4j Root is '$Neo4jHome'"
-      
+
       $thisServer = Get-Neo4jServer -Neo4jHome $Neo4jHome -ErrorAction Stop
       if ($thisServer -eq $null) { throw "Unable to determine the Neo4j Server installation information" }
       Write-Verbose "Neo4j Server Type is '$($thisServer.ServerType)'"
@@ -105,7 +105,7 @@ Function Invoke-Neo4j
         }
         "restart" {
           Write-Verbose "Restart command specified"
-          
+
           $result = (Stop-Neo4jServer -Neo4jServer $thisServer -ErrorAction Stop)
           if ($result -ne 0) { Return $result}
           Return (Start-Neo4jServer -Service -Neo4jServer $thisServer -ErrorAction Stop)
@@ -121,6 +121,10 @@ Function Invoke-Neo4j
         "uninstall-service" {
           Write-Verbose "Uninstall command specified"
           Return [int](Uninstall-Neo4jServer -Neo4jServer $thisServer -ErrorAction Stop)
+        }
+        "update-service" {
+          Write-Verbose "Update command specified"
+          Return [int](Update-Neo4jServer -Neo4jServer $thisServer -ErrorAction Stop)
         }
         default {
           if ($Command -ne '') { Write-StdErr "Unknown command $Command" }

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Update-Neo4jServer.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Update-Neo4jServer.ps1
@@ -1,0 +1,97 @@
+# Copyright (c) 2002-2018 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# This file is part of Neo4j.
+#
+# Neo4j is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+<#
+.SYNOPSIS
+Update an installed Neo4j Server Windows Service
+
+.DESCRIPTION
+Update an installed Neo4j Server Windows Service
+
+.PARAMETER Neo4jServer
+An object representing a valid Neo4j Server
+
+.EXAMPLE
+Update-Neo4jServer $ServerObject
+
+Update the Neo4j Windows Service for the Neo4j installation at $ServerObject
+
+.OUTPUTS
+System.Int32
+0 = Service is successfully updated
+non-zero = an error occured
+
+.NOTES
+This function is private to the powershell module
+
+#>
+Function Update-Neo4jServer
+{
+  [cmdletBinding(SupportsShouldProcess=$false,ConfirmImpact='Medium')]
+  param (
+    [Parameter(Mandatory=$true,ValueFromPipeline=$true)]
+    [PSCustomObject]$Neo4jServer
+  )
+
+  Begin
+  {
+  }
+
+  Process
+  {
+    $Name = Get-Neo4jWindowsServiceName -Neo4jServer $Neo4jServer -ErrorAction Stop
+
+    $result = Get-Service -Name $Name -ComputerName '.' -ErrorAction 'SilentlyContinue'
+    if ($result -ne $null)
+    {
+      $prunsrv = Get-Neo4jPrunsrv -Neo4jServer $Neo4jServer -ForServerUpdate
+      if ($prunsrv -eq $null) { throw "Could not determine the command line for PRUNSRV" }
+
+      Write-Verbose "Update installed Neo4j service with command line $($prunsrv.cmd) $($prunsrv.args)"
+      $stdError = New-Neo4jTempFile -Prefix 'stderr'
+      Write-Verbose $prunsrv
+      $result = (Start-Process -FilePath $prunsrv.cmd -ArgumentList $prunsrv.args -Wait -NoNewWindow -PassThru -WorkingDirectory $Neo4jServer.Home -RedirectStandardError $stdError)
+      Write-Verbose "Returned exit code $($result.ExitCode)"
+
+      # Process the output
+      if ($result.ExitCode -eq 0) {
+        Write-Host "Neo4j service updated"
+      } else {
+        Write-Host "Neo4j service did not update"
+        # Write out STDERR if it did not update
+        Get-Content -Path $stdError -ErrorAction 'SilentlyContinue' | ForEach-Object -Process {
+          Write-Host $_
+        }
+      }
+
+      # Remove the temp file
+      If (Test-Path -Path $stdError) { Remove-Item -Path $stdError -Force | Out-Null }
+
+      Write-Output $result.ExitCode
+    } else {
+      Write-Host "Service update failed - service '$Name' not found"
+      Write-Output 1
+    }
+  }
+
+  End
+  {
+  }
+}
+

--- a/packaging/standalone/src/tests/Neo4j-Management/Run-Tests.ps1
+++ b/packaging/standalone/src/tests/Neo4j-Management/Run-Tests.ps1
@@ -1,0 +1,26 @@
+# Copyright (c) 2002-2018 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# This file is part of Neo4j.
+#
+# Neo4j is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+# Run tests in this directory and subdirectories.
+# Usage:
+#     powershell.exe \\path\to\Run-Tests.ps1
+#     powershell.exe -NonInteractive -ExecutionPolicy ByPass -File \\path\to\Run-Tests.ps1
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Definition
+Invoke-Pester -OutputFile pester-nunit.xml -OutputFormat NUnitXml -EnableExit -Script $here

--- a/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Neo4jPrunsrv.Tests.ps1
+++ b/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Neo4jPrunsrv.Tests.ps1
@@ -65,13 +65,19 @@ InModuleScope Neo4j-Management {
         $prunsrv.args -join ' ' | Should Match ([regex]::Escape("//IS//$($global:mockServiceName)"))
       }
 
-      It "return //DS/xxx argument on service install" {
+      It "return //US/xxx argument on service update" {
+        $prunsrv = Get-Neo4jPrunsrv -Neo4jServer $serverObject -ForServerUpdate
+
+        $prunsrv.args -join ' ' | Should Match ([regex]::Escape("//US//$($global:mockServiceName)"))
+      }
+
+      It "return //DS/xxx argument on service uninstall" {
         $prunsrv = Get-Neo4jPrunsrv -Neo4jServer $serverObject -ForServerUninstall
 
         $prunsrv.args -join ' ' | Should Match ([regex]::Escape("//DS//$($global:mockServiceName)"))
       }
 
-      It "return //TS/xxx argument on service install" {
+      It "return //TS/xxx argument on service run console" {
         $prunsrv = Get-Neo4jPrunsrv -Neo4jServer $serverObject -ForConsole
 
         $prunsrv.args -join ' ' | Should Match ([regex]::Escape("//TS//$($global:mockServiceName)"))

--- a/packaging/standalone/src/tests/Neo4j-Management/unit/Update-Neo4jServer.Tests.ps1
+++ b/packaging/standalone/src/tests/Neo4j-Management/unit/Update-Neo4jServer.Tests.ps1
@@ -1,0 +1,88 @@
+# Copyright (c) 2002-2018 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# This file is part of Neo4j.
+#
+# Neo4j is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.", ".")
+$common = Join-Path (Split-Path -Parent $here) 'Common.ps1'
+. $common
+
+Import-Module "$src\Neo4j-Management.psm1"
+
+InModuleScope Neo4j-Management {
+  Describe "Update-Neo4jServer" {
+
+    # Setup mocking environment
+    # Mock Java environment
+    $javaHome = global:New-MockJavaHome
+    Mock Get-Neo4jEnv { $javaHome } -ParameterFilter { $Name -eq 'JAVA_HOME' }
+    Mock Set-Neo4jEnv { }
+    Mock Test-Path { $false } -ParameterFilter {
+      $Path -like 'Registry::*\JavaSoft\Java Runtime Environment'
+    }
+    Mock Get-ItemProperty { $null } -ParameterFilter {
+      $Path -like 'Registry::*\JavaSoft\Java Runtime Environment*'
+    }
+    # Mock Neo4j environment
+    Mock Get-Neo4jEnv { $global:mockNeo4jHome } -ParameterFilter { $Name -eq 'NEO4J_HOME' }
+    Mock Start-Process { throw "Should not call Start-Process mock" }
+
+    Context "Invalid or missing specified neo4j installation" {
+      $serverObject = global:New-InvalidNeo4jInstall
+
+      It "throws if invalid or missing neo4j directory" {
+        { Update-Neo4jServer -Neo4jServer $serverObject -ErrorAction Stop } | Should Throw
+      }
+    }
+
+    Context "Non-existing service" {
+      Mock Get-Service -Verifiable { return $null }
+      $serverObject = global:New-MockNeo4jInstall
+      $result = Update-Neo4jServer -Neo4jServer $serverObject
+
+      It "returns 1 for service that does not exist" {
+        $result | Should Be 1
+        Assert-VerifiableMocks
+      }
+    }
+
+    Context "Update service failure" {
+      Mock Get-Service -Verifiable { return "Fake service" }
+      Mock Start-Process -Verifiable { throw "Error reconfiguring" }
+      $serverObject = global:New-MockNeo4jInstall
+
+      It "throws when update encounters an error" {
+        { Update-Neo4jServer -Neo4jServer $serverObject } | Should Throw
+        Assert-VerifiableMocks
+      }
+    }
+
+    Context "Update service success" {
+      Mock Get-Service -Verifiable { return "Fake service" }
+      Mock Start-Process -Verifiable { @{'ExitCode' = 0} }
+      $serverObject = global:New-MockNeo4jInstall
+      $result = Update-Neo4jServer -Neo4jServer $serverObject
+
+      It "returns 0 when successfully updated" {
+        $result | Should Be 0
+        Assert-VerifiableMocks
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
On Windows, Java options and paths are read once when installing Neo4j as a service, and stored in the service configuration. Changes made after installing will not take effect until the service is uninstalled and reinstalled.

This adds a command to the PowerShell module to update the service configuration in place. When changing Java options (configuring heap size in _neo4j.conf_) or paths (upgrading to a new Java version), run the update service command and then restart the service.

## Usage

1. Make changes to Java options.
2. Run `bin\neo4j.bat update-service` or `Invoke-Neo4j update-service`.
3. Restart the service using any system tool for the purpose or `bin\neo4j.bat restart` or `Invoke-Neo4j restart`.