### PR TITLE
Adds a debug flag to report cost comparisons

### DIFF
--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/LogicalPlanningContext.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/LogicalPlanningContext.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v3_3.planner.logical
 
 import org.neo4j.csv.reader.Configuration.DEFAULT_LEGACY_STYLE_QUOTING
 import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.Metrics.QueryGraphSolverInput
-import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.steps.LogicalPlanProducer
+import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.steps.{CostComparisonListener, LogicalPlanProducer}
 import org.neo4j.cypher.internal.compiler.v3_3.spi.PlanContext
 import org.neo4j.cypher.internal.frontend.v3_3.SemanticTable
 import org.neo4j.cypher.internal.frontend.v3_3.ast.Variable
@@ -41,7 +41,8 @@ case class LogicalPlanningContext(planContext: PlanContext,
                                   errorIfShortestPathHasCommonNodesAtRuntime: Boolean = true,
                                   legacyCsvQuoteEscaping: Boolean = DEFAULT_LEGACY_STYLE_QUOTING,
                                   config: QueryPlannerConfiguration = QueryPlannerConfiguration.default,
-                                  leafPlanUpdater: LogicalPlan => LogicalPlan = identity) {
+                                  leafPlanUpdater: LogicalPlan => LogicalPlan = identity,
+                                  costComparisonListener: CostComparisonListener) {
   def withStrictness(strictness: StrictnessMode) = copy(input = input.withPreferredStrictness(strictness))
 
   def recurse(plan: LogicalPlan) = copy(input = input.recurse(plan))

--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/ReportCostComparisonsAsRows.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/ReportCostComparisonsAsRows.scala
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_3.planner.logical
+
+import org.neo4j.cypher.internal.compiler.v3_3.phases.LogicalPlanState
+import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.steps.CostComparisonListener
+import org.neo4j.cypher.internal.frontend.v3_3.InputPosition
+import org.neo4j.cypher.internal.frontend.v3_3.ast._
+import org.neo4j.cypher.internal.ir.v3_3.{Cardinality, CardinalityEstimation, Cost, PlannerQuery}
+import org.neo4j.cypher.internal.v3_3.logical.plans._
+
+import scala.collection.{immutable, mutable}
+
+/** *
+  * This class can listen to cost comparisons and report them back as normal rows. This is done by creating a fake plan
+  * that looks something like this:
+  *
+  * UNWIND [{comparison: 0, planText: "plan", planCost: "costs", cost: 12, ...}] as col
+  * RETURN col["comparison] as comparison
+  *
+  * This is the plan that actually gets run, and not the one that the user provided.
+  *
+  * WARNING: This is a debug feature, and as such, not tested as rigorously as other features are.
+  * Only run this on a system that is not live after taking proper backups!
+  */
+class ReportCostComparisonsAsRows extends CostComparisonListener {
+
+  private val rows = new mutable.ListBuffer[Row]()
+  private val pos = InputPosition(0, 0, 0)
+  private var comparisonCount = 0
+
+  override def report[X](projector: X => LogicalPlan,
+                         input: Iterable[X],
+                         inputOrdering: Ordering[X],
+                         context: LogicalPlanningContext): Unit = if (input.size > 1) {
+
+    def stringTo(level: Int, plan: LogicalPlan): String = {
+      def indent(level: Int, in: String): String = level match {
+        case 0 => in
+        case _ => System.lineSeparator() + "  " * level + in
+      }
+
+      val cost = context.cost(plan, context.input)
+      val thisPlan = indent(level, s"${plan.getClass.getSimpleName} costs $cost cardinality ${plan.solved.estimatedCardinality}")
+      val l = plan.lhs.map(p => stringTo(level + 1, p)).getOrElse("")
+      val r = plan.rhs.map(p => stringTo(level + 1, p)).getOrElse("")
+      thisPlan + l + r
+    }
+
+    val sortedPlans = input.toIndexedSeq.sorted(inputOrdering.reverse).map(projector)
+    val winner = sortedPlans.last
+
+    val theseRows: immutable.Seq[Row] = sortedPlans.map { plan =>
+      val planText = plan.toString.replaceAll(System.lineSeparator(), System.lineSeparator())
+      val planTextWithCosts = stringTo(0, plan).replaceAll(System.lineSeparator(), System.lineSeparator())
+      val cost = context.cost(plan, context.input)
+      val cardinality = plan.solved.estimatedCardinality
+
+      Row(comparisonCount, planText, planTextWithCosts, cost, cardinality, winner == plan)
+    }
+
+    rows ++= theseRows
+    comparisonCount += 1
+  }
+
+  def addPlan(in: LogicalPlanState): LogicalPlanState = {
+    val plan = asPlan()
+    val newStatement = asStatement()
+
+    var current: Option[LogicalPlan] = Some(plan)
+    do {
+      val thisPlan = current.get
+      current = current.get.lhs
+    } while (current.nonEmpty)
+
+    in.copy(maybePeriodicCommit = Some(None), maybeLogicalPlan = Some(plan), maybeStatement = Some(newStatement))
+  }
+
+  private def asStatement(): Statement = {
+    def ret(s: String) = AliasedReturnItem(varFor(s), varFor(s))(pos)
+
+    val returnItems = Seq(
+      ret("#"),
+      ret("planText"),
+      ret("planCost"),
+      ret("cost"),
+      ret("est cardinality"),
+      ret("winner")
+    )
+    val returnClause = Return(distinct = false, ReturnItems(includeExisting = false, returnItems)(pos), None, None, None, None, Set.empty)(pos)
+    Query(None, SingleQuery(Seq(returnClause))(pos))(pos)
+  }
+
+  private def varFor(s: String) = Variable(s)(pos)
+  private def str(s: String): Expression = StringLiteral(s)(pos)
+  private def int(i: Int): Expression = SignedDecimalIntegerLiteral(i.toString)(pos)
+  private def dbl(d: Double): Expression = DecimalDoubleLiteral(d.toString)(pos)
+  private def key(s: String): PropertyKeyName = PropertyKeyName(s)(pos)
+  private def map(values: (String, Expression)*): MapExpression = MapExpression(values map { case (str, e) => key(str) -> e })(pos)
+  private def solved = CardinalityEstimation.lift(PlannerQuery.empty, Cardinality.SINGLE)
+
+  private def mapRowsToExpressions(comparisonId: Int, planText: String, planCosts: String, cost: Cost, cardinality: Cardinality, winner: Boolean): Seq[MapExpression] = {
+    val planTestLines = planText.split(System.lineSeparator())
+    val planCostLines = planCosts.split(System.lineSeparator())
+
+    val details = planCostLines zip planTestLines map {
+      case (planCost, planTxt) =>
+        map(values =
+          "comparison" -> int(comparisonId),
+          "planDetails" -> str(planTxt),
+          "planCosts" -> str(planCost)
+        )
+    }
+
+    val summaryRow = map(
+      "comparison" -> int(comparisonId),
+      "planDetails" -> str(""),
+      "planCosts" -> str(""),
+      "cost" -> dbl(cost.gummyBears),
+      "est cardinality" -> dbl(cardinality.amount),
+      "winner" -> str(if (winner) "WON" else "LOST")
+    )
+    summaryRow +: details
+  }
+
+  private def asPlan(): LogicalPlan = {
+
+    val maps: immutable.Seq[MapExpression] =
+      rows.toIndexedSeq.reverse.flatMap(r => mapRowsToExpressions(r.comparisonId, r.planText, r.planCosts, r.cost, r.cardinality, r.winner))
+
+    val plan: LogicalPlan =
+      produceResult(
+        project(
+          unwindPlan(maps)))
+
+    plan
+  }
+
+  private def produceResult(project: LogicalPlan): LogicalPlan =
+    ProduceResult(Seq(
+      "#",
+      "planText",
+      "planCost",
+      "cost",
+      "est cardinality",
+      "winner"
+    ), project)
+
+  private def project(unwind: LogicalPlan): LogicalPlan = {
+    val column = varFor("col")
+    val comparisonE = Property(column, key("comparison"))(pos)
+    val planTextE = Property(column, key("planDetails"))(pos)
+    val planCostE = Property(column, key("planCosts"))(pos)
+    val costE = Property(column, key("cost"))(pos)
+    val cardinalityE = Property(column, key("est cardinality"))(pos)
+    val winnerE = Property(column, key("winner"))(pos)
+
+    val project: LogicalPlan = Projection(unwind, Map(
+      "#" -> comparisonE,
+      "planText" -> planTextE,
+      "planCost" -> planCostE,
+      "cost" -> costE,
+      "est cardinality" -> cardinalityE,
+      "winner" -> winnerE
+    ))(solved)
+    project
+  }
+
+  private def unwindPlan(maps: immutable.Seq[MapExpression]): LogicalPlan = {
+    val expression = ListLiteral(maps)(pos)
+    val unwind: LogicalPlan = UnwindCollection(SingleRow()(solved), "col", expression)(solved)
+    unwind
+  }
+
+  case class Row(comparisonId: Int, planText: String, planCosts: String, cost: Cost, cardinality: Cardinality, winner: Boolean)
+
+}

--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/ReportCostComparisonsAsRows.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/ReportCostComparisonsAsRows.scala
@@ -76,7 +76,9 @@ class ReportCostComparisonsAsRows extends CostComparisonListener {
       Row(comparisonCount, planText, planTextWithCosts, cost, cardinality, winner == plan)
     }
 
-    rows ++= theseRows
+    val divider = Row(comparisonCount, "*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-", "", Cost(0), Cardinality.SINGLE, false)
+
+    rows ++= (divider +: theseRows)
     comparisonCount += 1
   }
 

