### PR TITLE
Actually performs INDEX DROP transactions during recovery

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -21,11 +21,15 @@ package org.neo4j.kernel.impl.api.index;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiConsumer;
 
@@ -53,6 +57,7 @@ import org.neo4j.kernel.api.index.IndexProvider.Descriptor;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
 import org.neo4j.kernel.impl.api.SchemaState;
+import org.neo4j.kernel.impl.api.explicitindex.InternalAutoIndexOperations;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingController;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingMode;
 import org.neo4j.kernel.impl.store.UnderlyingStorageException;
@@ -103,6 +108,7 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
     private final Monitor monitor;
     private final SchemaState schemaState;
     private final IndexPopulationJobController populationJobController;
+    private final Map<Long,IndexProxy> indexesToDropAfterCompletedRecovery = new HashMap<>();
 
     enum State
     {
@@ -240,6 +246,10 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
     {
         state = State.STARTING;
 
+        // During recovery there could have been dropped indexes. Dropping an index means also updating the counts store,
+        // which is problematic during recovery. So instead drop those indexes here, after recovery completed.
+        performRecoveredIndexDropActions();
+
         // Recovery will not do refresh (update read views) while applying recovered transactions and instead
         // do it at one point after recovery... i.e. here
         indexMapRef.indexMapSnapshot().forEachIndexProxy( indexProxyOperation( "refresh", IndexProxy::refresh ) );
@@ -335,6 +345,31 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
                 } );
 
         state = State.RUNNING;
+    }
+
+    private void performRecoveredIndexDropActions()
+    {
+        indexesToDropAfterCompletedRecovery.values().forEach( index ->
+        {
+            try
+            {
+                index.drop();
+            }
+            catch ( Exception e )
+            {
+                // This is OK to get during recovery because the underlying index can be in any unknown state
+                // while we're recovering. Let's just move on to closing it instead.
+                try
+                {
+                    index.close();
+                }
+                catch ( IOException closeException )
+                {
+                    // This is OK for the same reason as above
+                }
+            }
+        } );
+        indexesToDropAfterCompletedRecovery.clear();
     }
 
     /**
@@ -486,23 +521,23 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
         }
     }
 
-    public void dropIndex( IndexRule rule )
+    public void dropIndex( IndexRule rule ) throws IOException
     {
         indexMapRef.modify( indexMap ->
         {
             long indexId = rule.getId();
             IndexProxy index = indexMap.removeIndexProxy( indexId );
+
             if ( state == State.RUNNING )
             {
                 assert index != null : "Index " + rule + " doesn't exists";
-                try
-                {
-                    index.drop();
-                }
-                catch ( Exception e )
-                {
-                    throw new RuntimeException( e );
-                }
+                index.drop();
+            }
+            else if ( index != null )
+            {
+                // Dropping an index means also updating the counts store, which is problematic during recovery.
+                // So instead make a note of it and actually perform the index drops after recovery.
+                indexesToDropAfterCompletedRecovery.put( indexId, index );
             }
             return indexMap;
         } );
@@ -706,6 +741,12 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
             for ( IndexRule rule : rules )
             {
                 long ruleId = rule.getId();
+                if ( state == State.NOT_STARTED )
+                {
+                    // In case of recovery remove any previously recorded INDEX DROP for this particular index rule id,
+                    // in some scenario where rule ids may be reused.
+                    indexesToDropAfterCompletedRecovery.remove( ruleId );
+                }
                 IndexProxy index = indexMap.getIndexProxy( ruleId );
                 if ( index != null && state == State.NOT_STARTED )
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogVersionedStoreChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogVersionedStoreChannel.java
@@ -19,11 +19,18 @@
  */
 package org.neo4j.kernel.impl.transaction.log;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileLock;
 
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.OpenMode;
 import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.kernel.impl.transaction.log.entry.LogHeader;
