### PR TITLE
Couple security-related improvements for server

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
@@ -367,7 +367,7 @@ public class Config implements DiagnosticsProvider, Configuration
      * @param value The initial value to give the setting.
      */
     @Nonnull
-    public static Config defaults( @Nonnull final Setting<?> setting, @Nonnull final String value )
+    public static Config defaults( @Nonnull final Setting<?> setting, final String value )
     {
         return builder().withSetting( setting, value ).build();
     }

--- a/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
@@ -192,6 +192,12 @@ public class ServerSettings implements LoadableConfig
                   "Value is expected to contain dirictives like 'max-age', 'includeSubDomains' and 'preload'." )
     public static final Setting<String> http_strict_transport_security = setting( "dbms.security.http_strict_transport_security", STRING, NO_DEFAULT );
 
+    @Description( "Value of the HTTP Public Key Pinning (HPKP) response header. " +
+                  "This header tells browsers about the public keys that belong to a webpage. It is attached to every HTTPS response. " +
+                  "Setting is not set by default so 'Public-Key-Pins' header is not sent. " +
+                  "Value is expected to contain dirictives like 'pin-sha256', 'max-age', 'includeSubDomains' and 'report-uri'." )
+    public static final Setting<String> http_public_key_pins = setting( "dbms.security.http_public_key_pins", STRING, NO_DEFAULT );
+
     @SuppressWarnings( "unused" ) // accessed from the browser
     @Description( "Commands to be run when Neo4j Browser successfully connects to this server. Separate multiple " +
                   "commands with semi-colon." )

--- a/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
@@ -186,6 +186,12 @@ public class ServerSettings implements LoadableConfig
     public static final Setting<Duration> transaction_idle_timeout = setting( "dbms.rest.transaction.idle_timeout",
             DURATION, "60s" );
 
+    @Description( "Value of the HTTP Strict-Transport-Security (HSTS) response header. " +
+                  "This header tells browsers that a webpage should only be accessed using HTTPS instead of HTTP. It is attached to every HTTPS response. " +
+                  "Setting is not set by default so 'Strict-Transport-Security' header is not sent. " +
+                  "Value is expected to contain dirictives like 'max-age', 'includeSubDomains' and 'preload'." )
+    public static final Setting<String> http_strict_transport_security = setting( "dbms.security.http_strict_transport_security", STRING, NO_DEFAULT );
+
     @SuppressWarnings( "unused" ) // accessed from the browser
     @Description( "Commands to be run when Neo4j Browser successfully connects to this server. Separate multiple " +
                   "commands with semi-colon." )

--- a/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
@@ -192,12 +192,6 @@ public class ServerSettings implements LoadableConfig
                   "Value is expected to contain dirictives like 'max-age', 'includeSubDomains' and 'preload'." )
     public static final Setting<String> http_strict_transport_security = setting( "dbms.security.http_strict_transport_security", STRING, NO_DEFAULT );
 
-    @Description( "Value of the HTTP Public Key Pinning (HPKP) response header. " +
-                  "This header tells browsers about the public keys that belong to a webpage. It is attached to every HTTPS response. " +
-                  "Setting is not set by default so 'Public-Key-Pins' header is not sent. " +
-                  "Value is expected to contain dirictives like 'pin-sha256', 'max-age', 'includeSubDomains' and 'report-uri'." )
-    public static final Setting<String> http_public_key_pins = setting( "dbms.security.http_public_key_pins", STRING, NO_DEFAULT );
-
     @SuppressWarnings( "unused" ) // accessed from the browser
     @Description( "Commands to be run when Neo4j Browser successfully connects to this server. Separate multiple " +
                   "commands with semi-colon." )

--- a/community/server/src/main/java/org/neo4j/server/security/ssl/HttpsRequestCustomizer.java
+++ b/community/server/src/main/java/org/neo4j/server/security/ssl/HttpsRequestCustomizer.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2002-2018 "Neo Technology,"
- * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
  *
  * This file is part of Neo4j.
  *

