### PR TITLE
3.4 Preserve step down term when old leader steps down in new term

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderInfo.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderInfo.java
@@ -39,11 +39,16 @@ public class LeaderInfo implements Serializable
         this( memberId, term, false );
     }
 
-    public LeaderInfo( MemberId memberId, long term, boolean isSteppingDown )
+    private LeaderInfo( MemberId memberId, long term, boolean isSteppingDown )
     {
         this.memberId = memberId;
         this.term = term;
         this.isSteppingDown = isSteppingDown;
+    }
+
+    public LeaderInfo stepDown()
+    {
+        return new LeaderInfo( null, this.term, true );
     }
 
     public boolean isSteppingDown()

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderInfo.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderInfo.java
@@ -46,6 +46,9 @@ public class LeaderInfo implements Serializable
         this.isSteppingDown = isSteppingDown;
     }
 
+    /**
+     * Produces a new LeaderInfo object for a step down event, setting memberId to null but maintaining the current term.
+     */
     public LeaderInfo stepDown()
     {
         return new LeaderInfo( null, this.term, true );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderListener.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderListener.java
@@ -19,10 +19,33 @@
  */
 package org.neo4j.causalclustering.core.consensus;
 
+import org.neo4j.causalclustering.core.consensus.outcome.Outcome;
+
 public interface LeaderListener
 {
-    void onLeaderSwitch( LeaderInfo leaderInfo );
+    /**
+     * Allows listeners to handle a leader step down for the given term.
+     * Note: actions taken as a result of a step down should typically happen *before* any
+     * actions taken as a result of the leader switch which has also, implicitly, taken place.
+     *
+     * @param stepDownTerm the term in which the the step down event occurred.
+     */
     default void onLeaderStepDown( long stepDownTerm )
     {
+    }
+
+    void onLeaderSwitch( LeaderInfo leaderInfo );
+
+    /**
+     * Standard catch-all method which delegates leader events to their appropriate handlers
+     * in the appropriate order, i.e. calls step down logic (if necessary) befor leader switch
+     * logic.
+     *
+     * @param outcome The outcome which contains details of the leader event
+     */
+    default void onLeaderEvent( Outcome outcome )
+    {
+        outcome.stepDownTerm().ifPresent( this::onLeaderStepDown );
+        onLeaderSwitch( new LeaderInfo( outcome.getLeader(), outcome.getTerm() ) );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderListener.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderListener.java
@@ -22,7 +22,7 @@ package org.neo4j.causalclustering.core.consensus;
 public interface LeaderListener
 {
     void onLeaderSwitch( LeaderInfo leaderInfo );
-    default void onLeaderStepDown( LeaderInfo leaderInfo )
+    default void onLeaderStepDown( long stepDownTerm )
     {
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMachine.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMachine.java
@@ -213,12 +213,9 @@ public class RaftMachine implements LeaderLocator, CoreMetaData
 
     private void notifyLeaderChanges( Outcome outcome )
     {
-        LeaderInfo leaderInfo = new LeaderInfo( outcome.getLeader(), outcome.getTerm() );
-
         for ( LeaderListener listener : leaderListeners )
         {
-            outcome.stepDownTerm().ifPresent( listener::onLeaderStepDown );
-            listener.onLeaderSwitch( leaderInfo );
+            listener.onLeaderEvent( outcome );
         }
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMachine.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMachine.java
@@ -213,14 +213,11 @@ public class RaftMachine implements LeaderLocator, CoreMetaData
 
     private void notifyLeaderChanges( Outcome outcome )
     {
-        LeaderInfo leaderInfo = new LeaderInfo( outcome.getLeader(), outcome.getTerm(), outcome.isSteppingDown() );
+        LeaderInfo leaderInfo = new LeaderInfo( outcome.getLeader(), outcome.getTerm() );
 
         for ( LeaderListener listener : leaderListeners )
         {
-            if ( outcome.isSteppingDown() )
-            {
-                listener.onLeaderStepDown( leaderInfo );
-            }
+            outcome.stepDownTerm().ifPresent( listener::onLeaderStepDown );
             listener.onLeaderSwitch( leaderInfo );
         }
     }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/Outcome.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/Outcome.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
-import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 
 import org.neo4j.causalclustering.messaging.Message;
@@ -32,7 +32,6 @@ import org.neo4j.causalclustering.core.consensus.roles.Role;
 import org.neo4j.causalclustering.core.consensus.state.ReadableRaftState;
 import org.neo4j.causalclustering.core.consensus.roles.follower.FollowerStates;
 import org.neo4j.causalclustering.identity.MemberId;
-import org.neo4j.register.Register;
 
 import static java.util.Collections.emptySet;
 
@@ -74,7 +73,7 @@ public class Outcome implements Message, ConsensusOutcome
     private FollowerStates<MemberId> followerStates;
     private Collection<ShipCommand> shipCommands = new ArrayList<>();
     private boolean electedLeader;
-    private Optional<Long> steppingDownInTerm;
+    private OptionalLong steppingDownInTerm;
     private Set<MemberId> heartbeatResponses;
 
     public Outcome( Role currentRole, ReadableRaftState ctx )
@@ -105,7 +104,7 @@ public class Outcome implements Message, ConsensusOutcome
         this.shipCommands.addAll( shipCommands );
         this.commitIndex = commitIndex;
         this.isPreElection = isPreElection;
-        this.steppingDownInTerm = Optional.empty();
+        this.steppingDownInTerm = OptionalLong.empty();
     }
 
     private void defaults( Role currentRole, ReadableRaftState ctx )
@@ -122,7 +121,7 @@ public class Outcome implements Message, ConsensusOutcome
         needsFreshSnapshot = false;
 
         isPreElection = (currentRole == Role.FOLLOWER) && ctx.isPreElection();
-        steppingDownInTerm = Optional.empty();
+        steppingDownInTerm = OptionalLong.empty();
         preVotesForMe = isPreElection ? new HashSet<>( ctx.preVotesForMe() ) : emptySet();
         votesForMe = (currentRole == Role.CANDIDATE) ? new HashSet<>( ctx.votesForMe() ) : emptySet();
         heartbeatResponses = (currentRole == Role.LEADER) ? new HashSet<>( ctx.heartbeatResponses() ) : emptySet();
@@ -207,7 +206,7 @@ public class Outcome implements Message, ConsensusOutcome
     public void steppingDown( long stepDownTerm )
     {
         assert !electedLeader;
-        steppingDownInTerm = Optional.of( stepDownTerm );
+        steppingDownInTerm = OptionalLong.of( stepDownTerm );
     }
 
     @Override
@@ -230,7 +229,7 @@ public class Outcome implements Message, ConsensusOutcome
                ", followerStates=" + followerStates +
                ", shipCommands=" + shipCommands +
                ", electedLeader=" + electedLeader +
-               ", steppingDown=" + steppingDownInTerm.map( t -> "true, steppingDownInTerm=" + t ).orElse( "false" ) +
+               ", steppingDownInTerm=" + steppingDownInTerm +
                '}';
     }
 
@@ -310,7 +309,7 @@ public class Outcome implements Message, ConsensusOutcome
         return steppingDownInTerm.isPresent();
     }
 
-    public Optional<Long> stepDownTerm()
+    public OptionalLong stepDownTerm()
     {
         return steppingDownInTerm;
     }
@@ -371,12 +370,12 @@ public class Outcome implements Message, ConsensusOutcome
         return term == outcome.term && leaderCommit == outcome.leaderCommit && commitIndex == outcome.commitIndex &&
                 renewElectionTimeout == outcome.renewElectionTimeout && needsFreshSnapshot == outcome.needsFreshSnapshot &&
                 isPreElection == outcome.isPreElection && lastLogIndexBeforeWeBecameLeader == outcome.lastLogIndexBeforeWeBecameLeader &&
-                electedLeader == outcome.electedLeader && nextRole == outcome.nextRole && Objects.equals( steppingDownInTerm, outcome.steppingDownInTerm ) &&
-                Objects.equals( leader, outcome.leader ) && Objects.equals( logCommands, outcome.logCommands ) &&
-                Objects.equals( outgoingMessages, outcome.outgoingMessages ) && Objects.equals( votedFor, outcome.votedFor ) &&
-                Objects.equals( preVotesForMe, outcome.preVotesForMe ) && Objects.equals( votesForMe, outcome.votesForMe ) &&
-                Objects.equals( followerStates, outcome.followerStates ) && Objects.equals( shipCommands, outcome.shipCommands ) &&
-                Objects.equals( heartbeatResponses, outcome.heartbeatResponses );
+                electedLeader == outcome.electedLeader && nextRole == outcome.nextRole &&
+                Objects.equals( steppingDownInTerm, outcome.steppingDownInTerm ) && Objects.equals( leader, outcome.leader ) &&
+                Objects.equals( logCommands, outcome.logCommands ) && Objects.equals( outgoingMessages, outcome.outgoingMessages ) &&
+                Objects.equals( votedFor, outcome.votedFor ) && Objects.equals( preVotesForMe, outcome.preVotesForMe ) &&
+                Objects.equals( votesForMe, outcome.votesForMe ) && Objects.equals( followerStates, outcome.followerStates ) &&
+                Objects.equals( shipCommands, outcome.shipCommands ) && Objects.equals( heartbeatResponses, outcome.heartbeatResponses );
     }
 
     @Override

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Leader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Leader.java
@@ -87,7 +87,7 @@ public class Leader implements RaftMessageHandler
                 return outcome;
             }
 
-            stepDownToFollower( outcome );
+            stepDownToFollower( outcome, ctx.term() );
             log.info( "Moving to FOLLOWER state after receiving heartbeat at term %d (my term is " + "%d) from %s",
                     heartbeat.leaderTerm(), ctx.term(), heartbeat.from() );
             Heart.beat( ctx, outcome, heartbeat, log );
@@ -113,7 +113,7 @@ public class Leader implements RaftMessageHandler
         {
             if ( !isQuorum( ctx.votingMembers().size(), ctx.heartbeatResponses().size() ) )
             {
-                stepDownToFollower( outcome );
+                stepDownToFollower( outcome, ctx.term() );
                 log.info( "Moving to FOLLOWER state after not receiving heartbeat responses in this election timeout " +
                         "period. Heartbeats received: %s", ctx.heartbeatResponses() );
             }
@@ -142,7 +142,7 @@ public class Leader implements RaftMessageHandler
             else
             {
                 // There is a new leader in a later term, we should revert to follower. (§5.1)
-                stepDownToFollower( outcome );
+                stepDownToFollower( outcome, ctx.term() );
                 log.info( "Moving to FOLLOWER state after receiving append request at term %d (my term is " +
                         "%d) from %s", req.leaderTerm(), ctx.term(), req.from() );
                 Appending.handleAppendEntriesRequest( ctx, outcome, req, log );
@@ -162,7 +162,7 @@ public class Leader implements RaftMessageHandler
             else if ( response.term() > ctx.term() )
             {
                 outcome.setNextTerm( response.term() );
-                stepDownToFollower( outcome );
+                stepDownToFollower( outcome, ctx.term() );
                 log.info( "Moving to FOLLOWER state after receiving append response at term %d (my term is " +
                         "%d) from %s", response.term(), ctx.term(), response.from() );
                 outcome.replaceFollowerStates( new FollowerStates<>() );
@@ -235,7 +235,7 @@ public class Leader implements RaftMessageHandler
         {
             if ( req.term() > ctx.term() )
             {
-                stepDownToFollower( outcome );
+                stepDownToFollower( outcome, ctx.term() );
                 log.info(
                         "Moving to FOLLOWER state after receiving vote request at term %d (my term is " + "%d) from %s",
                         req.term(), ctx.term(), req.from() );
@@ -286,7 +286,7 @@ public class Leader implements RaftMessageHandler
             {
                 if ( req.term() > ctx.term() )
                 {
-                    stepDownToFollower( outcome );
+                    stepDownToFollower( outcome, ctx.term() );
                     log.info( "Moving to FOLLOWER state after receiving pre vote request from %s at term %d (I am at %d)",
                             req.from(), req.term(), ctx.term() );
                 }
@@ -307,9 +307,9 @@ public class Leader implements RaftMessageHandler
             return outcome;
         }
 
-        private void stepDownToFollower( Outcome outcome )
+        private void stepDownToFollower( Outcome outcome, long inTerm )
         {
-            outcome.steppingDown();
+            outcome.steppingDown( inTerm );
             outcome.setNextRole( FOLLOWER );
             outcome.setLeader( null );
         }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyService.java
@@ -56,10 +56,10 @@ public interface CoreTopologyService extends TopologyService
      * Set the leader memberId to null for a given database (i.e. Raft consensus group).
      * This is intended to trigger state cleanup for informational procedures like {@link ClusterOverviewProcedure}
      *
-     * @param stepDownLeaderInfo Information about the stepdown event, including term
+     * @param term The term for which this topology member should handle a stepdown
      * @param dbName The database for which this topology member should handle a stepdown
      */
-    void handleStepDown( LeaderInfo stepDownLeaderInfo, String dbName );
+    void handleStepDown( long term, String dbName );
 
     interface Listener
     {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
@@ -146,9 +146,9 @@ public class HazelcastCoreTopologyService extends AbstractTopologyService implem
         boolean wasLeaderForTerm = Objects.equals( myself, leaderInfo.memberId() ) && term == leaderInfo.term();
         if ( wasLeaderForTerm )
         {
-            log.info( String.format( "Step down event detected. This topology member, with MemberId %s, was leader in term %s, now moving " +
-                    "to follower.", myself, leaderInfo.term() ) );
-            HazelcastClusterTopology.casLeaders( hazelcastInstance, leaderInfo.stepDown(), dbName, log);
+            log.info( "Step down event detected. This topology member, with MemberId %s, was leader in term %s, now moving " +
+                    "to follower.", myself, leaderInfo.term() );
+            HazelcastClusterTopology.casLeaders( hazelcastInstance, leaderInfo.stepDown(), dbName );
         }
     }
 
@@ -368,7 +368,7 @@ public class HazelcastCoreTopologyService extends AbstractTopologyService implem
         if ( leaderInfo.memberId() != null && leaderInfo.memberId().equals( myself ) )
         {
             log.info( "Leader %s updating leader info for database %s and term %s", myself, localDBName, leaderInfo.term() );
-            HazelcastClusterTopology.casLeaders( hazelcastInstance, leaderInfo, localDBName, log);
+            HazelcastClusterTopology.casLeaders( hazelcastInstance, leaderInfo, localDBName );
         }
 
         coreRoles = HazelcastClusterTopology.getCoreRoles( hazelcastInstance, allCoreServers().members().keySet() );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RaftCoreTopologyConnector.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RaftCoreTopologyConnector.java
@@ -64,9 +64,9 @@ public class RaftCoreTopologyConnector extends LifecycleAdapter implements CoreT
     }
 
     @Override
-    public void onLeaderStepDown( LeaderInfo leaderInfo )
+    public void onLeaderStepDown( long stepDownTerm )
     {
-        coreTopologyService.handleStepDown( leaderInfo, dbName );
+        coreTopologyService.handleStepDown( stepDownTerm, dbName );
     }
 
     @Override

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryService.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryService.java
@@ -132,17 +132,15 @@ public final class SharedDiscoveryService
         {
             Optional<LeaderInfo> current = Optional.ofNullable( leaderMap.get( dbName ) );
 
-            boolean noUpdate = current.map( LeaderInfo::memberId ).equals( Optional.ofNullable( leaderInfo.memberId() ) );
+            boolean sameLeader = current.map( LeaderInfo::memberId ).equals( Optional.ofNullable( leaderInfo.memberId() ) );
 
             int termComparison = current.map( l -> Long.compare( l.term(), leaderInfo.term() ) ).orElse( -1 );
 
             boolean greaterTermExists = termComparison > 0;
 
-            boolean invalidTerm = greaterTermExists || ( termComparison == 0 && !leaderInfo.isSteppingDown() );
+            boolean sameTermButNoStepDown = termComparison == 0 && !leaderInfo.isSteppingDown();
 
-            boolean success = !( invalidTerm || noUpdate);
-
-            if ( success )
+            if ( !( greaterTermExists || sameTermButNoStepDown || sameLeader ) )
             {
                 leaderMap.put( dbName, leaderInfo );
             }


### PR DESCRIPTION
So it turned out that the step down listener logic which was added to correct a `ClusterOverview` corner case (https://github.com/neo4j/neo4j/pull/11575) was actually breaking the `ClusterOverview` in some circumstances. 

The reason being that there are several distinct types of step down trigger:

1. A leader _a_ may step down because they haven't received heartbeats within a timeout. In this event, the `Outcome` which `isSteppingDown()` has the term **for which _a_ was leader** and is stepping down.

2. A leader _b_ may step down because they have received a heartbeat with a later term than their own. In this event, the `Outcome` which `isSteppingDown()` has **that later term**. 

The topology service was detecting step downs and writing `null` for the given database name and current term. Therefore, if a stepdown of type 2 occurs, the outgoing leader writes null for its database name and the **subsequent term**. The new leader is then unable to update the shared state because their is already an entry for its term. 

The solution is to modify the StepDown state in `Outcome` from a `boolean steppingDown` to an `Optional<Long> steppingDownInTerm` and assigning the right term to that state. This route is perhaps not the cleanest possible, but it also is relatively non-invasive to other parts of the Raft machinery, which seemed important at this late stage.