### PR TITLE
Add admin annotation for procedures

### DIFF
--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/ProcedureSignature.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/ProcedureSignature.java
@@ -41,6 +41,7 @@ public class ProcedureSignature
     private final List<FieldSignature> inputSignature;
     private final List<FieldSignature> outputSignature;
     private final Mode mode;
+    private final boolean admin;
     private final String deprecated;
     private final String[] allowed;
     private final String description;
@@ -52,6 +53,7 @@ public class ProcedureSignature
             List<FieldSignature> inputSignature,
             List<FieldSignature> outputSignature,
             Mode mode,
+            boolean admin,
             String deprecated,
             String[] allowed,
             String description,
@@ -62,6 +64,7 @@ public class ProcedureSignature
         this.inputSignature = unmodifiableList( inputSignature );
         this.outputSignature = outputSignature == VOID ? outputSignature : unmodifiableList( outputSignature );
         this.mode = mode;
+        this.admin = admin;
         this.deprecated = deprecated;
         this.allowed = allowed;
         this.description = description;
@@ -77,6 +80,11 @@ public class ProcedureSignature
     public Mode mode()
     {
         return mode;
+    }
+
+    public boolean admin()
+    {
+        return admin;
     }
 
     public Optional<String> deprecated()
@@ -167,6 +175,7 @@ public class ProcedureSignature
         private String[] allowed = new String[0];
         private String description;
         private String warning;
+        private boolean admin;
 
         public Builder( String[] namespace, String name )
         {
@@ -217,6 +226,12 @@ public class ProcedureSignature
             return this;
         }
 