--- a/community/server/src/main/java/org/neo4j/server/security/ssl/HttpsRequestCustomizer.java
+++ b/community/server/src/main/java/org/neo4j/server/security/ssl/HttpsRequestCustomizer.java
@@ -30,20 +30,15 @@ import org.eclipse.jetty.server.Request;
 import org.neo4j.kernel.configuration.Config;
 
 import static org.eclipse.jetty.http.HttpHeader.STRICT_TRANSPORT_SECURITY;
-import static org.neo4j.server.configuration.ServerSettings.http_public_key_pins;
 import static org.neo4j.server.configuration.ServerSettings.http_strict_transport_security;
 
 public class HttpsRequestCustomizer implements HttpConfiguration.Customizer
 {
-    public static final String PUBLIC_KEY_PINS_HTTP_HEADER = "Public-Key-Pins";
-
     private final HttpField hstsResponseField;
-    private final HttpField hpkpResponseField;
 
     public HttpsRequestCustomizer( Config config )
     {
         hstsResponseField = createHstsResponseField( config );
-        hpkpResponseField = createHpkpResponseField( config );
     }
 
     @Override
@@ -52,7 +47,6 @@ public class HttpsRequestCustomizer implements HttpConfiguration.Customizer
         request.setScheme( HttpScheme.HTTPS.asString() );
 
         addResponseFieldIfConfigured( request, hstsResponseField );
-        addResponseFieldIfConfigured( request, hpkpResponseField );
     }
 
     private static void addResponseFieldIfConfigured( Request request, HttpField field )
@@ -71,17 +65,5 @@ public class HttpsRequestCustomizer implements HttpConfiguration.Customizer
             return null;
         }
         return new PreEncodedHttpField( STRICT_TRANSPORT_SECURITY, configuredValue );
-    }
-
-    private static HttpField createHpkpResponseField( Config config )
-    {
-        String configuredValue = config.get( http_public_key_pins );
-        if ( StringUtils.isBlank( configuredValue ) )
-        {
-            return null;
-        }
-        // unable to use PreEncodedHttpField because of a bug, see https://github.com/eclipse/jetty.project/pull/2488
-        // should be possible to handle HSTS and HPKP field creation after bug is fixed in jetty version we depend on
-        return new HttpField( PUBLIC_KEY_PINS_HTTP_HEADER, configuredValue );
     }
 }

--- a/community/server/src/main/java/org/neo4j/server/security/ssl/HttpsRequestCustomizer.java
+++ b/community/server/src/main/java/org/neo4j/server/security/ssl/HttpsRequestCustomizer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.security.ssl;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.http.PreEncodedHttpField;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.Request;
+
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.server.configuration.ServerSettings;
+
+import static org.eclipse.jetty.http.HttpHeader.STRICT_TRANSPORT_SECURITY;
+
+public class HttpsRequestCustomizer implements HttpConfiguration.Customizer
+{
+    private final HttpField hstsResponseField;
+
+    public HttpsRequestCustomizer( Config config )
+    {
+        hstsResponseField = createHstsResponseField( config );
+    }
+
+    @Override
+    public void customize( Connector connector, HttpConfiguration channelConfig, Request request )
+    {
+        request.setScheme( HttpScheme.HTTPS.asString() );
+
+        if ( hstsResponseField != null )
+        {
+            request.getResponse().getHttpFields().add( hstsResponseField );
+        }
+    }
+
+    private static HttpField createHstsResponseField( Config config )
+    {
+        String configuredValue = config.get( ServerSettings.http_strict_transport_security );
+        if ( StringUtils.isBlank( configuredValue ) )
+        {
+            return null;
+        }
+        return new PreEncodedHttpField( STRICT_TRANSPORT_SECURITY, configuredValue );
+    }
+}

--- a/community/server/src/main/java/org/neo4j/server/security/ssl/SslSocketConnectorFactory.java
+++ b/community/server/src/main/java/org/neo4j/server/security/ssl/SslSocketConnectorFactory.java
@@ -19,9 +19,9 @@
  */
 package org.neo4j.server.security.ssl;
 
