### PR TITLE
The runtime interface.

### DIFF
--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ExecutionEngine.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ExecutionEngine.java
@@ -25,8 +25,10 @@ import org.neo4j.cypher.CypherException;
 import org.neo4j.cypher.internal.CompatibilityFactory;
 import org.neo4j.graphdb.Result;
 import org.neo4j.kernel.GraphDatabaseQueryService;
+import org.neo4j.kernel.impl.query.QueryExecution;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
 import org.neo4j.kernel.impl.query.QueryExecutionKernelException;
+import org.neo4j.kernel.impl.query.ResultBuffer;
 import org.neo4j.kernel.impl.query.TransactionalContext;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.values.virtual.MapValue;
@@ -59,6 +61,23 @@ public class ExecutionEngine implements QueryExecutionEngine
         try
         {
             return inner.execute( query, parameters, context );
+        }
+        catch ( CypherException e )
+        {
+            throw new QueryExecutionKernelException( e );
+        }
+    }
+
+    @Override
+    public QueryExecution executeQuery( String query,
+                                        MapValue parameters,
+                                        TransactionalContext context,
+                                        ResultBuffer resultBuffer )
+            throws QueryExecutionKernelException
+    {
+        try
+        {
+            return inner.execute( query, parameters, context, resultBuffer );
         }
         catch ( CypherException e )
         {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
@@ -35,7 +35,7 @@ import org.neo4j.internal.kernel.api.SchemaRead
 import org.neo4j.internal.kernel.api.security.AccessMode
 import org.neo4j.kernel.api.query.SchemaIndexUsage
 import org.neo4j.kernel.configuration.Config
-import org.neo4j.kernel.impl.query.{QueryExecutionMonitor, TransactionalContext}
+import org.neo4j.kernel.impl.query.{QueryExecution, QueryExecutionMonitor, ResultBuffer, TransactionalContext}
 import org.neo4j.kernel.monitoring.{Monitors => KernelMonitors}
 import org.neo4j.kernel.{GraphDatabaseQueryService, api}
 import org.neo4j.logging.{LogProvider, NullLogProvider}
@@ -117,6 +117,14 @@ class ExecutionEngine(val queryService: GraphDatabaseQueryService,
       checkParameters(queryParamNames, mapParams, preparedPlanExecution.extractedParams)
     }
     preparedPlanExecution.execute(wrappedContext, mapParams)
+  }
+
+  def execute(query: String,
+              mapParams: MapValue,
+              context: TransactionalContext,
+              resultBuffer: ResultBuffer
+             ): QueryExecution = {
+    ???
   }
 
   protected def parseQuery(queryText: String): ParsedQuery =

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/Runtime.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/Runtime.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.runtime
+
+import org.neo4j.cypher.internal.frontend.v3_4.semantics.SemanticTable
+import org.neo4j.cypher.internal.planner.v3_4.spi.TokenContext
+import org.neo4j.cypher.internal.util.v3_4.symbols.CypherType
+import org.neo4j.cypher.internal.v3_4.expressions.Expression
+import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlan
+import org.neo4j.internal.kernel.api.Transaction
+import org.neo4j.kernel.impl.query.{QueryExecution, ResultBuffer}
+import org.neo4j.values.virtual.MapValue
+
+// =============================================== /
+// RUNTIME INTERFACES, implemented by each runtime /
+// _______________________________________________ /
+
+/**
+  * A runtime knows how to compile logical plans into executable queries. Executable queries are intended to be reused
+  * for executing the same multiple times, also concurrently. To facilitate this, all execution state is held in a
+  * QueryExecutionState object. The runtime has the power to allocate and release these execution states,
+  *
+  * @tparam State the execution state type for this runtime.
+  */
+trait Runtime[State <: QueryExecutionState] {
+
+  def allocateExecutionState: QueryExecutionState
+  def compileToExecutable(query: String, logicalPlan: LogicalPlan, context: PhysicalCompilationContext): ExecutableQuery[State]
+  def releaseExecutionState(executionState: QueryExecutionState): Unit
+}
+
+/**
+  * An executable representation of a query.
+  *
+  * The ExecutableQuery holds no mutable state, and is safe to cache, reuse and use concurrently.
+  *
+  * @tparam State The type of execution state needed to execute this query.
+  */
+trait ExecutableQuery[State <: QueryExecutionState] {
+
+  /**
+    * Execute this query.
+    *
+    * @param params Parameters of the execution.
+    * @param state The execution state to use.
+    * @param resultBuffer The result buffer to write results to.
+    * @param transaction The transaction to execute the query in. If None, a new transaction will be begun
+    *                    for the duration of this execution.
+    * @return A QueryExecution representing the started exeucution.
+    */
+  def execute( params: MapValue,
+               state: State,
+               resultBuffer: ResultBuffer,
+               transaction: Option[Transaction]
+             ): QueryExecution
+}
+
+/**
+  * A QueryExecutionState holds the mutable state needed during execution of a query.
+  *
+  * QueryExecutionStates of the correct type are allocated and released by the relevant runtime.
+  */
+trait QueryExecutionState
+
+// ====================================================== /
+// SUPPORTING INTERFACES, implemented by execution engine /
+// ______________________________________________________ /
+
+/**
+  * Context for physical compilation.
+  */
+trait PhysicalCompilationContext {
+  def typeFor(expression: Expression): CypherType
+  def semanticTable: SemanticTable
+  def readOnly: Boolean
+  def tokenContext: TokenContext
+  def periodicCommit: Option[Long]
+}
+

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/NoQueryEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/NoQueryEngine.java
@@ -35,6 +35,13 @@ enum NoQueryEngine implements QueryExecutionEngine
     }
 
     @Override
