### PR TITLE
Unflake TransportWriteThrottleTest

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/transport/TransportWriteThrottleTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/transport/TransportWriteThrottleTest.java
@@ -36,6 +36,7 @@ import org.mockito.ArgumentCaptor;
 import java.net.InetSocketAddress;
 import java.time.Clock;
 import java.time.Duration;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -183,9 +184,15 @@ public class TransportWriteThrottleTest
 
         // stop the thread that is trying to acquire the lock
         // otherwise it remains actively spinning even after the test
-        when( channel.isWritable() ).thenReturn( true );
-        throttle.release( channel );
-        otherThread.get().awaitFuture( future );
+        future.cancel( true );
+        try
+        {
+            otherThread.get().awaitFuture( future );
+            fail( "Exception expected" );
+        }
+        catch ( CancellationException ignore )
+        {
+        }
     }
 
     @Test

--- a/community/bolt/src/test/java/org/neo4j/bolt/transport/TransportWriteThrottleTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/transport/TransportWriteThrottleTest.java
@@ -57,7 +57,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -185,6 +184,7 @@ public class TransportWriteThrottleTest
         // stop the thread that is trying to acquire the lock
         // otherwise it remains actively spinning even after the test
         when( channel.isWritable() ).thenReturn( true );
+        throttle.release( channel );
         otherThread.get().awaitFuture( future );
     }
 


### PR DESCRIPTION
This PR adds an explicit `throttle.release( channel )` before awaiting spawned thread to exit so that the lock is released and thread completion occurs sooner.