-import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConfiguration.Customizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
@@ -39,17 +39,19 @@ import org.neo4j.ssl.SslPolicy;
 
 public class SslSocketConnectorFactory extends HttpConnectorFactory
 {
-    public SslSocketConnectorFactory( Config configuration )
+    private final Customizer requestCustomizer;
+
+    public SslSocketConnectorFactory( Config config )
     {
-        super( configuration );
+        super( config );
+        requestCustomizer = new HttpsRequestCustomizer( config );
     }
 
     @Override
     protected HttpConfiguration createHttpConfig()
     {
         HttpConfiguration httpConfig = super.createHttpConfig();
-        httpConfig.addCustomizer(
-                ( connector, channelConfig, request ) -> request.setScheme( HttpScheme.HTTPS.asString() ) );
+        httpConfig.addCustomizer( requestCustomizer );
         return httpConfig;
     }
 

--- a/community/server/src/main/java/org/neo4j/server/web/HttpConnectorFactory.java
+++ b/community/server/src/main/java/org/neo4j/server/web/HttpConnectorFactory.java
@@ -50,6 +50,7 @@ public class HttpConnectorFactory
         HttpConfiguration httpConfig = new HttpConfiguration();
         httpConfig.setRequestHeaderSize( configuration.get( ServerSettings.maximum_request_header_size) );
         httpConfig.setResponseHeaderSize( configuration.get( ServerSettings.maximum_response_header_size) );
+        httpConfig.setSendServerVersion( false );
         return httpConfig;
     }
 

--- a/community/server/src/main/java/org/neo4j/server/web/StaticContentFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/web/StaticContentFilter.java
@@ -48,6 +48,8 @@ public class StaticContentFilter implements Filter
             response.addHeader( "Pragma", "no-cache" );
             response.addHeader( "Content-Security-Policy", "frame-ancestors 'none'" );
             response.addHeader( "X-Frame-Options", "DENY" );
+            response.addHeader( "X-Content-Type-Options", "nosniff" );
+            response.addHeader( "X-XSS-Protection", "1; mode=block" );
         }
         filterChain.doFilter( servletRequest, servletResponse);
     }

--- a/community/server/src/test/java/org/neo4j/server/HttpHeadersIT.java
+++ b/community/server/src/test/java/org/neo4j/server/HttpHeadersIT.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2002-2018 "Neo Technology,"
- * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
  *
  * This file is part of Neo4j.
  *

