### PR TITLE
Node/relationship by id seek should handle negative ids properly

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/DelegatingQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/DelegatingQueryContext.scala
@@ -274,8 +274,6 @@ class DelegatingOperations[T <: PropertyContainer](protected val inner: Operatio
 
   override def releaseExclusiveLock(obj: Long): Unit = inner.releaseExclusiveLock(obj)
 
-  override def exists(id: Long): Boolean = singleDbHit(inner.exists(id))
-
   override def getByIdIfExists(id: Long): Option[T] = singleDbHit(inner.getByIdIfExists(id))
 }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/QueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/QueryContext.scala
@@ -235,8 +235,6 @@ trait Operations[T <: PropertyContainer] {
 
   def releaseExclusiveLock(obj: Long): Unit
 
-  def exists(id: Long): Boolean
-
   def getByIdIfExists(id: Long): Option[T]
 }
 


### PR DESCRIPTION
This changes the behaviour to be in line with previous versions where
the negative id was checked before asking kernel if it exists.

Also removes unused method from Operations