### PR TITLE
Normalize nanos to be between 0 and 1s

### DIFF
--- a/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
@@ -87,12 +87,8 @@ public final class DurationValue extends ScalarValue implements TemporalAmount, 
     {
         seconds += nanos / NANOS_PER_SECOND;
         nanos %= NANOS_PER_SECOND;
-        if ( seconds < 0 && nanos > 0 )
-        {
-            seconds += 1;
-            nanos -= NANOS_PER_SECOND;
-        }
-        else if ( seconds > 0 && nanos < 0 )
+        // normalize nanos to be between 0 and NANOS_PER_SECOND-1
+        if ( nanos < 0 )
         {
             seconds -= 1;
             nanos += NANOS_PER_SECOND;
@@ -214,12 +210,8 @@ public final class DurationValue extends ScalarValue implements TemporalAmount, 
     {
         seconds += nanos / NANOS_PER_SECOND;
         nanos %= NANOS_PER_SECOND;
-        if ( seconds < 0 && nanos > 0 )
-        {
-            seconds += 1;
-            nanos -= NANOS_PER_SECOND;
-        }
-        else if ( seconds > 0 && nanos < 0 )
+        // normalize nanos to be between 0 and NANOS_PER_SECOND-1
+        if ( nanos < 0 )
         {
             seconds -= 1;
             nanos += NANOS_PER_SECOND;
@@ -614,28 +606,40 @@ public final class DurationValue extends ScalarValue implements TemporalAmount, 
         append( str, days, 'D' );
         if ( seconds != 0 || nanos != 0 )
         {
+            boolean negative = seconds < 0;
+            long s = seconds;
+            int n = nanos;
+            if ( negative && nanos != 0 )
+            {
+                s++;
+                n -= NANOS_PER_SECOND;
+            }
             str.append( 'T' );
-            long s = seconds % 3600;
-            append( str, seconds / 3600, 'H' );
+            append( str, s / 3600, 'H' );
+            s %= 3600;
             append( str, s / 60, 'M' );
             s %= 60;
             if ( s != 0 )
             {
-                str.append( s );
-                if ( nanos != 0 )
+                if ( negative && s >= 0 && n != 0 )
                 {
-                    nanos( str );
+                    str.append( '-' );
+                }
+                str.append( s );
+                if ( n != 0 )
+                {
+                    nanos( str, n );
                 }
                 str.append( 'S' );
             }
-            else if ( nanos != 0 )
+            else if ( n != 0 )
             {
-                if ( nanos < 0 )
+                if ( negative )
                 {
                     str.append( '-' );
                 }
                 str.append( '0' );
-                nanos( str );
+                nanos( str, n );
                 str.append( 'S' );
             }
         }
@@ -646,7 +650,7 @@ public final class DurationValue extends ScalarValue implements TemporalAmount, 
         return str.toString();
     }
 
-    private void nanos( StringBuilder str )
+    private void nanos( StringBuilder str, int nanos )
     {
         str.append( '.' );
         int n = nanos < 0 ? -nanos : nanos;

--- a/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
@@ -85,14 +85,6 @@ public final class DurationValue extends ScalarValue implements TemporalAmount, 
 
     public static DurationValue duration( long months, long days, long seconds, long nanos )
     {
-        seconds += nanos / NANOS_PER_SECOND;
-        nanos %= NANOS_PER_SECOND;
-        // normalize nanos to be between 0 and NANOS_PER_SECOND-1
-        if ( nanos < 0 )
-        {
-            seconds -= 1;
-            nanos += NANOS_PER_SECOND;
-        }
         return newDuration( months, days, seconds, (int) nanos );
     }
 

--- a/community/values/src/test/java/org/neo4j/values/storable/DurationValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DurationValueTest.java
@@ -68,13 +68,54 @@ public class DurationValueTest
         // then
         assertEquals( "+nanos", 500_000_000, pos.get( NANOS ) );
         assertEquals( "+seconds", 1, pos.get( SECONDS ) );
-        assertEquals( "-nanos", -400_000_000, neg.get( NANOS ) );
-        assertEquals( "-seconds", -1, neg.get( SECONDS ) );
+        assertEquals( "+nanos", 600_000_000, neg.get( NANOS ) );
+        assertEquals( "-seconds", -2, neg.get( SECONDS ) );
 
         assertEquals( "+nanos", 0, evenPos.get( NANOS ) );
         assertEquals( "+seconds", 1, evenPos.get( SECONDS ) );
-        assertEquals( "-nanos", 0, evenNeg.get( NANOS ) );
+        assertEquals( "+nanos", 0, evenNeg.get( NANOS ) );
         assertEquals( "-seconds", -1, evenNeg.get( SECONDS ) );
+    }
+
+    @Test
+    public void shouldFormatDurationToString()
+    {
+        testDurationToString( 1, 0, "PT1S" );
+        testDurationToString( -1, 0, "PT-1S" );
+
+        testDurationToString( 59, -500_000_000, "PT58.5S" );
+        testDurationToString( 59, 500_000_000, "PT59.5S" );
+        testDurationToString( 60, -500_000_000, "PT59.5S" );
+        testDurationToString( 60, 500_000_000, "PT1M0.5S" );
+        testDurationToString( 61, -500_000_000, "PT1M0.5S" );
+
+        testDurationToString( -59, 500_000_000, "PT-58.5S" );
+        testDurationToString( -59, -500_000_000, "PT-59.5S" );
+        testDurationToString( -60, 500_000_000, "PT-59.5S" );
+        testDurationToString( -60, -500_000_000, "PT-1M-0.5S" );
+        testDurationToString( -61, 500_000_000, "PT-1M-0.5S" );
+        testDurationToString( -61, -500_000_000, "PT-1M-1.5S" );
+
+        testDurationToString( 0, 5, "PT0.000000005S" );
+        testDurationToString( 0, -5, "PT-0.000000005S" );
+        testDurationToString( 0, 999_999_999, "PT0.999999999S" );
+        testDurationToString( 0, -999_999_999, "PT-0.999999999S" );
+
+        testDurationToString( 1, 5, "PT1.000000005S" );
+        testDurationToString( -1, -5, "PT-1.000000005S" );
+        testDurationToString( 1, -5, "PT0.999999995S" );
+        testDurationToString( -1, 5, "PT-0.999999995S" );
+        testDurationToString( 1, 999999999, "PT1.999999999S" );
+        testDurationToString( -1, -999999999, "PT-1.999999999S" );
+        testDurationToString( 1, -999999999, "PT0.000000001S" );
+        testDurationToString( -1, 999999999, "PT-0.000000001S" );
+
+        testDurationToString( -78036, -143000000, "PT-21H-40M-36.143S" );
+    }
+
+    private void testDurationToString( long seconds, int nanos, String expectedValue )
+    {
+        assertEquals( expectedValue, duration( 0, 0, seconds, nanos ).prettyPrint() );
     }
 
     @Test
@@ -85,13 +126,20 @@ public class DurationValueTest
         DurationValue neg = duration( 0, 0, -5, 1_500_000_000 );
         DurationValue x = duration( 0, 0, 1, -1_400_000_000 );
 
+        DurationValue y = duration( 0, 0, -59, -500_000_000 );
+        DurationValue y2 = duration( 0, 0, -60, 500_000_000 );
+
         // then
         assertEquals( "+nanos", 600_000_000, pos.get( NANOS ) );
         assertEquals( "+seconds", 3, pos.get( SECONDS ) );
-        assertEquals( "-nanos", -500_000_000, neg.get( NANOS ) );
-        assertEquals( "-seconds", -3, neg.get( SECONDS ) );
-        assertEquals( "-nanos", -400_000_000, x.get( NANOS ) );
-        assertEquals( "-seconds", 0, x.get( SECONDS ) );
+        assertEquals( "+nanos", 500_000_000, neg.get( NANOS ) );
+        assertEquals( "-seconds", -4, neg.get( SECONDS ) );
+        assertEquals( "+nanos", 600_000_000, x.get( NANOS ) );
+        assertEquals( "-seconds", -1, x.get( SECONDS ) );
+        assertEquals( "+nanos", 500_000_000, y.get( NANOS ) );
+        assertEquals( "-seconds", -60, y.get( SECONDS ) );
+        assertEquals( "+nanos", 500_000_000, y2.get( NANOS ) );
+        assertEquals( "-seconds", -60, y2.get( SECONDS ) );
     }
 
     @Test
@@ -107,6 +155,10 @@ public class DurationValueTest
         assertEquals( "PT0.000000001S", prettyPrint( 0, 0, 0, 1 ) );
         assertEquals( "PT0.1S", prettyPrint( 0, 0, 0, 100_000_000 ) );
         assertEquals( "PT0S", prettyPrint( 0, 0, 0, 0 ) );
+        assertEquals( "PT1S", prettyPrint( 0, 0, 0, 1_000_000_000 ) );
+        assertEquals( "PT-1S", prettyPrint( 0, 0, 0, -1_000_000_000 ) );
+        assertEquals( "PT1.5S", prettyPrint( 0, 0, 1, 500_000_000 ) );
+        assertEquals( "PT-1.4S", prettyPrint( 0, 0, -1, -400_000_000 ) );
     }
 
     private static String prettyPrint( long months, long days, long seconds, int nanos )

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/DurationBetweenAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/DurationBetweenAcceptance.feature
@@ -373,7 +373,7 @@ Feature: DurationBetweenAcceptance
       | 'PT0.4S'      |
       | 'PT0.6S'      |
       | 'PT10M0.6S'   |
-      | 'PT-9M-59.4S' |
+      | 'PT-10M0.6S'  |
       | 'PT-0.3S'     |
       | 'PT9M59.7S'   |
       | 'PT-10M-0.3S' |

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/DurationBetweenAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/DurationBetweenAcceptance.feature
@@ -373,7 +373,7 @@ Feature: DurationBetweenAcceptance
       | 'PT0.4S'      |
       | 'PT0.6S'      |
       | 'PT10M0.6S'   |
-      | 'PT-10M0.6S'  |
+      | 'PT-9M-59.4S' |
       | 'PT-0.3S'     |
       | 'PT9M59.7S'   |
       | 'PT-10M-0.3S' |

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/TemporalToStringAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/TemporalToStringAcceptance.feature
@@ -91,7 +91,10 @@ Feature: TemporalToStringAcceptance
               duration({seconds: -2, milliseconds: 1}),
               duration({seconds: -2, milliseconds: -1}),
               duration({days: 1, milliseconds: 1}),
-              duration({days: 1, milliseconds: -1})
+              duration({days: 1, milliseconds: -1}),
+              duration({seconds: 60, milliseconds: -1}),
+              duration({seconds: -60, milliseconds: 1}),
+              duration({seconds: -60, milliseconds: -1})
               ] as d
       RETURN toString(d) as ts, duration(toString(d)) = d as b
       """
@@ -105,6 +108,9 @@ Feature: TemporalToStringAcceptance
       | 'PT-2.001S'                     | true |
       | 'P1DT0.001S'                    | true |
       | 'P1DT-0.001S'                   | true |
+      | 'PT59.999S'                     | true |
+      | 'PT-59.999S'                    | true |
+      | 'PT-1M-0.001S'                  | true |
     And no side effects
 
   Scenario: Should serialize timezones correctly


### PR DESCRIPTION
Normalize nanoseconds to be between 0 and 999_999_999 instead of between -999_999_999 and 999_999_999.