--- a/community/server/src/test/java/org/neo4j/server/HttpHeadersIT.java
+++ b/community/server/src/test/java/org/neo4j/server/HttpHeadersIT.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server;
+
+import com.sun.jersey.api.client.Client;
+import com.sun.jersey.api.client.ClientRequest;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.config.ClientConfig;
+import com.sun.jersey.api.client.config.DefaultClientConfig;
+import com.sun.jersey.client.urlconnection.HTTPSProperties;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.List;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.neo4j.test.server.ExclusiveServerTestBase;
+import org.neo4j.test.server.InsecureTrustManager;
+
+import static com.sun.jersey.client.urlconnection.HTTPSProperties.PROPERTY_HTTPS_PROPERTIES;
+import static org.eclipse.jetty.http.HttpHeader.SERVER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.neo4j.server.helpers.CommunityServerBuilder.serverOnRandomPorts;
+
+public class HttpHeadersIT extends ExclusiveServerTestBase
+{
+    private CommunityNeoServer server;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        server = serverOnRandomPorts().withHttpsEnabled()
+                .usingDataDir( folder.directory( name.getMethodName() ).getAbsolutePath() )
+                .build();
+
+        server.start();
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        if ( server != null )
+        {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void shouldNotSendJettyVersionWithHttpResponseHeaders() throws Exception
+    {
+        URI httpUri = server.baseUri();
+        testNoJettyVersionInResponseHeaders( httpUri );
+    }
+
+    @Test
+    public void shouldNotSendJettyVersionWithHttpsResponseHeaders() throws Exception
+    {
+        URI httpsUri = server.httpsUri().orElseThrow( IllegalStateException::new );
+        testNoJettyVersionInResponseHeaders( httpsUri );
+    }
+
+    private static void testNoJettyVersionInResponseHeaders( URI baseUri ) throws Exception
+    {
+        URI uri = baseUri.resolve( "db/data/transaction/commit" );
+        ClientRequest request = createClientRequest( uri );
+
+        ClientResponse response = createClient().handle( request );
+
+        assertEquals( 200, response.getStatus() );
+
+        MultivaluedMap<String,String> headers = response.getHeaders();
+        assertNull( headers.get( SERVER.name() ) ); // no 'Server' header
+        for ( List<String> values : headers.values() )
+        {
+            assertFalse( values.stream().anyMatch( value -> value.toLowerCase().contains( "jetty" ) ) ); // no 'jetty' in other header values
+        }
+    }
+
+    private static ClientRequest createClientRequest( URI uri )
+    {
+        return ClientRequest.create()
+                .header( "Accept", "application/json" )
+                .build( uri, "POST" );
+    }
+
+    private static Client createClient() throws Exception
+    {
+        HostnameVerifier hostnameVerifier = HttpsURLConnection.getDefaultHostnameVerifier();
+        ClientConfig config = new DefaultClientConfig();
+        SSLContext ctx = SSLContext.getInstance( "TLS" );
+        ctx.init( null, new TrustManager[]{new InsecureTrustManager()}, null );
+        config.getProperties().put( PROPERTY_HTTPS_PROPERTIES, new HTTPSProperties( hostnameVerifier, ctx ) );
+        return Client.create( config );
+    }
+}

--- a/community/server/src/test/java/org/neo4j/server/HttpsAccessIT.java
+++ b/community/server/src/test/java/org/neo4j/server/HttpsAccessIT.java
@@ -27,15 +27,13 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
 
 import org.neo4j.test.server.ExclusiveServerTestBase;
 import org.neo4j.test.server.HTTP;
+import org.neo4j.test.server.InsecureTrustManager;
 
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.Matchers.is;
@@ -64,24 +62,7 @@ public class HttpsAccessIT extends ExclusiveServerTestBase
 
         // Because we are generating a non-CA-signed certificate, we need to turn off verification in the client.
         // This is ironic, since there is no proper verification on the CA side in the first place, but I digress.
-
-        TrustManager[] trustAllCerts = new TrustManager[]{
-                new X509TrustManager()
-        {
-            public void checkClientTrusted( X509Certificate[] arg0, String arg1 )
-            {
-            }
-
-            public void checkServerTrusted( X509Certificate[] arg0, String arg1 )
-            {
-            }
-
-            public X509Certificate[] getAcceptedIssuers()
-            {
-                return null;
-            }
-        }
-        };
+        TrustManager[] trustAllCerts = {new InsecureTrustManager()};
 
         // Install the all-trusting trust manager
         SSLContext sc = SSLContext.getInstance( "TLS" );

--- a/community/server/src/test/java/org/neo4j/server/security/ssl/HttpsRequestCustomizerTest.java
+++ b/community/server/src/test/java/org/neo4j/server/security/ssl/HttpsRequestCustomizerTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2002-2018 "Neo Technology,"
- * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
  *
  * This file is part of Neo4j.
  *

--- a/community/server/src/test/java/org/neo4j/server/security/ssl/HttpsRequestCustomizerTest.java
+++ b/community/server/src/test/java/org/neo4j/server/security/ssl/HttpsRequestCustomizerTest.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.server.security.ssl;
 
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.HttpConfiguration;
@@ -28,9 +29,12 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.junit.Test;
 
-import org.neo4j.kernel.configuration.Config;
-import org.neo4j.server.configuration.ServerSettings;
+import java.util.Map;
 
+import org.neo4j.kernel.configuration.Config;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableMap;
 import static org.eclipse.jetty.http.HttpHeader.STRICT_TRANSPORT_SECURITY;
 import static org.eclipse.jetty.http.HttpScheme.HTTPS;
 import static org.eclipse.jetty.server.HttpConfiguration.Customizer;
@@ -39,9 +43,18 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.server.configuration.ServerSettings.http_public_key_pins;
+import static org.neo4j.server.configuration.ServerSettings.http_strict_transport_security;
+import static org.neo4j.server.security.ssl.HttpsRequestCustomizer.PUBLIC_KEY_PINS_HTTP_HEADER;
 
 public class HttpsRequestCustomizerTest
 {
+    private static final Map<String,String> settingNameToHttpHeader = unmodifiableMap( stringMap(
+            http_strict_transport_security.name(), STRICT_TRANSPORT_SECURITY.asString(),
+            http_public_key_pins.name(), PUBLIC_KEY_PINS_HTTP_HEADER
+    ) );
+
     @Test
     public void shouldSetRequestSchemeToHttps()
     {
@@ -56,26 +69,65 @@ public class HttpsRequestCustomizerTest
     @Test
     public void shouldAddHstsHeaderWhenConfigured()
     {
-        String configuredValue = "max-age=3600; includeSubDomains";
-        Customizer customizer = newCustomizer( configuredValue );
-        Request request = newRequest();
-
-        customize( customizer, request );
-
-        String receivedValue = request.getResponse().getHttpFields().get( STRICT_TRANSPORT_SECURITY );
-        assertEquals( configuredValue, receivedValue );
+        testHeadersPresence( stringMap( http_strict_transport_security.name(), "max-age=3600; includeSubDomains" ) );
     }
 
     @Test
     public void shouldNotAddHstsHeaderWhenNotConfigured()
+    {
+        testHeaderNotPresentWhenConfigurationMissing( STRICT_TRANSPORT_SECURITY.asString() );
+    }
+
+    @Test
+    public void shouldAddHpkpHeaderWhenConfigured()
+    {
+        testHeadersPresence( stringMap( http_public_key_pins.name(), "pin-sha256=\"cUPcTAZWKaASuYWhhneDttWpY3oBAkE3h2+soZS7sWs=\"; " +
+                                                                     "pin-sha256=\"M8HztCzM3elUxkcjR2S5P4hhyBNf6lHkmjAHKhpGPWE=\"; " +
+                                                                     "max-age=5184000; includeSubDomains;" ) );
+    }
+
+    @Test
+    public void shouldNotAddHpkpHeaderWhenNotConfigured()
+    {
+        testHeaderNotPresentWhenConfigurationMissing( PUBLIC_KEY_PINS_HTTP_HEADER );
+    }
+
+    @Test
+    public void shouldAddBothHstsAndHpkpHeadersWhenConfigured()
+    {
+        testHeadersPresence( stringMap(
+                http_strict_transport_security.name(), "max-age=31536000; includeSubDomains; preload",
+                http_public_key_pins.name(), "pin-sha256=\"cUPcTAZWKaASuYWhhneDttWpY3oBAkE3h2+soZS7sWs=\"; " +
+                                             "pin-sha256=\"M8HztCzM3elUxkcjR2S5P4hhyBNf6lHkmjAHKhpGPWE=\"; " +
+                                             "max-age=5184000; includeSubDomains; " +
+                                             "report-uri=\"https://www.example.org/hpkp-report\"" ) );
+    }
+
+    private static void testHeadersPresence( Map<String,String> settingsWithValues )
+    {
+        Customizer customizer = newCustomizer( settingsWithValues );
+        Request request = newRequest();
+
+        customize( customizer, request );
+
+        HttpFields httpFields = request.getResponse().getHttpFields();
+        for ( Map.Entry<String,String> entry : settingsWithValues.entrySet() )
+        {
+            String settingName = entry.getKey();
+            String settingValue = entry.getValue();
+            String headerName = settingNameToHttpHeader.get( settingName );
+            assertEquals( settingValue, httpFields.get( headerName ) );
+        }
+    }
+
+    private static void testHeaderNotPresentWhenConfigurationMissing( String header )
     {
         Customizer customizer = newCustomizer();
         Request request = newRequest();
 
         customize( customizer, request );
 
-        String hstsValue = request.getResponse().getHttpFields().get( STRICT_TRANSPORT_SECURITY );
-        assertNull( hstsValue );
+        assertNull( request.getResponse().getHttpFields().get( header ) );
     }
 
     private static void customize( Customizer customizer, Request request )
@@ -95,12 +147,12 @@ public class HttpsRequestCustomizerTest
 
     private static Customizer newCustomizer()
     {
-        return newCustomizer( null );
+        return newCustomizer( emptyMap() );
     }
 
-    private static Customizer newCustomizer( String hstsValue )
+    private static Customizer newCustomizer( Map<String,String> settingsWithValues )
     {
-        Config config = Config.defaults( ServerSettings.http_strict_transport_security, hstsValue );
+        Config config = Config.defaults( settingsWithValues );
         return new HttpsRequestCustomizer( config );
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/security/ssl/HttpsRequestCustomizerTest.java
+++ b/community/server/src/test/java/org/neo4j/server/security/ssl/HttpsRequestCustomizerTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.security.ssl;
+
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpInput;
+import org.eclipse.jetty.server.HttpOutput;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.junit.Test;
+
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.server.configuration.ServerSettings;
+
+import static org.eclipse.jetty.http.HttpHeader.STRICT_TRANSPORT_SECURITY;
+import static org.eclipse.jetty.http.HttpScheme.HTTPS;
+import static org.eclipse.jetty.server.HttpConfiguration.Customizer;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class HttpsRequestCustomizerTest
+{
+    @Test
+    public void shouldSetRequestSchemeToHttps()
+    {
+        Customizer customizer = newCustomizer();
+        Request request = mock( Request.class );
+
+        customize( customizer, request );
+
+        verify( request ).setScheme( HTTPS.asString() );
+    }
+
+    @Test
+    public void shouldAddHstsHeaderWhenConfigured()
+    {
+        String configuredValue = "max-age=3600; includeSubDomains";
+        Customizer customizer = newCustomizer( configuredValue );
+        Request request = newRequest();
+
+        customize( customizer, request );
+
+        String receivedValue = request.getResponse().getHttpFields().get( STRICT_TRANSPORT_SECURITY );
+        assertEquals( configuredValue, receivedValue );
+    }
+
+    @Test
+    public void shouldNotAddHstsHeaderWhenNotConfigured()
+    {
+        Customizer customizer = newCustomizer();
+        Request request = newRequest();
+
+        customize( customizer, request );
+
+        String hstsValue = request.getResponse().getHttpFields().get( STRICT_TRANSPORT_SECURITY );
+        assertNull( hstsValue );
+    }
+
+    private static void customize( Customizer customizer, Request request )
+    {
+        customizer.customize( mock( Connector.class ), new HttpConfiguration(), request );
+    }
+
+    private static Request newRequest()
+    {
+        HttpChannel channel = mock( HttpChannel.class );
+        Response response = new Response( channel, mock( HttpOutput.class ) );
+        Request request = new Request( channel, mock( HttpInput.class ) );
+        when( channel.getRequest() ).thenReturn( request );
+        when( channel.getResponse() ).thenReturn( response );
+        return request;
+    }
+
+    private static Customizer newCustomizer()
+    {
+        return newCustomizer( null );
+    }
+
+    private static Customizer newCustomizer( String hstsValue )
+    {
+        Config config = Config.defaults( ServerSettings.http_strict_transport_security, hstsValue );
+        return new HttpsRequestCustomizer( config );
+    }
+}

--- a/community/server/src/test/java/org/neo4j/server/web/Jetty9WebServerIT.java
+++ b/community/server/src/test/java/org/neo4j/server/web/Jetty9WebServerIT.java
@@ -73,7 +73,7 @@ public class Jetty9WebServerIT extends ExclusiveServerTestBase
     @Test
     public void shouldStopCleanlyEvenWhenItHasntBeenStarted()
     {
-        new Jetty9WebServer( NullLogProvider.getInstance(), null ).stop();
+        new Jetty9WebServer( NullLogProvider.getInstance(), Config.defaults() ).stop();
     }
 
     @After

--- a/community/server/src/test/java/org/neo4j/server/web/StaticContentFilterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/web/StaticContentFilterTest.java
@@ -19,11 +19,11 @@
  */
 package org.neo4j.server.web;
 
+import org.junit.Test;
+
 import javax.servlet.FilterChain;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import org.junit.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -49,6 +49,8 @@ public class StaticContentFilterTest
         verify( response ).addHeader( "Pragma", "no-cache" );
         verify( response ).addHeader( "Content-Security-Policy", "frame-ancestors 'none'" );
         verify( response ).addHeader( "X-Frame-Options", "DENY" );
+        verify( response ).addHeader( "X-Content-Type-Options", "nosniff" );
+        verify( response ).addHeader( "X-XSS-Protection", "1; mode=block" );
         verify( filterChain ).doFilter( request, response );
     }
 

--- a/community/server/src/test/java/org/neo4j/test/server/InsecureTrustManager.java
+++ b/community/server/src/test/java/org/neo4j/test/server/InsecureTrustManager.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2002-2018 "Neo Technology,"
- * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
  *
  * This file is part of Neo4j.
  *

--- a/community/server/src/test/java/org/neo4j/test/server/InsecureTrustManager.java
+++ b/community/server/src/test/java/org/neo4j/test/server/InsecureTrustManager.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test.server;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.X509TrustManager;
+
+public class InsecureTrustManager implements X509TrustManager
+{
+    @Override
+    public void checkClientTrusted( X509Certificate[] x509Certificates, String s ) throws CertificateException
+    {
+    }
+
+    @Override
+    public void checkServerTrusted( X509Certificate[] x509Certificates, String s ) throws CertificateException
+    {
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers()
+    {
+        return null;
+    }
+}

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
@@ -226,10 +226,25 @@ dbms.connector.https.enabled=true
 # clauses that load data from the file system.
 #dbms.security.allow_csv_import_from_file_urls=true
 
+
 # Value of the Access-Control-Allow-Origin header sent over any HTTP or HTTPS
 # connector. This defaults to '*', which allows broadest compatibility. Note
 # that any URI provided here limits HTTP/HTTPS access to that URI only.
 #dbms.security.http_access_control_allow_origin=*
+
+# Value of the HTTP Strict-Transport-Security (HSTS) response header. This header
+# tells browsers that a webpage should only be accessed using HTTPS instead of HTTP.
+# It is attached to every HTTPS response. Setting is not set by default so
+# 'Strict-Transport-Security' header is not sent. Value is expected to contain
+# dirictives like 'max-age', 'includeSubDomains' and 'preload'.
+#dbms.security.http_strict_transport_security=
+
+# Value of the HTTP Public Key Pinning (HPKP) response header. This header tells
+# browsers about the public keys that belong to a webpage. It is attached to every
+# HTTPS response. Setting is not set by default so 'Public-Key-Pins' header is not
+# sent. Value is expected to contain dirictives like 'pin-sha256', 'max-age',
+# 'includeSubDomains' and 'report-uri'.
+#dbms.security.http_public_key_pins=
 
 # Retention policy for transaction logs needed to perform recovery and backups.
 dbms.tx_log.rotation.retention_policy=1 days

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
@@ -239,13 +239,6 @@ dbms.connector.https.enabled=true
 # dirictives like 'max-age', 'includeSubDomains' and 'preload'.
 #dbms.security.http_strict_transport_security=
 
-# Value of the HTTP Public Key Pinning (HPKP) response header. This header tells
-# browsers about the public keys that belong to a webpage. It is attached to every
-# HTTPS response. Setting is not set by default so 'Public-Key-Pins' header is not
-# sent. Value is expected to contain dirictives like 'pin-sha256', 'max-age',
-# 'includeSubDomains' and 'report-uri'.
-#dbms.security.http_public_key_pins=
-
 # Retention policy for transaction logs needed to perform recovery and backups.
 dbms.tx_log.rotation.retention_policy=1 days
 


### PR DESCRIPTION
PR includes:
1. Made Jetty not attach 'Server' HTTP response with its name and version
2. Allow configuration of HSTS `Strict-Transport-Security` HTTP response header for HTTPS requests
3. More security-related headers for static assets

Docs on HSTS:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
https://www.owasp.org/index.php/HTTP_Strict_Transport_Security_Cheat_Sheet

Related to https://github.com/neo4j/neo4j/pull/11580/