+
+import static org.neo4j.kernel.impl.transaction.log.entry.LogHeader.LOG_HEADER_SIZE;
+import static org.neo4j.kernel.impl.transaction.log.entry.LogHeaderReader.readLogHeader;
 
 public class PhysicalLogVersionedStoreChannel implements LogVersionedStoreChannel
 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryWriter.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Collection;
 
 import org.neo4j.helpers.collection.Visitor;
+import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.FlushableChannel;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
@@ -54,12 +55,23 @@ public class LogEntryWriter
         channel.put( CURRENT.byteCode() ).put( type );
     }
 
+    public void writeStartEntry( LogEntryStart entry ) throws IOException
+    {
+        writeStartEntry( entry.getMasterId(), entry.getLocalId(), entry.getTimeWritten(), entry.getLastCommittedTxWhenTransactionStarted(),
+                entry.getAdditionalHeader() );
+    }
+
     public void writeStartEntry( int masterId, int authorId, long timeWritten, long latestCommittedTxWhenStarted,
                                  byte[] additionalHeaderData ) throws IOException
     {
         writeLogEntryHeader( TX_START );
         channel.putInt( masterId ).putInt( authorId ).putLong( timeWritten ).putLong( latestCommittedTxWhenStarted )
                .putInt( additionalHeaderData.length ).put( additionalHeaderData, additionalHeaderData.length );
+    }
+
+    public void writeCommitEntry( LogEntryCommit entry ) throws IOException
+    {
+        writeCommitEntry( entry.getTxId(), entry.getTimeWritten() );
     }
 
     public void writeCommitEntry( long transactionId, long timeWritten ) throws IOException
@@ -71,6 +83,13 @@ public class LogEntryWriter
     public void serialize( TransactionRepresentation tx ) throws IOException
     {
         tx.accept( serializer );
+    }
+
+    public void serialize( CommittedTransactionRepresentation tx ) throws IOException
+    {
+        writeStartEntry( tx.getStartEntry() );
+        serialize( tx.getTransactionRepresentation() );
+        writeCommitEntry( tx.getCommitEntry() );
     }
 
     public void serialize( Collection<StorageCommand> commands ) throws IOException

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
@@ -72,6 +72,7 @@ import org.neo4j.kernel.impl.api.SchemaState;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingController;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingMode;
+import org.neo4j.kernel.impl.scheduler.CentralJobScheduler;
 import org.neo4j.kernel.impl.store.UnderlyingStorageException;
 import org.neo4j.kernel.impl.store.record.IndexRule;
 import org.neo4j.kernel.impl.storemigration.StoreMigrationParticipant;
@@ -80,7 +81,6 @@ import org.neo4j.kernel.impl.transaction.command.Command.PropertyCommand;
 import org.neo4j.kernel.impl.transaction.state.DefaultIndexProviderMap;
 import org.neo4j.kernel.impl.transaction.state.DirectIndexUpdates;
 import org.neo4j.kernel.impl.transaction.state.IndexUpdates;
-import org.neo4j.kernel.impl.scheduler.CentralJobScheduler;
 import org.neo4j.kernel.lifecycle.LifeRule;
 import org.neo4j.kernel.lifecycle.LifecycleException;
 import org.neo4j.logging.AssertableLogProvider;
@@ -102,6 +102,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -1094,6 +1095,25 @@ public class IndexingServiceTest
 
         // Then
         verify( accessor, times( 1 ) ).refresh();
+    }
+
+    @Test
+    public void shouldForgetDeferredIndexDropDuringRecoveryIfCreatedIndexWithSameRuleId() throws Exception
+    {
+        // given
+        IndexRule rule = IndexRule.indexRule( 0, index, PROVIDER_DESCRIPTOR );
+        IndexingService indexing = newIndexingServiceWithMockedDependencies( populator, accessor, withData(), rule );
+        life.init();
+
+        // when
+        indexing.dropIndex( rule );
+        indexing.createIndexes( rule );
+        life.start();
+
+        // then
+        IndexProxy proxy = indexing.getIndexProxy( rule.getId() );
+        assertNotNull( proxy );
+        verify( accessor, never() ).drop();
     }
 
     private IndexProxy createIndexProxyMock()

