### PR TITLE
Minor performance improvements

### DIFF
--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledCursorUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledCursorUtils.java
@@ -96,7 +96,7 @@ public final class CompiledCursorUtils
         }
         singleNode( read, nodeCursor, node );
 
-        return nodeCursor.labels().contains( label );
+        return nodeCursor.hasLabel( label );
     }
 
     public static RelationshipSelectionCursor nodeGetRelationships( Read read, CursorFactory cursors, NodeCursor node,

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
@@ -176,7 +176,7 @@ final class TransactionBoundQueryContext(tc: TransactionalContextWrapper, val re
     val cursor = nodeCursor
     reads().singleNode(node, cursor)
     if (!cursor.next()) false
-    else cursor.labels().contains(label)
+    else cursor.hasLabel(label)
   }
 
   def getOrCreateLabelId(labelName: String) =

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundQueryContext.scala
@@ -36,7 +36,7 @@ import org.neo4j.cypher.internal.compiler.v3_1.spi._
 import org.neo4j.cypher.internal.frontend.v3_1.SemanticDirection.{BOTH, INCOMING, OUTGOING}
 import org.neo4j.cypher.internal.frontend.v3_1.{Bound, EntityNotFoundException, FailedIndexException, SemanticDirection}
 import org.neo4j.cypher.internal.javacompat.GraphDatabaseCypherService
-import org.neo4j.cypher.internal.runtime.interpreted.{JavaConversionSupport, ResourceManager}
+import org.neo4j.cypher.internal.runtime.interpreted.ResourceManager
 import org.neo4j.cypher.internal.spi.v3_1.TransactionBoundQueryContext.IndexSearchMonitor
 import org.neo4j.cypher.internal.spi.{CursorIterator, PrimitiveCursorIterator}
 import org.neo4j.graphalgo.impl.path.ShortestPath
@@ -175,7 +175,7 @@ final class TransactionBoundQueryContext(txContext: TransactionalContextWrapper,
     val cursor = nodeCursor
     reads().singleNode(node, cursor)
     if (!cursor.next()) false
-    else cursor.labels().contains(label)
+    else cursor.hasLabel(label)
   }
 
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/codegen/CompiledCursorUtilsTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/codegen/CompiledCursorUtilsTest.scala
@@ -24,7 +24,6 @@ import org.neo4j.cypher.internal.codegen.CompiledCursorUtils.{nodeGetProperty, n
 import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.internal.kernel.api.exceptions.EntityNotFoundException
 import org.neo4j.internal.kernel.api.{NodeCursor, PropertyCursor, Read, RelationshipScanCursor}
-import org.neo4j.kernel.impl.newapi.Labels
 import org.neo4j.values.storable.Values.{NO_VALUE, stringValue}
 
 class CompiledCursorUtilsTest extends CypherFunSuite {
@@ -113,7 +112,8 @@ class CompiledCursorUtilsTest extends CypherFunSuite {
     // Given
     val nodeCursor = mock[NodeCursor]
     when(nodeCursor.next()).thenReturn(true)
-    when(nodeCursor.labels()).thenReturn(Labels.from(Array(1337L, 42L, 13L)))
+    when(nodeCursor.hasLabel(1337)).thenReturn(true)
+    when(nodeCursor.hasLabel(1980)).thenReturn(false)
 
     // Then
     nodeHasLabel(mock[Read], nodeCursor, 1L, 1337) shouldBe true

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
@@ -162,10 +162,13 @@ sealed class TransactionBoundQueryContext(val transactionalContext: Transactiona
 
 
   override def isLabelSetOnNode(label: Int, node: Long): Boolean = {
-    val cursor = nodeCursor
-    reads().singleNode(node, cursor)
-    if (!cursor.next()) false
-    else cursor.labels().contains(label)
+    if (label == StatementConstants.NO_SUCH_LABEL) false
+    else {
+      val cursor = nodeCursor
+      reads().singleNode(node, cursor)
+      if (!cursor.next()) false
+      else cursor.hasLabel(label)
+    }
   }
 
   override def getOrCreateLabelId(labelName: String): Int = {

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
@@ -93,7 +93,8 @@ sealed class TransactionBoundQueryContext(val transactionalContext: Transactiona
 
     val context = transactionalContext.tc.asInstanceOf[Neo4jTransactionalContext]
     val newTx = transactionalContext.graph.beginTransaction(context.transactionType, context.securityContext)
-    val neo4jTransactionalContext = context.copyFrom(context.graph, guard, statementProvider, locker, newTx, query)
+    val neo4jTransactionalContext = context.copyFrom(context.graph, guard, statementProvider, locker, newTx,
+                                                     statementProvider.get(), query)
     new TransactionBoundQueryContext(TransactionalContextWrapper(neo4jTransactionalContext))
   }
 

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContextTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContextTest.scala
@@ -91,7 +91,7 @@ class TransactionBoundQueryContextTest extends CypherFunSuite {
     val transaction = mock[KernelTransaction]
     when(transaction.cursors()).thenReturn(new DefaultCursors())
     when(bridge.getKernelTransactionBoundToThisThread(true)).thenReturn(transaction)
-    val tc = new Neo4jTransactionalContext(graph, null, bridge, locker, outerTx, null, null)
+    val tc = new Neo4jTransactionalContext(graph, null, bridge, locker, outerTx, statement,null, null)
     val transactionalContext = TransactionalContextWrapper(tc)
     val context = new TransactionBoundQueryContext(transactionalContext)(indexSearchMonitor)
     // WHEN
@@ -115,7 +115,7 @@ class TransactionBoundQueryContextTest extends CypherFunSuite {
     when(transaction.acquireStatement()).thenReturn(statement)
     when(transaction.cursors()).thenReturn(new DefaultCursors())
     when(bridge.getKernelTransactionBoundToThisThread(true)).thenReturn(transaction)
-    val tc = new Neo4jTransactionalContext(graph, null, bridge, locker, outerTx, null, null)
+    val tc = new Neo4jTransactionalContext(graph, null, bridge, locker, outerTx, statement,null, null)
     val transactionalContext = TransactionalContextWrapper(tc)
     val context = new TransactionBoundQueryContext(transactionalContext)(indexSearchMonitor)
     // WHEN
@@ -218,7 +218,7 @@ class TransactionBoundQueryContextTest extends CypherFunSuite {
     when(transaction.acquireStatement()).thenReturn(statement)
     when(transaction.cursors()).thenReturn(new DefaultCursors())
     when(bridge.getKernelTransactionBoundToThisThread(true)).thenReturn(transaction)
-    val tc = new Neo4jTransactionalContext(graph, null, bridge, locker, outerTx, null, null)
+    val tc = new Neo4jTransactionalContext(graph, null, bridge, locker, outerTx, statement, null, null)
     val transactionalContext = TransactionalContextWrapper(tc)
     val context = new TransactionBoundQueryContext(transactionalContext)(indexSearchMonitor)
     val resource1 = mock[AutoCloseable]

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContextTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContextTest.scala
@@ -69,6 +69,7 @@ class TransactionBoundQueryContextTest extends CypherFunSuite {
     outerTx = mock[InternalTransaction]
     val kernelTransaction = mock[KernelTransactionImplementation]
     when(kernelTransaction.securityContext()).thenReturn(AUTH_DISABLED)
+    when(kernelTransaction.acquireStatement()).thenReturn(statement)
     val storeStatement = mock[StorageStatement]
     val operations = mock[StatementOperationParts](RETURNS_DEEP_STUBS)
     statement = new KernelStatement(kernelTransaction, null, storeStatement, LockTracer.NONE, operations, new ClockContext(), EmptyVersionContextSupplier.EMPTY)
@@ -90,7 +91,7 @@ class TransactionBoundQueryContextTest extends CypherFunSuite {
     val transaction = mock[KernelTransaction]
     when(transaction.cursors()).thenReturn(new DefaultCursors())
     when(bridge.getKernelTransactionBoundToThisThread(true)).thenReturn(transaction)
-    val tc = new Neo4jTransactionalContext(graph, null, bridge, locker, outerTx, statement, null, null)
+    val tc = new Neo4jTransactionalContext(graph, null, bridge, locker, outerTx, null, null)
     val transactionalContext = TransactionalContextWrapper(tc)
     val context = new TransactionBoundQueryContext(transactionalContext)(indexSearchMonitor)
     // WHEN
@@ -111,9 +112,10 @@ class TransactionBoundQueryContextTest extends CypherFunSuite {
     when(outerTx.securityContext()).thenReturn(AUTH_DISABLED)
     val bridge = mock[ThreadToStatementContextBridge]
     val transaction = mock[KernelTransaction]
+    when(transaction.acquireStatement()).thenReturn(statement)
     when(transaction.cursors()).thenReturn(new DefaultCursors())
     when(bridge.getKernelTransactionBoundToThisThread(true)).thenReturn(transaction)
-    val tc = new Neo4jTransactionalContext(graph, null, bridge, locker, outerTx, statement, null, null)
+    val tc = new Neo4jTransactionalContext(graph, null, bridge, locker, outerTx, null, null)
     val transactionalContext = TransactionalContextWrapper(tc)
     val context = new TransactionBoundQueryContext(transactionalContext)(indexSearchMonitor)
     // WHEN
@@ -213,9 +215,10 @@ class TransactionBoundQueryContextTest extends CypherFunSuite {
     // GIVEN
     val bridge = mock[ThreadToStatementContextBridge]
     val transaction = mock[KernelTransaction]
+    when(transaction.acquireStatement()).thenReturn(statement)
     when(transaction.cursors()).thenReturn(new DefaultCursors())
     when(bridge.getKernelTransactionBoundToThisThread(true)).thenReturn(transaction)
-    val tc = new Neo4jTransactionalContext(graph, null, bridge, locker, outerTx, statement, null, null)
+    val tc = new Neo4jTransactionalContext(graph, null, bridge, locker, outerTx, null, null)
     val transactionalContext = TransactionalContextWrapper(tc)
     val context = new TransactionBoundQueryContext(transactionalContext)(indexSearchMonitor)
     val resource1 = mock[AutoCloseable]

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/NodeCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/NodeCursor.java
@@ -28,6 +28,8 @@ public interface NodeCursor extends Cursor
 
     LabelSet labels();
 
+    boolean hasLabel( int label );
+
     boolean hasProperties();
 
     void relationships( RelationshipGroupCursor cursor );

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeCursorTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeCursorTestBase.java
@@ -141,6 +141,7 @@ public abstract class NodeCursorTestBase<G extends KernelAPIReadTestSupport> ext
             labels = nodes.labels();
             assertEquals( "number of labels", 1, labels.numberOfLabels() );
             int fooLabel = labels.label( 0 );
+            assertTrue( nodes.hasLabel( fooLabel ) );
             assertFalse( "should only access a single node", nodes.next() );
 
             // when
@@ -151,6 +152,8 @@ public abstract class NodeCursorTestBase<G extends KernelAPIReadTestSupport> ext
             labels = nodes.labels();
             assertEquals( "number of labels", 1, labels.numberOfLabels() );
             int barLabel = labels.label( 0 );
+            assertFalse( nodes.hasLabel( fooLabel ) );
+            assertTrue( nodes.hasLabel( barLabel ) );
             assertFalse( "should only access a single node", nodes.next() );
 
             // when
@@ -161,6 +164,9 @@ public abstract class NodeCursorTestBase<G extends KernelAPIReadTestSupport> ext
             labels = nodes.labels();
             assertEquals( "number of labels", 1, labels.numberOfLabels() );
             int bazLabel = labels.label( 0 );
+            assertFalse( nodes.hasLabel( fooLabel ) );
+            assertFalse( nodes.hasLabel( barLabel ) );
+            assertTrue( nodes.hasLabel( bazLabel ) );
             assertFalse( "should only access a single node", nodes.next() );
 
             assertNotEquals( "distinct labels", fooLabel, barLabel );
@@ -183,6 +189,10 @@ public abstract class NodeCursorTestBase<G extends KernelAPIReadTestSupport> ext
                 assertEquals( bazLabel, labels.label( 0 ) );
                 assertEquals( barLabel, labels.label( 1 ) );
             }
+            assertFalse( nodes.hasLabel( fooLabel ) );
+            assertTrue( nodes.hasLabel( barLabel ) );
+            assertTrue( nodes.hasLabel( barLabel ) );
+
             assertFalse( "should only access a single node", nodes.next() );
 
             // when
@@ -192,6 +202,9 @@ public abstract class NodeCursorTestBase<G extends KernelAPIReadTestSupport> ext
             assertTrue( "should access defined node", nodes.next() );
             labels = nodes.labels();
             assertEquals( "number of labels", 0, labels.numberOfLabels() );
+            assertFalse( nodes.hasLabel( fooLabel ) );
+            assertFalse( nodes.hasLabel( barLabel ) );
+            assertFalse( nodes.hasLabel( barLabel ) );
             assertFalse( "should only access a single node", nodes.next() );
         }
     }

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeCursorTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeCursorTestBase.java
@@ -191,7 +191,7 @@ public abstract class NodeCursorTestBase<G extends KernelAPIReadTestSupport> ext
             }
             assertFalse( nodes.hasLabel( fooLabel ) );
             assertTrue( nodes.hasLabel( barLabel ) );
-            assertTrue( nodes.hasLabel( barLabel ) );
+            assertTrue( nodes.hasLabel( bazLabel ) );
 
             assertFalse( "should only access a single node", nodes.next() );
 
@@ -204,7 +204,7 @@ public abstract class NodeCursorTestBase<G extends KernelAPIReadTestSupport> ext
             assertEquals( "number of labels", 0, labels.numberOfLabels() );
             assertFalse( nodes.hasLabel( fooLabel ) );
             assertFalse( nodes.hasLabel( barLabel ) );
-            assertFalse( nodes.hasLabel( barLabel ) );
+            assertFalse( nodes.hasLabel( bazLabel ) );
             assertFalse( "should only access a single node", nodes.next() );
         }
     }

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeTransactionStateTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeTransactionStateTestBase.java
@@ -83,6 +83,8 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
                 LabelSet labels = node.labels();
                 assertEquals( 1, labels.numberOfLabels() );
                 assertEquals( labelId, labels.label( 0 ) );
+                assertTrue( node.hasLabel( labelId ) );
+                assertFalse( node.hasLabel( labelId + 1 ) );
                 assertFalse( "should only find one node", node.next() );
             }
             tx.success();
@@ -139,6 +141,10 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
                 assertTrue( "should access node", node.next() );
 
                 assertLabels( node.labels(), toRetain, toAdd );
+                assertTrue( node.hasLabel( toAdd ) );
+                assertTrue( node.hasLabel( toRetain ) );
+                assertFalse( node.hasLabel( toDelete ) );
+                assertFalse( node.hasLabel( toRegret ) );
                 assertFalse( "should only find one node", node.next() );
             }
             tx.success();

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubNodeCursor.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/helpers/StubNodeCursor.java
@@ -95,6 +95,12 @@ public class StubNodeCursor implements NodeCursor
     }
 
     @Override
+    public boolean hasLabel( int label )
+    {
+        return labels().contains( label );
+    }
+
+    @Override
     public boolean hasProperties()
     {
         return (offset >= 0 && offset < nodes.size()) && !nodes.get( offset ).properties.isEmpty();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -631,7 +631,7 @@ public class NodeProxy implements Node, RelationshipFactory<Relationship>
                 return false;
             }
             transaction.dataRead().singleNode( nodeId, nodes );
-            return nodes.next() && nodes.labels().contains( labelId );
+            return nodes.next() && nodes.hasLabel( labelId );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeCursor.java
@@ -34,6 +34,7 @@ import org.neo4j.kernel.impl.store.NodeLabelsField;
 import org.neo4j.kernel.impl.store.RecordCursor;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.storageengine.api.txstate.ReadableDiffSets;
 
 import static java.util.Collections.emptySet;
 
@@ -134,9 +135,14 @@ class DefaultNodeCursor extends NodeRecord implements NodeCursor
         if ( hasChanges() )
         {
             TransactionState txState = read.txState();
-            if ( txState.nodeStateLabelDiffSets( getId() ).getAdded().contains( label ) )
+            ReadableDiffSets<Integer> diffSets = txState.nodeStateLabelDiffSets( getId() );
+            if ( diffSets.getAdded().contains( label ) )
             {
                 return true;
+            }
+            if ( diffSets.getRemoved().contains( label ) )
+            {
+                return false;
             }
         }
 
@@ -146,6 +152,7 @@ class DefaultNodeCursor extends NodeRecord implements NodeCursor
         {
             if ( labelToken == label )
             {
+                assert (int) labelToken == labelToken : "value too big to be represented as and int";
                 return true;
             }
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeCursor.java
@@ -129,6 +129,30 @@ class DefaultNodeCursor extends NodeRecord implements NodeCursor
     }
 
     @Override
+    public boolean hasLabel( int label )
+    {
+        if ( hasChanges() )
+        {
+            TransactionState txState = read.txState();
+            if ( txState.nodeStateLabelDiffSets( getId() ).getAdded().contains( label ) )
+            {
+                return true;
+            }
+        }
+
+        //Get labels from store and put in intSet, unfortunately we get longs back
+        long[] longs = NodeLabelsField.get( this, labelCursor() );
+        for ( long labelToken : longs )
+        {
+            if ( labelToken == label )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public boolean hasProperties()
     {
         return nextProp != NO_ID;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Labels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Labels.java
@@ -88,6 +88,7 @@ public class Labels implements LabelSet
         //label sizes (≤100 labels)
         for ( long label : labels )
         {
+            assert (int) label == label : "value too big to be represented as and int";
             if ( label == labelToken )
             {
                 return true;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeSchemaMatcher.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeSchemaMatcher.java
@@ -71,7 +71,7 @@ public class NodeSchemaMatcher
         {
             SUPPLIER schemaSupplier = schemaSuppliers.next();
             SchemaDescriptor schema = schemaSupplier.schema();
-            if ( node.labels().contains( schema.keyId() ) )
+            if ( node.hasLabel( schema.keyId() ) )
             {
                 if ( nodePropertyIds == null )
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
@@ -44,6 +44,7 @@ import org.neo4j.internal.kernel.api.Token;
 import org.neo4j.internal.kernel.api.Write;
 import org.neo4j.internal.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
+import org.neo4j.internal.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.internal.kernel.api.exceptions.explicitindex.AutoIndexingKernelException;
 import org.neo4j.internal.kernel.api.exceptions.explicitindex.ExplicitIndexNotFoundKernelException;
 import org.neo4j.internal.kernel.api.exceptions.schema.ConstraintValidationException;
@@ -54,7 +55,6 @@ import org.neo4j.internal.kernel.api.schema.SchemaDescriptor;
 import org.neo4j.internal.kernel.api.schema.constraints.ConstraintDescriptor;
 import org.neo4j.kernel.api.SilentTokenNameLookup;
 import org.neo4j.kernel.api.StatementConstants;
-import org.neo4j.internal.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotApplicableKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
@@ -227,7 +227,7 @@ public class Operations implements Write, ExplicitIndexWrite, SchemaWrite
         ktx.assertOpen();
         singleNode( node );
 
-        if ( nodeCursor.labels().contains( nodeLabel ) )
+        if ( nodeCursor.hasLabel( nodeLabel ) )
         {
             //label already there, nothing to do
             return false;
@@ -446,7 +446,7 @@ public class Operations implements Write, ExplicitIndexWrite, SchemaWrite
 
         singleNode( node );
 
-        if ( !nodeCursor.labels().contains( nodeLabel ) )
+        if ( !nodeCursor.hasLabel( nodeLabel ) )
         {
             //the label wasn't there, nothing to do
             return false;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/Neo4jTransactionalContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/Neo4jTransactionalContext.java
@@ -70,6 +70,7 @@ public class Neo4jTransactionalContext implements TransactionalContext
             ThreadToStatementContextBridge txBridge,
             PropertyContainerLocker locker,
             InternalTransaction initialTransaction,
+            Statement intitialStatement,
             ExecutingQuery executingQuery,
             Kernel kernel
     )
@@ -84,7 +85,7 @@ public class Neo4jTransactionalContext implements TransactionalContext
 
         this.transaction = initialTransaction;
         this.kernelTransaction = txBridge.getKernelTransactionBoundToThisThread( true );
-        this.statement = kernelTransaction.acquireStatement();
+        this.statement = intitialStatement;
         this.kernel = kernel;
     }
 
@@ -245,7 +246,8 @@ public class Neo4jTransactionalContext implements TransactionalContext
     public TransactionalContext beginInNewThread()
     {
         InternalTransaction newTx = graph.beginTransaction( transactionType, securityContext );
-        return new Neo4jTransactionalContext( graph, guard, txBridge, locker, newTx, executingQuery, kernel );
+        return new Neo4jTransactionalContext( graph, guard, txBridge, locker, newTx, txBridge.get(),
+                executingQuery, kernel );
     }
 
     private void checkNotTerminated()
@@ -333,16 +335,18 @@ public class Neo4jTransactionalContext implements TransactionalContext
             Guard guard,
             ThreadToStatementContextBridge txBridge, PropertyContainerLocker locker,
             InternalTransaction initialTransaction,
+            Statement initialStatement,
             ExecutingQuery executingQuery )
     {
         return new Neo4jTransactionalContext( graph, guard, txBridge, locker, initialTransaction,
-                executingQuery, kernel );
+                initialStatement, executingQuery, kernel );
     }
 
     interface Creator
     {
         Neo4jTransactionalContext create(
                 InternalTransaction tx,
+                Statement initialStatement,
                 ExecutingQuery executingQuery
         );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/Neo4jTransactionalContextFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/Neo4jTransactionalContextFactory.java
@@ -50,13 +50,12 @@ public class Neo4jTransactionalContextFactory implements TransactionalContextFac
         Supplier<GraphDatabaseQueryService> queryService = lazySingleton( spi::queryService );
         Supplier<Kernel> kernel = lazySingleton( spi::kernel );
         Neo4jTransactionalContext.Creator contextCreator =
-                ( tx, initialStatement, executingQuery ) -> new Neo4jTransactionalContext( queryService.get(),
+                ( tx, executingQuery ) -> new Neo4jTransactionalContext( queryService.get(),
 
                         guard,
                     txBridge,
                     locker,
                     tx,
-                    initialStatement,
                     executingQuery,
                     kernel.get()
                 );
@@ -74,14 +73,13 @@ public class Neo4jTransactionalContextFactory implements TransactionalContextFac
         Kernel kernel = resolver.resolveDependency( Kernel.class );
         Guard guard = resolver.resolveDependency( Guard.class );
         Neo4jTransactionalContext.Creator contextCreator =
-                ( tx, initialStatement, executingQuery ) ->
+                ( tx, executingQuery ) ->
                         new Neo4jTransactionalContext(
                                 queryService,
                                 guard,
                                 txBridge,
                                 locker,
                                 tx,
-                                initialStatement,
                                 executingQuery,
                                 kernel
                         );
@@ -112,6 +110,6 @@ public class Neo4jTransactionalContextFactory implements TransactionalContextFac
         ExecutingQuery executingQuery = initialStatement.queryRegistration().startQueryExecution(
                 connectionWithUserName, queryText, queryParameters
         );
-        return contextCreator.create( tx, initialStatement, executingQuery );
+        return contextCreator.create( tx, executingQuery );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/Neo4jTransactionalContextFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/Neo4jTransactionalContextFactory.java
@@ -50,12 +50,13 @@ public class Neo4jTransactionalContextFactory implements TransactionalContextFac
         Supplier<GraphDatabaseQueryService> queryService = lazySingleton( spi::queryService );
         Supplier<Kernel> kernel = lazySingleton( spi::kernel );
         Neo4jTransactionalContext.Creator contextCreator =
-                ( tx, executingQuery ) -> new Neo4jTransactionalContext( queryService.get(),
+                ( tx, initialStatement, executingQuery ) -> new Neo4jTransactionalContext( queryService.get(),
 
                         guard,
                     txBridge,
                     locker,
                     tx,
+                    initialStatement,
                     executingQuery,
                     kernel.get()
                 );
@@ -73,13 +74,14 @@ public class Neo4jTransactionalContextFactory implements TransactionalContextFac
         Kernel kernel = resolver.resolveDependency( Kernel.class );
         Guard guard = resolver.resolveDependency( Guard.class );
         Neo4jTransactionalContext.Creator contextCreator =
-                ( tx, executingQuery ) ->
+                ( tx, initialStatement, executingQuery ) ->
                         new Neo4jTransactionalContext(
                                 queryService,
                                 guard,
                                 txBridge,
                                 locker,
                                 tx,
+                                initialStatement,
                                 executingQuery,
                                 kernel
                         );
@@ -110,6 +112,6 @@ public class Neo4jTransactionalContextFactory implements TransactionalContextFac
         ExecutingQuery executingQuery = initialStatement.queryRegistration().startQueryExecution(
                 connectionWithUserName, queryText, queryParameters
         );
-        return contextCreator.create( tx, executingQuery );
+        return contextCreator.create( tx, initialStatement, executingQuery );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
@@ -43,10 +43,10 @@ import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.Transaction;
 import org.neo4j.internal.kernel.api.Write;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
+import org.neo4j.internal.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.dbms.DbmsOperations;
-import org.neo4j.internal.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.security.AnonymousContext;
 import org.neo4j.kernel.impl.api.KernelImpl;
 import org.neo4j.kernel.impl.api.index.IndexingService;
@@ -213,7 +213,7 @@ public abstract class KernelIntegrationTest
         try ( NodeCursor cursor = transaction.cursors().allocateNodeCursor() )
         {
             transaction.dataRead().singleNode( node, cursor );
-            return cursor.next() && cursor.labels().contains( label );
+            return cursor.next() && cursor.hasLabel( label );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/query/Neo4jTransactionalContextTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/query/Neo4jTransactionalContextTest.java
@@ -81,7 +81,7 @@ public class Neo4jTransactionalContextTest
         InternalTransaction initialTransaction = mock( InternalTransaction.class, new ReturnsDeepStubs() );
         Kernel kernel = mock( Kernel.class );
         ThreadToStatementContextBridge txBridge = mock( ThreadToStatementContextBridge.class );
-        KernelTransaction kernelTransaction = mockTransaction();
+        KernelTransaction kernelTransaction = mockTransaction( initialStatement );
         when( txBridge.getKernelTransactionBoundToThisThread( true ) ).thenReturn( kernelTransaction );
 
         Neo4jTransactionalContext transactionalContext =
@@ -91,7 +91,7 @@ public class Neo4jTransactionalContextTest
                         txBridge
                         ,
                         null,
-                        initialTransaction, initialStatement,
+                        initialTransaction,
                         null,
                         kernel
                 );
@@ -106,7 +106,7 @@ public class Neo4jTransactionalContextTest
     public void neverStopsExecutingQueryDuringCommitAndRestartTx()
     {
         // Given
-        KernelTransaction initialKTX = mockTransaction();
+        KernelTransaction initialKTX = mockTransaction( initialStatement );
         InternalTransaction initialTransaction = mock( InternalTransaction.class, new ReturnsDeepStubs() );
         KernelTransaction.Type transactionType = KernelTransaction.Type.implicit;
         SecurityContext securityContext = SecurityContext.AUTH_DISABLED;
@@ -118,22 +118,20 @@ public class Neo4jTransactionalContextTest
         PropertyContainerLocker locker = null;
         ThreadToStatementContextBridge txBridge = mock( ThreadToStatementContextBridge.class );
 
-        KernelTransaction secondKTX = mockTransaction();
+        Statement secondStatement = mock( Statement.class );
+        KernelTransaction secondKTX = mockTransaction( secondStatement );
         InternalTransaction secondTransaction = mock( InternalTransaction.class );
         when( secondTransaction.terminationReason() ).thenReturn( Optional.empty() );
-        Statement secondStatement = mock( Statement.class );
         QueryRegistryOperations secondQueryRegistry = mock( QueryRegistryOperations.class );
 
         when( executingQuery.queryText() ).thenReturn( "X" );
         when( executingQuery.queryParameters() ).thenReturn( EMPTY_MAP );
         when( initialStatement.queryRegistration() ).thenReturn( initialQueryRegistry );
         when( queryService.beginTransaction( transactionType, securityContext ) ).thenReturn( secondTransaction );
-        KernelTransaction t = mockTransaction();
         when( txBridge.getKernelTransactionBoundToThisThread( true ) ).thenReturn(
                 initialKTX,
                 initialKTX,
                 secondKTX );
-        when( txBridge.get() ).thenReturn( secondStatement );
         when( secondStatement.queryRegistration() ).thenReturn( secondQueryRegistry );
 
         Kernel kernel = mock( Kernel.class );
@@ -142,7 +140,6 @@ public class Neo4jTransactionalContextTest
                 txBridge,
                 locker,
                 initialTransaction,
-                initialStatement,
                 executingQuery,
                 kernel
         );
@@ -152,16 +149,17 @@ public class Neo4jTransactionalContextTest
 
         // Then
         Object[] mocks =
-                {txBridge, initialTransaction, initialQueryRegistry, initialKTX, secondQueryRegistry, secondKTX};
+                {txBridge, initialTransaction, initialKTX, initialQueryRegistry, secondQueryRegistry, secondKTX};
         InOrder order = Mockito.inOrder( mocks );
 
         // (0) Constructor
         order.verify( initialTransaction ).transactionType();
         order.verify( initialTransaction ).securityContext();
+        order.verify( txBridge ).getKernelTransactionBoundToThisThread( true );
+        order.verify( initialKTX ).acquireStatement();
         order.verify( initialTransaction ).terminationReason(); // not terminated check
 
         // (1) Collect stats
-        order.verify( txBridge ).getKernelTransactionBoundToThisThread( true );
         order.verify( initialKTX ).executionStatistics();
 
         // (2) Unbind old
@@ -169,9 +167,9 @@ public class Neo4jTransactionalContextTest
         order.verify( txBridge ).unbindTransactionFromCurrentThread();
 
         // (3) Register and unbind new
-        order.verify( txBridge ).get();
-        order.verify( secondQueryRegistry ).registerExecutingQuery( executingQuery );
         order.verify( txBridge ).getKernelTransactionBoundToThisThread( true );
+        order.verify( secondKTX ).acquireStatement( );
+        order.verify( secondQueryRegistry ).registerExecutingQuery( executingQuery );
         order.verify( txBridge ).unbindTransactionFromCurrentThread();
 
         // (4) Rebind, unregister, and close old
@@ -199,17 +197,17 @@ public class Neo4jTransactionalContextTest
         when( initialTransaction.terminationReason() ).thenReturn( Optional.empty() );
 
         GraphDatabaseQueryService queryService = mock( GraphDatabaseQueryService.class );
-        KernelTransaction initialKTX = mockTransaction();
         Statement initialStatement = mock( Statement.class );
+        KernelTransaction initialKTX = mockTransaction( initialStatement );
         QueryRegistryOperations initialQueryRegistry = mock( QueryRegistryOperations.class );
         ExecutingQuery executingQuery = mock( ExecutingQuery.class );
         PropertyContainerLocker locker = new PropertyContainerLocker();
         ThreadToStatementContextBridge txBridge = mock( ThreadToStatementContextBridge.class );
 
-        KernelTransaction secondKTX = mockTransaction();
+        Statement secondStatement = mock( Statement.class );
+        KernelTransaction secondKTX = mockTransaction( secondStatement );
         InternalTransaction secondTransaction = mock( InternalTransaction.class );
         when( secondTransaction.terminationReason() ).thenReturn( Optional.empty() );
-        Statement secondStatement = mock( Statement.class );
         QueryRegistryOperations secondQueryRegistry = mock( QueryRegistryOperations.class );
 
         when( executingQuery.queryText() ).thenReturn( "X" );
@@ -228,7 +226,6 @@ public class Neo4jTransactionalContextTest
                 txBridge,
                 locker,
                 initialTransaction,
-                initialStatement,
                 executingQuery,
                 kernel
         );
@@ -250,10 +247,11 @@ public class Neo4jTransactionalContextTest
             // (0) Constructor
             order.verify( initialTransaction ).transactionType();
             order.verify( initialTransaction ).securityContext();
+            order.verify( txBridge ).getKernelTransactionBoundToThisThread( true );
+            order.verify( initialKTX ).acquireStatement();
             order.verify( initialTransaction ).terminationReason(); // not terminated check
 
             // (1) Collect statistics
-            order.verify( txBridge ).getKernelTransactionBoundToThisThread( true );
             order.verify( initialKTX ).executionStatistics();
 
             // (2) Unbind old
@@ -261,9 +259,9 @@ public class Neo4jTransactionalContextTest
             order.verify( txBridge ).unbindTransactionFromCurrentThread();
 
             // (3) Register and unbind new
-            order.verify( txBridge ).get();
-            order.verify( secondQueryRegistry ).registerExecutingQuery( executingQuery );
             order.verify( txBridge ).getKernelTransactionBoundToThisThread( true );
+            order.verify( secondKTX ).acquireStatement();
+            order.verify( secondQueryRegistry ).registerExecutingQuery( executingQuery );
             order.verify( txBridge ).unbindTransactionFromCurrentThread();
 
             // (4) Rebind, unregister, and close old
@@ -287,8 +285,7 @@ public class Neo4jTransactionalContextTest
         when( initialTransaction.terminationReason() ).thenReturn( Optional.empty() );
         Kernel kernel = mock( Kernel.class );
         Neo4jTransactionalContext transactionalContext = new Neo4jTransactionalContext( queryService,
-                guard, txBridge, null, initialTransaction,
-                initialStatement, null, kernel );
+                guard, txBridge, null, initialTransaction, null, kernel );
 
         statistics.setFaults( 2 );
         statistics.setHits( 5 );
@@ -477,7 +474,7 @@ public class Neo4jTransactionalContextTest
         when( resolver.resolveDependency( Guard.class ) ).thenReturn( guard );
         when( queryService.beginTransaction( any(), any() ) ).thenReturn( internalTransaction );
 
-        KernelTransaction mockTransaction = mockTransaction();
+        KernelTransaction mockTransaction = mockTransaction( initialStatement );
         when( txBridge.get() ).thenReturn( initialStatement );
         when( txBridge.getKernelTransactionBoundToThisThread(true ) ).thenReturn( mockTransaction );
     }
@@ -485,13 +482,14 @@ public class Neo4jTransactionalContextTest
     private Neo4jTransactionalContext newContext( InternalTransaction initialTx )
     {
         return new Neo4jTransactionalContext( queryService, guard,
-                txBridge, new PropertyContainerLocker(), initialTx, initialStatement, null, null );
+                txBridge, new PropertyContainerLocker(), initialTx, null, null );
     }
 
-    private KernelTransaction mockTransaction()
+    private KernelTransaction mockTransaction( Statement statement )
     {
-        KernelTransaction kernelTransaction = mock( KernelTransaction.class );
+        KernelTransaction kernelTransaction = mock( KernelTransaction.class, new ReturnsDeepStubs() );
         when( kernelTransaction.executionStatistics() ).thenReturn( statistics );
+        when( kernelTransaction.acquireStatement() ).thenReturn( statement );
         return kernelTransaction;
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/query/Neo4jTransactionalContextTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/query/Neo4jTransactionalContextTest.java
@@ -92,6 +92,7 @@ public class Neo4jTransactionalContextTest
                         ,
                         null,
                         initialTransaction,
+                        initialStatement,
                         null,
                         kernel
                 );
@@ -140,6 +141,7 @@ public class Neo4jTransactionalContextTest
                 txBridge,
                 locker,
                 initialTransaction,
+                initialStatement,
                 executingQuery,
                 kernel
         );
@@ -156,7 +158,6 @@ public class Neo4jTransactionalContextTest
         order.verify( initialTransaction ).transactionType();
         order.verify( initialTransaction ).securityContext();
         order.verify( txBridge ).getKernelTransactionBoundToThisThread( true );
-        order.verify( initialKTX ).acquireStatement();
         order.verify( initialTransaction ).terminationReason(); // not terminated check
 
         // (1) Collect stats
@@ -226,6 +227,7 @@ public class Neo4jTransactionalContextTest
                 txBridge,
                 locker,
                 initialTransaction,
+                initialStatement,
                 executingQuery,
                 kernel
         );
@@ -248,7 +250,6 @@ public class Neo4jTransactionalContextTest
             order.verify( initialTransaction ).transactionType();
             order.verify( initialTransaction ).securityContext();
             order.verify( txBridge ).getKernelTransactionBoundToThisThread( true );
-            order.verify( initialKTX ).acquireStatement();
             order.verify( initialTransaction ).terminationReason(); // not terminated check
 
             // (1) Collect statistics
@@ -285,7 +286,7 @@ public class Neo4jTransactionalContextTest
         when( initialTransaction.terminationReason() ).thenReturn( Optional.empty() );
         Kernel kernel = mock( Kernel.class );
         Neo4jTransactionalContext transactionalContext = new Neo4jTransactionalContext( queryService,
-                guard, txBridge, null, initialTransaction, null, kernel );
+                guard, txBridge, null, initialTransaction, initialStatement, null, kernel );
 
         statistics.setFaults( 2 );
         statistics.setHits( 5 );
@@ -482,7 +483,7 @@ public class Neo4jTransactionalContextTest
     private Neo4jTransactionalContext newContext( InternalTransaction initialTx )
     {
         return new Neo4jTransactionalContext( queryService, guard,
-                txBridge, new PropertyContainerLocker(), initialTx, null, null );
+                txBridge, new PropertyContainerLocker(), initialTx, initialStatement, null, null );
     }
 
     private KernelTransaction mockTransaction( Statement statement )


### PR DESCRIPTION
- Add `hasLabel` on `NodeCursor` that doesn't require creating a `LabelSet`
- Don't fetch KernelTransaction from ThreadLocal on each access.