### PR TITLE
Unflake BoltSchedulerShouldReportFailureWhenBusyIT

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/SocketConnection.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/SocketConnection.java
@@ -65,6 +65,7 @@ public class SocketConnection implements TransportConnection
     public TransportConnection send( byte[] rawBytes ) throws IOException
     {
         out.write( rawBytes );
+        out.flush();
         return this;
     }
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/WebSocketConnection.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/WebSocketConnection.java
@@ -103,6 +103,7 @@ public class WebSocketConnection implements TransportConnection, WebSocketListen
         // ownership
         ByteBuffer wrap = ByteBuffer.wrap( Arrays.copyOf( rawBytes, rawBytes.length ) );
         server.sendBytes( wrap );
+        server.flush();
         return this;
     }
 


### PR DESCRIPTION
It used to fail sometimes because bolt server rejected incoming messages. They were rejected because server did not have free threads to process them. It might take some time for a thread to get returned to the thread pool after the previous task is executed.

This PR makes the test retry finite amount of time on message rejection. It also adds increasing sleeps between messages with every retry.