### PR TITLE
Tweak cost planning with minimum cardinality

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/CardinalityCostModel.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/CardinalityCostModel.scala
@@ -111,7 +111,7 @@ case class CardinalityCostModel(config: CypherCompilerConfiguration) extends Cos
     case _: NodeIndexContainsScan | _: NodeIndexEndsWithScan =>
       Cardinality(5)
     case _ =>
-      Cardinality.SINGLE
+      Cardinality.EMPTY
   }
 
   private val planWithMinimumCardinalityEstimates: Boolean = config.planWithMinimumCardinalityEstimates

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/LogicalPlanningTestSupport2.scala
@@ -204,6 +204,9 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
 
   class given extends StubbedLogicalPlanningConfiguration(realConfig)
 
+  class givenPlanWithMinimumCardinalityEnabled
+    extends StubbedLogicalPlanningConfiguration(RealLogicalPlanningConfiguration(cypherCompilerConfig.copy(planWithMinimumCardinalityEstimates = true)))
+
   class fromDbStructure(dbStructure: Visitable[DbStructureVisitor])
     extends DelegatingLogicalPlanningConfiguration(DbStructureLogicalPlanningConfiguration(cypherCompilerConfig)(dbStructure))
 


### PR DESCRIPTION
We should not lose selectivity information when cardinality < 1.0
in sub-plans.