### PR TITLE
Move all index to atomic files.

### DIFF
--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupCommandCcIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupCommandCcIT.java
@@ -263,8 +263,6 @@ public class OnlineBackupCommandCcIT
         assertTrue( output.contains( "Start receiving transactions from " ) );
         assertTrue( output.contains( "Finish receiving transactions at " ) );
         assertTrue( output.contains( "Start receiving index snapshots" ) );
-        assertTrue( output.contains( "Start receiving index snapshot id 1" ) );
-        assertTrue( output.contains( "Finished receiving index snapshot id 1" ) );
         assertTrue( output.contains( "Finished receiving index snapshots" ) );
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyRequestHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyRequestHandler.java
@@ -95,7 +95,7 @@ public class PrepareStoreCopyRequestHandler extends SimpleChannelInboundHandler<
 
     private PrepareStoreCopyResponse createSuccessfulResponse( CheckPointer checkPointer, PrepareStoreCopyFiles prepareStoreCopyFiles ) throws IOException
     {
-        PrimitiveLongSet indexIds = prepareStoreCopyFiles.getIndexIds();
+        PrimitiveLongSet indexIds = prepareStoreCopyFiles.getNonAtomicIndexIds();
         File[] files = prepareStoreCopyFiles.listReplayableFiles();
         long lastCommittedTxId = checkPointer.lastCheckPointedTransactionId();
         return PrepareStoreCopyResponse.success( files, indexIds, lastCommittedTxId );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/CatchupServerIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/CatchupServerIT.java
@@ -148,7 +148,8 @@ public class CatchupServerIT
         assertTransactionIdMatches( prepareStoreCopyResponse.lastTransactionId() );
 
         //and
-        assertIndexIdsAreEmpty( prepareStoreCopyResponse.getIndexIds() );
+        assertTrue( "Expected an empty set of ids. Found size " + prepareStoreCopyResponse.getIndexIds().size(),
+                prepareStoreCopyResponse.getIndexIds().isEmpty() );
     }
 
     @Test
@@ -275,11 +276,6 @@ public class CatchupServerIT
         List<String> expectedStoreFiles = getExpectedStoreFiles( neoStoreDataSource );
         List<String> givenFile = Arrays.stream( files ).map( File::getName ).collect( toList() );
         assertThat( givenFile, containsInAnyOrder( expectedStoreFiles.toArray( new String[givenFile.size()] ) ) );
-    }
-
-    private void assertIndexIdsAreEmpty( PrimitiveLongSet indexIds )
-    {
-        assertTrue( indexIds.isEmpty() );
     }
 
     private PrimitiveLongSet getExpectedIndexIds( NeoStoreDataSource neoStoreDataSource )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/CatchupServerIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/CatchupServerIT.java
@@ -58,11 +58,11 @@ import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.io.fs.FileUtils.relativePath;
 
@@ -148,7 +148,7 @@ public class CatchupServerIT
         assertTransactionIdMatches( prepareStoreCopyResponse.lastTransactionId() );
 
         //and
-        assertIndexIdsMatch( prepareStoreCopyResponse.getIndexIds(), neoStoreDataSource );
+        assertIndexIdsAreEmpty( prepareStoreCopyResponse.getIndexIds() );
     }
 
     @Test
@@ -277,10 +277,9 @@ public class CatchupServerIT
         assertThat( givenFile, containsInAnyOrder( expectedStoreFiles.toArray( new String[givenFile.size()] ) ) );
     }
 
-    private void assertIndexIdsMatch( PrimitiveLongSet indexIds, NeoStoreDataSource neoStoreDataSource )
+    private void assertIndexIdsAreEmpty( PrimitiveLongSet indexIds )
     {
-        PrimitiveLongSet expectedIndexIds = getExpectedIndexIds( neoStoreDataSource );
-        assertThat( expectedIndexIds, equalTo( indexIds ) );
+        assertTrue( indexIds.isEmpty() );
     }
 
     private PrimitiveLongSet getExpectedIndexIds( NeoStoreDataSource neoStoreDataSource )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyFilesTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyFilesTest.java
@@ -26,6 +26,8 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
@@ -129,11 +131,11 @@ public class PrepareStoreCopyFilesTest
     }
 
     @Test
-    public void shouldReturnEmptySetOfIds()
+    public void shouldReturnEmptySetOfIdsAndIgnoreIndexListing()
     {
-        PrimitiveLongSet expectedIndexIds = Primitive.longSet();
-        expectedIndexIds.add( 42 );
-        when( indexListingMock.getIndexIds() ).thenReturn( expectedIndexIds );
+        PrimitiveLongSet existingIds = Primitive.longSet();
+        existingIds.add( 42 );
+        when( indexListingMock.getIndexIds() ).thenReturn( existingIds );
 
         PrimitiveLongSet actualIndexIndexIds = prepareStoreCopyFiles.getNonAtomicIndexIds();
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyFilesTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyFilesTest.java
@@ -42,6 +42,7 @@ import org.neo4j.test.rule.TestDirectory;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -122,21 +123,21 @@ public class PrepareStoreCopyFilesTest
     @Test
     public void shouldHandleEmptyDescriptors()
     {
-        PrimitiveLongSet indexIds = prepareStoreCopyFiles.getIndexIds();
+        PrimitiveLongSet indexIds = prepareStoreCopyFiles.getNonAtomicIndexIds();
 
         assertEquals( 0, indexIds.size() );
     }
 
     @Test
-    public void shouldReturnExpectedDescriptors()
+    public void shouldReturnEmptySetOfIds()
     {
         PrimitiveLongSet expectedIndexIds = Primitive.longSet();
         expectedIndexIds.add( 42 );
         when( indexListingMock.getIndexIds() ).thenReturn( expectedIndexIds );
 
-        PrimitiveLongSet actualIndexIndexIds = prepareStoreCopyFiles.getIndexIds();
+        PrimitiveLongSet actualIndexIndexIds = prepareStoreCopyFiles.getNonAtomicIndexIds();
 
-        assertEquals( expectedIndexIds, actualIndexIndexIds );
+        assertTrue( actualIndexIndexIds.isEmpty() );
     }
 
     private String getRelativePath( StoreFileMetadata f )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyRequestHandlerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/PrepareStoreCopyRequestHandlerTest.java
@@ -155,7 +155,7 @@ public class PrepareStoreCopyRequestHandlerTest
             throws IOException
     {
         when( prepareStoreCopyFiles.getAtomicFilesSnapshot() ).thenReturn( atomicFiles );
-        when( prepareStoreCopyFiles.getIndexIds() ).thenReturn( indexIds );
+        when( prepareStoreCopyFiles.getNonAtomicIndexIds() ).thenReturn( indexIds );
         when( prepareStoreCopyFiles.listReplayableFiles() ).thenReturn( files );
         when( checkPointer.lastCheckPointedTransactionId() ).thenReturn( lastCommitedTx );
     }


### PR DESCRIPTION
Index ids will for the time being always be an empty set in prepare
store copy request.