### PR TITLE
Increase swapper id limit, allowing more files (like indexes) to be opened by the page cache, and fix a MemoryManager bug around alignment handling.

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/PageList.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/PageList.java
@@ -53,8 +53,6 @@ class PageList
     private static final boolean forceSlowMemoryClear = flag( PageList.class, "forceSlowMemoryClear", false );
 
     private static final int UNBOUND_LAST_MODIFIED_TX_ID = -1;
-    private static final int UNSIGNED_BYTE_MASK = 0xFF;
-    private static final long UNSIGNED_INT_MASK = 0xFFFFFFFFL;
 
     // 40 bits for file page id
     private static final long MAX_FILE_PAGE_ID = 0b11111111_11111111_11111111_11111111_11111111L;
@@ -64,8 +62,10 @@ class PageList
     private static final int OFFSET_ADDRESS = 8; // 8 bytes
     private static final int OFFSET_LAST_TX_ID = 16; // 8 bytes
     private static final int OFFSET_FILE_PAGE_ID = 24; // 5 bytes
-    private static final int OFFSET_USAGE_COUNTER = 29; // 1 byte
-    private static final int OFFSET_SWAPPER_ID = 30; // 2 bytes
+    @SuppressWarnings( "unused" )
+    private static final int OFFSET_SWAPPER_ID = 29; // 2 bytes, plus the 5 high-bits from usage counter
+    @SuppressWarnings( "unused" )
+    private static final int OFFSET_USAGE_COUNTER = 31; // 1 byte, but only the 3 low bits.
 
     // todo we can alternatively also make use of the lower 12 bits of the address field, because
     // todo the addresses are page aligned, and we can assume them to be at least 4096 bytes in size.
@@ -153,7 +153,7 @@ class PageList
             UnsafeUtil.putLong( address += Long.BYTES, OffHeapPageLock.initialLockWordWithExclusiveLock() ); // lock word
             UnsafeUtil.putLong( address += Long.BYTES, 0 ); // pointer
             UnsafeUtil.putLong( address += Long.BYTES, 0 ); // last tx id
-            UnsafeUtil.putLong( address += Long.BYTES, MAX_FILE_PAGE_ID );
+            UnsafeUtil.putLong( address += Long.BYTES, MAX_FILE_PAGE_ID << 24 );
         }
     }
 
@@ -222,19 +222,9 @@ class PageList
         return pageRef + OFFSET_ADDRESS;
     }
 
-    private long offUsage( long pageRef )
-    {
-        return pageRef + OFFSET_USAGE_COUNTER;
-    }
-
     private long offFilePageId( long pageRef )
     {
         return pageRef + OFFSET_FILE_PAGE_ID;
-    }
-
-    private long offSwapperId( long pageRef )
-    {
-        return pageRef + OFFSET_SWAPPER_ID;
     }
 
     public long tryOptimisticReadLock( long pageRef )