--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/steps/CostComparisonListener.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/steps/CostComparisonListener.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_3.planner.logical.steps
+
+import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.LogicalPlanningContext
+import org.neo4j.cypher.internal.v3_3.logical.plans.LogicalPlan
+
+trait CostComparisonListener {
+  def report[X](projector: X => LogicalPlan,
+                input: Iterable[X],
+                inputOrdering: Ordering[X],
+                context: LogicalPlanningContext): Unit
+}
+
+object devNullListener extends CostComparisonListener {
+  override def report[X](projector: X => LogicalPlan,
+                         input: Iterable[X],
+                         inputOrdering: Ordering[X],
+                         context: LogicalPlanningContext): Unit = {}
+}
+
+object SystemOutCostLogger extends CostComparisonListener {
+  def report[X](projector: X => LogicalPlan,
+                input: Iterable[X],
+                inputOrdering: Ordering[X],
+                context: LogicalPlanningContext): Unit = {
+    def stringTo(level: Int, plan: LogicalPlan): String = {
+      def indent(level: Int, in: String): String = level match {
+        case 0 => in
+        case _ => System.lineSeparator() + "  " * level + in
+      }
+
+      val cost = context.cost(plan, context.input)
+      val thisPlan = indent(level, s"${plan.getClass.getSimpleName} costs $cost cardinality ${plan.solved.estimatedCardinality}")
+      val l = plan.lhs.map(p => stringTo(level + 1, p)).getOrElse("")
+      val r = plan.rhs.map(p => stringTo(level + 1, p)).getOrElse("")
+      thisPlan + l + r
+    }
+
+    val sortedPlans = input.toIndexedSeq.sorted(inputOrdering).map(projector)
+
+    if (sortedPlans.size > 1) {
+      println("- Get best of:")
+      for (plan <- sortedPlans) {
+
+        val planTextWithCosts = stringTo(0, plan).replaceAll(System.lineSeparator(), System.lineSeparator() + "\t\t")
+        val planText = plan.toString.replaceAll(System.lineSeparator(), System.lineSeparator() + "\t\t")
+        println("=-" * 10)
+        println(s"* Plan #${plan.debugId}")
+        println(s"\t$planTextWithCosts")
+        println(s"\t$planText")
+        println(s"\t\tHints(${plan.solved.numHints})")
+        println(s"\t\tlhs: ${plan.lhs}")
+      }
+
+      val best = sortedPlans.head
+      println("!¡" * 10)
+      println("- Best is:")
+      println(s"Plan #${best.debugId}")
+      println(s"\t${best.toString}")
+      val planTextWithCosts = stringTo(0, best)
+      println(s"\t$planTextWithCosts")
+      println(s"\t\tHints(${best.solved.numHints})")
+      println(s"\t\tlhs: ${best.lhs}")
+      println("!¡" * 10)
+      println()
+    }
+  }
+}

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/LogicalPlanningTestSupport.scala
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.compiler.v3_3.phases._
 import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.Metrics._
 import org.neo4j.cypher.internal.compiler.v3_3.planner.logical._
 import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.idp._