+    public QueryExecution executeQuery( String query, MapValue parameters, TransactionalContext context,
+                                        ResultBuffer resultBuffer )
+    {
+        throw noQueryEngine();
+    }
+
+    @Override
     public Result executeQuery( String query, Map<String,Object> parameters, TransactionalContext context )
     {
         throw noQueryEngine();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryExecution.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryExecution.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.query;
+
+/**
+ * The execution of a query.
+ */
+public interface QueryExecution
+{
+
+    /**
+     * The names of the result columns
+     *
+     * @return Array containing the names of the result columns in order.
+     */
+    String[] header();
+
+    /**
+     * Returns the result buffer of this execution.
+     *
+     * @return the result buffer of this execution.
+     */
+    ResultBuffer resultBuffer();
+
+    /**
+     * Wait for more results to be written to the resultBuffer.
+     *
+     * @return true if more results were written.
+     */
+    boolean waitForResult();
+
+    /**
+     * Terminate this execution, throwing away any buffered results, and releasing any other resources.
+     *
+     * TODO: what should this really be called... close? abort? terminate?
+     */
+    void terminate();
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryExecutionEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryExecutionEngine.java
@@ -29,6 +29,12 @@ public interface QueryExecutionEngine
     Result executeQuery( String query, MapValue parameters, TransactionalContext context )
             throws QueryExecutionKernelException;
 
+    QueryExecution executeQuery( String query,
+                                 MapValue parameters,
+                                 TransactionalContext context,
+                                 ResultBuffer resultBuffer )
+            throws QueryExecutionKernelException;
+
     Result executeQuery( String query, Map<String,Object> parameters, TransactionalContext context )
             throws QueryExecutionKernelException;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/ResultBuffer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/ResultBuffer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.query;
+
+import org.neo4j.values.AnyValue;
+
+/**
+ * Result buffer holding the results of a query execution.
+ */
+public interface ResultBuffer
+{
+    /**
+     * Signal that a new query execution is starting, which will return {@code valuesPerResult}  many values per result.
+     */
+    void beginQueryExecution( int valuesPerResult );
+
+    /**
+     * Prepare the result stage for the next result row.
+     *
+     * @return the id of the new row, or -1 if the stage could not be cleared.
+     */
+    long beginResultRow() throws ResultBufferException;
+
+    /**
+     * Write a value of the result stage.
+     *
+     * This method is expected to be called for every valueId in the range [0..valuesPerResult), for every row.
+     *
+     * @param columnId column id of the value to write.
+     * @param value the Value to write.
+     */
+    void writeValue( int columnId, AnyValue value );
+
+    /**
+     * Commit the result row in the result stage to the buffer.
+     *
+     * @return true if the buffer can accept the next result row.
+     */
+    boolean endResultRow() throws ResultBufferException;
+
+// Suggestion for additional methods: add if needed.
+
+//    /**
+//     * Signals to the buffer that some error occurred during query execution.
+//     *
+//     * After onError is called, only endQueryExecution() will be called by this query.
+//     *
+//     * @param status The status code of the error
+//     * @param msg The error message associated with the error, or null if no message is provided
+//     */
+//    void onError( Status status, String msg );
+//
+//    /**
+//     * Signal that the current query execution is completed.
+//     */
+//    void endQueryExecution();
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/ResultBufferException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/ResultBufferException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.query;
+
+import java.io.IOException;
+
+/**
+ * IOException thrown by {@link ResultBuffer}.
+ */
+public class ResultBufferException extends IOException
+{
+    public ResultBufferException( Throwable cause )
+    {
+        super( cause );
+    }
+}


### PR DESCRIPTION
Initial draft of the runtime interface. This interface defines how a query is transformed from a logical plan to a executable and cacheable query, and how executing that query will result in
a query execution.

In reverse to previous result handling, this interface uses a push model where the runtime code controls the pace of results. To enable this, execution clients now have to supply a ResultBuffer
which the query execution will write results to.

Note that in https://github.com/fickludd/neo4j/tree/3.5-runtime-interface-design, we have also explored implementing this interface in interpreted, and using it from Bolt and Core API. Those code snippets are rather hacky though, and will be reworked into propers PRs before merging.