### PR TITLE
Revert record cursor change that caused performance regression

### DIFF
--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelection.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelection.java
@@ -168,7 +168,7 @@ abstract class RelationshipDenseSelection
      *
      * @return True is a valid relationship was found
      */
-    protected final boolean fetchNext()
+    protected boolean fetchNext()
     {
         if ( onRelationship )
         {

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionCursor.java
@@ -27,7 +27,12 @@ public final class RelationshipDenseSelectionCursor extends RelationshipDenseSel
     @Override
     public boolean next()
     {
-        return fetchNext();
+        if ( !fetchNext() )
+        {
+            close();
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelection.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelection.java
@@ -124,7 +124,7 @@ abstract class RelationshipSparseSelection
      *
      * @return True is a valid relationship was found
      */
-    protected final boolean fetchNext()
+    protected boolean fetchNext()
     {
         if ( onRelationship || firstNext )
         {
@@ -150,7 +150,7 @@ abstract class RelationshipSparseSelection
         return types == null || ArrayUtils.contains( types, cursor.type() );
     }
 
-    public final void close()
+    public void close()
     {
         try
         {

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionCursor.java
@@ -27,7 +27,12 @@ public final class RelationshipSparseSelectionCursor extends RelationshipSparseS
     @Override
     public boolean next()
     {
-        return fetchNext();
+        if ( !fetchNext() )
+        {
+            close();
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
@@ -27,9 +27,11 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
 import java.util.Optional;
+import java.util.function.Function;
 
 import org.neo4j.graphdb.NotInTransactionException;
 import org.neo4j.graphdb.TransactionTerminatedException;
+import org.neo4j.internal.kernel.api.security.AccessMode;
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer;
 import org.neo4j.io.pagecache.tracing.cursor.context.VersionContext;
 import org.neo4j.io.pagecache.tracing.cursor.context.VersionContextSupplier;
@@ -264,6 +266,11 @@ public class KernelStatement extends CloseableResourceManager implements TxState
     public VersionContext getVersionContext()
     {
         return versionContextSupplier.getVersionContext();
+    }
+
+    void assertAllows( Function<AccessMode,Boolean> allows, String mode )
+    {
+      transaction.assertAllows( allows, mode );
     }
 
     private void recordOpenCloseMethods()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreRecordCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreRecordCursor.java
@@ -77,8 +77,15 @@ class StoreRecordCursor<RECORD extends AbstractBaseRecord> implements RecordCurs
             return false;
         }
 
-        store.getRecordByCursor( id, record, mode, pageCursor );
-        return record.inUse();
+        try
+        {
+            store.readIntoRecord( id, record, mode, pageCursor );
+            return record.inUse();
+        }
+        catch ( IOException e )
+        {
+            throw new UnderlyingStorageException( e );
+        }
     }
 
     @Override


### PR DESCRIPTION
Revert "Merge pull request #11559 from pontusmelke/3.4-expand-expand"

This reverts commit 056add22bdb458f05f1e95138b4a8bc0f7f773ff, reversing
changes made to 121e278ec2852e4ec422da763cb927d666468dff.

The reverted PR caused a regression in LDBC read throughput