-import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.steps.LogicalPlanProducer
+import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.steps.{LogicalPlanProducer, devNullListener}
 import org.neo4j.cypher.internal.compiler.v3_3.spi.{GraphStatistics, PlanContext}
 import org.neo4j.cypher.internal.compiler.v3_3.test_helpers.ContextHelper
 import org.neo4j.cypher.internal.frontend.v3_3._
@@ -113,7 +113,7 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
     LogicalPlanningContext(planContext, LogicalPlanProducer(metrics.cardinality), metrics, semanticTable,
       strategy, QueryGraphSolverInput(Map.empty, cardinality, strictness),
       notificationLogger = notificationLogger, useErrorsOverWarnings = useErrorsOverWarnings,
-      legacyCsvQuoteEscaping = config.legacyCsvQuoteEscaping, config = QueryPlannerConfiguration.default)
+      legacyCsvQuoteEscaping = config.legacyCsvQuoteEscaping, config = QueryPlannerConfiguration.default, costComparisonListener = devNullListener)
 
   def newMockedStatistics = mock[GraphStatistics]
   def hardcodedStatistics = HardcodedGraphStatistics

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/LogicalPlanningTestSupport2.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.Metrics._
 import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.cardinality.QueryGraphCardinalityModel
 import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.idp._
 import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.plans.rewriter.unnestApply
