### PR TITLE
Set the Cypher version to the planner version.

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/PipeExecutionResult.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/PipeExecutionResult.scala
@@ -56,7 +56,6 @@ class PipeExecutionResult(val result: ResultIterator,
 
   def executionPlanDescription(): InternalPlanDescription =
     executionPlanBuilder()
-      .addArgument(Version(s"CYPHER ${CypherVersion.default.name}"))
       .addArgument(RuntimeVersion(CypherVersion.default.name))
 
   def javaColumnAs[T](column: String): ResourceIterator[T] = new WrappingResourceIterator[T] {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/RootPlanAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/RootPlanAcceptanceTest.scala
@@ -21,7 +21,6 @@ package org.neo4j.cypher
 
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.{InterpretedRuntimeName, RuntimeName}
 import org.neo4j.cypher.internal.frontend.v3_4.PlannerName
-import org.neo4j.cypher.internal.javacompat.PlanDescription
 import org.neo4j.cypher.internal.planner.v3_4.spi.CostBasedPlannerName
 import org.neo4j.graphdb.ExecutionPlanDescription
 
@@ -31,6 +30,12 @@ class RootPlanAcceptanceTest extends ExecutionEngineFunSuite {
     given("match (n) return n")
       .withCypherVersion(CypherVersion.v3_4)
       .shouldHavePlanner(CostBasedPlannerName.default)
+  }
+
+  test("3.3 query should have 3.3 version") {
+    given("match (n) return n")
+      .withCypherVersion(CypherVersion.v3_3)
+      .shouldHaveCypherVersion(CypherVersion.v3_3)
   }
 
   test("interpreted should be default runtime in 3.4") {

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/planDescription/LogicalPlan2PlanDescription.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/planDescription/LogicalPlan2PlanDescription.scala
@@ -36,7 +36,7 @@ object LogicalPlan2PlanDescription extends ((LogicalPlan, PlannerName, ReadOnlie
                      cardinalities: Cardinalities): InternalPlanDescription = {
     val readOnly = readOnlies.get(input.id)
     new LogicalPlan2PlanDescription(readOnly, cardinalities).create(input)
-      .addArgument(Version("CYPHER 3.4"))
+      .addArgument(Version("CYPHER "+plannerName.version))
       .addArgument(RuntimeVersion("3.4"))
       .addArgument(Planner(plannerName.toTextOutput))
       .addArgument(PlannerImpl(plannerName.name))


### PR DESCRIPTION
Fixes a bug where calling a `CYPHER 3.3 ...` query would get `Compiler CYPHER 3.4` in the execution plan.