--- a/community/neo4j/src/test/java/org/neo4j/kernel/impl/index/schema/RecoverIndexDropIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/kernel/impl/index/schema/RecoverIndexDropIT.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.schema.IndexDefinition;
+import org.neo4j.io.fs.OpenMode;
+import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.kernel.impl.api.index.IndexMap;
+import org.neo4j.kernel.impl.api.index.IndexProxy;
+import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.log.LogPosition;
+import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
+import org.neo4j.kernel.impl.transaction.log.PhysicalFlushableChannel;
+import org.neo4j.kernel.impl.transaction.log.TransactionCursor;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryWriter;
+import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
+import org.neo4j.kernel.impl.transaction.log.files.LogFilesBuilder;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.kernel.recovery.RecoveryMonitor;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.helpers.collection.Iterables.count;
+import static org.neo4j.test.TestLabels.LABEL_ONE;
+
+/**
+ * Issue came up when observing that recovering an INDEX DROP command didn't actually call {@link IndexProxy#drop()},
+ * and actually did nothing to that {@link IndexProxy} except removing it from its {@link IndexMap}.
+ * This would have {@link IndexingService} forget about that index and at shutdown not call {@link IndexProxy#close()},
+ * resulting in open page cache files, for any page cache mapped native index files.
+ *
+ * This would be a problem if the INDEX DROP command was present in the transaction log, but the db had been killed
+ * before the command had been applied and so the files would still remain, and not be dropped either when that command
+ * was recovered.
+ */
+public class RecoverIndexDropIT
+{
+    private static final String KEY = "key";
+
+    @Rule
+    public final DefaultFileSystemRule fs = new DefaultFileSystemRule();
+    @Rule
+    public final TestDirectory directory = TestDirectory.testDirectory( fs );
+
+    @Test
+    public void shouldDropIndexOnRecovery() throws IOException
+    {
+        // given a transaction stream ending in an INDEX DROP command.
+        CommittedTransactionRepresentation dropTransaction = prepareDropTransaction();
+        File storeDir = directory.graphDbDir();
+        GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( storeDir );
+        createIndex( db );
+        db.shutdown();
+        appendDropTransactionToTransactionLog( storeDir, dropTransaction );
+
+        // when recovering this (the drop transaction with the index file intact)
+        Monitors monitors = new Monitors();
+        AssertRecoveryIsPerformed recoveryMonitor = new AssertRecoveryIsPerformed();
+        monitors.addMonitorListener( recoveryMonitor );
+        db = new TestGraphDatabaseFactory().setMonitors( monitors ).newEmbeddedDatabase( storeDir );
+        try
+        {
+            assertTrue( recoveryMonitor.recoveryWasPerformed );
+
+            // then
+            try ( Transaction tx = db.beginTx() )
+            {
+                assertEquals( 0, count( db.schema().getIndexes() ) );
+                tx.success();
+            }
+        }
+        finally
+        {
+            // and the ability to shut down w/o failing on still open files
+            db.shutdown();
+        }
+    }
+
+    private IndexDefinition createIndex( GraphDatabaseService db )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            IndexDefinition index = db.schema().indexFor( LABEL_ONE ).on( KEY ).create();
+            tx.success();
+            return index;
+        }
+    }
+
+    private void appendDropTransactionToTransactionLog( File storeDir, CommittedTransactionRepresentation dropTransaction ) throws IOException
+    {
+        LogFiles logFiles = LogFilesBuilder.logFilesBasedOnlyBuilder( storeDir, fs ).build();
+        File logFile = logFiles.getLogFileForVersion( logFiles.getHighestLogVersion() );
+        StoreChannel writeStoreChannel = fs.open( logFile, OpenMode.READ_WRITE );
+        writeStoreChannel.position( writeStoreChannel.size() );
+        try ( PhysicalFlushableChannel writeChannel = new PhysicalFlushableChannel( writeStoreChannel ) )
+        {
+            new LogEntryWriter( writeChannel ).serialize( dropTransaction );
+        }
+    }
+
+    private CommittedTransactionRepresentation prepareDropTransaction() throws IOException
+    {
+        GraphDatabaseAPI db = (GraphDatabaseAPI) new TestGraphDatabaseFactory().newEmbeddedDatabase( directory.directory( "preparation" ) );
+        try
+        {
+            // Create index
+            IndexDefinition index;
+            index = createIndex( db );
+            try ( Transaction tx = db.beginTx() )
+            {
+                index.drop();
+                tx.success();
+            }
+            return extractLastTransaction( db );
+        }
+        finally
+        {
+            db.shutdown();
+        }
+    }
+
+    private CommittedTransactionRepresentation extractLastTransaction( GraphDatabaseAPI db ) throws IOException
+    {
+        LogicalTransactionStore txStore = db.getDependencyResolver().resolveDependency( LogicalTransactionStore.class );
+        CommittedTransactionRepresentation transaction = null;
+        try ( TransactionCursor cursor = txStore.getTransactions( TransactionIdStore.BASE_TX_ID + 1 ) )
+        {
+            while ( cursor.next() )
+            {
+                transaction = cursor.get();
+            }
+        }
+        return transaction;
+    }
+
+    private static class AssertRecoveryIsPerformed implements RecoveryMonitor
+    {
+        boolean recoveryWasPerformed;
+
+        @Override
+        public void recoveryRequired( LogPosition recoveryPosition )
+        {
+            recoveryWasPerformed = true;
+        }
+    }
+}

