### PR TITLE
Unify and extend thread dump utils used for reporting and during testing

### DIFF
--- a/community/io/src/test/java/org/neo4j/test/ThreadTestUtils.java
+++ b/community/io/src/test/java/org/neo4j/test/ThreadTestUtils.java
@@ -20,7 +20,6 @@
 package org.neo4j.test;
 
 import java.util.EnumSet;
-import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
@@ -64,23 +63,5 @@ public class ThreadTestUtils
             }
         }
         while ( !set.contains( currentState ) );
-    }
-
-    public static void dumpAllStackTraces()
-    {
-        synchronized ( System.err )
-        {
-            Map<Thread, StackTraceElement[]> allStackTraces = Thread.getAllStackTraces();
-            for ( Map.Entry<Thread, StackTraceElement[]> entry : allStackTraces.entrySet() )
-            {
-                System.err.println( "Stack Trace for " + entry.getKey().getName() );
-                StackTraceElement[] elements = entry.getValue();
-                for ( StackTraceElement element : elements )
-                {
-                    System.err.println( "\tat " + element.toString() );
-                }
-                System.err.println();
-            }
-        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/utils/DumpUtils.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/utils/DumpUtils.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.diagnostics.utils;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MonitorInfo;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.Properties;
+
+public class DumpUtils
+{
+    private DumpUtils()
+    {
+    }
+
+    /**
+     * Creates threads dump and try to mimic JVM stack trace as much as possible to allow existing analytics tools to be used
+     *
+     * @return string that contains thread dump
+     */
+    public static String threadDump()
+    {
+        ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
+        Properties systemProperties = System.getProperties();
+
+        return threadDump( threadMxBean, systemProperties );
+    }
+
+    /**
+     * Creates threads dump and try to mimic JVM stack trace as much as possible to allow existing analytics tools to be used
+     *
+     * @param threadMxBean bean to use for thread dump
+     * @param systemProperties dumped vm system properties
+     * @return string that contains thread dump
+     */
+    public static String threadDump( ThreadMXBean threadMxBean, Properties systemProperties )
+    {
+        ThreadInfo[] threadInfos = threadMxBean.dumpAllThreads( true, true );
+
+        // Reproduce JVM stack trace as far as possible to allow existing analytics tools to be used
+        String vmName = systemProperties.getProperty( "java.vm.name" );
+        String vmVersion = systemProperties.getProperty( "java.vm.version" );
+        String vmInfoString = systemProperties.getProperty( "java.vm.info" );
+
+        StringBuilder sb = new StringBuilder();
+        sb.append( String.format( "Full thread dump %s (%s %s):\n\n", vmName, vmVersion, vmInfoString ) );
+        for ( ThreadInfo threadInfo : threadInfos )
+        {
+            sb.append( String.format( "\"%s\" #%d\n", threadInfo.getThreadName(), threadInfo.getThreadId() ) );
+            sb.append( "   java.lang.Thread.State: " ).append( threadInfo.getThreadState() ).append( "\n" );
+
+            StackTraceElement[] stackTrace = threadInfo.getStackTrace();
+            for ( int i = 0; i < stackTrace.length; i++ )
+            {
+                StackTraceElement e = stackTrace[i];
+                sb.append( "\tat " ).append( e.toString() );
+
+                // First stack element info can be found in the thread state
+                if ( i == 0 && threadInfo.getLockInfo() != null )
+                {
+                    Thread.State ts = threadInfo.getThreadState();
+                    switch ( ts )
+                    {
+                    case BLOCKED:
+                        sb.append( "\t-  blocked on " ).append( threadInfo.getLockInfo() ).append( '\n' );
+                        break;
+                    case WAITING:
+                        sb.append( "\t-  waiting on " ).append( threadInfo.getLockInfo() ).append( '\n' );
+                        break;
+                    case TIMED_WAITING:
+                        sb.append( "\t-  waiting on " ).append( threadInfo.getLockInfo() ).append( '\n' );
+                        break;
+                    default:
+                    }
+                }
+                for ( MonitorInfo mi : threadInfo.getLockedMonitors() )
+                {
+                    if ( mi.getLockedStackDepth() == i )
+                    {
+                        sb.append( "\t-  locked " ).append( mi ).append( '\n' );
+                    }
+                }
+            }
+        }
+
+        return sb.toString();
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/test/rule/VerboseTimeout.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/VerboseTimeout.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
-import org.neo4j.test.ThreadTestUtils;
+import org.neo4j.diagnostics.utils.DumpUtils;
 
 /**
  * Timeout rule implementation that print out stack traces of all thread
@@ -199,7 +199,7 @@ public class VerboseTimeout extends Timeout
             }
             catch ( ExecutionException e )
             {
-                ThreadTestUtils.dumpAllStackTraces();
+                printThreadDump();
                 return e.getCause();
             }
             catch ( TimeoutException e )
@@ -213,7 +213,7 @@ public class VerboseTimeout extends Timeout
                     }
                 }
                 System.err.println( "=== Thread dump ===" );
-                ThreadTestUtils.dumpAllStackTraces();
+                printThreadDump();
                 return buildTimeoutException( thread );
             }
         }
@@ -250,5 +250,10 @@ public class VerboseTimeout extends Timeout
                 startLatch.await();
             }
         }
+    }
+
+    private static void printThreadDump()
+    {
+        System.err.println( DumpUtils.threadDump() );
     }
 }

--- a/stresstests/src/test/java/org/neo4j/backup/stresstests/BackupServiceStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/backup/stresstests/BackupServiceStressTesting.java
@@ -34,11 +34,11 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.neo4j.causalclustering.stresstests.Config;
 import org.neo4j.causalclustering.stresstests.Control;
 import org.neo4j.concurrent.Futures;
+import org.neo4j.diagnostics.utils.DumpUtils;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.io.fs.FileUtils;
-import org.neo4j.test.ThreadTestUtils;
 
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.Integer.parseInt;
@@ -110,14 +110,14 @@ public class BackupServiceStressTesting
             service.shutdown();
             if ( !service.awaitTermination( 30, SECONDS ) )
             {
-                ThreadTestUtils.dumpAllStackTraces();
+                printThreadDump();
                 fail( "Didn't manage to shut down the workers correctly, dumped threads for forensic purposes" );
             }
         }
         catch ( TimeoutException t )
         {
             System.err.println( format( "Timeout waiting task completion. Dumping all threads." ) );
-            ThreadTestUtils.dumpAllStackTraces();
+            printThreadDump();
             throw t;
         }
         finally
@@ -129,5 +129,10 @@ public class BackupServiceStressTesting
         // let's cleanup disk space when everything went well
         FileUtils.deleteRecursively( storeDirectory );
         FileUtils.deletePathRecursively( workDirectory );
+    }
+
+    private static void printThreadDump()
+    {
+        System.err.println( DumpUtils.threadDump() );
     }
 }


### PR DESCRIPTION
Update Verbose timeout to use more tools friendly full thread dump,
unify how we make thread dump between different tools.