### PR TITLE
Acquires shared label locks on more node operations

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
@@ -109,6 +109,9 @@ import static org.neo4j.values.storable.Values.NO_VALUE;
 
 /**
  * Collects all Kernel API operations and guards them from being used outside of transaction.
+ *
+ * Many methods assume cursors to be initialized before use in private methods, even if they're not passed in explicitly.
+ * Keep that in mind: e.g. nodeCursor, propertyCursor and relationshipCursor
  */
 public class Operations implements Write, ExplicitIndexWrite, SchemaWrite
 {
@@ -295,7 +298,9 @@ public class Operations implements Write, ExplicitIndexWrite, SchemaWrite
         return false;
     }
 
-    // Assuming that the nodeCursor have been initialized to the node that labels are retrieved from
+    /**
+     * Assuming that the nodeCursor have been initialized to the node that labels are retrieved from
+     */
     private void acquireSharedNodeLabelLocks()
     {
         ktx.statementLocks().optimistic().acquireShared( ktx.lockTracer(), ResourceTypes.LABEL, nodeCursor.labels().all() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
@@ -44,6 +44,7 @@ import org.neo4j.internal.kernel.api.Token;
 import org.neo4j.internal.kernel.api.Write;
 import org.neo4j.internal.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
+import org.neo4j.internal.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.internal.kernel.api.exceptions.explicitindex.AutoIndexingKernelException;
 import org.neo4j.internal.kernel.api.exceptions.explicitindex.ExplicitIndexNotFoundKernelException;
 import org.neo4j.internal.kernel.api.exceptions.schema.ConstraintValidationException;
@@ -54,7 +55,6 @@ import org.neo4j.internal.kernel.api.schema.SchemaDescriptor;
 import org.neo4j.internal.kernel.api.schema.constraints.ConstraintDescriptor;
 import org.neo4j.kernel.api.SilentTokenNameLookup;
 import org.neo4j.kernel.api.StatementConstants;
-import org.neo4j.internal.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotApplicableKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
@@ -95,8 +95,7 @@ import org.neo4j.values.storable.Values;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static org.neo4j.internal.kernel.api.exceptions.schema.ConstraintValidationException.Phase.VALIDATION;
-import static org.neo4j.internal.kernel.api.exceptions.schema.SchemaKernelException.OperationContext
-        .CONSTRAINT_CREATION;
+import static org.neo4j.internal.kernel.api.exceptions.schema.SchemaKernelException.OperationContext.CONSTRAINT_CREATION;
 import static org.neo4j.internal.kernel.api.schema.SchemaDescriptorPredicates.hasProperty;
 import static org.neo4j.kernel.api.StatementConstants.NO_SUCH_NODE;
 import static org.neo4j.kernel.api.StatementConstants.NO_SUCH_PROPERTY_KEY;
@@ -258,7 +257,7 @@ public class Operations implements Write, ExplicitIndexWrite, SchemaWrite
         return true;
     }
 
-    public boolean nodeDelete( long node, boolean lock ) throws AutoIndexingKernelException
+    private boolean nodeDelete( long node, boolean lock ) throws AutoIndexingKernelException
     {
         ktx.assertOpen();
 
@@ -281,8 +280,12 @@ public class Operations implements Write, ExplicitIndexWrite, SchemaWrite
         {
             ktx.statementLocks().optimistic().acquireExclusive( ktx.lockTracer(), ResourceTypes.NODE, node );
         }
-        if ( allStoreHolder.nodeExistsInStore( node ) )
+
+        allStoreHolder.singleNode( node, nodeCursor );
+        if ( nodeCursor.next() )
         {
+            acquireSharedNodeLabelLocks();
+
             autoIndexing.nodes().entityRemoved( this, node );
             ktx.txState().nodeDoDelete( node );
             return true;
@@ -290,6 +293,12 @@ public class Operations implements Write, ExplicitIndexWrite, SchemaWrite
 
         // tried to delete node that does not exist
         return false;
+    }
+
+    // Assuming that the nodeCursor have been initialized to the node that labels are retrieved from
+    private void acquireSharedNodeLabelLocks()
+    {
+        ktx.statementLocks().optimistic().acquireShared( ktx.lockTracer(), ResourceTypes.LABEL, nodeCursor.labels().all() );
     }
 
     private boolean relationshipDelete( long relationship, boolean lock ) throws AutoIndexingKernelException
@@ -439,35 +448,34 @@ public class Operations implements Write, ExplicitIndexWrite, SchemaWrite
     }
 
     @Override
-    public boolean nodeRemoveLabel( long node, int nodeLabel ) throws EntityNotFoundException
+    public boolean nodeRemoveLabel( long node, int labelId ) throws EntityNotFoundException
     {
         acquireExclusiveNodeLock( node );
         ktx.assertOpen();
 
         singleNode( node );
 
-        if ( !nodeCursor.labels().contains( nodeLabel ) )
+        if ( !nodeCursor.labels().contains( labelId ) )
         {
             //the label wasn't there, nothing to do
             return false;
         }
 
-        ktx.txState().nodeDoRemoveLabel( nodeLabel, node );
-        updater.onLabelChange( nodeLabel, nodeCursor, propertyCursor, REMOVED_LABEL );
+        acquireSharedLabelLock( labelId );
+        ktx.txState().nodeDoRemoveLabel( labelId, node );
+        updater.onLabelChange( labelId, nodeCursor, propertyCursor, REMOVED_LABEL );
         return true;
     }
 
     @Override
     public Value nodeSetProperty( long node, int propertyKey, Value value )
             throws EntityNotFoundException, ConstraintValidationException, AutoIndexingKernelException
-
     {
         acquireExclusiveNodeLock( node );
         ktx.assertOpen();
 
         singleNode( node );
-        ktx.statementLocks().optimistic().acquireShared( ktx.lockTracer(), ResourceTypes.LABEL,
-                nodeCursor.labels().all() );
+        acquireSharedNodeLabelLocks();
         Iterator<ConstraintDescriptor> constraints = Iterators.filter( hasProperty( propertyKey ),
                 allStoreHolder.constraintsGetAll() );
         Iterator<IndexBackedConstraintDescriptor> uniquenessConstraints =
@@ -523,6 +531,7 @@ public class Operations implements Write, ExplicitIndexWrite, SchemaWrite
 
         if ( existingValue != NO_VALUE )
         {
+            acquireSharedNodeLabelLocks();
             autoIndexing.nodes().propertyRemoved( this, node, propertyKey );
             ktx.txState().nodeDoRemoveProperty( node, propertyKey );
             updater.onPropertyRemove( nodeCursor, propertyCursor, propertyKey, existingValue );

--- a/community/kernel/src/test/java/org/neo4j/graphdb/schema/UpdateDeletedIndexIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/schema/UpdateDeletedIndexIT.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb.schema;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
+import org.neo4j.test.Race;
+import org.neo4j.test.TestLabels;
+import org.neo4j.test.rule.DatabaseRule;
+import org.neo4j.test.rule.ImpermanentDatabaseRule;
+
+import static org.neo4j.test.Race.throwing;
+
+public class UpdateDeletedIndexIT
+{
+    private static final TestLabels LABEL = TestLabels.LABEL_ONE;
+    private static final String KEY = "key";
+    private static final int NODES = 100;
+    @Rule
+    public final DatabaseRule db = new ImpermanentDatabaseRule();
+
+    @Test
+    public void shouldHandleUpdateRemovalOfLabelConcurrentlyWithIndexDrop() throws Throwable
+    {
+        // given
+        long[] nodes = createNodes();
+        IndexDefinition indexDefinition = createIndex();
+
+        // when
+        Race race = new Race();
+        race.addContestant( indexDropper( indexDefinition ), 1 );
+        for ( int i = 0; i < NODES; i++ )
+        {
+            race.addContestant( nodeLabelRemover( nodes[i] ) );
+        }
+
+        // then
+        race.go();
+    }
+
+    @Test
+    public void shouldHandleDeleteNodeConcurrentlyWithIndexDrop() throws Throwable
+    {
+        // given
+        long[] nodes = createNodes();
+        IndexDefinition indexDefinition = createIndex();
+
+        // when
+        Race race = new Race();
+        race.addContestant( indexDropper( indexDefinition ), 1 );
+        for ( int i = 0; i < NODES; i++ )
+        {
+            race.addContestant( nodeDeleter( nodes[i] ) );
+        }
+
+        // then
+        race.go();
+    }
+
+    @Test
+    public void shouldHandleRemovePropertyConcurrentlyWithIndexDrop() throws Throwable
+    {
+        // given
+        long[] nodes = createNodes();
+        IndexDefinition indexDefinition = createIndex();
+
+        // when
+        Race race = new Race();
+        race.addContestant( indexDropper( indexDefinition ), 1 );
+        for ( int i = 0; i < NODES; i++ )
+        {
+            race.addContestant( nodePropertyRemover( nodes[i] ) );
+        }
+
+        // then
+        race.go();
+    }
+
+    @Test
+    public void shouldHandleNodeDetachDeleteConcurrentlyWithIndexDrop() throws Throwable
+    {
+        // given
+        long[] nodes = createNodes();
+        IndexDefinition indexDefinition = createIndex();
+
+        // when
+        Race race = new Race();
+        race.addContestant( indexDropper( indexDefinition ), 1 );
+        for ( int i = 0; i < NODES; i++ )
+        {
+            race.addContestant( nodeDetachDeleter( nodes[i] ) );
+        }
+
+        // then
+        race.go();
+    }
+
+    private Runnable indexDropper( IndexDefinition indexDefinition )
+    {
+        return () ->
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+                indexDefinition.drop();
+                tx.success();
+            }
+        };
+    }
+
+    private Runnable nodeLabelRemover( long nodeId )
+    {
+        return () ->
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+                db.getNodeById( nodeId ).removeLabel( LABEL );
+                tx.success();
+            }
+        };
+    }
+
+    private Runnable nodeDeleter( long nodeId )
+    {
+        return () ->
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+                db.getNodeById( nodeId ).delete();
+                tx.success();
+            }
+        };
+    }
+
+    private Runnable nodeDetachDeleter( long nodeId )
+    {
+        return throwing( () ->
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+                db.getDependencyResolver().resolveDependency( ThreadToStatementContextBridge.class ).getKernelTransactionBoundToThisThread(
+                        true ).dataWrite().nodeDetachDelete( nodeId );
+                tx.success();
+            }
+        } );
+    }
+
+    private Runnable nodePropertyRemover( long nodeId )
+    {
+        return () ->
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+                db.getNodeById( nodeId ).removeProperty( KEY );
+                tx.success();
+            }
+        };
+    }
+
+    private long[] createNodes()
+    {
+        long[] nodes = new long[NODES];
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( int i = 0; i < NODES; i++ )
+            {
+                Node node = db.createNode( LABEL );
+                node.setProperty( KEY, i );
+                nodes[i] = node.getId();
+            }
+            tx.success();
+        }
+        return nodes;
+    }
+
+    private IndexDefinition createIndex()
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( int i = 0; i < NODES; i++ )
+            {
+                db.createNode( LABEL ).setProperty( KEY, i );
+            }
+            tx.success();
+        }
+        IndexDefinition indexDefinition;
+        try ( Transaction tx = db.beginTx() )
+        {
+            indexDefinition = db.schema().indexFor( LABEL ).on( KEY ).create();
+            tx.success();
+        }
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.schema().awaitIndexesOnline( 10, TimeUnit.SECONDS );
+            tx.success();
+        }
+        return indexDefinition;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/OperationsLockTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/OperationsLockTest.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.internal.kernel.api.LabelSet;
 import org.neo4j.internal.kernel.api.Write;
