### PR TITLE
Increase the swapper id limit.

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/mem/GrabAllocator.java
+++ b/community/io/src/main/java/org/neo4j/io/mem/GrabAllocator.java
@@ -98,7 +98,7 @@ public final class GrabAllocator implements MemoryAllocator
                 grabSize = bytes;
                 Grab nextGrab = grabs == null ? null : grabs.next;
                 Grab allocationGrab = new Grab( nextGrab, grabSize, memoryTracker );
-                if ( !allocationGrab.canAllocate( bytes ) )
+                if ( !allocationGrab.canAllocate( bytes, alignment ) )
                 {
                     allocationGrab.free();
                     grabSize = bytes + alignment;
@@ -110,13 +110,13 @@ public final class GrabAllocator implements MemoryAllocator
                 return allocation;
             }
 
-            if ( grabs == null || !grabs.canAllocate( bytes ) )
+            if ( grabs == null || !grabs.canAllocate( bytes, alignment ) )
             {
                 if ( grabSize < bytes )
                 {
                     grabSize = bytes;
                     Grab grab = new Grab( grabs, grabSize, memoryTracker );
-                    if ( grab.canAllocate( bytes ) )
+                    if ( grab.canAllocate( bytes, alignment ) )
                     {
                         memoryReserve -= grabSize;
                         grabs = grab;
@@ -203,12 +203,16 @@ public final class GrabAllocator implements MemoryAllocator
 
         private long nextAligned( long pointer, long alignment )
         {
-            long mask = alignment - 1;
-            if ( (pointer & ~mask) == pointer )
+            if ( alignment == 1 )
             {
                 return pointer;
             }
-            return (pointer + mask) & ~mask;
+            long off = pointer % alignment;
+            if ( off == 0 )
+            {
+                return pointer;
+            }
+            return pointer + (alignment - off);
         }
 
         long allocate( long bytes, long alignment )
@@ -223,9 +227,9 @@ public final class GrabAllocator implements MemoryAllocator
             UnsafeUtil.free( address, limit - address, memoryTracker );
         }
 
-        boolean canAllocate( long bytes )
+        boolean canAllocate( long bytes, long alignment )
         {
-            return nextPointer + bytes <= limit;
+            return nextAligned( nextPointer, alignment ) + bytes <= limit;
         }
 
         Grab setNext( Grab grab )

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
@@ -60,10 +60,11 @@ final class MuninnPagedFile extends PageList implements PagedFile, Flushable
     private static final int headerStateRefCountMax = 0x7FFF;
     private static final long headerStateRefCountMask = 0x7FFF_0000_0000_0000L;
     private static final long headerStateLastPageIdMask = 0x8000_FFFF_FFFF_FFFFL;
+    private static final int PF_LOCK_MASK = PF_SHARED_WRITE_LOCK | PF_SHARED_READ_LOCK;
 
     final MuninnPageCache pageCache;
     final int filePageSize;
-    final PageCacheTracer pageCacheTracer;
+    private final PageCacheTracer pageCacheTracer;
     final LatchMap pageFaultLatches;
 
     // This is the table where we translate file-page-ids to cache-page-ids. Only one thread can perform a resize at
@@ -173,29 +174,37 @@ final class MuninnPagedFile extends PageList implements PagedFile, Flushable
     @Override
     public PageCursor io( long pageId, int pf_flags )
     {
-        int lockMask = PF_SHARED_WRITE_LOCK | PF_SHARED_READ_LOCK;
-        if ( (pf_flags & lockMask) == 0 )
-        {
-            throw new IllegalArgumentException(
-                    "Must specify either PF_SHARED_WRITE_LOCK or PF_SHARED_READ_LOCK" );
-        }
-        if ( (pf_flags & lockMask) == lockMask )
-        {
-            throw new IllegalArgumentException(
-                    "Cannot specify both PF_SHARED_WRITE_LOCK and PF_SHARED_READ_LOCK" );
-        }
+        int lockFlags = pf_flags & PF_LOCK_MASK;
         MuninnPageCursor cursor;
-        if ( (pf_flags & PF_SHARED_READ_LOCK) == 0 )
+        if ( lockFlags == PF_SHARED_READ_LOCK )
+        {
+            cursor = cursorPool.takeReadCursor( pageId, pf_flags );
+        }
+        else if ( lockFlags == PF_SHARED_WRITE_LOCK )
         {
             cursor = cursorPool.takeWriteCursor( pageId, pf_flags );
         }
         else
         {
-            cursor = cursorPool.takeReadCursor( pageId, pf_flags );
+            throw wrongLocksArgument( lockFlags );
         }
 
         cursor.rewind();
         return cursor;
+    }
+
+    private IllegalArgumentException wrongLocksArgument( int lockFlags )
+    {
+        if ( lockFlags == 0 )
+        {
+            return new IllegalArgumentException(
+                    "Must specify either PF_SHARED_WRITE_LOCK or PF_SHARED_READ_LOCK" );
+        }
+        else
+        {
+            return new IllegalArgumentException(
+                    "Cannot specify both PF_SHARED_WRITE_LOCK and PF_SHARED_READ_LOCK" );
+        }
     }
 
     @Override
@@ -525,15 +534,20 @@ final class MuninnPagedFile extends PageList implements PagedFile, Flushable
         long state = getHeaderState();
         if ( refCountOf( state ) == 0 )
         {
-            FileIsNotMappedException exception = new FileIsNotMappedException( file() );
-            Exception closedBy = closeStackTrace;
-            if ( closedBy != null )
-            {
-                exception.addSuppressed( closedBy );
-            }
-            throw exception;
+            throw fileIsNotMappedException();
         }
         return state & headerStateLastPageIdMask;
+    }
+
+    private FileIsNotMappedException fileIsNotMappedException()
+    {
+        FileIsNotMappedException exception = new FileIsNotMappedException( file() );
+        Exception closedBy = closeStackTrace;
+        if ( closedBy != null )
+        {
+            exception.addSuppressed( closedBy );
+        }
+        return exception;
     }
 
     private long getHeaderState()
@@ -651,7 +665,7 @@ final class MuninnPagedFile extends PageList implements PagedFile, Flushable
      * Remove the mapping of the given filePageId from the translation table, and return the evicted page object.
      * @param filePageId The id of the file page to evict.
      */
-    void evictPage( long filePageId )
+    private void evictPage( long filePageId )
     {
         int chunkId = computeChunkId( filePageId );
         long chunkOffset = computeChunkOffset( filePageId );

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/PageList.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/PageList.java
@@ -35,17 +35,17 @@ import static org.neo4j.util.FeatureToggles.flag;
 
 /**
  * The PageList maintains the off-heap meta-data for the individual memory pages.
- *
+ * <p>
  * The meta-data for each page is the following:
  *
  * <table>
- *     <tr><th>Bytes</th><th>Use</th></tr>
- *     <tr><td>8</td><td>Sequence lock word.</td></tr>
- *     <tr><td>8</td><td>Pointer to the memory page.</td></tr>
- *     <tr><td>8</td><td>Last modified transaction id.</td></tr>
- *     <tr><td>5</td><td>File page id.</td></tr>
- *     <tr><td>1</td><td>Usage stamp. Optimistically incremented; truncated to a max of 4.</td></tr>
- *     <tr><td>2</td><td>Page swapper id.</td></tr>
+ * <tr><th>Bytes</th><th>Use</th></tr>
+ * <tr><td>8</td><td>Sequence lock word.</td></tr>
+ * <tr><td>8</td><td>Pointer to the memory page.</td></tr>
+ * <tr><td>8</td><td>Last modified transaction id.</td></tr>
+ * <tr><td>5</td><td>File page id.</td></tr>
+ * <tr><td>1</td><td>Usage stamp. Optimistically incremented; truncated to a max of 4.</td></tr>
+ * <tr><td>2</td><td>Page swapper id.</td></tr>
  * </table>
  */
 class PageList
@@ -151,6 +151,7 @@ class PageList
      * All data and state will be shared between this and the given {@code PageList}. This means that changing the page
      * list state through one has the same effect as changing it through the other – they are both effectively the same
      * object.
+     *
      * @param pageList The {@code PageList} instance whose state to copy.
      */
     PageList( PageList pageList )
@@ -225,6 +226,7 @@ class PageList
     /**
      * Turn a {@code pageId} into a {@code pageRef} that can be used for accessing and manipulating the given page
      * using the other methods in this class.
+     *
      * @param pageId The {@code pageId} to turn into a {@code pageRef}.
      * @return A {@code pageRef} which is an opaque, internal and direct pointer to the meta-data of the given memory
      * page.
@@ -485,7 +487,8 @@ class PageList
     }
 
     private static IllegalStateException cannotFaultException( long pageRef, PageSwapper swapper, int swapperId,
-                                                        long filePageId, int currentSwapper, long currentFilePageId )
+                                                               long filePageId, int currentSwapper,
+                                                               long currentFilePageId )
     {
         String msg = format(
                 "Cannot fault page {filePageId = %s, swapper = %s (swapper id = %s)} into " +

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/PageList.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/PageList.java
@@ -167,12 +167,12 @@ class PageList
     /**
      * @return The capacity of the page list.
      */
-    public int getPageCount()
+    int getPageCount()
     {
         return pageCount;
     }
 
-    public SwapperSet getSwappers()
+    SwapperSet getSwappers()
     {
         return swappers;
     }
@@ -185,14 +185,14 @@ class PageList
      * @return A {@code pageRef} which is an opaque, internal and direct pointer to the meta-data of the given memory
      * page.
      */
-    public long deref( int pageId )
+    long deref( int pageId )
     {
         //noinspection UnnecessaryLocalVariable
         long id = pageId; // convert to long to avoid int multiplication
         return baseAddress + (id * META_DATA_BYTES_PER_PAGE);
     }
 
-    public int toId( long pageRef )
+    int toId( long pageRef )
     {
         // >> 5 is equivalent to dividing by 32, META_DATA_BYTES_PER_PAGE.
         return (int) ((pageRef - baseAddress) >> 5);
@@ -218,82 +218,82 @@ class PageList
         return pageRef + OFFSET_PAGE_BINDING;
     }
 
-    public long tryOptimisticReadLock( long pageRef )
+    long tryOptimisticReadLock( long pageRef )
     {
         return OffHeapPageLock.tryOptimisticReadLock( offLock( pageRef ) );
     }
 
-    public boolean validateReadLock( long pageRef, long stamp )
+    boolean validateReadLock( long pageRef, long stamp )
     {
         return OffHeapPageLock.validateReadLock( offLock( pageRef ), stamp );
     }
 
-    public boolean isModified( long pageRef )
+    boolean isModified( long pageRef )
     {
         return OffHeapPageLock.isModified( offLock( pageRef ) );
     }
 
-    public boolean isExclusivelyLocked( long pageRef )
+    boolean isExclusivelyLocked( long pageRef )
     {
         return OffHeapPageLock.isExclusivelyLocked( offLock( pageRef ) );
     }
 
-    public boolean tryWriteLock( long pageRef )
+    boolean tryWriteLock( long pageRef )
     {
         return OffHeapPageLock.tryWriteLock( offLock( pageRef ) );
     }
 
-    public void unlockWrite( long pageRef )
+    void unlockWrite( long pageRef )
     {
         OffHeapPageLock.unlockWrite( offLock( pageRef ) );
     }
 
-    public long unlockWriteAndTryTakeFlushLock( long pageRef )
+    long unlockWriteAndTryTakeFlushLock( long pageRef )
     {
         return OffHeapPageLock.unlockWriteAndTryTakeFlushLock( offLock( pageRef ) );
     }
 
-    public boolean tryExclusiveLock( long pageRef )
+    boolean tryExclusiveLock( long pageRef )
     {
         return OffHeapPageLock.tryExclusiveLock( offLock( pageRef ) );
     }
 
-    public long unlockExclusive( long pageRef )
+    long unlockExclusive( long pageRef )
     {
         return OffHeapPageLock.unlockExclusive( offLock( pageRef ) );
     }
 
-    public void unlockExclusiveAndTakeWriteLock( long pageRef )
+    void unlockExclusiveAndTakeWriteLock( long pageRef )
     {
         OffHeapPageLock.unlockExclusiveAndTakeWriteLock( offLock( pageRef ) );
     }
 
-    public long tryFlushLock( long pageRef )
+    long tryFlushLock( long pageRef )
     {
         return OffHeapPageLock.tryFlushLock( offLock( pageRef ) );
     }
 
-    public void unlockFlush( long pageRef, long stamp, boolean success )
+    void unlockFlush( long pageRef, long stamp, boolean success )
     {
         OffHeapPageLock.unlockFlush( offLock( pageRef ), stamp, success );
     }
 
-    public void explicitlyMarkPageUnmodifiedUnderExclusiveLock( long pageRef )
+    void explicitlyMarkPageUnmodifiedUnderExclusiveLock( long pageRef )
     {
         OffHeapPageLock.explicitlyMarkPageUnmodifiedUnderExclusiveLock( offLock( pageRef ) );
     }
 
-    public int getCachePageSize()
+    int getCachePageSize()
     {
         return cachePageSize;
     }
 
-    public long getAddress( long pageRef )
+    long getAddress( long pageRef )
     {
         return UnsafeUtil.getLong( offAddress( pageRef ) );
     }
 
-    public void initBuffer( long pageRef )
+    void initBuffer( long pageRef )
     {
         if ( getAddress( pageRef ) == 0L )
         {
@@ -310,7 +310,7 @@ class PageList
     /**
      * Increment the usage stamp to at most 4.
      **/
-    public void incrementUsage( long pageRef )
+    void incrementUsage( long pageRef )
     {
         // This is intentionally left benignly racy for performance.
         long address = offPageBinding( pageRef );
@@ -331,7 +331,7 @@ class PageList
     /**
      * Decrement the usage stamp. Returns true if it reaches 0.
      **/
-    public boolean decrementUsage( long pageRef )
+    boolean decrementUsage( long pageRef )
     {
         // This is intentionally left benignly racy for performance.
         long address = offPageBinding( pageRef );
@@ -346,7 +346,7 @@ class PageList
         return usage == 0;
     }
 
-    public long getFilePageId( long pageRef )
+    long getFilePageId( long pageRef )
     {
         long filePageId = UnsafeUtil.getLong( offPageBinding( pageRef ) ) >>> SHIFT_FILE_PAGE_ID;
         return filePageId == MAX_FILE_PAGE_ID ? PageCursor.UNBOUND_PAGE_ID : filePageId;
@@ -383,7 +383,7 @@ class PageList
         UnsafeUtil.compareAndSetMaxLong( null, offLastModifiedTransactionId( pageRef ), modifierTxId );
     }
 
-    public int getSwapperId( long pageRef )
+    int getSwapperId( long pageRef )
     {
         long v = UnsafeUtil.getLong( offPageBinding( pageRef ) ) >>> SHIFT_SWAPPER_ID;
         return (int) (v & MASK_SHIFTED_SWAPPER_ID); // 21 bits.
@@ -397,12 +397,12 @@ class PageList
         UnsafeUtil.putLong( address, v + swapperId );
     }
 
-    public boolean isLoaded( long pageRef )
+    boolean isLoaded( long pageRef )
     {
         return getFilePageId( pageRef ) != PageCursor.UNBOUND_PAGE_ID;
     }
 
-    public boolean isBoundTo( long pageRef, int swapperId, long filePageId )
+    boolean isBoundTo( long pageRef, int swapperId, long filePageId )
     {
         long address = offPageBinding( pageRef );
         long expectedBinding = (filePageId << SHIFT_PARTIAL_FILE_PAGE_ID) + swapperId;
@@ -410,7 +410,7 @@ class PageList
         return expectedBinding == actualBinding;
     }
 
-    public void fault( long pageRef, PageSwapper swapper, int swapperId, long filePageId, PageFaultEvent event )
+    void fault( long pageRef, PageSwapper swapper, int swapperId, long filePageId, PageFaultEvent event )
             throws IOException
     {
         if ( swapper == null )
@@ -455,7 +455,7 @@ class PageList
         return new IllegalStateException( msg );
     }
 
-    public boolean tryEvict( long pageRef, EvictionEventOpportunity evictionOpportunity ) throws IOException
+    boolean tryEvict( long pageRef, EvictionEventOpportunity evictionOpportunity ) throws IOException
     {
         if ( tryExclusiveLock( pageRef ) )
         {
@@ -526,14 +526,7 @@ class PageList
         UnsafeUtil.putLong( offPageBinding( pageRef ), UNBOUND_PAGE_BINDING );
     }
 
-    public String toString( long pageRef )
-    {
-        StringBuilder sb = new StringBuilder();
-        toString( pageRef, sb );
-        return sb.toString();
-    }
-
-    public void toString( long pageRef, StringBuilder sb )
+    void toString( long pageRef, StringBuilder sb )
     {
         sb.append( "Page[ id = " ).append( toId( pageRef ) );
         sb.append( ", address = " ).append( getAddress( pageRef ) );

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/PageList.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/PageList.java
@@ -52,10 +52,19 @@ class PageList
 {
     private static final boolean forceSlowMemoryClear = flag( PageList.class, "forceSlowMemoryClear", false );
 
-    public static final int META_DATA_BYTES_PER_PAGE = 32;
-    public static final long MAX_PAGES = Integer.MAX_VALUE;
+    static final int META_DATA_BYTES_PER_PAGE = 32;
+    static final long MAX_PAGES = Integer.MAX_VALUE;
 
     private static final int UNBOUND_LAST_MODIFIED_TX_ID = -1;
+    private static final long MASK_USAGE_COUNT = 0x07;
+    private static final long MASK_NOT_USAGE_COUNT = ~MASK_USAGE_COUNT;
+    private static final int MAX_USAGE_COUNT = 4;
+    private static final int MASK_NOT_FILE_PAGE_ID = 0xFFFFFF;
+    private static final int SHIFT_FILE_PAGE_ID = 24;
+    private static final int SHIFT_SWAPPER_ID = 3;
+    private static final long MASK_SHIFTED_SWAPPER_ID = 0b1_11111_11111_11111_11111;
+    private static final long MASK_NOT_SWAPPER_ID = ~(MASK_SHIFTED_SWAPPER_ID << SHIFT_SWAPPER_ID);
+    private static final long UNBOUND_PAGE_BINDING = PageCursor.UNBOUND_PAGE_ID << SHIFT_FILE_PAGE_ID;
 
     // 40 bits for file page id
     private static final long MAX_FILE_PAGE_ID = 0b11111111_11111111_11111111_11111111_11111111L;
@@ -68,6 +77,7 @@ class PageList
     private static final int OFFSET_SWAPPER_ID = 29; // 2 bytes, plus the 5 high-bits from usage counter
     @SuppressWarnings( "unused" )
     private static final int OFFSET_USAGE_COUNTER = 31; // 1 byte, but only the 3 low bits.
+    // The last word-line, with the file page id, swapper id, and usage counter, is called the page binding word.
 
     // todo we can alternatively also make use of the lower 12 bits of the address field, because
     // todo the addresses are page aligned, and we can assume them to be at least 4096 bytes in size.
@@ -178,7 +188,7 @@ class PageList
             UnsafeUtil.putLong( address += Long.BYTES, initialLockWord ); // lock word
             UnsafeUtil.putLong( address += Long.BYTES, 0 ); // pointer
             UnsafeUtil.putLong( address += Long.BYTES, 0 ); // last tx id
-            UnsafeUtil.putLong( address += Long.BYTES, MAX_FILE_PAGE_ID << 24 );
+            UnsafeUtil.putLong( address += Long.BYTES, UNBOUND_PAGE_BINDING );
         }
     }
 
@@ -247,7 +257,7 @@ class PageList
         return pageRef + OFFSET_ADDRESS;
     }
 
-    private long offFilePageId( long pageRef )
+    private long offPageBinding( long pageRef )
     {
         return pageRef + OFFSET_FILE_PAGE_ID;
     }
@@ -338,7 +348,7 @@ class PageList
 
     private byte getUsageCounter( long pageRef )
     {
-        return (byte) (UnsafeUtil.getLongVolatile( offFilePageId( pageRef ) ) & 0x07);
+        return (byte) (UnsafeUtil.getLongVolatile( offPageBinding( pageRef ) ) & MASK_USAGE_COUNT);
     }
 
     /**
@@ -347,10 +357,10 @@ class PageList
     public void incrementUsage( long pageRef )
     {
         // This is intentionally left benignly racy for performance.
-        long address = offFilePageId( pageRef );
+        long address = offPageBinding( pageRef );
         long v = UnsafeUtil.getLongVolatile( address );
-        long usage = v & 0x07;
-        if ( usage < 4 ) // avoid cache sloshing by not doing a write if counter is already maxed out
+        long usage = v & MASK_USAGE_COUNT;
+        if ( usage < MAX_USAGE_COUNT ) // avoid cache sloshing by not doing a write if counter is already maxed out
         {
             usage++;
             // Use compareAndSwapLong to only actually store the updated count if nothing else changed
@@ -358,7 +368,7 @@ class PageList
             // Those fields are updated under guard of the exclusive lock, but we *might* race with
             // that here, and in that case we would never want a usage counter update to clobber a page
             // binding update.
-            UnsafeUtil.compareAndSwapLong( null, address, v, (v & 0xFFFFFFFF_FFFFFFF8L) + usage );
+            UnsafeUtil.compareAndSwapLong( null, address, v, (v & MASK_NOT_USAGE_COUNT) + usage );
         }
     }
 
@@ -368,21 +378,21 @@ class PageList
     public boolean decrementUsage( long pageRef )
     {
         // This is intentionally left benignly racy for performance.
-        long address = offFilePageId( pageRef );
+        long address = offPageBinding( pageRef );
         long v = UnsafeUtil.getLongVolatile( address );
-        long usage = v & 0x07;
+        long usage = v & MASK_USAGE_COUNT;
         if ( usage > 0 )
         {
             usage--;
             // See `incrementUsage` about why we use `compareAndSwapLong`.
-            UnsafeUtil.compareAndSwapLong( null, address, v, (v & 0xFFFFFFFF_FFFFFFF8L) + usage );
+            UnsafeUtil.compareAndSwapLong( null, address, v, (v & MASK_NOT_USAGE_COUNT) + usage );
         }
         return usage == 0;
     }
 
     public long getFilePageId( long pageRef )
     {
-        long filePageId = UnsafeUtil.getLong( offFilePageId( pageRef ) ) >>> 24;
+        long filePageId = UnsafeUtil.getLong( offPageBinding( pageRef ) ) >>> SHIFT_FILE_PAGE_ID;
         return filePageId == MAX_FILE_PAGE_ID ? PageCursor.UNBOUND_PAGE_ID : filePageId;
     }
 
@@ -393,9 +403,9 @@ class PageList
             throw new IllegalArgumentException(
                     format( "File page id: %s is bigger then max supported value %s.", filePageId, MAX_FILE_PAGE_ID ) );
         }
-        long address = offFilePageId( pageRef );
+        long address = offPageBinding( pageRef );
         long v = UnsafeUtil.getLong( address );
-        filePageId = (filePageId << 24) + (v & 0xFFFFFF);
+        filePageId = (filePageId << SHIFT_FILE_PAGE_ID) + (v & MASK_NOT_FILE_PAGE_ID);
         UnsafeUtil.putLong( address, filePageId );
     }
 
@@ -419,15 +429,15 @@ class PageList
 
     public int getSwapperId( long pageRef )
     {
-        long v = UnsafeUtil.getLong( offFilePageId( pageRef ) ) >>> 3;
-        return (int) (v & 0b1_11111_11111_11111_11111); // 21 bits.
+        long v = UnsafeUtil.getLong( offPageBinding( pageRef ) ) >>> SHIFT_SWAPPER_ID;
+        return (int) (v & MASK_SHIFTED_SWAPPER_ID); // 21 bits.
     }
 
     private void setSwapperId( long pageRef, int swapperId )
     {
-        swapperId = swapperId << 3;
-        long address = offFilePageId( pageRef );
-        long v = UnsafeUtil.getLong( address ) & (~(0b1_11111_11111_11111_11111 << 3));
+        swapperId = swapperId << SHIFT_SWAPPER_ID;
+        long address = offPageBinding( pageRef );
+        long v = UnsafeUtil.getLong( address ) & MASK_NOT_SWAPPER_ID;
         UnsafeUtil.putLong( address, v + swapperId );
     }
 
@@ -551,10 +561,9 @@ class PageList
         }
     }
 
-    protected void clearBinding( long pageRef )
+    private void clearBinding( long pageRef )
     {
-        setFilePageId( pageRef, PageCursor.UNBOUND_PAGE_ID );
-        setSwapperId( pageRef, (short) 0 );
+        UnsafeUtil.putLong( offPageBinding( pageRef ), UNBOUND_PAGE_BINDING );
     }
 
     public String toString( long pageRef )

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/SwapperSet.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/SwapperSet.java
@@ -45,7 +45,7 @@ final class SwapperSet
     // The tombstone is used as a marker to reserve allocation entries that have been freed, but not yet vacuumed.
     // An allocation cannot be reused until it has been vacuumed.
     private static final SwapperMapping TOMBSTONE = new SwapperMapping( 0, null );
-    private static final int MAX_SWAPPER_ID = Short.MAX_VALUE;
+    private static final int MAX_SWAPPER_ID = (1 << 21) - 1;
     private volatile SwapperMapping[] swapperMappings = new SwapperMapping[] { SENTINEL };
     private final PrimitiveIntSet free = Primitive.intSet();
     private final Object vacuumLock = new Object();
@@ -69,7 +69,7 @@ final class SwapperSet
     /**
      * Get the {@link SwapperMapping} for the given swapper id.
      */
-    SwapperMapping getAllocation( short id )
+    SwapperMapping getAllocation( int id )
     {
         checkId( id );
         SwapperMapping swapperMapping = swapperMappings[id];
@@ -197,10 +197,10 @@ final class SwapperSet
         }
     }
 
-    synchronized short countAvailableIds()
+    synchronized int countAvailableIds()
     {
         // the max id is one less than the allowed count, but we subtract one for the reserved id 0
-        short available = MAX_SWAPPER_ID;
+        int available = MAX_SWAPPER_ID;
         available -= swapperMappings.length; // ids that are allocated are not available
         available += free.size(); // add back the ids that are free to be reused
         return available;

--- a/community/io/src/test/java/org/neo4j/io/mem/MemoryAllocatorTest.java
+++ b/community/io/src/test/java/org/neo4j/io/mem/MemoryAllocatorTest.java
@@ -60,6 +60,27 @@ public class MemoryAllocatorTest
     }
 
     @Test
+    public void allocatedPointerMustBeAlignedToArbitraryByte()
+    {
+        int pageSize = UnsafeUtil.pageSize();
+        for ( int initialOffset = 0; initialOffset < 8; initialOffset++ )
+        {
+            for ( int i = 0; i < pageSize - 1; i++ )
+            {
+                MemoryAllocator mman = createAllocator( ONE_PAGE );
+                mman.allocateAligned( initialOffset, 1 );
+                long alignment = 1 + i;
+                long address = mman.allocateAligned( PageCache.PAGE_SIZE, alignment );
+                assertThat( "With initial offset " + initialOffset +
+                            ", iteration " + i +
+                            ", aligning to " + alignment +
+                            " and got address " + address,
+                        address % alignment, is( 0L ) );
+            }
+        }
+    }
+
+    @Test
     public void mustBeAbleToAllocatePastMemoryLimit()
     {
         MemoryAllocator mman = createAllocator( ONE_PAGE );
@@ -68,6 +89,24 @@ public class MemoryAllocatorTest
             assertThat( mman.allocateAligned( 1, 2 ) % 2, is( 0L ) );
         }
         // Also asserts that no OutOfMemoryError is thrown.
+    }
+
+    @Test
+    public void allocatedPointersMustBeAlignedPastMemoryLimit()
+    {
+        MemoryAllocator mman = createAllocator( ONE_PAGE );
+        for ( int i = 0; i < 4100; i++ )
+        {
+            assertThat( mman.allocateAligned( 1, 2 ) % 2, is( 0L ) );
+        }
+
+        int pageSize = UnsafeUtil.pageSize();
+        for ( int i = 0; i < pageSize - 1; i++ )
+        {
+            int alignment = pageSize - i;
+            long address = mman.allocateAligned( PageCache.PAGE_SIZE, alignment );
+            assertThat( "iteration " + i + ", aligning to " + alignment,  address % alignment, is( 0L ) );
+        }
     }
 
     @Test( expected = IllegalArgumentException.class )

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/PageListTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/PageListTest.java
@@ -1369,7 +1369,7 @@ public class PageListTest
     public void pageMustBeLoadedAndBoundAfterFault() throws Exception
     {
         // exclusive lock implied by constructor
-        short swapperId = 1;
+        int swapperId = 1;
         long filePageId = 42;
         pageList.initBuffer( pageRef );
         pageList.fault( pageRef, DUMMY_SWAPPER, swapperId, filePageId, PageFaultEvent.NULL );
@@ -1383,7 +1383,7 @@ public class PageListTest
     public void pageWith5BytesFilePageIdMustBeLoadedAndBoundAfterFault() throws Exception
     {
         // exclusive lock implied by constructor
-        short swapperId = 12;
+        int swapperId = 12;
         long filePageId = Integer.MAX_VALUE + 1L;
         pageList.initBuffer( pageRef );
         pageList.fault( pageRef, DUMMY_SWAPPER, swapperId, filePageId, PageFaultEvent.NULL );
@@ -1405,7 +1405,7 @@ public class PageListTest
                 throw new IOException( "boo" );
             }
         };
-        short swapperId = 1;
+        int swapperId = 1;
         long filePageId = 42;
         pageList.initBuffer( pageRef );
         try
@@ -1418,7 +1418,7 @@ public class PageListTest
             assertThat( e.getMessage(), is( "boo" ) );
         }
         assertThat( pageList.getFilePageId( pageRef ), is( filePageId ) );
-        assertThat( pageList.getSwapperId( pageRef ), is( (short) 0 ) ); // 0 means not bound
+        assertThat( pageList.getSwapperId( pageRef ), is( 0 ) ); // 0 means not bound
         assertTrue( pageList.isLoaded( pageRef ) );
         assertFalse( pageList.isBoundTo( pageRef, swapperId, filePageId ) );
     }
@@ -1631,16 +1631,16 @@ public class PageListTest
     public void pageMustNotBeBoundAfterSuccessfulEviction() throws Exception
     {
         pageList.unlockExclusive( pageRef );
-        short swapperId = swappers.allocate( DUMMY_SWAPPER );
+        int swapperId = swappers.allocate( DUMMY_SWAPPER );
         doFault( swapperId, 42 ); // page now bound & exclusively locked
         pageList.unlockExclusive( pageRef ); // no longer exclusively locked; can now be evicted
         assertTrue( pageList.isBoundTo( pageRef, (short) 1, 42 ) );
         assertTrue( pageList.isLoaded( pageRef ) );
-        assertThat( pageList.getSwapperId( pageRef ), is( (short) 1 ) );
+        assertThat( pageList.getSwapperId( pageRef ), is( 1 ) );
         pageList.tryEvict( pageRef, EvictionRunEvent.NULL );
         assertFalse( pageList.isBoundTo( pageRef, (short) 1, 42 ) );
         assertFalse( pageList.isLoaded( pageRef ) );
-        assertThat( pageList.getSwapperId( pageRef ), is( (short) 0 ) );
+        assertThat( pageList.getSwapperId( pageRef ), is( 0 ) );
     }
 
     @Test
@@ -2071,7 +2071,7 @@ public class PageListTest
         doFault( swapperId, Long.MAX_VALUE );
     }
 