-import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.steps.LogicalPlanProducer
+import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.steps.{LogicalPlanProducer, devNullListener}
 import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.{LogicalPlanningContext, _}
 import org.neo4j.cypher.internal.compiler.v3_3.spi._
 import org.neo4j.cypher.internal.compiler.v3_3.test_helpers.ContextHelper
@@ -196,7 +196,8 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
         semanticTable = semanticTable,
         strategy = queryGraphSolver,
         input = QueryGraphSolverInput.empty,
-        notificationLogger = devNullLogger
+        notificationLogger = devNullLogger,
+        costComparisonListener = devNullListener
       )
       f(config, ctx)
     }

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/DefaultQueryPlannerTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/DefaultQueryPlannerTest.scala
@@ -23,7 +23,7 @@ import org.mockito.Matchers.any
 import org.mockito.Mockito.{times, verify, when}
 import org.neo4j.cypher.internal.compiler.v3_3.planner._
 import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.Metrics.QueryGraphSolverInput
-import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.steps.LogicalPlanProducer
+import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.steps.{LogicalPlanProducer, devNullListener}
 import org.neo4j.cypher.internal.compiler.v3_3.spi.PlanContext
 import org.neo4j.cypher.internal.frontend.v3_3.ast.{ASTAnnotationMap, Expression, Hint}
 import org.neo4j.cypher.internal.frontend.v3_3.phases.devNullLogger
@@ -102,6 +102,7 @@ class DefaultQueryPlannerTest extends CypherFunSuite with LogicalPlanningTestSup
     when(producer.planStarProjection(any(), any(), any())(any())).thenReturn(lp)
     when(producer.planEmptyProjection(any())(any())).thenReturn(lp)
     when(context.logicalPlanProducer).thenReturn(producer)
+    when(context.costComparisonListener).thenReturn(devNullListener)
     val queryPlanner = QueryPlanner(planSingleQuery = PlanSingleQuery())
 
     // when
@@ -123,5 +124,6 @@ class DefaultQueryPlannerTest extends CypherFunSuite with LogicalPlanningTestSup
     semanticTable = semanticTable,
     strategy = mock[QueryGraphSolver],
     config = QueryPlannerConfiguration.default,
-    notificationLogger = devNullLogger)
+    notificationLogger = devNullLogger,
+    costComparisonListener = devNullListener)
 }

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/PickBestPlanUsingHintsAndCostTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/PickBestPlanUsingHintsAndCostTest.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_3.planner.logical
 
 import org.neo4j.cypher.internal.compiler.v3_3.planner.LogicalPlanningTestSupport2