@@ -323,12 +313,7 @@ class PageList
 
     private byte getUsageCounter( long pageRef )
     {
-        return UnsafeUtil.getByteVolatile( offUsage( pageRef ) );
-    }
-
-    private void setUsageCounter( long pageRef, byte count )
-    {
-        UnsafeUtil.putByteVolatile( offUsage( pageRef ), count );
+        return (byte) (UnsafeUtil.getLongVolatile( offFilePageId( pageRef ) ) & 0x07);
     }
 
     /**
@@ -337,11 +322,18 @@ class PageList
     public void incrementUsage( long pageRef )
     {
         // This is intentionally left benignly racy for performance.
-        byte usage = getUsageCounter( pageRef );
+        long address = offFilePageId( pageRef );
+        long v = UnsafeUtil.getLongVolatile( address );
+        long usage = v & 0x07;
         if ( usage < 4 ) // avoid cache sloshing by not doing a write if counter is already maxed out
         {
             usage++;
-            setUsageCounter( pageRef, usage );
+            // Use compareAndSwapLong to only actually store the updated count if nothing else changed
+            // in this word-line. The word-line is shared with the file page id, and the swapper id.
+            // Those fields are updated under guard of the exclusive lock, but we *might* race with
+            // that here, and in that case we would never want a usage counter update to clobber a page
+            // binding update.
+            UnsafeUtil.compareAndSwapLong( null, address, v, (v & 0xFFFFFFFF_FFFFFFF8L) + usage );
         }
     }
 
@@ -351,20 +343,21 @@ class PageList
     public boolean decrementUsage( long pageRef )
     {
         // This is intentionally left benignly racy for performance.
-        byte usage = getUsageCounter( pageRef );
+        long address = offFilePageId( pageRef );
+        long v = UnsafeUtil.getLongVolatile( address );
+        long usage = v & 0x07;
         if ( usage > 0 )
         {
             usage--;
-            setUsageCounter( pageRef, usage );
+            // See `incrementUsage` about why we use `compareAndSwapLong`.
+            UnsafeUtil.compareAndSwapLong( null, address, v, (v & 0xFFFFFFFF_FFFFFFF8L) + usage );
         }
         return usage == 0;
     }
 
     public long getFilePageId( long pageRef )
     {
-        int highByte = UnsafeUtil.getByte( offFilePageId( pageRef ) ) & UNSIGNED_BYTE_MASK;
-        long lowInt = UnsafeUtil.getInt( offFilePageId( pageRef ) + Byte.BYTES ) & UNSIGNED_INT_MASK;
-        long filePageId = (((long) highByte) << Integer.SIZE) | lowInt;
+        long filePageId = UnsafeUtil.getLong( offFilePageId( pageRef ) ) >>> 24;
         return filePageId == MAX_FILE_PAGE_ID ? PageCursor.UNBOUND_PAGE_ID : filePageId;
     }
 
@@ -375,9 +368,10 @@ class PageList
             throw new IllegalArgumentException(
                     format( "File page id: %s is bigger then max supported value %s.", filePageId, MAX_FILE_PAGE_ID ) );
         }
-        byte highByte = (byte) (filePageId >> Integer.SIZE);
-        UnsafeUtil.putByte( offFilePageId( pageRef ), highByte );
-        UnsafeUtil.putInt( offFilePageId( pageRef ) + Byte.BYTES, (int) filePageId );
+        long address = offFilePageId( pageRef );
+        long v = UnsafeUtil.getLong( address );
+        filePageId = (filePageId << 24) + (v & 0xFFFFFF);
+        UnsafeUtil.putLong( address, filePageId );
     }
 
     long getLastModifiedTxId( long pageRef )
@@ -398,14 +392,18 @@ class PageList
         UnsafeUtil.compareAndSetMaxLong( null, offLastModifiedTransactionId( pageRef ), modifierTxId );
     }
 
-    public short getSwapperId( long pageRef )
+    public int getSwapperId( long pageRef )
     {
-        return UnsafeUtil.getShort( offSwapperId( pageRef ) );
+        long v = UnsafeUtil.getLong( offFilePageId( pageRef ) ) >>> 3;
+        return (int) (v & 0b1_11111_11111_11111_11111); // 21 bits.
     }
 
-    private void setSwapperId( long pageRef, short swapperId )
+    private void setSwapperId( long pageRef, int swapperId )
     {
-        UnsafeUtil.putShort( offSwapperId( pageRef ), swapperId );
+        swapperId = swapperId << 3;
+        long address = offFilePageId( pageRef );
+        long v = UnsafeUtil.getLong( address ) & (~(0b1_11111_11111_11111_11111 << 3));
+        UnsafeUtil.putLong( address, v + swapperId );
     }
 
     public boolean isLoaded( long pageRef )
@@ -413,12 +411,12 @@ class PageList
         return getFilePageId( pageRef ) != PageCursor.UNBOUND_PAGE_ID;
     }
 
-    public boolean isBoundTo( long pageRef, short swapperId, long filePageId )
+    public boolean isBoundTo( long pageRef, int swapperId, long filePageId )
     {
         return getSwapperId( pageRef ) == swapperId && getFilePageId( pageRef ) == filePageId;
     }
 
-    public void fault( long pageRef, PageSwapper swapper, short swapperId, long filePageId, PageFaultEvent event )
+    public void fault( long pageRef, PageSwapper swapper, int swapperId, long filePageId, PageFaultEvent event )
             throws IOException
     {
         if ( swapper == null )
@@ -451,7 +449,7 @@ class PageList
         return new IllegalArgumentException( "swapper cannot be null" );
     }
 
-    private static IllegalStateException cannotFaultException( long pageRef, PageSwapper swapper, short swapperId,
+    private static IllegalStateException cannotFaultException( long pageRef, PageSwapper swapper, int swapperId,
                                                         long filePageId, int currentSwapper, long currentFilePageId )
     {
         String msg = format(
@@ -484,7 +482,7 @@ class PageList
         long filePageId = getFilePageId( pageRef );
         evictionEvent.setFilePageId( filePageId );
         evictionEvent.setCachePageId( pageRef );
-        short swapperId = getSwapperId( pageRef );
+        int swapperId = getSwapperId( pageRef );
         if ( swapperId != 0 )
         {
             // If the swapper id is non-zero, then the page was not only loaded, but also bound, and possibly modified.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/SwapperSet.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/SwapperSet.java
@@ -45,7 +45,7 @@ final class SwapperSet
     // The tombstone is used as a marker to reserve allocation entries that have been freed, but not yet vacuumed.
     // An allocation cannot be reused until it has been vacuumed.
     private static final SwapperMapping TOMBSTONE = new SwapperMapping( 0, null );
-    private static final int MAX_SWAPPER_ID = Short.MAX_VALUE;
+    private static final int MAX_SWAPPER_ID = (1 << 21) - 1;
     private volatile SwapperMapping[] swapperMappings = new SwapperMapping[] { SENTINEL };
     private final PrimitiveIntSet free = Primitive.intSet();
     private final Object vacuumLock = new Object();
@@ -69,7 +69,7 @@ final class SwapperSet
     /**
      * Get the {@link SwapperMapping} for the given swapper id.
      */
