### PR TITLE
Expose CRS code in REST endpoints

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/Neo4jJsonCodec.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/Neo4jJsonCodec.java
@@ -131,7 +131,7 @@ public class Neo4jJsonCodec extends ObjectMapper
         else if ( value instanceof CRS )
         {
             CRS crs = (CRS) value;
-            writeMap( out, genericMap( new LinkedHashMap<>(), "code", crs.getCode(), "name", crs.getType(), "type", "link", "properties",
+            writeMap( out, genericMap( new LinkedHashMap<>(), "srid", crs.getCode(), "name", crs.getType(), "type", "link", "properties",
                     genericMap( new LinkedHashMap<>(), "href", crs.getHref() + "ogcwkt/", "type", "ogcwkt" ) ) );
         }
         else if ( value instanceof Temporal || value instanceof TemporalAmount )

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/Neo4jJsonCodec.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/Neo4jJsonCodec.java
@@ -131,7 +131,7 @@ public class Neo4jJsonCodec extends ObjectMapper
         else if ( value instanceof CRS )
         {
             CRS crs = (CRS) value;
-            writeMap( out, genericMap( new LinkedHashMap<>(), "name", crs.getType(), "type", "link", "properties",
+            writeMap( out, genericMap( new LinkedHashMap<>(), "code", crs.getCode(), "name", crs.getType(), "type", "link", "properties",
                     genericMap( new LinkedHashMap<>(), "href", crs.getHref() + "ogcwkt/", "type", "ogcwkt" ) ) );
         }
         else if ( value instanceof Temporal || value instanceof TemporalAmount )

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/ExecutionResultSerializerTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/ExecutionResultSerializerTest.java
@@ -430,19 +430,19 @@ public class ExecutionResultSerializerTest extends TxStateCheckerTestSupport
         String result = output.toString( UTF_8.name() );
         assertEquals( "{\"results\":[{\"columns\":[\"geom\"],\"data\":[" +
                       "{\"row\":[{\"type\":\"Point\",\"coordinates\":[12.3,45.6],\"crs\":" +
-                        "{\"name\":\"WGS-84\",\"type\":\"link\",\"properties\":" +
+                        "{\"srid\":4326,\"name\":\"WGS-84\",\"type\":\"link\",\"properties\":" +
                           "{\"href\":\"http://spatialreference.org/ref/epsg/4326/ogcwkt/\",\"type\":\"ogcwkt\"}" +
                         "}}],\"meta\":[{\"type\":\"point\"}]}," +
                       "{\"row\":[{\"type\":\"Point\",\"coordinates\":[123.0,456.0],\"crs\":" +
-                        "{\"name\":\"cartesian\",\"type\":\"link\",\"properties\":" +
+                        "{\"srid\":7203,\"name\":\"cartesian\",\"type\":\"link\",\"properties\":" +
                           "{\"href\":\"http://spatialreference.org/ref/sr-org/7203/ogcwkt/\",\"type\":\"ogcwkt\"}" +
                         "}}],\"meta\":[{\"type\":\"point\"}]}," +
                       "{\"row\":[{\"type\":\"Point\",\"coordinates\":[12.3,45.6,78.9],\"crs\":" +
-                        "{\"name\":\"WGS-84-3D\",\"type\":\"link\",\"properties\":" +
+                        "{\"srid\":4979,\"name\":\"WGS-84-3D\",\"type\":\"link\",\"properties\":" +
                           "{\"href\":\"http://spatialreference.org/ref/epsg/4979/ogcwkt/\",\"type\":\"ogcwkt\"}" +
                         "}}],\"meta\":[{\"type\":\"point\"}]}," +
                       "{\"row\":[{\"type\":\"Point\",\"coordinates\":[123.0,456.0,789.0],\"crs\":" +
-                        "{\"name\":\"cartesian-3D\",\"type\":\"link\",\"properties\":" +
+                        "{\"srid\":9157,\"name\":\"cartesian-3D\",\"type\":\"link\",\"properties\":" +
                           "{\"href\":\"http://spatialreference.org/ref/sr-org/9157/ogcwkt/\",\"type\":\"ogcwkt\"}" +
                         "}}],\"meta\":[{\"type\":\"point\"}]}" +
                         "]}],\"errors\":[]}",
@@ -509,7 +509,7 @@ public class ExecutionResultSerializerTest extends TxStateCheckerTestSupport
         String result = output.toString( UTF_8.name() );
         assertThat( result, startsWith( "{\"results\":[{\"columns\":[\"geom\"],\"data\":[" +
                 "{\"row\":[{\"type\":\"LineString\",\"coordinates\":[[1.0,2.0],[2.0,3.0]],\"crs\":" +
-                "{\"name\":\"cartesian\",\"type\":\"link\",\"properties\":" +
+                "{\"srid\":7203,\"name\":\"cartesian\",\"type\":\"link\",\"properties\":" +
                 "{\"href\":\"http://spatialreference.org/ref/sr-org/7203/ogcwkt/\",\"type\":\"ogcwkt\"}}}],\"meta\":[]}]}]," +
                 "\"errors\":[{\"code\":\"Neo.DatabaseError.Statement.ExecutionFailed\"," +
                 "\"message\":\"Unsupported Geometry type: type=MockGeometry, value=LineString\"," +

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/Neo4jJsonCodecTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/Neo4jJsonCodecTest.java
@@ -337,7 +337,7 @@ public class Neo4jJsonCodecTest extends TxStateCheckerTestSupport
         // Start CRS object
         inOrder.verify( jsonGenerator ).writeStartObject();
         // Code
-        inOrder.verify( jsonGenerator ).writeFieldName( "code" );
+        inOrder.verify( jsonGenerator ).writeFieldName( "srid" );
         inOrder.verify( jsonGenerator ).writeNumber( crs.getCode() );
         // Name
         inOrder.verify( jsonGenerator ).writeFieldName( "name" );

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/Neo4jJsonCodecTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/Neo4jJsonCodecTest.java
@@ -22,6 +22,8 @@ package org.neo4j.server.rest.transactional;
 import org.codehaus.jackson.JsonGenerator;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -35,6 +37,7 @@ import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.SpatialMocks;
+import org.neo4j.graphdb.spatial.CRS;
 import org.neo4j.graphdb.spatial.Coordinate;
 import org.neo4j.graphdb.spatial.Geometry;
 import org.neo4j.graphdb.spatial.Point;
@@ -42,6 +45,7 @@ import org.neo4j.graphdb.spatial.Point;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -296,5 +300,60 @@ public class Neo4jJsonCodecTest extends TxStateCheckerTestSupport
 
         //Then
         verify( jsonGenerator, times( 3 ) ).writeEndObject();
+    }
+
+    @Test
+    public void testGeometryCrsStructureCartesian() throws IOException
+    {
+        verifyCRSStructure( mockCartesian() );
+    }
+
+    @Test
+    public void testGeometryCrsStructureCartesian_3D() throws IOException
+    {
+        verifyCRSStructure( mockCartesian_3D() );
+    }
+
+    @Test
+    public void testGeometryCrsStructureWGS84() throws IOException
+    {
+        verifyCRSStructure( mockWGS84() );
+    }
+
+    @Test
+    public void testGeometryCrsStructureWGS84_3D() throws IOException
+    {
+        verifyCRSStructure( mockWGS84_3D() );
+    }
+
+    private void verifyCRSStructure( CRS crs ) throws IOException
+    {
+        // When
+        jsonCodec.writeValue( jsonGenerator, crs );
+
+        // Then verify in order
+        InOrder inOrder = Mockito.inOrder( jsonGenerator );
+
+        // Start CRS object
+        inOrder.verify( jsonGenerator ).writeStartObject();
+        // Code
+        inOrder.verify( jsonGenerator ).writeFieldName( "code" );
+        inOrder.verify( jsonGenerator ).writeNumber( crs.getCode() );
+        // Name
+        inOrder.verify( jsonGenerator ).writeFieldName( "name" );
+        inOrder.verify( jsonGenerator ).writeString( crs.getType() );
+        // Type
+        inOrder.verify( jsonGenerator ).writeFieldName( "type" );
+        inOrder.verify( jsonGenerator ).writeString( "link" );
+        // Properties
+        inOrder.verify( jsonGenerator ).writeFieldName( "properties" );
+        // Properties object
+        inOrder.verify( jsonGenerator ).writeStartObject();
+        inOrder.verify( jsonGenerator ).writeFieldName( "href" );
+        inOrder.verify( jsonGenerator ).writeString( startsWith( crs.getHref() ) );
+        inOrder.verify( jsonGenerator ).writeFieldName( "type" );
+        inOrder.verify( jsonGenerator ).writeString( "ogcwkt" );
+        // Close both properties and CRS objects
+        inOrder.verify( jsonGenerator, times( 2 ) ).writeEndObject();
     }
 }


### PR DESCRIPTION
This PR adds `code` property to `CRS` objects that are being serialized as part of their containing geometry objects. This modification is kind of required because `code` property is now exposed through drivers and our tooling.

`CRS` objects are serialized to the following JSON string;

```
{
  "code": 7203,
  "name": "cartesian",
  "type": "link",
  "properties":
  {
    "href": "http://spatialreference.org/ref/sr-org/7203/ogcwkt/",
    "type": "ogcwkt"
  }
}
``` 