+import org.neo4j.internal.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.internal.kernel.api.exceptions.InvalidTransactionTypeKernelException;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.exceptions.explicitindex.AutoIndexingKernelException;
@@ -78,6 +79,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.neo4j.collection.primitive.PrimitiveLongCollections.EMPTY_LONG_ARRAY;
 import static org.neo4j.helpers.collection.Iterators.asList;
 import static org.neo4j.kernel.api.schema.constaints.ConstraintDescriptorFactory.existsForRelType;
 import static org.neo4j.kernel.api.schema.constaints.ConstraintDescriptorFactory.uniqueForLabel;
@@ -494,6 +496,10 @@ public class OperationsLockTest
         long nodeId = 1L;
         returnRelationships( transaction, false, new TestRelationshipChain( nodeId ) );
         when( transaction.ambientNodeCursor() ).thenReturn( new StubNodeCursor( false ) );
+        when( nodeCursor.next() ).thenReturn( true );
+        LabelSet labels = mock( LabelSet.class );
+        when( labels.all() ).thenReturn( EMPTY_LONG_ARRAY );
+        when( nodeCursor.labels() ).thenReturn( labels );
 
         operations.nodeDetachDelete( nodeId );
 
@@ -509,6 +515,11 @@ public class OperationsLockTest
         returnRelationships( transaction, false,
                 new TestRelationshipChain( nodeId ).outgoing( 1, 2L, 42 ) );
         when( transaction.ambientNodeCursor() ).thenReturn( new StubNodeCursor( false ) );
