### PR TITLE
Revert to using IdentityHashMap for NodeStateImpl index diffs.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/NodeStateImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/NodeStateImpl.java
@@ -19,7 +19,8 @@
  */
 package org.neo4j.kernel.impl.api.state;
 
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.Set;
 
@@ -334,7 +335,7 @@ class NodeStateImpl extends PropertyContainerStateImpl implements NodeState
     {
         if ( indexDiffs == null )
         {
-            indexDiffs = new HashSet<>();
+            indexDiffs = Collections.newSetFromMap( new IdentityHashMap<PrimitiveLongDiffSets, Boolean>() );
         }
         indexDiffs.add( diff );
     }


### PR DESCRIPTION
Fixes (at least partially) regression in remove label query (Pokec WQ28).

The IdentityHashMap is semantically correct because it's the diffsets-instance we want to store, not it's contents. 