### PR TITLE
DefaultCapableIndexReference should not use provider in hash code

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DefaultCapableIndexReference.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DefaultCapableIndexReference.java
@@ -19,52 +19,26 @@
  */
 package org.neo4j.kernel.impl.api.store;
 
-import java.util.Arrays;
-
 import org.neo4j.internal.kernel.api.CapableIndexReference;
 import org.neo4j.internal.kernel.api.IndexCapability;
 import org.neo4j.internal.kernel.api.IndexOrder;
-import org.neo4j.internal.kernel.api.IndexReference;
 import org.neo4j.internal.kernel.api.IndexValueCapability;
 import org.neo4j.internal.kernel.api.schema.SchemaDescriptor;
 import org.neo4j.kernel.api.index.IndexProvider;
 import org.neo4j.kernel.api.schema.index.SchemaIndexDescriptor;
 import org.neo4j.values.storable.ValueCategory;
 
-public class DefaultCapableIndexReference implements CapableIndexReference
+public class DefaultCapableIndexReference extends DefaultIndexReference implements CapableIndexReference
 {
-    private final int label;
-    private final int[] properties;
-    private final boolean unique;
     private final IndexProvider.Descriptor providerDescriptor;
     private final IndexCapability capability;
 
     public DefaultCapableIndexReference( boolean unique, IndexCapability indexCapability,
-                IndexProvider.Descriptor providerDescriptor, int label, int... properties )
+            IndexProvider.Descriptor providerDescriptor, int label, int... properties )
     {
-        this.unique = unique;
+        super( unique, label, properties );
         this.capability = indexCapability;
-        this.label = label;
         this.providerDescriptor = providerDescriptor;
-        this.properties = properties;
-    }
-
-    @Override
-    public boolean isUnique()
-    {
-        return unique;
-    }
-
-    @Override
-    public int label()
-    {
-        return label;
-    }
-
-    @Override
-    public int[] properties()
-    {
-        return properties;
     }
 
     @Override
@@ -91,42 +65,9 @@ public class DefaultCapableIndexReference implements CapableIndexReference
         return capability.valueCapability( valueCategories );
     }
 
-    @Override
-    public boolean equals( Object o )
-    {
-        if ( this == o )
-        {
-            return true;
-        }
-        if ( !(o instanceof IndexReference) )
-        {
-            return false;
-        }
-
-        IndexReference that = (IndexReference) o;
-
-        return label == that.label() && unique == that.isUnique() && Arrays.equals( properties, that.properties() );
-    }
-
-    @Override
-    public String toString()
-    {
-        return String.format( "Index(%d:%s)", label, Arrays.toString( properties ) );
-    }
-
-    @Override
-    public int hashCode()
-    {
-        int result = label;
-        result = 31 * result + Arrays.hashCode( properties );
-        result = 31 * result + (unique ? 1 : 0);
-        result = 31 * result + (providerDescriptor != null ? providerDescriptor.hashCode() : 0);
-        return result;
-    }
-
     public static CapableIndexReference fromDescriptor( SchemaIndexDescriptor descriptor )
     {
-        boolean unique =  descriptor.type() == SchemaIndexDescriptor.Type.UNIQUE;
+        boolean unique = descriptor.type() == SchemaIndexDescriptor.Type.UNIQUE;
         final SchemaDescriptor schema = descriptor.schema();
         return new DefaultCapableIndexReference( unique, IndexCapability.NO_CAPABILITY, IndexProvider.UNDECIDED,
                 schema.keyId(), schema.getPropertyIds() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DefaultIndexReference.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DefaultIndexReference.java
@@ -32,7 +32,7 @@ public class DefaultIndexReference implements IndexReference
     private final int label;
     private final int[] properties;
 
-    private DefaultIndexReference( boolean unique, int label, int[] properties )
+    protected DefaultIndexReference( boolean unique, int label, int[] properties )
     {
         this.unique = unique;
         this.label = label;
@@ -57,12 +57,12 @@ public class DefaultIndexReference implements IndexReference
         return properties;
     }
 
-    public static IndexReference unique( int label, int...properties )
+    public static IndexReference unique( int label, int... properties )
     {
         return new DefaultIndexReference( true, label, properties );
     }
 
-    public static IndexReference general( int label, int...properties )
+    public static IndexReference general( int label, int... properties )
     {
         return new DefaultIndexReference( false, label, properties );
     }
@@ -93,7 +93,7 @@ public class DefaultIndexReference implements IndexReference
         {
             return true;
         }
-        if ( o == null || !( o instanceof IndexReference ) )
+        if ( o == null || !(o instanceof IndexReference) )
         {
             return false;
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DefaultCapableIndexReferenceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DefaultCapableIndexReferenceTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.store;
+
+
+import org.junit.Test;
+
+import org.neo4j.internal.kernel.api.IndexReference;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.neo4j.internal.kernel.api.IndexCapability.NO_CAPABILITY;
+import static org.neo4j.kernel.api.index.IndexProvider.UNDECIDED;
+
+public class DefaultCapableIndexReferenceTest
+{
+
+    private static final int LABEL = 42;
+    private static final int PROPERTY = 1337;
+
+    @Test
+    public void capableIndexReferenceShouldBeEquivalentToNormalIndexReference()
+    {
+        // Given
+        DefaultCapableIndexReference capable =
+                new DefaultCapableIndexReference( false, NO_CAPABILITY, UNDECIDED, LABEL, PROPERTY );
+        IndexReference incapable = DefaultIndexReference.general( LABEL, PROPERTY );
+
+        // Then
+        assertThat( capable, equalTo( incapable ));
+        assertThat( capable.hashCode(), equalTo( incapable.hashCode() ));
+    }
+
+}


### PR DESCRIPTION
Equivalence of IndexReferences should only be governed by label and
 properties.