### PR TITLE
Do not pass null to SyntaxException

### DIFF
--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/exceptionHandler.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/exceptionHandler.scala
@@ -125,7 +125,7 @@ object exceptionHandler extends MapToPublicExceptions[CypherException] {
         exceptionHandler.arithmeticException(e.getMessage, e)
       case e: TemporalParseException =>
         if (e.getParsedData == null) {
-          exceptionHandler.syntaxException(e.getMessage, "", null, e)
+          exceptionHandler.syntaxException(e.getMessage, "", None, e)
         }
         else {
           exceptionHandler.syntaxException(e.getMessage, e.getParsedData, Option(e.getErrorIndex), e)


### PR DESCRIPTION
Running queries with incorrect values passed to new temporal functions was causing no response to the client and errors in the server log that did not explain the actual error. Turns out that null was being passed to the offset:Option[Int], instead of None, causing knock-on exceptions later.