### PR TITLE
Abort catchup request if channel is closed

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpClient.java
@@ -28,13 +28,12 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 
-import java.io.IOException;
 import java.net.ConnectException;
 import java.time.Clock;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 
 import org.neo4j.causalclustering.messaging.CatchUpRequest;
 import org.neo4j.helpers.AdvertisedSocketAddress;
@@ -144,6 +143,7 @@ public class CatchUpClient extends LifecycleAdapter
                 throw new ConnectException( "Channel is not connected" );
             }
             nettyChannel.write( request.messageType() );
+            nettyChannel.closeFuture().addListener( (ChannelFutureListener) future -> handler.onClose() );
             nettyChannel.writeAndFlush( request ).addListener( ChannelFutureListener.CLOSE_ON_FAILURE );
         }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpClient.java
@@ -143,8 +143,7 @@ public class CatchUpClient extends LifecycleAdapter
                 throw new ConnectException( "Channel is not connected" );
             }
             nettyChannel.write( request.messageType() );
-            nettyChannel.closeFuture().addListener( (ChannelFutureListener) future -> handler.onClose() );
-            nettyChannel.writeAndFlush( request ).addListener( ChannelFutureListener.CLOSE_ON_FAILURE );
+            nettyChannel.writeAndFlush( request );
         }
 
         Optional<Long> millisSinceLastResponse()
@@ -163,6 +162,8 @@ public class CatchUpClient extends LifecycleAdapter
         {
             ChannelFuture channelFuture = bootstrap.connect( destination.socketAddress() );
             nettyChannel = channelFuture.sync().channel();
+            nettyChannel.closeFuture().addListener( (ChannelFutureListener) future -> handler.onClose() );
+
         }
 
         @Override

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/CatchUpClientIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/CatchUpClientIT.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.catchup;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.MessageToByteEncoder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.channels.ClosedChannelException;
+import java.time.Clock;
+import java.util.concurrent.ExecutionException;
+
+import org.neo4j.causalclustering.catchup.storecopy.GetStoreIdRequest;
+import org.neo4j.causalclustering.net.Server;
+import org.neo4j.helpers.AdvertisedSocketAddress;
+import org.neo4j.helpers.ListenSocketAddress;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.kernel.lifecycle.LifecycleException;
+import org.neo4j.logging.NullLogProvider;
+import org.neo4j.ports.allocation.PortAuthority;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class CatchUpClientIT
+{
+
+    private LifeSupport lifeSupport;
+
+    @Before
+    public void initLifeCycles()
+    {
+        lifeSupport = new LifeSupport();
+    }
+
+    @After
+    public void shutdownLifeSupport()
+    {
+        lifeSupport.stop();
+        lifeSupport.shutdown();
+    }
+
+    @Test
+    public void shouldCloseHandlerIfChannelIsClosedInClient() throws LifecycleException
+    {
+        // given
+        String hostname = "localhost";
+        int port = PortAuthority.allocatePort();
+        ListenSocketAddress listenSocketAddress = new ListenSocketAddress( hostname, port );
+
+        Server emptyServer = catchupServer( listenSocketAddress );
+        CatchUpClient closingClient = closingChannelCatchupClient();
+
+        lifeSupport.add( emptyServer );
+        lifeSupport.add( closingClient );
+
+        // when
+        lifeSupport.init();
+        lifeSupport.start();
+
+        // then
+        assertClosedChannelException( hostname, port, closingClient );
+    }
+
+    @Test
+    public void shouldCloseHandlerIfChannelIsClosedOnServer()
+    {
+        // given
+        String hostname = "localhost";
+        int port = PortAuthority.allocatePort();
+        ListenSocketAddress listenSocketAddress = new ListenSocketAddress( hostname, port );
+
+        Server closingChannelServer = closingChannelCatchupServer( listenSocketAddress );
+        CatchUpClient emptyClient = catchupClient();
+
+        lifeSupport.add( closingChannelServer );
+        lifeSupport.add( emptyClient );
+
+        // when
+        lifeSupport.init();
+        lifeSupport.start();
+
+        // then
+        assertClosedChannelException( hostname, port, emptyClient );
+    }
+
+    private void assertClosedChannelException( String hostname, int port, CatchUpClient closingClient )
+    {
+        try
+        {
+            closingClient.makeBlockingRequest( new AdvertisedSocketAddress( hostname, port ), new GetStoreIdRequest(), neverCompletingAdaptor() );
+            fail();
+        }
+        catch ( CatchUpClientException e )
+        {
+            Throwable cause = e.getCause();
+            assertEquals( cause.getClass(), ExecutionException.class );
+            Throwable actualCause = cause.getCause();
+            assertEquals( actualCause.getClass(), ClosedChannelException.class );
+        }
+    }
+
+    private CatchUpResponseAdaptor<Object> neverCompletingAdaptor()
+    {
+        return new CatchUpResponseAdaptor<>();
+    }
+
+    private CatchUpClient closingChannelCatchupClient()
+    {
+        return catchupClient( new MessageToByteEncoder()
+        {
+            @Override
+            protected void encode( ChannelHandlerContext ctx, Object msg, ByteBuf out )
+            {
+                ctx.channel().close();
+            }
+        } );
+    }
+
+    private Server closingChannelCatchupServer( ListenSocketAddress listenSocketAddress )
+    {
+        return catchupServer( listenSocketAddress, new SimpleChannelInboundHandler<NioSocketChannel>()
+        {
+            @Override
+            protected void channelRead0( ChannelHandlerContext ctx, NioSocketChannel msg )
+            {
+                ctx.channel().close();
+            }
+        } );
+    }
+
+    private CatchUpClient catchupClient( ChannelHandler... channelHandlers )
+    {
+        return new CatchUpClient( NullLogProvider.getInstance(), Clock.systemUTC(), 10000, catchUpResponseHandler -> new ChannelInitializer<SocketChannel>()
+        {
+            @Override
+            protected void initChannel( SocketChannel ch )
+            {
+                ch.pipeline().addLast( channelHandlers );
+            }
+        } );
+    }
+
+    private Server catchupServer( ListenSocketAddress listenSocketAddress, ChannelHandler... channelHandlers )
+    {
+        return new Server( channel -> channel.pipeline().addLast( channelHandlers ), listenSocketAddress, "empty-test-server" );
+    }
+}


### PR DESCRIPTION
Adds a listener to the channel that will trigger onClose if the channel
is closed. This solves the issue where a catchup request would await
a full timeout if the handshake failed and request was never sent.