### PR TITLE
Cost reporting debug feature

### DIFF
--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/QueryPlanner.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/QueryPlanner.scala
@@ -21,14 +21,14 @@ package org.neo4j.cypher.internal.compiler.v3_4.planner.logical
 
 import org.neo4j.cypher.internal.compiler.v3_4.phases._
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.Metrics.{CostModel, QueryGraphSolverInput}
-import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps.LogicalPlanProducer
+import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps.{LogicalPlanProducer, SystemOutCostLogger, devNullListener}
 import org.neo4j.cypher.internal.frontend.v3_4.phases.CompilationPhaseTracer.CompilationPhase.LOGICAL_PLANNING
 import org.neo4j.cypher.internal.frontend.v3_4.phases.Phase
 import org.neo4j.cypher.internal.ir.v3_4.{PeriodicCommit, PlannerQuery, UnionQuery}
 import org.neo4j.cypher.internal.planner.v3_4.spi.PlanningAttributes.{Cardinalities, Solveds}
 import org.neo4j.cypher.internal.util.v3_4.Cost
 import org.neo4j.cypher.internal.util.v3_4.attribution.IdGen
-import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlan
+import org.neo4j.cypher.internal.v3_4.logical.plans._
 
 case class QueryPlanner(planSingleQuery: ((PlannerQuery, LogicalPlanningContext, Solveds, Cardinalities, IdGen) => LogicalPlan) = PlanSingleQuery()) extends Phase[CompilerContext, LogicalPlanState, LogicalPlanState] {
 
@@ -40,6 +40,15 @@ case class QueryPlanner(planSingleQuery: ((PlannerQuery, LogicalPlanningContext,
   override def postConditions = Set(CompilationContains[LogicalPlan])
 
   override def process(from: LogicalPlanState, context: CompilerContext): LogicalPlanState = {
+    val debugCosts = context.debugOptions.contains("dumpcosts")
+
+    val costComparisonListener = if (debugCosts)
+      new ReportCostComparisonsAsRows
+    else if (java.lang.Boolean.getBoolean("pickBestPlan.VERBOSE"))
+      SystemOutCostLogger
+    else
+      devNullListener
+
     val logicalPlanProducer = LogicalPlanProducer(context.metrics.cardinality, from.solveds, from.cardinalities, context.logicalPlanIdGen)
     val logicalPlanningContext = LogicalPlanningContext(
       planContext = context.planContext,
@@ -52,11 +61,16 @@ case class QueryPlanner(planSingleQuery: ((PlannerQuery, LogicalPlanningContext,
       errorIfShortestPathFallbackUsedAtRuntime = context.config.errorIfShortestPathFallbackUsedAtRuntime,
       errorIfShortestPathHasCommonNodesAtRuntime = context.config.errorIfShortestPathHasCommonNodesAtRuntime,
       config = QueryPlannerConfiguration.default.withUpdateStrategy(context.updateStrategy),
-      legacyCsvQuoteEscaping = context.config.legacyCsvQuoteEscaping
+      legacyCsvQuoteEscaping = context.config.legacyCsvQuoteEscaping,
+      costComparisonListener = costComparisonListener
     )
 
     val (perCommit, logicalPlan) = plan(from.unionQuery, logicalPlanningContext, from.solveds, from.cardinalities, context.logicalPlanIdGen)
-    from.copy(maybePeriodicCommit = Some(perCommit), maybeLogicalPlan = Some(logicalPlan))
+
+    costComparisonListener match {
+      case debug: ReportCostComparisonsAsRows => debug.addPlan(from)
+      case _ => from.copy(maybePeriodicCommit = Some(perCommit), maybeLogicalPlan = Some(logicalPlan))
+    }
   }
 
   private def getMetricsFrom(context: CompilerContext) = if (context.debugOptions.contains("inverse_cost")) {
@@ -77,7 +91,7 @@ case class QueryPlanner(planSingleQuery: ((PlannerQuery, LogicalPlanningContext,
   private def createProduceResultOperator(in: LogicalPlan,
                                           unionQuery: UnionQuery,
                                           context: LogicalPlanningContext): LogicalPlan =
-  context.logicalPlanProducer.planProduceResult(in, unionQuery.returns, context)
+    context.logicalPlanProducer.planProduceResult(in, unionQuery.returns, context)
 
   private def planQueries(queries: Seq[PlannerQuery], distinct: Boolean, context: LogicalPlanningContext, solveds: Solveds, cardinalities: Cardinalities, idGen: IdGen) = {
     val logicalPlans: Seq[LogicalPlan] = queries.map(p => planSingleQuery(p, context, solveds, cardinalities, idGen))

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/QueryPlannerConfiguration.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/QueryPlannerConfiguration.scala
@@ -56,28 +56,34 @@ object QueryPlannerConfiguration {
     OrLeafPlanner(leafPlanFromExpressions))
 
 
-  val default: QueryPlannerConfiguration = QueryPlannerConfiguration(
-    pickBestCandidate = pickBestPlanUsingHintsAndCost,
-    applySelections = Selector(pickBestPlanUsingHintsAndCost,
+  val default: QueryPlannerConfiguration = {
+    val predicateSelector = Selector(pickBestPlanUsingHintsAndCost,
       selectPatternPredicates,
       triadicSelectionFinder,
       selectCovered,
       selectHasLabelWithJoin
-    ),
-    optionalSolvers = Seq(
-      applyOptional,
-      leftOuterHashJoin,
-      rightOuterHashJoin
-    ),
-    leafPlanners = LeafPlannerList(allLeafPlanners),
-  updateStrategy = defaultUpdateStrategy
-  )
+    )
+
+
+    QueryPlannerConfiguration(
+      pickBestCandidate = pickBestPlanUsingHintsAndCost,
+      applySelections = predicateSelector,
+      optionalSolvers = Seq(
+        applyOptional,
+        leftOuterHashJoin,
+        rightOuterHashJoin
+      ),
+      leafPlanners = LeafPlannerList(allLeafPlanners),
+      updateStrategy = defaultUpdateStrategy
+    )
+
+  }
 }
 
 case class QueryPlannerConfiguration(leafPlanners: LeafPlannerIterable,
                                      applySelections: PlanTransformer[QueryGraph],
                                      optionalSolvers: Seq[OptionalSolver],
-                                     pickBestCandidate: (LogicalPlanningContext, Solveds, Cardinalities) => CandidateSelector,
+                                     pickBestCandidate: CandidateSelectorFactory,
                                      updateStrategy: UpdateStrategy) {
 
   def toKit(context: LogicalPlanningContext, solveds: Solveds, cardinalities: Cardinalities): QueryPlannerKit =
@@ -86,9 +92,9 @@ case class QueryPlannerConfiguration(leafPlanners: LeafPlannerIterable,
       pickBest = pickBestCandidate(context, solveds, cardinalities)
     )
 
-  def withLeafPlanners(leafPlanners: LeafPlannerIterable) = copy(leafPlanners = leafPlanners)
+  def withLeafPlanners(leafPlanners: LeafPlannerIterable): QueryPlannerConfiguration = copy(leafPlanners = leafPlanners)
 
-  def withUpdateStrategy(updateStrategy: UpdateStrategy) = copy(updateStrategy = updateStrategy)
+  def withUpdateStrategy(updateStrategy: UpdateStrategy): QueryPlannerConfiguration = copy(updateStrategy = updateStrategy)
 }
 
 case class QueryPlannerKit(select: (LogicalPlan, QueryGraph) => LogicalPlan, pickBest: CandidateSelector) {

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/ReportCostComparisonsAsRows.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/ReportCostComparisonsAsRows.scala
@@ -82,7 +82,8 @@ class ReportCostComparisonsAsRows extends CostComparisonListener {
       Row(comparisonCount, plan.id, planText, planTextWithCosts, cost, cardinality, winner.id == plan.id)
     }
 
-    val divider = Row(comparisonCount, Id(0), "*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-", "", Cost(0), Cardinality.SINGLE, winner = false)
+    val stars = "*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-"
+    val divider = Row(comparisonCount, Id(0), stars, stars, Cost(0), Cardinality.SINGLE, winner = false)
 
     rows ++= (divider +: theseRows)
     comparisonCount += 1

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/ReportCostComparisonsAsRows.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/ReportCostComparisonsAsRows.scala
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_4.planner.logical
+
+import org.neo4j.cypher.internal.compiler.v3_4.phases.LogicalPlanState
+import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps.CostComparisonListener
+import org.neo4j.cypher.internal.frontend.v3_4.ast._
+import org.neo4j.cypher.internal.ir.v3_4.PlannerQuery
+import org.neo4j.cypher.internal.planner.v3_4.spi.PlanningAttributes.{Cardinalities, Solveds}
+import org.neo4j.cypher.internal.util.v3_4.attribution.{Id, SequentialIdGen}
+import org.neo4j.cypher.internal.util.v3_4.{Cardinality, Cost, InputPosition}
+import org.neo4j.cypher.internal.v3_4.expressions._
+import org.neo4j.cypher.internal.v3_4.logical.plans._
+
+import scala.collection.{immutable, mutable}
+
+/***
+  * This class can be invoked by writing CYPHER debug=printCosts <query>.
+  *
+  * This class can listen to cost comparisons and report them back as normal rows. This is done by creating a fake plan
+  * that looks something like this:
+  *
+  * UNWIND [{comparison: 0, planId: 1, planText: "plan", planCost: "costs", cost: 12, ...}] as col
+  * RETURN col["comparison] as comparison
+  *
+  * This is the plan that actually gets run, and not the one that the user provided.
+  *
+  * WARNING: This is a debug feature, and as such, not tested as rigorously as other features are.
+  *          Only run this on a system that is not live after taking proper backups!
+  *
+  */
+class ReportCostComparisonsAsRows extends CostComparisonListener {
+
+  private val rows = new mutable.ListBuffer[Row]()
+  private var comparisonCount = 0
+  private val pos = InputPosition(0, 0, 0)
+
+  override def report[X](projector: X => LogicalPlan,
+                         input: Iterable[X],
+                         inputOrdering: Ordering[X],
+                         context: LogicalPlanningContext,
+                         solveds: Solveds,
+                         cardinalities: Cardinalities): Unit = if (input.size > 1) {
+
+    def stringTo(level: Int, plan: LogicalPlan): String = {
+      def indent(level: Int, in: String): String = level match {
+        case 0 => in
+        case _ => "\n" + "  " * level + in
+      }
+
+      val cost = context.cost(plan, context.input, cardinalities)
+      val thisPlan = indent(level, s"${plan.getClass.getSimpleName} costs $cost cardinality ${cardinalities.get(plan.id)}")
+      val l = plan.lhs.map(p => stringTo(level + 1, p)).getOrElse("")
+      val r = plan.rhs.map(p => stringTo(level + 1, p)).getOrElse("")
+      thisPlan + l + r
+    }
+
+    val sortedPlans = input.toIndexedSeq.sorted(inputOrdering).map(projector).reverse
+    val winner = sortedPlans.last
+
+    val theseRows: immutable.Seq[Row] = sortedPlans.map { plan =>
+      val planText = plan.toString.replaceAll(System.lineSeparator(), System.lineSeparator())
+      val planTextWithCosts = stringTo(0, plan).replaceAll(System.lineSeparator(), System.lineSeparator())
+      val cost = context.cost(plan, context.input, cardinalities)
+      val cardinality = cardinalities.get(plan.id)
+
+      Row(comparisonCount, plan.id, planText, planTextWithCosts, cost, cardinality, winner.id == plan.id)
+    }
+
+    rows ++= theseRows
+    comparisonCount += 1
+  }
+
+  def addPlan(in: LogicalPlanState): LogicalPlanState = {
+    val plan = asPlan()
+    val newStatement = asStatement()
+    val solveds = new Solveds
+    val cardinalities = new Cardinalities
+
+    var current: Option[LogicalPlan] = Some(plan)
+    do {
+      val thisPlan = current.get
+      solveds.set(thisPlan.id, PlannerQuery.empty)
+      cardinalities.set(thisPlan.id, Cardinality.SINGLE)
+      current = current.get.lhs
+    } while (current.nonEmpty)
+
+    in.copy(maybePeriodicCommit = Some(None), maybeLogicalPlan = Some(plan), maybeStatement = Some(newStatement), solveds = solveds, cardinalities = cardinalities)
+  }
+
+  private def varFor(s: String) = Variable(s)(pos)
+
+  private def asStatement(): Statement = {
+    def ret(s: String)= AliasedReturnItem(varFor(s), varFor(s))(pos)
+    val returnItems = Seq(
+      ret("#"),
+      ret("planId"),
+      ret("planText"),
+      ret("planCost"),
+      ret("cost"),
+      ret("est cardinality"),
+      ret("winner")
+    )
+    val returnClause = Return(distinct = false, ReturnItems(includeExisting = false, returnItems)(pos), None, None, None, None, Set.empty)(pos)
+    Query(None, SingleQuery(Seq(returnClause))(pos))(pos)
+  }
+
+  private def asPlan(): LogicalPlan = {
+    implicit val idGen = new SequentialIdGen()
+
+    def str(s: String): Expression = StringLiteral(s)(pos)
+    def int(i: Int): Expression = SignedDecimalIntegerLiteral(i.toString)(pos)
+    def dbl(d: Double): Expression = DecimalDoubleLiteral(d.toString)(pos)
+    def key(s: String): PropertyKeyName = PropertyKeyName(s)(pos)
+    def map(values: (String, Expression)*): MapExpression = MapExpression(values map { case (str, e) => key(str) -> e })(pos)
+
+    val maps: immutable.Seq[MapExpression] = rows.toIndexedSeq.reverse.flatMap {
+      case Row(comparisonId: Int, planId: Id, planText: String, planCosts: String, cost: Cost, cardinality: Cardinality, winner: Boolean) =>
+        val planTestLines = planText.split('\n')
+        val planCostLines = planCosts.split('\n')
+
+        val details = planCostLines zip planTestLines map {
+          case (planCost, planTxt) =>
+            map( values =
+              "comparison" -> int(comparisonId),
+              "planDetails" -> str(planTxt),
+              "planCosts" -> str(planCost)
+            )
+        }
+
+        val xxx = map(
+          "comparison" -> int(comparisonId),
+          "planId" -> int(planId.x),
+          "planDetails" -> str(""),
+          "planCosts" -> str(""),
+          "cost" -> dbl(cost.gummyBears),
+          "est cardinality" -> dbl(cardinality.amount),
+          "winner" -> str(if (winner) "WON" else "LOST")
+        )
+        xxx +: details
+    }
+
+    val expression = ListLiteral(maps)(pos)
+    val unwind: LogicalPlan = UnwindCollection(Argument(Set.empty), "col", expression)
+    val column = varFor("col")
+    val comparisonE = Property(column, key("comparison"))(pos)
+    val planIdE = Property(column, key("planId"))(pos)
+    val planTextE = Property(column, key("planDetails"))(pos)
+    val planCostE = Property(column, key("planCosts"))(pos)
+    val costE = Property(column, key("cost"))(pos)
+    val cardinalityE = Property(column, key("est cardinality"))(pos)
+    val winnerE = Property(column, key("winner"))(pos)
+
+    val project: LogicalPlan = Projection(unwind, Map(
+      "#" -> comparisonE,
+      "planId" -> planIdE,
+      "planText" -> planTextE,
+      "planCost" -> planCostE,
+      "cost" -> costE,
+      "est cardinality" -> cardinalityE,
+      "winner" -> winnerE
+    ))
+
+    ProduceResult(project, Seq(
+      "#",
+      "planId",
+      "planText",
+      "planCost",
+      "cost",
+      "est cardinality",
+      "winner"
+    ))
+
+  }
+
+  case class Row(comparisonId: Int, planId: Id, planText: String, planCosts: String, cost: Cost, cardinality: Cardinality, winner: Boolean)
+}

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/ReportCostComparisonsAsRows.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/ReportCostComparisonsAsRows.scala
@@ -82,7 +82,9 @@ class ReportCostComparisonsAsRows extends CostComparisonListener {
       Row(comparisonCount, plan.id, planText, planTextWithCosts, cost, cardinality, winner.id == plan.id)
     }
 
-    rows ++= theseRows
+    val divider = Row(comparisonCount, Id(0), "*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-", "", Cost(0), Cardinality.SINGLE, winner = false)
+
+    rows ++= (divider +: theseRows)
     comparisonCount += 1
   }
 
@@ -185,7 +187,6 @@ class ReportCostComparisonsAsRows extends CostComparisonListener {
       "est cardinality",
       "winner"
     ))
-
   }
 
   case class Row(comparisonId: Int, planId: Id, planText: String, planCosts: String, cost: Cost, cardinality: Cardinality, winner: Boolean)

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/CostComparisonListener.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/CostComparisonListener.scala
@@ -51,7 +51,7 @@ object SystemOutCostLogger extends CostComparisonListener {
     def stringTo(level: Int, plan: LogicalPlan): String = {
       def indent(level: Int, in: String): String = level match {
         case 0 => in
-        case _ => "\n" + "  " * level + in
+        case _ => System.lineSeparator() + "  " * level + in
       }
 
       val cost = context.cost(plan, context.input, cardinalities)

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/CostComparisonListener.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/CostComparisonListener.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps
+
+import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.LogicalPlanningContext
+import org.neo4j.cypher.internal.planner.v3_4.spi.PlanningAttributes.{Cardinalities, Solveds}
+import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlan
+
+trait CostComparisonListener {
+  def report[X](projector: X => LogicalPlan,
+                input: Iterable[X],
+                inputOrdering: Ordering[X],
+                context: LogicalPlanningContext,
+                solveds: Solveds,
+                cardinalities: Cardinalities): Unit
+}
+
+object devNullListener extends CostComparisonListener {
+  override def report[X](projector: X => LogicalPlan,
+                         input: Iterable[X],
+                         inputOrdering: Ordering[X],
+                         context: LogicalPlanningContext,
+                         solveds: Solveds,
+                         cardinalities: Cardinalities): Unit = {}
+}
+
+object SystemOutCostLogger extends CostComparisonListener {
+  def report[X](projector: X => LogicalPlan,
+                input: Iterable[X],
+                inputOrdering: Ordering[X],
+                context: LogicalPlanningContext,
+                solveds: Solveds,
+                cardinalities: Cardinalities): Unit = {
+    def stringTo(level: Int, plan: LogicalPlan): String = {
+      def indent(level: Int, in: String): String = level match {
+        case 0 => in
+        case _ => "\n" + "  " * level + in
+      }
+
+      val cost = context.cost(plan, context.input, cardinalities)
+      val thisPlan = indent(level, s"${plan.getClass.getSimpleName} costs $cost cardinality ${cardinalities.get(plan.id)}")
+      val l = plan.lhs.map(p => stringTo(level + 1, p)).getOrElse("")
+      val r = plan.rhs.map(p => stringTo(level + 1, p)).getOrElse("")
+      thisPlan + l + r
+    }
+
+    val sortedPlans = input.toIndexedSeq.sorted(inputOrdering).map(projector)
+
+    if (sortedPlans.size > 1) {
+      println("- Get best of:")
+      for (plan <- sortedPlans) {
+
+        val planTextWithCosts = stringTo(0, plan).replaceAll(System.lineSeparator(), System.lineSeparator() + "\t\t")
+        val planText = plan.toString.replaceAll(System.lineSeparator(), System.lineSeparator() + "\t\t")
+        println("=-" * 10)
+        println(s"* Plan #${plan.debugId}")
+        println(s"\t$planTextWithCosts")
+        println(s"\t$planText")
+        println(s"\t\tHints(${solveds.get(plan.id).numHints})")
+        println(s"\t\tlhs: ${plan.lhs}")
+      }
+
+      val best = sortedPlans.head
+      println("!¡" * 10)
+      println("- Best is:")
+      println(s"Plan #${best.debugId}")
+      println(s"\t${best.toString}")
+      val planTextWithCosts = stringTo(0, best)
+      println(s"\t$planTextWithCosts")
+      println(s"\t\tHints(${solveds.get(best.id).numHints})")
+      println(s"\t\tlhs: ${best.lhs}")
+      println("!¡" * 10)
+      println()
+    }
+  }
+}

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/Selector.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/Selector.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlan
 
 import scala.annotation.tailrec
 
-case class Selector(pickBestFactory: (LogicalPlanningContext, Solveds, Cardinalities) => CandidateSelector,
+case class Selector(pickBestFactory: CandidateSelectorFactory,
                     planGenerators: CandidateGenerator[LogicalPlan]*) extends PlanTransformer[QueryGraph] {
   def apply(input: LogicalPlan, queryGraph: QueryGraph, context: LogicalPlanningContext, solveds: Solveds, cardinalities: Cardinalities): LogicalPlan = {
     val pickBest = pickBestFactory(context, solveds, cardinalities)

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/pickBestPlanUsingHintsAndCost.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/pickBestPlanUsingHintsAndCost.scala
@@ -23,67 +23,30 @@ import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.{CandidateSelecto
 import org.neo4j.cypher.internal.planner.v3_4.spi.PlanningAttributes.{Cardinalities, Solveds}
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlan
 
-object pickBestPlanUsingHintsAndCost extends ((LogicalPlanningContext, Solveds, Cardinalities) => CandidateSelector) {
-  val VERBOSE = java.lang.Boolean.getBoolean("pickBestPlan.VERBOSE")
+trait CandidateSelectorFactory extends ((LogicalPlanningContext, Solveds, Cardinalities) => CandidateSelector)
+
+object pickBestPlanUsingHintsAndCost extends CandidateSelectorFactory {
   private val baseOrdering = implicitly[Ordering[(Int, Double, Int)]]
 
-  override def apply(context: LogicalPlanningContext, solveds: Solveds, cardinalities: Cardinalities): CandidateSelector = new CandidateSelector {
-    override def apply[X](projector: (X) => LogicalPlan, input: Iterable[X]): Option[X] = {
+  override def apply(context: LogicalPlanningContext, solveds: Solveds, cardinalities: Cardinalities): CandidateSelector =
+    new CandidateSelector {
+      override def apply[X](projector: X => LogicalPlan, input: Iterable[X]): Option[X] = {
 
-      def stringTo(level: Int, plan: LogicalPlan): String = {
-        def indent(level: Int, in: String): String = level match {
-          case 0 => in
-          case _ => "\n" + "  " * level + in
-        }
-
-        val cost = context.cost(plan, context.input, cardinalities)
-        val thisPlan = indent(level, s"${plan.getClass.getSimpleName} costs $cost cardinality ${cardinalities.get(plan.id)}")
-        val l = plan.lhs.map(p => stringTo(level + 1, p)).getOrElse("")
-        val r = plan.rhs.map(p => stringTo(level + 1, p)).getOrElse("")
-        thisPlan + l + r
-      }
-
-
-      val inputOrdering = new Ordering[X] {
-        override def compare(x: X, y: X): Int = baseOrdering.compare(score(projector, x, context, solveds, cardinalities), score(projector, y, context, solveds, cardinalities))
-      }
-
-      if (VERBOSE) {
-        val sortedPlans = input.toIndexedSeq.sorted(inputOrdering).map(projector)
-
-        if (sortedPlans.size > 1) {
-          println("- Get best of:")
-          for (plan <- sortedPlans) {
-
-            val planTextWithCosts = stringTo(0, plan).replaceAll(System.lineSeparator(), System.lineSeparator() + "\t\t")
-            val planText = plan.toString.replaceAll(System.lineSeparator(), System.lineSeparator() + "\t\t")
-            println("=-" * 10)
-            println(s"* Plan #${plan.debugId}")
-            println(s"\t$planTextWithCosts")
-            println(s"\t$planText")
-            println(s"\t\tHints(${solveds.get(plan.id).numHints})")
-            println(s"\t\tlhs: ${plan.lhs}")
+        val inputOrdering = new Ordering[X] {
+          override def compare(x: X, y: X): Int = {
+            val xCost = score(projector, x, context, solveds, cardinalities)
+            val yCost = score(projector, y, context, solveds, cardinalities)
+            baseOrdering.compare(xCost, yCost)
           }
-
-          val best = sortedPlans.head
-          println("!¡" * 10)
-          println("- Best is:")
-          println(s"Plan #${best.debugId}")
-          println(s"\t${best.toString}")
-          val planTextWithCosts = stringTo(0, best)
-          println(s"\t$planTextWithCosts")
-          println(s"\t\tHints(${solveds.get(best.id).numHints})")
-          println(s"\t\tlhs: ${best.lhs}")
-          println("!¡" * 10)
-          println()
         }
+
+        context.costComparisonListener.report(projector, input, inputOrdering, context, solveds, cardinalities)
+
+        if (input.isEmpty) None else Some(input.min(inputOrdering))
       }
-
-      if (input.isEmpty) None else Some(input.min(inputOrdering))
     }
-  }
 
-  private def score[X](projector: (X) => LogicalPlan, input: X, context: LogicalPlanningContext, solveds: Solveds, cardinalities: Cardinalities) = {
+  private def score[X](projector: X => LogicalPlan, input: X, context: LogicalPlanningContext, solveds: Solveds, cardinalities: Cardinalities) = {
     val costs = context.cost
     val plan = projector(input)
     (-solveds.get(plan.id).numHints, costs(plan, context.input, cardinalities).gummyBears, -plan.availableSymbols.size)

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/LogicalPlanningTestSupport.scala
@@ -29,7 +29,7 @@ import org.neo4j.cypher.internal.compiler.v3_4.phases._
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.Metrics._
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical._
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.idp._
-import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps.LogicalPlanProducer
+import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps.{devNullListener, LogicalPlanProducer}
 import org.neo4j.cypher.internal.compiler.v3_4.test_helpers.ContextHelper
 import org.neo4j.cypher.internal.frontend.v3_4.ast._
 import org.neo4j.cypher.internal.frontend.v3_4.ast.rewriters._
@@ -145,7 +145,7 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
     (LogicalPlanningContext(planContext, LogicalPlanProducer(metrics.cardinality, solveds, cardinalities, idGen), metrics, semanticTable,
       strategy, QueryGraphSolverInput(Map.empty, cardinality, strictness),
       notificationLogger = notificationLogger, useErrorsOverWarnings = useErrorsOverWarnings,
-      legacyCsvQuoteEscaping = config.legacyCsvQuoteEscaping, config = QueryPlannerConfiguration.default),
+      legacyCsvQuoteEscaping = config.legacyCsvQuoteEscaping, config = QueryPlannerConfiguration.default, costComparisonListener = devNullListener),
       solveds, cardinalities)
   }
 
@@ -162,7 +162,7 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
     LogicalPlanningContext(planContext, LogicalPlanProducer(metrics.cardinality, new StubSolveds, new StubCardinalities, idGen), metrics, semanticTable,
       strategy, QueryGraphSolverInput(Map.empty, cardinality, strictness),
       notificationLogger = notificationLogger, useErrorsOverWarnings = useErrorsOverWarnings,
-      legacyCsvQuoteEscaping = config.legacyCsvQuoteEscaping, config = QueryPlannerConfiguration.default)
+      legacyCsvQuoteEscaping = config.legacyCsvQuoteEscaping, config = QueryPlannerConfiguration.default, costComparisonListener = devNullListener)
   }
 
   def newMockedStatistics = mock[GraphStatistics]

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/LogicalPlanningTestSupport2.scala
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.Metrics._
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.cardinality.QueryGraphCardinalityModel
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.idp._
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.plans.rewriter.unnestApply
-import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps.LogicalPlanProducer
+import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps.{LogicalPlanProducer, devNullListener}
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.{LogicalPlanningContext, _}
 import org.neo4j.cypher.internal.compiler.v3_4.test_helpers.ContextHelper
 import org.neo4j.cypher.internal.frontend.v3_4.ast._
@@ -201,7 +201,8 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
         semanticTable = semanticTable,
         strategy = queryGraphSolver,
         input = QueryGraphSolverInput.empty,
-        notificationLogger = devNullLogger
+        notificationLogger = devNullLogger,
+        costComparisonListener = devNullListener
       )
       f(config, ctx, solveds, cardinalities)
     }
@@ -217,7 +218,8 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
         semanticTable = semanticTable,
         strategy = queryGraphSolver,
         input = QueryGraphSolverInput.empty,
-        notificationLogger = devNullLogger
+        notificationLogger = devNullLogger,
+        costComparisonListener = devNullListener
       )
       f(config, ctx)
     }

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/DefaultQueryPlannerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/DefaultQueryPlannerTest.scala
@@ -105,6 +105,7 @@ class DefaultQueryPlannerTest extends CypherFunSuite with LogicalPlanningTestSup
         lp
       }
     })
+    when(context.costComparisonListener).thenReturn(devNullListener)
     when(context.withStrictness(any())).thenReturn(context)
     val producer = mock[LogicalPlanProducer]
     when(producer.planStarProjection(any(), any(), any(), any())).thenReturn(lp)

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/DefaultQueryPlannerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/DefaultQueryPlannerTest.scala
@@ -24,7 +24,7 @@ import org.mockito.Mockito.{times, verify, when}
 import org.neo4j.cypher.internal.planner.v3_4.spi.PlanningAttributes.{Cardinalities, Solveds}
 import org.neo4j.cypher.internal.compiler.v3_4.planner._
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.Metrics.QueryGraphSolverInput
-import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps.LogicalPlanProducer
+import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps.{LogicalPlanProducer, devNullListener}
 import org.neo4j.cypher.internal.frontend.v3_4.ast.{ASTAnnotationMap, Hint}
 import org.neo4j.cypher.internal.frontend.v3_4.phases.devNullLogger
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.{ExpressionTypeInfo, SemanticTable}
@@ -131,5 +131,6 @@ class DefaultQueryPlannerTest extends CypherFunSuite with LogicalPlanningTestSup
     semanticTable = semanticTable,
     strategy = mock[QueryGraphSolver],
     config = QueryPlannerConfiguration.default,
-    notificationLogger = devNullLogger)
+    notificationLogger = devNullLogger,
+    costComparisonListener = devNullListener)
 }

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PickBestPlanUsingHintsAndCostTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PickBestPlanUsingHintsAndCostTest.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v3_4.planner.logical
 
 import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport2
-import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps.{LogicalPlanProducer, pickBestPlanUsingHintsAndCost}
+import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps.{LogicalPlanProducer, devNullListener, pickBestPlanUsingHintsAndCost}
 import org.neo4j.cypher.internal.frontend.v3_4.ast.UsingIndexHint
 import org.neo4j.cypher.internal.frontend.v3_4.phases.devNullLogger
 import org.neo4j.cypher.internal.ir.v3_4.PlannerQuery
@@ -112,7 +112,8 @@ class PickBestPlanUsingHintsAndCostTest extends CypherFunSuite with LogicalPlann
   private def assertTopPlan(winner: LogicalPlan, solveds: Solveds, cardinalities: Cardinalities, candidates: LogicalPlan*)(GIVEN: given)= {
     val environment = LogicalPlanningEnvironment(GIVEN)
     val metrics: Metrics = environment.metricsFactory.newMetrics(GIVEN.statistics, GIVEN.expressionEvaluator, cypherCompilerConfig)
-    val context = LogicalPlanningContext(null, LogicalPlanProducer(metrics.cardinality, solveds, cardinalities, idGen), metrics, null, null, notificationLogger = devNullLogger)
+    val producer = LogicalPlanProducer(metrics.cardinality, solveds, cardinalities, idGen)
+    val context = LogicalPlanningContext(null, producer, metrics, null, null, notificationLogger = devNullLogger, costComparisonListener = devNullListener)
     pickBestPlanUsingHintsAndCost(context, solveds, cardinalities)(candidates).get shouldBe theSameInstanceAs(winner)
     pickBestPlanUsingHintsAndCost(context, solveds, cardinalities)(candidates.reverse).get shouldBe theSameInstanceAs(winner)
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/DebugToStringTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/DebugToStringTest.scala
@@ -79,5 +79,28 @@ class DebugToStringTest extends ExecutionEngineFunSuite {
     textResult should include("ScopeLocation")
   }
 
+  test("cost reporting") {
+    val stringResult = graph.execute("CYPHER debug=dumpCosts MATCH (a:A) RETURN *").resultAsString()
+    stringResult should equal("""+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+                                || # | planId | planText                                                             | planCost                                                          | cost   | est cardinality | winner |
+                                |+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+                                || 1 | 0      | ""                                                                   | ""                                                                | 10.0   | 1.0             | "WON"  |
+                                || 1 | <null> | "NodeByLabelScan(a, LabelName(A), Set()) {}"                         | "NodeByLabelScan costs Cost(10.0) cardinality Cardinality(1.0)"   | <null> | <null>          | <null> |
+                                || 1 | 2      | ""                                                                   | ""                                                                | 13.0   | 1.0             | "LOST" |
+                                || 1 | <null> | "Selection(ListBuffer(HasLabels(Variable(a),List(LabelName(A))))) {" | "Selection costs Cost(13.0) cardinality Cardinality(1.0)"         | <null> | <null>          | <null> |
+                                || 1 | <null> | "  LHS -> AllNodesScan(a, Set()) {}"                                 | "  AllNodesScan costs Cost(12.0) cardinality Cardinality(1.0)"    | <null> | <null>          | <null> |
+                                || 0 | 2      | ""                                                                   | ""                                                                | 13.0   | 1.0             | "WON"  |
+                                || 0 | <null> | "Selection(ListBuffer(HasLabels(Variable(a),List(LabelName(A))))) {" | "Selection costs Cost(13.0) cardinality Cardinality(1.0)"         | <null> | <null>          | <null> |
+                                || 0 | <null> | "  LHS -> AllNodesScan(a, Set()) {}"                                 | "  AllNodesScan costs Cost(12.0) cardinality Cardinality(1.0)"    | <null> | <null>          | <null> |
+                                || 0 | 4      | ""                                                                   | ""                                                                | 27.5   | 1.0             | "LOST" |
+                                || 0 | <null> | "NodeHashJoin(Set(a)) {"                                             | "NodeHashJoin costs Cost(27.5) cardinality Cardinality(1.0)"      | <null> | <null>          | <null> |
+                                || 0 | <null> | "  LHS -> AllNodesScan(a, Set()) {}"                                 | "  AllNodesScan costs Cost(12.0) cardinality Cardinality(1.0)"    | <null> | <null>          | <null> |
+                                || 0 | <null> | "  RHS -> NodeByLabelScan(a, LabelName(A), Set()) {}"                | "  NodeByLabelScan costs Cost(10.0) cardinality Cardinality(1.0)" | <null> | <null>          | <null> |
+                                |+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+                                |12 rows
+                                |""".stripMargin)
+    graph.execute("CYPHER debug=dumpCosts MATCH (a:A:B:C)-[:T]->(b:A:B:C) RETURN *").stream().count()
+  }
+
   private def queryWithOutputOf(s: String) = s"CYPHER debug=tostring debug=$s MATCH (a)-[:T]->(b) RETURN *"
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/DebugToStringTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/DebugToStringTest.scala
@@ -89,6 +89,8 @@ class DebugToStringTest extends ExecutionEngineFunSuite {
                                 || 1 | 2      | ""                                                                   | ""                                                                | 13.0   | 1.0             | "LOST" |
                                 || 1 | <null> | "Selection(ListBuffer(HasLabels(Variable(a),List(LabelName(A))))) {" | "Selection costs Cost(13.0) cardinality Cardinality(1.0)"         | <null> | <null>          | <null> |
                                 || 1 | <null> | "  LHS -> AllNodesScan(a, Set()) {}"                                 | "  AllNodesScan costs Cost(12.0) cardinality Cardinality(1.0)"    | <null> | <null>          | <null> |
+                                || 1 | 0      | ""                                                                   | ""                                                                | 0.0    | 1.0             | "LOST" |
+                                || 1 | <null> | "*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-"                       | "*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-"                    | <null> | <null>          | <null> |
                                 || 0 | 2      | ""                                                                   | ""                                                                | 13.0   | 1.0             | "WON"  |
                                 || 0 | <null> | "Selection(ListBuffer(HasLabels(Variable(a),List(LabelName(A))))) {" | "Selection costs Cost(13.0) cardinality Cardinality(1.0)"         | <null> | <null>          | <null> |
                                 || 0 | <null> | "  LHS -> AllNodesScan(a, Set()) {}"                                 | "  AllNodesScan costs Cost(12.0) cardinality Cardinality(1.0)"    | <null> | <null>          | <null> |
@@ -96,8 +98,10 @@ class DebugToStringTest extends ExecutionEngineFunSuite {
                                 || 0 | <null> | "NodeHashJoin(Set(a)) {"                                             | "NodeHashJoin costs Cost(27.5) cardinality Cardinality(1.0)"      | <null> | <null>          | <null> |
                                 || 0 | <null> | "  LHS -> AllNodesScan(a, Set()) {}"                                 | "  AllNodesScan costs Cost(12.0) cardinality Cardinality(1.0)"    | <null> | <null>          | <null> |
                                 || 0 | <null> | "  RHS -> NodeByLabelScan(a, LabelName(A), Set()) {}"                | "  NodeByLabelScan costs Cost(10.0) cardinality Cardinality(1.0)" | <null> | <null>          | <null> |
+                                || 0 | 0      | ""                                                                   | ""                                                                | 0.0    | 1.0             | "LOST" |
+                                || 0 | <null> | "*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-"                       | "*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-"                    | <null> | <null>          | <null> |
                                 |+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-                                |12 rows
+                                |16 rows
                                 |""".stripMargin)
     graph.execute("CYPHER debug=dumpCosts MATCH (a:A:B:C)-[:T]->(b:A:B:C) RETURN *").stream().count()
   }


### PR DESCRIPTION
This makes it possible to prepend queries with `debug=dumpCosts`, and get a report on all cost comparisons made in order to plan the query.

As an example, here is the output for `CYPHER debug=dumpCosts MATCH (a:A) RETURN *`:


```
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| # | planId | planText                                                             | planCost                                                          | cost   | est cardinality | winner |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| 1 | 0      | ""                                                                   | ""                                                                | 10.0   | 1.0             | "WON"  |
| 1 | <null> | "NodeByLabelScan(a, LabelName(A), Set()) {}"                         | "NodeByLabelScan costs Cost(10.0) cardinality Cardinality(1.0)"   | <null> | <null>          | <null> |
| 1 | 2      | ""                                                                   | ""                                                                | 13.0   | 1.0             | "LOST" |
| 1 | <null> | "Selection(ListBuffer(HasLabels(Variable(a),List(LabelName(A))))) {" | "Selection costs Cost(13.0) cardinality Cardinality(1.0)"         | <null> | <null>          | <null> |
| 1 | <null> | "  LHS -> AllNodesScan(a, Set()) {}"                                 | "  AllNodesScan costs Cost(12.0) cardinality Cardinality(1.0)"    | <null> | <null>          | <null> |
| 0 | 2      | ""                                                                   | ""                                                                | 13.0   | 1.0             | "WON"  |
| 0 | <null> | "Selection(ListBuffer(HasLabels(Variable(a),List(LabelName(A))))) {" | "Selection costs Cost(13.0) cardinality Cardinality(1.0)"         | <null> | <null>          | <null> |
| 0 | <null> | "  LHS -> AllNodesScan(a, Set()) {}"                                 | "  AllNodesScan costs Cost(12.0) cardinality Cardinality(1.0)"    | <null> | <null>          | <null> |
| 0 | 4      | ""                                                                   | ""                                                                | 27.5   | 1.0             | "LOST" |
| 0 | <null> | "NodeHashJoin(Set(a)) {"                                             | "NodeHashJoin costs Cost(27.5) cardinality Cardinality(1.0)"      | <null> | <null>          | <null> |
| 0 | <null> | "  LHS -> AllNodesScan(a, Set()) {}"                                 | "  AllNodesScan costs Cost(12.0) cardinality Cardinality(1.0)"    | <null> | <null>          | <null> |
| 0 | <null> | "  RHS -> NodeByLabelScan(a, LabelName(A), Set()) {}"                | "  NodeByLabelScan costs Cost(10.0) cardinality Cardinality(1.0)" | <null> | <null>          | <null> |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
12 rows
```