### PR TITLE
Make sure to not hide costs underneath cartesian product

### DIFF
--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/CardinalityCostModel.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/CardinalityCostModel.scala
@@ -117,7 +117,9 @@ case class CardinalityCostModel(config: CypherCompilerConfiguration) extends Cos
   def apply(plan: LogicalPlan, input: QueryGraphSolverInput): Cost = {
     val cost = plan match {
       case CartesianProduct(lhs, rhs) =>
-        apply(lhs, input) + lhs.solved.estimatedCardinality * apply(rhs, input)
+        val lhsCardinality = Cardinality.max(Cardinality.SINGLE, lhs.solved.estimatedCardinality)
+
+        apply(lhs, input) + lhsCardinality * apply(rhs, input)
 
       case ApplyVariants(lhs, rhs) =>
         val lCost = apply(lhs, input)


### PR DESCRIPTION
If one side of the cartesian product is estimated to return few rows,
the cost of the other side could be hidden, which can lead to really
bad plans.

Fixes #11463