-    private void doFault( short swapperId, long filePageId ) throws IOException
+    private void doFault( int swapperId, long filePageId ) throws IOException
     {
         assertTrue( pageList.tryExclusiveLock( pageRef ) );
         pageList.initBuffer( pageRef );

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/SequenceLockStressIT.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/SequenceLockStressIT.java
@@ -21,6 +21,7 @@ package org.neo4j.io.pagecache.impl.muninn;
 
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -35,28 +36,35 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.neo4j.memory.GlobalMemoryTracker;
 import org.neo4j.test.rule.RepeatRule;
 import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
 public class SequenceLockStressIT
 {
-    private static final ExecutorService executor = Executors.newCachedThreadPool( new DaemonThreadFactory() );
+    private static ExecutorService executor;
+    private static long lockAddr;
+
+    @BeforeClass
+    public static void initialise()
+    {
+        lockAddr = UnsafeUtil.allocateMemory( Long.BYTES );
+        executor = Executors.newCachedThreadPool( new DaemonThreadFactory() );
+    }
 
     @AfterClass
-    public static void shutDownExecutor()
+    public static void cleanup()
     {
         executor.shutdown();
+        UnsafeUtil.free( lockAddr, Long.BYTES, GlobalMemoryTracker.INSTANCE );
     }
 
     @Rule
     public RepeatRule repeatRule = new RepeatRule();
 
-    private long lockAddr;
-
     @Before
     public void allocateLock()
     {
-        lockAddr = UnsafeUtil.allocateMemory( Long.BYTES );
         UnsafeUtil.putLong( lockAddr, 0 );
     }
 

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/SwapperSetTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/SwapperSetTest.java
@@ -188,12 +188,12 @@ public class SwapperSetTest
     public void mustKeepTrackOfAvailableSwapperIds()
     {
         PageSwapper swapper = new DummyPageSwapper( "a", 42 );
-        short initial = Short.MAX_VALUE - 1;
+        int initial = (1 << 21) - 2;
         assertThat( set.countAvailableIds(), is( initial ) );
         int id = set.allocate( swapper );
-        assertThat( set.countAvailableIds(), is( (short) (initial - 1) ) );
+        assertThat( set.countAvailableIds(), is( initial - 1 ) );
         set.free( id );
-        assertThat( set.countAvailableIds(), is( (short) (initial - 1) ) );
+        assertThat( set.countAvailableIds(), is( initial - 1 ) );
         set.vacuum( x -> {} );
         assertThat( set.countAvailableIds(), is( initial ) );
     }


### PR DESCRIPTION
This means that the page cache can now have roughly 2 million files mapped, instead of the 32.768 it could handle before.

This is important as we have more and more indexes that are backed by the page cache.

I'm not sure if we should target this to 3.4 or 3.4.1.