-import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.steps.{LogicalPlanProducer, pickBestPlanUsingHintsAndCost}
+import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.steps.{LogicalPlanProducer, devNullListener, pickBestPlanUsingHintsAndCost}
 import org.neo4j.cypher.internal.frontend.v3_3.ast.{LabelName, PropertyKeyName, UsingIndexHint}
 import org.neo4j.cypher.internal.frontend.v3_3.phases.devNullLogger
 import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
@@ -101,7 +101,8 @@ class PickBestPlanUsingHintsAndCostTest extends CypherFunSuite with LogicalPlann
   private def assertTopPlan(winner: LogicalPlan, candidates: LogicalPlan*)(GIVEN: given) {
     val environment = LogicalPlanningEnvironment(GIVEN)
     val metrics: Metrics = environment.metricsFactory.newMetrics(GIVEN.statistics, GIVEN.expressionEvaluator, cypherCompilerConfig)
-    implicit val context = LogicalPlanningContext(null, LogicalPlanProducer(metrics.cardinality), metrics, null, null, notificationLogger = devNullLogger)
+    implicit val context = LogicalPlanningContext(null, LogicalPlanProducer(metrics.cardinality), metrics, null, null, notificationLogger = devNullLogger,
+      costComparisonListener = devNullListener)
     pickBestPlanUsingHintsAndCost(context)(candidates) should equal(Some(winner))
     pickBestPlanUsingHintsAndCost(context)(candidates.reverse) should equal(Some(winner))
   }

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/PlanEventHorizonTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/PlanEventHorizonTest.scala
@@ -20,20 +20,21 @@
 package org.neo4j.cypher.internal.compiler.v3_3.planner.logical
 
 import org.neo4j.cypher.internal.compiler.v3_3.planner.ProcedureCallProjection
-import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.steps.LogicalPlanProducer
+import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.steps.{CostComparisonListener, LogicalPlanProducer}
 import org.neo4j.cypher.internal.compiler.v3_3.spi.PlanContext
+import org.neo4j.cypher.internal.frontend.v3_3.SemanticTable
 import org.neo4j.cypher.internal.frontend.v3_3.ast._
 import org.neo4j.cypher.internal.frontend.v3_3.phases.InternalNotificationLogger
 import org.neo4j.cypher.internal.frontend.v3_3.symbols.{CTInteger, CTList, CTNode}
 import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