--- a/community/neo4j/src/test/java/schema/MultiIndexPopulationConcurrentUpdatesIT.java
+++ b/community/neo4j/src/test/java/schema/MultiIndexPopulationConcurrentUpdatesIT.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -646,7 +647,6 @@ public class MultiIndexPopulationConcurrentUpdatesIT
 
     private class IndexDropAction implements Runnable
     {
-
         private int labelIdToDropIndexFor;
 
         private IndexDropAction( int labelIdToDropIndexFor )
@@ -660,7 +660,14 @@ public class MultiIndexPopulationConcurrentUpdatesIT
             org.neo4j.kernel.api.schema.LabelSchemaDescriptor descriptor =
                     SchemaDescriptorFactory.forLabel( labelIdToDropIndexFor, propertyId );
             IndexRule rule = findRuleForLabel( descriptor );
-            indexService.dropIndex( rule );
+            try
+            {
+                indexService.dropIndex( rule );
+            }
+            catch ( IOException e )
+            {
+                throw new UncheckedIOException( e );
+            }
         }
 
         private IndexRule findRuleForLabel( LabelSchemaDescriptor schemaDescriptor )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullResponseEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullResponseEncoder.java
@@ -25,7 +25,7 @@ import io.netty.handler.codec.MessageToByteEncoder;
 
 import org.neo4j.causalclustering.messaging.NetworkFlushableByteBuf;
 import org.neo4j.causalclustering.messaging.marshalling.storeid.StoreIdMarshal;
-import org.neo4j.com.CommittedTransactionSerializer;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryWriter;
 
 public class TxPullResponseEncoder extends MessageToByteEncoder<TxPullResponse>
 {
@@ -34,6 +34,6 @@ public class TxPullResponseEncoder extends MessageToByteEncoder<TxPullResponse>
     {
         NetworkFlushableByteBuf channel = new NetworkFlushableByteBuf( out );
         StoreIdMarshal.INSTANCE.marshal( response.storeId(), channel );
-        new CommittedTransactionSerializer( channel ).visit( response.tx() );
+        new LogEntryWriter( channel ).serialize( response.tx() );
     }
 }

