### PR TITLE
Disable restriction on open maps as arguments to point function

### DIFF
--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/PointFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/PointFunction.scala
@@ -32,15 +32,14 @@ import org.neo4j.values.virtual.{MapValue, VirtualNodeValue, VirtualRelationship
 import scala.collection.JavaConverters._
 
 case class PointFunction(data: Expression) extends NullInNullOutExpression(data) {
-  val allowOpenMaps = true
-
   override def compute(value: AnyValue, ctx: ExecutionContext, state: QueryState): AnyValue = value match {
     case IsMap(mapCreator) =>
       val map = mapCreator(state.query)
       if (containsNull(map)) {
         Values.NO_VALUE
       } else {
-        if (allowOpenMaps || value.isInstanceOf[VirtualNodeValue] || value.isInstanceOf[VirtualRelationshipValue]) {
+        //TODO: We might consider removing this code if the PointBuilder.allowOpenMaps=true remains default
+        if (value.isInstanceOf[VirtualNodeValue] || value.isInstanceOf[VirtualRelationshipValue]) {
           // We need to filter out any non-spatial properties from the map, otherwise PointValue.fromMap will throw
           val allowedKeys = PointValue.ALLOWED_KEYS
           val filteredMap = VirtualValues.map(map.getMapCopy.asScala.filterKeys( k => allowedKeys.exists( _.equalsIgnoreCase(k) )).asJava)

--- a/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
@@ -469,6 +469,7 @@ public class PointValue extends ScalarValue implements Point, Comparable<PointVa
         private Double latitude;
         private Double height;
         private int srid = -1;
+        private boolean allowOpenMaps = true;
 
         @Override
         public void assign( String key, Object value )
@@ -511,7 +512,10 @@ public class PointValue extends ScalarValue implements Point, Comparable<PointVa
                 assignIntegral( key, value, i -> srid = i );
                 break;
             default:
-                throwOnUnrecognizedKey( key );
+                if ( !allowOpenMaps )
+                {
+                    throwOnUnrecognizedKey( key );
+                }
             }
         }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
@@ -144,7 +144,8 @@ class SpatialFunctionsAcceptanceTest extends ExecutionEngineFunSuite with Cypher
     result.toList should equal(List(Map("point" -> Values.pointValue(CoordinateReferenceSystem.Cartesian, 2, 4))))
   }
 
-  test("point function should throw on unrecognized map entry") {
+  // We can un-ignore this if/when we re-enable strict map checks in PointFunction.scala
+  ignore("point function should throw on unrecognized map entry") {
     val stillWithoutFix = Configs.Version3_1 + Configs.AllRulePlanners
     failWithError(pointConfig - stillWithoutFix + Configs.Procs, "RETURN point({x: 2, y:3, a: 4}) as point", Seq("Unknown key 'a' for creating new point"))
   }


### PR DESCRIPTION
This fixes a behaviour regression from 3.3 where point function was previously allowed to take maps of arbitrary values.