-import org.neo4j.cypher.internal.frontend.v3_3.{DummyPosition, SemanticTable}
 import org.neo4j.cypher.internal.ir.v3_3.{Cardinality, CardinalityEstimation, RegularPlannerQuery, RegularQueryProjection}
 import org.neo4j.cypher.internal.v3_3.logical.plans._
 
 class PlanEventHorizonTest extends CypherFunSuite with AstConstructionTestSupport {
 
   implicit val context = LogicalPlanningContext(mock[PlanContext], LogicalPlanProducer(mock[Metrics.CardinalityModel]),
-    mock[Metrics], SemanticTable(), mock[QueryGraphSolver], notificationLogger = mock[InternalNotificationLogger])
+    mock[Metrics], SemanticTable(), mock[QueryGraphSolver], notificationLogger = mock[InternalNotificationLogger],
+    costComparisonListener = mock[CostComparisonListener])
 
   test("should do projection if necessary") {
     // Given

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/idp/ExpandSolverStepTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/idp/ExpandSolverStepTest.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v3_3.planner.logical.idp
 
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.Metrics.CardinalityModel
-import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.steps.LogicalPlanProducer
+import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.steps.{CostComparisonListener, LogicalPlanProducer}
 import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.{LogicalPlanningContext, Metrics, QueryGraphSolver}
 import org.neo4j.cypher.internal.compiler.v3_3.spi.PlanContext
 import org.neo4j.cypher.internal.frontend.v3_3.ast._
@@ -59,7 +59,8 @@ class ExpandSolverStepTest extends CypherFunSuite  with AstConstructionTestSuppo
   private val qg = mock[QueryGraph]
 
   private implicit val context = LogicalPlanningContext(mock[PlanContext], LogicalPlanProducer(mock[CardinalityModel]),
-    mock[Metrics], mock[SemanticTable], mock[QueryGraphSolver], notificationLogger = mock[InternalNotificationLogger])
+    mock[Metrics], mock[SemanticTable], mock[QueryGraphSolver], notificationLogger = mock[InternalNotificationLogger],
+    costComparisonListener = mock[CostComparisonListener])
 
   test("does not expand based on empty table") {
     implicit val registry = IdRegistry[PatternRelationship]

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/idp/JoinSolverStepTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/idp/JoinSolverStepTest.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_3.planner.logical.idp
 
 import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.Metrics.CardinalityModel
-import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.steps.LogicalPlanProducer
+import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.steps.{CostComparisonListener, LogicalPlanProducer}
 import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.{LogicalPlanningContext, Metrics, QueryGraphSolver}
 import org.neo4j.cypher.internal.compiler.v3_3.spi.PlanContext
 import org.neo4j.cypher.internal.frontend.v3_3.phases.InternalNotificationLogger
@@ -34,7 +34,8 @@ class JoinSolverStepTest extends CypherFunSuite  {
   implicit def converter(s: Symbol): String = s.toString()
 
   private implicit val context = LogicalPlanningContext(mock[PlanContext], LogicalPlanProducer(mock[CardinalityModel]),
-    mock[Metrics], mock[SemanticTable], mock[QueryGraphSolver], notificationLogger = mock[InternalNotificationLogger])
+    mock[Metrics], mock[SemanticTable], mock[QueryGraphSolver], notificationLogger = mock[InternalNotificationLogger],
+    costComparisonListener = mock[CostComparisonListener])
 
   case class TestPlan(availableSymbols: Set[String] = Set.empty, solved: PlannerQuery with CardinalityEstimation = PlannerQuery.empty) extends LogicalPlan {
 

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/steps/countStorePlannerTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/steps/countStorePlannerTest.scala
@@ -151,7 +151,8 @@ class countStorePlannerTest extends CypherFunSuite with LogicalPlanningTestSuppo
   }
 
   implicit val context = LogicalPlanningContext(mock[PlanContext], LogicalPlanProducer(mock[Metrics.CardinalityModel]),
-    mock[Metrics], SemanticTable(), mock[QueryGraphSolver], notificationLogger = mock[InternalNotificationLogger])
+    mock[Metrics], SemanticTable(), mock[QueryGraphSolver], notificationLogger = mock[InternalNotificationLogger],
+    costComparisonListener = mock[CostComparisonListener])
 
   def producePlannerQuery(query: String, variable: String) = {
     val (pq, _) = producePlannerQueryForPattern(query)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/DebugToStringTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/DebugToStringTest.scala
@@ -41,6 +41,8 @@ class DebugToStringTest extends ExecutionEngineFunSuite {
                                 || 1 | ""                                                                   | ""                                                                        | 2.2               | 1.0             | "LOST" |
                                 || 1 | "Selection(ListBuffer(HasLabels(Variable(a),List(LabelName(A))))) {" | "Selection costs Cost(2.2) cardinality Cardinality(1.0)"                  | <null>            | <null>          | <null> |
                                 || 1 | "  LHS -> AllNodesScan(a, Set()) {}"                                 | "  AllNodesScan costs Cost(1.2) cardinality Cardinality(1.0)"             | <null>            | <null>          | <null> |
+                                || 1 | ""                                                                   | ""                                                                        | 0.0               | 1.0             | "LOST" |
+                                || 1 | "*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-"                       | "*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-"                            | <null>            | <null>          | <null> |
                                 || 0 | ""                                                                   | ""                                                                        | 2.2               | 1.0             | "WON"  |
                                 || 0 | "Selection(ListBuffer(HasLabels(Variable(a),List(LabelName(A))))) {" | "Selection costs Cost(2.2) cardinality Cardinality(1.0)"                  | <null>            | <null>          | <null> |
                                 || 0 | "  LHS -> AllNodesScan(a, Set()) {}"                                 | "  AllNodesScan costs Cost(1.2) cardinality Cardinality(1.0)"             | <null>            | <null>          | <null> |
@@ -48,8 +50,10 @@ class DebugToStringTest extends ExecutionEngineFunSuite {
                                 || 0 | "NodeHashJoin(Set(a)) {"                                             | "NodeHashJoin costs Cost(7.700000000000001) cardinality Cardinality(1.0)" | <null>            | <null>          | <null> |
                                 || 0 | "  LHS -> AllNodesScan(a, Set()) {}"                                 | "  AllNodesScan costs Cost(1.2) cardinality Cardinality(1.0)"             | <null>            | <null>          | <null> |
                                 || 0 | "  RHS -> NodeByLabelScan(a, LabelName(A), Set()) {}"                | "  NodeByLabelScan costs Cost(1.0) cardinality Cardinality(1.0)"          | <null>            | <null>          | <null> |
+                                || 0 | ""                                                                   | ""                                                                        | 0.0               | 1.0             | "LOST" |
+                                || 0 | "*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-"                       | "*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-"                            | <null>            | <null>          | <null> |
                                 |+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-                                |12 rows
+                                |16 rows
                                 |""".stripMargin)
     graph.execute("CYPHER debug=dumpCosts MATCH (a:A:B:C)-[:T]->(b:A:B:C) RETURN *").stream().count()
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/DebugToStringTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/DebugToStringTest.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import org.neo4j.cypher.ExecutionEngineFunSuite
+import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.WindowsStringSafe
+
+
+class DebugToStringTest extends ExecutionEngineFunSuite {
+
+  implicit val windowsSafe = WindowsStringSafe
+
+  /**
+    * This tests an internal feature that is not supported or critical for end users. Still nice to see that it works
+    * and what the expected outputs are.
+    */
+  test("cost reporting") {
+    val stringResult = graph.execute("CYPHER debug=dumpCosts MATCH (a:A) RETURN *").resultAsString()
+    stringResult should equal("""+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+                                || # | planText                                                             | planCost                                                                  | cost              | est cardinality | winner |
+                                |+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+                                || 1 | ""                                                                   | ""                                                                        | 1.0               | 1.0             | "WON"  |
+                                || 1 | "NodeByLabelScan(a, LabelName(A), Set()) {}"                         | "NodeByLabelScan costs Cost(1.0) cardinality Cardinality(1.0)"            | <null>            | <null>          | <null> |
+                                || 1 | ""                                                                   | ""                                                                        | 2.2               | 1.0             | "LOST" |
+                                || 1 | "Selection(ListBuffer(HasLabels(Variable(a),List(LabelName(A))))) {" | "Selection costs Cost(2.2) cardinality Cardinality(1.0)"                  | <null>            | <null>          | <null> |
+                                || 1 | "  LHS -> AllNodesScan(a, Set()) {}"                                 | "  AllNodesScan costs Cost(1.2) cardinality Cardinality(1.0)"             | <null>            | <null>          | <null> |
+                                || 0 | ""                                                                   | ""                                                                        | 2.2               | 1.0             | "WON"  |
+                                || 0 | "Selection(ListBuffer(HasLabels(Variable(a),List(LabelName(A))))) {" | "Selection costs Cost(2.2) cardinality Cardinality(1.0)"                  | <null>            | <null>          | <null> |
+                                || 0 | "  LHS -> AllNodesScan(a, Set()) {}"                                 | "  AllNodesScan costs Cost(1.2) cardinality Cardinality(1.0)"             | <null>            | <null>          | <null> |
+                                || 0 | ""                                                                   | ""                                                                        | 7.700000000000001 | 1.0             | "LOST" |
+                                || 0 | "NodeHashJoin(Set(a)) {"                                             | "NodeHashJoin costs Cost(7.700000000000001) cardinality Cardinality(1.0)" | <null>            | <null>          | <null> |
+                                || 0 | "  LHS -> AllNodesScan(a, Set()) {}"                                 | "  AllNodesScan costs Cost(1.2) cardinality Cardinality(1.0)"             | <null>            | <null>          | <null> |
+                                || 0 | "  RHS -> NodeByLabelScan(a, LabelName(A), Set()) {}"                | "  NodeByLabelScan costs Cost(1.0) cardinality Cardinality(1.0)"          | <null>            | <null>          | <null> |
+                                |+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+                                |12 rows
+                                |""".stripMargin)
+    graph.execute("CYPHER debug=dumpCosts MATCH (a:A:B:C)-[:T]->(b:A:B:C) RETURN *").stream().count()
+  }
+}


### PR DESCRIPTION
By prepending a query with "-dumpCosts", the result
of the query won't be the normal output - instead,
the output will be a log of all cost comparisons done
to plan the query.

This is a 3.3 version of #11651

When merging this PR, it should be forward merged with a null merge