+        public Builder admin( boolean admin )
+        {
+            this.admin = admin;
+            return this;
+        }
+
         public Builder warning( String warning )
         {
             this.warning =  warning;
@@ -225,7 +240,7 @@ public class ProcedureSignature
 
         public ProcedureSignature build()
         {
-            return new ProcedureSignature( name, inputSignature, outputSignature, mode, deprecated, allowed,
+            return new ProcedureSignature( name, inputSignature, outputSignature, mode, admin, deprecated, allowed,
                     description, warning, false );
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProcedures.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.builtinprocs;
 import java.util.Comparator;
 import java.util.stream.Stream;
 
-import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.internal.kernel.api.procs.ProcedureSignature;
 import org.neo4j.internal.kernel.api.procs.UserFunctionSignature;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
@@ -31,12 +30,12 @@ import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.Log;
+import org.neo4j.procedure.Admin;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
-import static org.neo4j.graphdb.security.AuthorizationViolationException.PERMISSION_DENIED;
 import static org.neo4j.procedure.Mode.DBMS;
 
 @SuppressWarnings( "unused" )
@@ -51,15 +50,11 @@ public class BuiltInDbmsProcedures
     @Context
     public SecurityContext securityContext;
 
+    @Admin
     @Description( "List the currently active config of Neo4j." )
     @Procedure( name = "dbms.listConfig", mode = DBMS )
     public Stream<ConfigResult> listConfig( @Name( value = "searchString", defaultValue = "" ) String searchString )
     {
-        securityContext.assertCredentialsNotExpired();
-        if ( !securityContext.isAdmin() )
-        {
-            throw new AuthorizationViolationException( PERMISSION_DENIED );
-        }
         Config config = graph.getDependencyResolver().resolveDependency( Config.class );
         return config.getConfigValues().values().stream()
                 .filter( c -> !c.internal() )
@@ -88,16 +83,11 @@ public class BuiltInDbmsProcedures
                 .map( FunctionResult::new );
     }
 
+    @Admin
     @Description( "Clears all query caches." )
     @Procedure( name = "dbms.clearQueryCaches", mode = DBMS )
     public Stream<StringResult> clearAllQueryCaches()
     {
-        securityContext.assertCredentialsNotExpired();
-        if ( !securityContext.isAdmin() )
-        {
-            throw new AuthorizationViolationException( PERMISSION_DENIED );
-        }
-
         QueryExecutionEngine queryExecutionEngine = graph.getDependencyResolver().resolveDependency( QueryExecutionEngine.class );
         long numberOfClearedQueries = queryExecutionEngine.clearQueryCaches() - 1; // this query itself does not count
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
 
 import org.neo4j.collection.RawIterator;
 import org.neo4j.graphdb.Resource;
+import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.exceptions.ProcedureException;
 import org.neo4j.internal.kernel.api.procs.FieldSignature;
@@ -43,6 +44,7 @@ import org.neo4j.internal.kernel.api.procs.ProcedureSignature;
 import org.neo4j.internal.kernel.api.procs.QualifiedName;
 import org.neo4j.internal.kernel.api.procs.UserAggregator;
 import org.neo4j.internal.kernel.api.procs.UserFunctionSignature;
+import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.io.IOUtils;
 import org.neo4j.kernel.api.ResourceTracker;
 import org.neo4j.kernel.api.exceptions.ComponentInjectionException;
@@ -57,6 +59,7 @@ import org.neo4j.kernel.api.proc.FailedLoadFunction;
 import org.neo4j.kernel.api.proc.FailedLoadProcedure;
 import org.neo4j.kernel.impl.proc.OutputMappers.OutputMapper;
 import org.neo4j.logging.Log;
+import org.neo4j.procedure.Admin;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Mode;
 import org.neo4j.procedure.PerformsWrites;
@@ -71,6 +74,7 @@ import org.neo4j.values.ValueMapper;
 import static java.util.Collections.emptyIterator;
 import static java.util.Collections.emptyList;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.procedure_unrestricted;
+import static org.neo4j.graphdb.security.AuthorizationViolationException.PERMISSION_DENIED;
 import static org.neo4j.helpers.collection.Iterators.asRawIterator;
 
 /**
@@ -271,6 +275,7 @@ class ReflectiveProcedureCompiler
         String description = description( method );
         Procedure procedure = method.getAnnotation( Procedure.class );
         Mode mode = procedure.mode();
+        boolean admin = method.isAnnotationPresent( Admin.class );
         if ( method.isAnnotationPresent( PerformsWrites.class ) )
         {
             if ( procedure.mode() != org.neo4j.procedure.Mode.DEFAULT )
@@ -299,13 +304,13 @@ class ReflectiveProcedureCompiler
                 description = describeAndLogLoadFailure( procName );
                 ProcedureSignature signature =
                         new ProcedureSignature( procName, inputSignature, outputMapper.signature(), Mode.DEFAULT,
-                                null, new String[0], description, warning, false );
+                                admin, null, new String[0], description, warning, false );
                 return new FailedLoadProcedure( signature );
             }
         }
 
         ProcedureSignature signature =
-                new ProcedureSignature( procName, inputSignature, outputMapper.signature(), mode, deprecated,
+                new ProcedureSignature( procName, inputSignature, outputMapper.signature(), mode, admin, deprecated,
                         config.rolesFor( procName.toString() ), description, warning, false );
         return new ReflectiveProcedure( signature, constructor, method, outputMapper, setters );
     }
@@ -642,6 +647,17 @@ class ReflectiveProcedureCompiler
                 Object cls = constructor.invoke();
                 //API injection
                 inject( ctx, cls );
+
+                // Admin check
+                if ( signature.admin() )
+                {
+                    SecurityContext securityContext = ctx.get( Context.SECURITY_CONTEXT );
+                    securityContext.assertCredentialsNotExpired();
+                    if ( !securityContext.isAdmin() )
+                    {
+                        throw new AuthorizationViolationException( PERMISSION_DENIED );
+                    }
+                }
 
                 // Call the method
                 Object rs = procedureMethod.invoke( cls, input );

--- a/community/procedure-api/src/main/java/org/neo4j/procedure/Admin.java
+++ b/community/procedure-api/src/main/java/org/neo4j/procedure/Admin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.procedure;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation marks a {@link Procedure} as only being executable by a user with admin permissions.
+ */
+@Target( ElementType.METHOD )
+@Retention( RetentionPolicy.RUNTIME )
+public @interface Admin
+{
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/ReplicationBenchmarkProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/ReplicationBenchmarkProcedure.java
@@ -25,16 +25,15 @@ import java.util.concurrent.Future;
 import java.util.stream.Stream;
 
 import org.neo4j.causalclustering.core.state.machines.dummy.DummyRequest;
-import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.logging.Log;
+import org.neo4j.procedure.Admin;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
 import static java.lang.Math.toIntExact;
-import static org.neo4j.graphdb.security.AuthorizationViolationException.PERMISSION_DENIED;
 import static org.neo4j.procedure.Mode.DBMS;
 
 @SuppressWarnings( "unused" )
@@ -52,12 +51,11 @@ public class ReplicationBenchmarkProcedure
     private static long startTime;
     private static List<Worker> workers;
 
+    @Admin
     @Description( "Start the benchmark." )
     @Procedure( name = "dbms.cluster.benchmark.start", mode = DBMS )
     public synchronized void start( @Name( "nThreads" ) Long nThreads, @Name( "blockSize" ) Long blockSize )
     {
-        checkSecurity();
-
         if ( workers != null )
         {
             throw new IllegalStateException( "Already running." );
@@ -76,12 +74,11 @@ public class ReplicationBenchmarkProcedure
         }
     }
 
+    @Admin
     @Description( "Stop a running benchmark." )
     @Procedure( name = "dbms.cluster.benchmark.stop", mode = DBMS )
     public synchronized Stream<BenchmarkResult> stop() throws InterruptedException
     {
-        checkSecurity();
-
         if ( workers == null )
         {
             throw new IllegalStateException( "Not running." );
@@ -113,15 +110,6 @@ public class ReplicationBenchmarkProcedure
         workers = null;
 
         return Stream.of( new BenchmarkResult( totalRequests, totalBytes, runTime ) );
-    }
-
-    private void checkSecurity() throws AuthorizationViolationException
-    {
-        securityContext.assertCredentialsNotExpired();
-        if ( !securityContext.isAdmin() )
-        {
-            throw new AuthorizationViolationException( PERMISSION_DENIED );
-        }
     }
 
     private class Worker implements Runnable

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/CloseTransactionTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/CloseTransactionTest.scala
@@ -491,7 +491,7 @@ class CloseTransactionTest extends CypherFunSuite with GraphIcing {
     val procedureName = new QualifiedName(Array[String]("org", "neo4j", "bench"), "getAllNodes")
     val emptySignature: util.List[FieldSignature] = List.empty[FieldSignature].asJava
     val signature: ProcedureSignature = new ProcedureSignature(
-      procedureName, paramSignature, resultSignature, Mode.READ, null, Array.empty,
+      procedureName, paramSignature, resultSignature, Mode.READ, false, null, Array.empty,
       null, null, false)
 
     def paramSignature: util.List[FieldSignature] = List.empty[FieldSignature].asJava

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineIT.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineIT.scala
@@ -71,7 +71,7 @@ class ExecutionEngineIT extends CypherFunSuite with GraphIcing {
     val procedureName = new QualifiedName(Array[String]("org", "neo4j", "bench"), "getAllNodes")
     val emptySignature: util.List[FieldSignature] = List.empty[FieldSignature].asJava
     val signature: ProcedureSignature = new ProcedureSignature(
-      procedureName, paramSignature, resultSignature, Mode.READ, null, Array.empty,
+      procedureName, paramSignature, resultSignature, Mode.READ, false, null, Array.empty,
       null, null, false)
 
     def paramSignature: util.List[FieldSignature] = List.empty[FieldSignature].asJava

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
@@ -53,6 +53,7 @@ import org.neo4j.kernel.impl.core.EmbeddedProxySPI;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.procedure.Admin;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
@@ -136,11 +137,10 @@ public class EnterpriseBuiltInDbmsProcedures
         return terminateTransactionsForValidUser( graph.getDependencyResolver(), username, getCurrentTx() );
     }
 
+    //@Admin
     //@Procedure( name = "dbms.listConnections", mode = DBMS )
     public Stream<ConnectionResult> listConnections()
     {
-        assertAdmin();
-
         BoltConnectionTracker boltConnectionTracker = getBoltConnectionTracker( graph.getDependencyResolver() );
         return countConnectionsByUsername(
             boltConnectionTracker
@@ -204,10 +204,10 @@ public class EnterpriseBuiltInDbmsProcedures
     @SuppressWarnings( "WeakerAccess" )
     public static class ProcedureResult
     {
+        // These two procedures are admin procedures but may be executed for your own user,
+        // this is not documented anywhere but we cannot change the behaviour in a point release
         private static final List<String> ADMIN_PROCEDURES =
-                Arrays.asList( "createUser", "deleteUser", "listUsers", "clearAuthCache", "changeUserPassword",
-                        "addRoleToUser", "removeRoleFromUser", "suspendUser", "activateUser", "listRoles",
-                        "listRolesForUser", "listUsersForRole", "createRole", "deleteRole" );
+                Arrays.asList( "changeUserPassword", "listRolesForUser" );
 
         public final String name;
         public final String signature;
@@ -225,8 +225,7 @@ public class EnterpriseBuiltInDbmsProcedures
             switch ( signature.mode() )
             {
             case DBMS:
-                // TODO: not enough granularity for dbms and user management, needs fix
-                if ( isAdminProcedure( signature.name().name() ) )
+                if ( signature.admin() || isAdminProcedure( signature.name().name() ) )
                 {
                     roles.add( "admin" );
                 }
@@ -256,21 +255,16 @@ public class EnterpriseBuiltInDbmsProcedures
 
         private boolean isAdminProcedure( String procedureName )
         {
-            return name.startsWith( "dbms.security." ) && ADMIN_PROCEDURES.contains( procedureName ) ||
-                    name.equals( "dbms.listConfig" ) ||
-                    name.equals( "dbms.setConfigValue" ) ||
-                    name.equals( "dbms.clearQueryCaches" );
+            return name.startsWith( "dbms.security." ) && ADMIN_PROCEDURES.contains( procedureName );
         }
     }
 
+    @Admin
     @Description( "Updates a given setting value. Passing an empty value will result in removing the configured value " +
             "and falling back to the default value. Changes will not persist and will be lost if the server is restarted." )
     @Procedure( name = "dbms.setConfigValue", mode = DBMS )
     public void setConfigValue( @Name( "setting" ) String setting, @Name( "value" ) String value )
     {
-        securityContext.assertCredentialsNotExpired();
-        assertAdmin();
-
         Config config = resolver.resolveDependency( Config.class );
         config.updateDynamicSetting( setting, value, "dbms.setConfigValue" ); // throws if something goes wrong
     }
@@ -532,22 +526,9 @@ public class EnterpriseBuiltInDbmsProcedures
         return config.get( GraphDatabaseSettings.db_timezone ).getZoneId();
     }
 
-    private boolean isAdmin()
-    {
-        return securityContext.isAdmin();
-    }
-
-    private void assertAdmin()
-    {
-        if ( !isAdmin() )
-        {
-            throw new AuthorizationViolationException( PERMISSION_DENIED );
-        }
-    }
-
     private boolean isAdminOrSelf( String username )
     {
-        return isAdmin() || securityContext.subject().hasUsername( username );
+        return securityContext.isAdmin() || securityContext.subject().hasUsername( username );
     }
 
     private void assertAdminOrSelf( String username )

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/SecurityProcedures.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/SecurityProcedures.java
@@ -21,13 +21,12 @@ package org.neo4j.server.security.enterprise.auth;
 
 import java.util.stream.Stream;
 
-import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthManager;
+import org.neo4j.procedure.Admin;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Procedure;
 
-import static org.neo4j.graphdb.security.AuthorizationViolationException.PERMISSION_DENIED;
 import static org.neo4j.procedure.Mode.DBMS;
 
 @SuppressWarnings( {"unused", "WeakerAccess"} )
@@ -51,15 +50,11 @@ public class SecurityProcedures extends AuthProceduresBase
         return Stream.of( userResultForSubject() );
     }
 
+    @Admin
     @Description( "Clears authentication and authorization cache." )
     @Procedure( name = "dbms.security.clearAuthCache", mode = DBMS )
     public void clearAuthenticationCache()
     {
-        securityContext.assertCredentialsNotExpired();
-        if ( !securityContext.isAdmin() )
-        {
-            throw new AuthorizationViolationException( PERMISSION_DENIED );
-        }
         authManager.clearAuthCache();
     }
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/UserManagementProcedures.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/UserManagementProcedures.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
+import org.neo4j.procedure.Admin;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
@@ -34,13 +35,13 @@ import static org.neo4j.procedure.Mode.DBMS;
 public class UserManagementProcedures extends AuthProceduresBase
 {
 
+    @Admin
     @Description( "Create a new user." )
     @Procedure( name = "dbms.security.createUser", mode = DBMS )
     public void createUser( @Name( "username" ) String username, @Name( "password" ) String password,
             @Name( value = "requirePasswordChange", defaultValue = "true" ) boolean requirePasswordChange )
             throws InvalidArgumentsException, IOException
     {
-        securityContext.assertCredentialsNotExpired();
         userManager.newUser( username, password, requirePasswordChange );
     }
 
@@ -72,59 +73,59 @@ public class UserManagementProcedures extends AuthProceduresBase
         setUserPassword( username, newPassword, requirePasswordChange );
     }
 
+    @Admin
     @Description( "Assign a role to the user." )
     @Procedure( name = "dbms.security.addRoleToUser", mode = DBMS )
     public void addRoleToUser( @Name( "roleName" ) String roleName, @Name( "username" ) String username )
             throws IOException, InvalidArgumentsException
     {
-        securityContext.assertCredentialsNotExpired();
         userManager.addRoleToUser( roleName, username );
     }
 
+    @Admin
     @Description( "Unassign a role from the user." )
     @Procedure( name = "dbms.security.removeRoleFromUser", mode = DBMS )
     public void removeRoleFromUser( @Name( "roleName" ) String roleName, @Name( "username" ) String username )
             throws InvalidArgumentsException, IOException
     {
-        securityContext.assertCredentialsNotExpired();
         userManager.removeRoleFromUser( roleName, username );
     }
 
+    @Admin
     @Description( "Delete the specified user." )
     @Procedure( name = "dbms.security.deleteUser", mode = DBMS )
     public void deleteUser( @Name( "username" ) String username ) throws InvalidArgumentsException, IOException
     {
-        securityContext.assertCredentialsNotExpired();
         if ( userManager.deleteUser( username ) )
         {
             kickoutUser( username, "deletion" );
         }
     }
 
+    @Admin
     @Description( "Suspend the specified user." )
     @Procedure( name = "dbms.security.suspendUser", mode = DBMS )
     public void suspendUser( @Name( "username" ) String username ) throws IOException, InvalidArgumentsException
     {
-        securityContext.assertCredentialsNotExpired();
         userManager.suspendUser( username );
         kickoutUser( username, "suspension" );
     }
 
+    @Admin
     @Description( "Activate a suspended user." )
     @Procedure( name = "dbms.security.activateUser", mode = DBMS )
     public void activateUser( @Name( "username" ) String username,
             @Name( value = "requirePasswordChange", defaultValue = "true" ) boolean requirePasswordChange )
             throws IOException, InvalidArgumentsException
     {
-        securityContext.assertCredentialsNotExpired();
         userManager.activateUser( username, requirePasswordChange );
     }
 
+    @Admin
     @Description( "List all local users." )
     @Procedure( name = "dbms.security.listUsers", mode = DBMS )
     public Stream<UserResult> listUsers()
     {
-        securityContext.assertCredentialsNotExpired();
         Set<String> users = userManager.getAllUsernames();
         if ( users.isEmpty() )
         {
@@ -136,11 +137,11 @@ public class UserManagementProcedures extends AuthProceduresBase
         }
     }
 
+    @Admin
     @Description( "List all available roles." )
     @Procedure( name = "dbms.security.listRoles", mode = DBMS )
     public Stream<RoleResult> listRoles()
     {
-        securityContext.assertCredentialsNotExpired();
         Set<String> roles = userManager.getAllRoleNames();
         return roles.stream().map( this::roleResultForName );
     }
@@ -154,28 +155,28 @@ public class UserManagementProcedures extends AuthProceduresBase
         return userManager.getRoleNamesForUser( username ).stream().map( StringResult::new );
     }
 
+    @Admin
     @Description( "List all users currently assigned the specified role." )
     @Procedure( name = "dbms.security.listUsersForRole", mode = DBMS )
     public Stream<StringResult> listUsersForRole( @Name( "roleName" ) String roleName )
             throws InvalidArgumentsException
     {
-        securityContext.assertCredentialsNotExpired();
         return userManager.getUsernamesForRole( roleName ).stream().map( StringResult::new );
     }
 
+    @Admin
     @Description( "Create a new role." )
     @Procedure( name = "dbms.security.createRole", mode = DBMS )
     public void createRole( @Name( "roleName" ) String roleName ) throws InvalidArgumentsException, IOException
     {
-        securityContext.assertCredentialsNotExpired();
         userManager.newRole( roleName );
     }
 
+    @Admin
     @Description( "Delete the specified role. Any role assignments will be removed." )
     @Procedure( name = "dbms.security.deleteRole", mode = DBMS )
     public void deleteRole( @Name( "roleName" ) String roleName ) throws InvalidArgumentsException, IOException
     {
-        securityContext.assertCredentialsNotExpired();
         userManager.deleteRole( roleName );
     }
 

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/EnterpriseAuthenticationTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/EnterpriseAuthenticationTestBase.java
@@ -194,7 +194,7 @@ public abstract class EnterpriseAuthenticationTestBase extends AbstractLdapTestU
     protected void assertAuthAndChangePassword( String username, String password, String newPassword ) throws Exception
     {
         assertAuth( username, password );
-        String query = format( "CALL dbms.security.changeUserPassword('%s', '%s', false)", username, newPassword );
+        String query = format( "CALL dbms.security.changePassword('%s')", newPassword );
         client.send( util.chunk( run( query ), pullAll() ) );
         assertThat( client, util.eventuallyReceives( msgSuccess(), msgSuccess() ) );
     }


### PR DESCRIPTION
A procedure with this annotation will check that the executing SecurityContext has admin permissions and that the credentials haven't expired.