### PR TITLE
Use File.separator instead of "/" in RecoveryCleanupIT

### DIFF
--- a/community/neo4j/src/test/java/recovery/RecoveryCleanupIT.java
+++ b/community/neo4j/src/test/java/recovery/RecoveryCleanupIT.java
@@ -172,7 +172,7 @@ public class RecoveryCleanupIT
                 "Schema index recovery completed",
                 "descriptor",
                 "file=",
-                "/" + subIndexProviderKey,
+                File.separator + subIndexProviderKey,
                 "cleaned crashed pointers",
                 "pages visited",
                 "Time spent" ) );


### PR DESCRIPTION
Windows was MAD about this, felt completely left out.