+        LabelSet labels = mock( LabelSet.class );
+        when( labels.all() ).thenReturn( EMPTY_LONG_ARRAY );
+        when( nodeCursor.labels() ).thenReturn( labels );
+        when( nodeCursor.next() ).thenReturn( true );
+
         operations.nodeDetachDelete( nodeId );
 
         order.verify( locks ).acquireExclusive(
@@ -516,6 +527,100 @@ public class OperationsLockTest
         order.verify( locks, never() ).releaseExclusive( ResourceTypes.NODE, nodeId );
         order.verify( locks, never() ).releaseExclusive( ResourceTypes.NODE, 2L );
         order.verify( txState ).nodeDoDelete( nodeId );
+    }
+
+    @Test
+    public void shouldAcquiredSharedLabelLocksWhenDeletingNode() throws AutoIndexingKernelException
+    {
+        // given
+        long nodeId = 1L;
+        long labelId1 = 1;
+        long labelId2 = 2;
+        when( nodeCursor.next() ).thenReturn( true );
+        LabelSet labels = mock( LabelSet.class );
+        when( labels.all() ).thenReturn( new long[]{labelId1, labelId2} );
+        when( nodeCursor.labels() ).thenReturn( labels );
+
+        // when
+        operations.nodeDelete( nodeId );
+
+        // then
+        InOrder order = inOrder( locks );
+        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, nodeId );
+        order.verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.LABEL, labelId1, labelId2 );
+        order.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void shouldAcquiredSharedLabelLocksWhenDetachDeletingNode() throws KernelException
+    {
+        // given
+        long nodeId = 1L;
+        long labelId1 = 1;
+        long labelId2 = 2;
+
+        returnRelationships( transaction, false, new TestRelationshipChain( nodeId ) );
+        when( transaction.ambientNodeCursor() ).thenReturn( new StubNodeCursor( false ) );
+        when( nodeCursor.next() ).thenReturn( true );
+        LabelSet labels = mock( LabelSet.class );
+        when( labels.all() ).thenReturn( new long[]{labelId1, labelId2} );
+        when( nodeCursor.labels() ).thenReturn( labels );
+
+        // when
+        operations.nodeDetachDelete( nodeId );
+
+        // then
+        InOrder order = inOrder( locks );
+        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, nodeId );
+        order.verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.LABEL, labelId1, labelId2 );
+        order.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void shouldAcquiredSharedLabelLocksWhenRemovingNodeLabel() throws EntityNotFoundException
+    {
+        // given
+        long nodeId = 1L;
+        int labelId = 1;
+        when( nodeCursor.next() ).thenReturn( true );
+        LabelSet labels = mock( LabelSet.class );
+        when( labels.contains( labelId ) ).thenReturn( true );
+        when( nodeCursor.labels() ).thenReturn( labels );
+
+        // when
+        operations.nodeRemoveLabel( nodeId, labelId );
+
+        // then
+        InOrder order = inOrder( locks );
+        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, nodeId );
+        order.verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.LABEL, labelId );
+        order.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void shouldAcquiredSharedLabelLocksWhenRemovingNodeProperty() throws AutoIndexingKernelException, EntityNotFoundException
+    {
+        // given
+        long nodeId = 1L;
+        long labelId1 = 1;
+        long labelId2 = 1;
+        int propertyKeyId = 5;
+        when( nodeCursor.next() ).thenReturn( true );
+        LabelSet labels = mock( LabelSet.class );
+        when( labels.all() ).thenReturn( new long[]{labelId1, labelId2} );
+        when( nodeCursor.labels() ).thenReturn( labels );
+        when( propertyCursor.next() ).thenReturn( true );
+        when( propertyCursor.propertyKey() ).thenReturn( propertyKeyId );
+        when( propertyCursor.propertyValue() ).thenReturn( Values.of( "abc" ) );
+
+        // when
+        operations.nodeRemoveProperty( nodeId, propertyKeyId );
+
+        // then
+        InOrder order = inOrder( locks );
+        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, nodeId );
+        order.verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.LABEL, labelId1, labelId2 );
+        order.verifyNoMoreInteractions();
     }
 
     private void setStoreRelationship( long relationshipId, long sourceNode, long targetNode, int relationshipLabel )


### PR DESCRIPTION
- Delete node
- Remove node property
- Remove node label

These weren't acquired previously, but could result in race
conditions with concurrent schema changes like create/delete index.

co-author: @burqen