-    SwapperMapping getAllocation( short id )
+    SwapperMapping getAllocation( int id )
     {
         checkId( id );
         SwapperMapping swapperMapping = swapperMappings[id];
@@ -197,10 +197,10 @@ final class SwapperSet
         }
     }
 
-    synchronized short countAvailableIds()
+    synchronized int countAvailableIds()
     {
         // the max id is one less than the allowed count, but we subtract one for the reserved id 0
-        short available = MAX_SWAPPER_ID;
+        int available = MAX_SWAPPER_ID;
         available -= swapperMappings.length; // ids that are allocated are not available
         available += free.size(); // add back the ids that are free to be reused
         return available;

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/PageListTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/PageListTest.java
@@ -1368,7 +1368,7 @@ public class PageListTest
     public void pageMustBeLoadedAndBoundAfterFault() throws Exception
     {
         // exclusive lock implied by constructor
-        short swapperId = 1;
+        int swapperId = 1;
         long filePageId = 42;
         pageList.initBuffer( pageRef );
         pageList.fault( pageRef, DUMMY_SWAPPER, swapperId, filePageId, PageFaultEvent.NULL );
@@ -1382,7 +1382,7 @@ public class PageListTest
     public void pageWith5BytesFilePageIdMustBeLoadedAndBoundAfterFault() throws Exception
     {
         // exclusive lock implied by constructor
-        short swapperId = 12;
+        int swapperId = 12;
         long filePageId = Integer.MAX_VALUE + 1L;
         pageList.initBuffer( pageRef );
         pageList.fault( pageRef, DUMMY_SWAPPER, swapperId, filePageId, PageFaultEvent.NULL );
@@ -1404,7 +1404,7 @@ public class PageListTest
                 throw new IOException( "boo" );
             }
         };
-        short swapperId = 1;
+        int swapperId = 1;
         long filePageId = 42;
         pageList.initBuffer( pageRef );
         try
@@ -1416,7 +1416,7 @@ public class PageListTest
             assertThat( e.getMessage(), is( "boo" ) );
         }
         assertThat( pageList.getFilePageId( pageRef ), is( filePageId ) );
-        assertThat( pageList.getSwapperId( pageRef ), is( (short) 0 ) ); // 0 means not bound
+        assertThat( pageList.getSwapperId( pageRef ), is( 0 ) ); // 0 means not bound
         assertTrue( pageList.isLoaded( pageRef ) );
         assertFalse( pageList.isBoundTo( pageRef, swapperId, filePageId ) );
     }
@@ -1629,16 +1629,16 @@ public class PageListTest
     public void pageMustNotBeBoundAfterSuccessfulEviction() throws Exception
     {
         pageList.unlockExclusive( pageRef );
-        short swapperId = swappers.allocate( DUMMY_SWAPPER );
+        int swapperId = swappers.allocate( DUMMY_SWAPPER );
         doFault( swapperId, 42 ); // page now bound & exclusively locked
         pageList.unlockExclusive( pageRef ); // no longer exclusively locked; can now be evicted
         assertTrue( pageList.isBoundTo( pageRef, (short) 1, 42 ) );
         assertTrue( pageList.isLoaded( pageRef ) );
-        assertThat( pageList.getSwapperId( pageRef ), is( (short) 1 ) );
+        assertThat( pageList.getSwapperId( pageRef ), is( 1 ) );
         pageList.tryEvict( pageRef, EvictionRunEvent.NULL );
         assertFalse( pageList.isBoundTo( pageRef, (short) 1, 42 ) );
         assertFalse( pageList.isLoaded( pageRef ) );
-        assertThat( pageList.getSwapperId( pageRef ), is( (short) 0 ) );
+        assertThat( pageList.getSwapperId( pageRef ), is( 0 ) );
     }
 
     @Test
@@ -2069,7 +2069,7 @@ public class PageListTest
         doFault( swapperId, Long.MAX_VALUE );
     }
 
-    private void doFault( short swapperId, long filePageId ) throws IOException
+    private void doFault( int swapperId, long filePageId ) throws IOException
     {
         assertTrue( pageList.tryExclusiveLock( pageRef ) );
         pageList.initBuffer( pageRef );

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/SwapperSetTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/SwapperSetTest.java
@@ -191,12 +191,12 @@ public class SwapperSetTest
     public void mustKeepTrackOfAvailableSwapperIds() throws Exception
     {
         PageSwapper swapper = new DummyPageSwapper( "a", 42 );
-        short initial = Short.MAX_VALUE - 1;
+        int initial = (1 << 21) - 2;
         assertThat( set.countAvailableIds(), is( initial ) );
         int id = set.allocate( swapper );
-        assertThat( set.countAvailableIds(), is( (short) (initial - 1) ) );
+        assertThat( set.countAvailableIds(), is( initial - 1 ) );
         set.free( id );
-        assertThat( set.countAvailableIds(), is( (short) (initial - 1) ) );
+        assertThat( set.countAvailableIds(), is( initial - 1 ) );
         set.vacuum( x -> {} );
         assertThat( set.countAvailableIds(), is( initial ) );
     }


### PR DESCRIPTION
This is back-porting fixes from the #11668 PR, and should be null-merged into 3.4.