--- a/enterprise/com/src/main/java/org/neo4j/com/CommittedTransactionSerializer.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/CommittedTransactionSerializer.java
@@ -26,8 +26,6 @@ import java.io.IOException;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.FlushableChannel;
-import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommit;
-import org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryWriter;
 
 /**
@@ -47,13 +45,7 @@ public class CommittedTransactionSerializer implements Visitor<CommittedTransact
     @Override
     public boolean visit( CommittedTransactionRepresentation tx ) throws IOException
     {
-        LogEntryStart startEntry = tx.getStartEntry();
-        writer.writeStartEntry( startEntry.getMasterId(), startEntry.getLocalId(),
-                startEntry.getTimeWritten(), startEntry.getLastCommittedTxWhenTransactionStarted(),
-                startEntry.getAdditionalHeader() );
-        writer.serialize( tx.getTransactionRepresentation() );
-        LogEntryCommit commitEntry = tx.getCommitEntry();
-        writer.writeCommitEntry( commitEntry.getTxId(), commitEntry.getTimeWritten() );
+        writer.serialize( tx );
         return false;
     }
 }

--- a/enterprise/com/src/main/java/org/neo4j/com/Server.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Server.java
@@ -611,7 +611,7 @@ public abstract class Server<T, R> extends SimpleChannelHandler implements Chann
         public Visitor<CommittedTransactionRepresentation,Exception> transactions()
         {
             targetBuffer.writeByte( 1 );
-            return new CommittedTransactionSerializer( new NetworkFlushableChannel(  targetBuffer ) );
+            return new CommittedTransactionSerializer( new NetworkFlushableChannel( targetBuffer ) );
         }
     }
 

--- a/tools/src/main/java/org/neo4j/tools/dump/TransactionLogAnalyzer.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/TransactionLogAnalyzer.java
@@ -46,8 +46,8 @@ import org.neo4j.tools.dump.log.TransactionLogEntryCursor;
 
 import static java.lang.String.format;
 import static org.neo4j.kernel.impl.transaction.log.LogVersionBridge.NO_MORE_CHANNELS;
-import static org.neo4j.kernel.impl.transaction.log.entry.LogEntryByteCodes.CHECK_POINT;
 import static org.neo4j.tools.util.TransactionLogUtils.openVersionedChannel;
+import static org.neo4j.kernel.impl.transaction.log.entry.LogEntryByteCodes.CHECK_POINT;
 
 /**
  * Merely a utility which, given a store directory or log file, reads the transaction log(s) as a stream of transactions

--- a/tools/src/main/java/org/neo4j/tools/util/TransactionLogUtils.java
+++ b/tools/src/main/java/org/neo4j/tools/util/TransactionLogUtils.java
@@ -81,12 +81,11 @@ public class TransactionLogUtils
      * @return {@link LogVersionedStoreChannel} for the file. Its version is determined by its log header.
      * @throws IOException on I/O error.
      */
-    public static LogVersionedStoreChannel openVersionedChannel( FileSystemAbstraction fileSystem, File file ) throws IOException
+    public static PhysicalLogVersionedStoreChannel openVersionedChannel( FileSystemAbstraction fileSystem, File file ) throws IOException
     {
         StoreChannel fileChannel = fileSystem.open( file, OpenMode.READ );
         LogHeader logHeader = readLogHeader( ByteBuffer.allocate( LOG_HEADER_SIZE ), fileChannel, true, file );
-        PhysicalLogVersionedStoreChannel channel =
-                new PhysicalLogVersionedStoreChannel( fileChannel, logHeader.logVersion, logHeader.logFormatVersion );
+        PhysicalLogVersionedStoreChannel channel = new PhysicalLogVersionedStoreChannel( fileChannel, logHeader.logVersion, logHeader.logFormatVersion );
         return channel;
     }
 }


### PR DESCRIPTION
Previously such transactions resulted in removal of that IndexProxy
from the index map, but no call to drop() or even close() was made.
This could result in that index being left open and its files still
remaining on disk if the database was previously killed very close
to appending such a INDEX DROP transaction. Recovery would complete
successfully, but the following db.shutdown() would fail due to
files still being mapped in the page cache. The index files would
also remain on disk, never to be deleted.

This commit changes so that INDEX DROP commands gets recorded
during recovery and executed right after it has completed, this to
avoid issues with updating the counts store during recovery
(yes dropping an index cleares some entries from the counts store).