### PR TITLE
3.4 Change stepdown updates to be handled in RobustJobScheduler

### DIFF
--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterOverviewIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterOverviewIT.java
@@ -314,7 +314,7 @@ public class ClusterOverviewIT
         Function<List<MemberInfo>, String> printableMemberInfos =
                 memberInfos -> memberInfos.stream().map( MemberInfo::toString ).collect( Collectors.joining( ", " ) );
         assertEventually( memberInfos -> "should have overview from core " + coreServerId + " but view was " + printableMemberInfos.apply( memberInfos ),
-                () -> clusterOverview( cluster.getCoreMemberById( coreServerId ).database() ), expected, 60, SECONDS );
+                () -> clusterOverview( cluster.getCoreMemberById( coreServerId ).database() ), expected, 90, SECONDS );
     }
 
     @SafeVarargs


### PR DESCRIPTION
Potential fix for panic being caused by direct Raft<->Hazelcast communication. Updated stepdown handler to set local state on each core, which then gets read on each `refreshRoles` call inside `RobustJobScheduler`.