### PR TITLE
Prevent the CheckPointer from blocking CausalCluster Catchup.

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -22,6 +22,7 @@ package org.neo4j.io.pagecache.impl.muninn;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.channels.ClosedChannelException;
 import java.nio.file.OpenOption;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
@@ -596,6 +597,19 @@ public class MuninnPageCache implements PageCache
                 {
                     FlushEventOpportunity flushOpportunity = fileFlush.flushEventOpportunity();
                     muninnPagedFile.flushAndForceInternal( flushOpportunity, false, limiter );
+                }
+                catch ( ClosedChannelException e )
+                {
+                    if ( muninnPagedFile.getRefCount() > 0 )
+                    {
+                        // The file is not supposed to be closed, since we have a positive ref-count, yet we got a
+                        // ClosedChannelException anyway? It's an odd situation, so let's tell the outside world about
+                        // this failure.
+                        throw e;
+                    }
+                    // Otherwise: The file was closed while we were trying to flush it. Since unmapping implies a flush
+                    // anyway, we can safely assume that this is not a problem. The file was flushed, and it doesn't
+                    // really matter how that happened. We'll ignore this exception.
                 }
             }
             syncDevice();

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -30,6 +30,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.nio.channels.ClosedChannelException;
@@ -373,7 +374,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
     @Test( timeout = LONG_TIMEOUT_MILLIS )
     public void writesFlushedFromPageFileMustBeObservableEvenWhenRacingWithEviction() throws IOException
     {
-        PageCache cache = getPageCache( fs, 20, PageCacheTracer.NULL,
+        getPageCache( fs, 20, PageCacheTracer.NULL,
                 PageCursorTracerSupplier.NULL );
 
         long startPageId = 0;
@@ -381,7 +382,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         int iterations = 500;
         int shortsPerPage = pageCachePageSize / 2;
 
-        try ( PagedFile pagedFile = cache.map( file( "a" ), pageCachePageSize ) )
+        try ( PagedFile pagedFile = pageCache.map( file( "a" ), pageCachePageSize ) )
         {
             for ( int i = 1; i <= iterations; i++ )
             {
@@ -414,6 +415,62 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
                     }
                 }
             }
+        }
+    }
+
+    @Test( timeout = SHORT_TIMEOUT_MILLIS )
+    public void flushAndForceMustNotLockPageCacheForWholeDuration() throws Exception
+    {
+        maxPages = 5000;
+        configureStandardPageCache();
+        PageCache pageCache = this.pageCache;
+        this.pageCache = null; // `null` out to prevent `tearDown` from getting stuck if test fails.
+        File a = existingFile( "a" );
+        File b = existingFile( "b" );
+        try ( PagedFile pfA = pageCache.map( a, filePageSize ) )
+        {
+            // Dirty a bunch of pages.
+            try ( PageCursor cursor = pfA.io( 0, PF_SHARED_WRITE_LOCK ) )
+            {
+                for ( int i = 0; i < maxPages; i++ )
+                {
+                    assertTrue( cursor.next() );
+                }
+            }
+
+            BinaryLatch limiterStartLatch = new BinaryLatch();
+            BinaryLatch limiterBlockLatch = new BinaryLatch();
+            Future<?> flusher = executor.submit( () ->
+            {
+                pageCache.flushAndForce( ( stamp, ios, flushable ) ->
+                {
+                    limiterStartLatch.release();
+                    limiterBlockLatch.await();
+                    return 0;
+                } );
+                return null;
+            } );
+
+            limiterStartLatch.await(); // Flusher is now stuck inside flushAndForce.
+
+            // We should be able to map and close paged files.
+            pageCache.map( b, filePageSize ).close();
+            // We should be able to get and list existing mappings.
+            pageCache.listExistingMappings();
+            pageCache.getExistingMapping( a ).ifPresent( pf ->
+            {
+                try
+                {
+                    pf.close();
+                }
+                catch ( IOException e )
+                {
+                    throw new UncheckedIOException( e );
+                }
+            } );
+
+            limiterBlockLatch.release();
+            flusher.get();
         }
     }
 

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/consistency/HighLimitFullCheckIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/consistency/HighLimitFullCheckIT.java
@@ -29,5 +29,4 @@ public class HighLimitFullCheckIT extends FullCheckIntegrationTest
     {
         return HighLimitWithSmallRecords.NAME;
     }
-
 }


### PR DESCRIPTION
By making the checkpointer not hold on to the PageCache monitor lock
for the whole check point process.

It turned out that this behaviour could inconvenience the Causal Cluster
catchup process.
The CC catchup would ask the page cache warmer to list its files.
To do that, the page cache warmer would call `listExistingMappings` on
the page cache, and that method would also require the PageCache lock.

The fix is that the checkpointer now also uses `listExistingMappings`
to grab a snapshot of the mapped files, and then flush them without
holding on to the lock on the entire page cache.
The `listExistingMappings` method does still take the page cache lock,
but it returns much, much faster than a complete page cache flush would.