### PR TITLE
Configurable default time zone

### DIFF
--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/CsvImporter.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/CsvImporter.java
@@ -115,8 +115,8 @@ class CsvImporter implements Importer
                 null, false, databaseConfig, storeDir, highIO ) );
 
         // Extract the default time zone from the database configuration
-        LogTimeZone dbTimeZone = databaseConfig.get( GraphDatabaseSettings.db_timezone );
-        Supplier<ZoneId> defaultTimeZone = () -> dbTimeZone.getZoneId();
+        ZoneId dbTimeZone = databaseConfig.get( GraphDatabaseSettings.db_temporal_timezone );
+        Supplier<ZoneId> defaultTimeZone = () -> dbTimeZone;
 
         CsvInput input = new CsvInput(
                 nodeData( inputEncoding, nodesFiles ), defaultFormatNodeFileHeader( defaultTimeZone ),

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -21,6 +21,8 @@ package org.neo4j.graphdb.factory;
 
 import java.io.File;
 import java.time.Duration;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import org.neo4j.configuration.Description;
@@ -45,6 +47,7 @@ import org.neo4j.kernel.configuration.Title;
 import org.neo4j.kernel.configuration.ssl.SslPolicyConfigValidator;
 import org.neo4j.logging.Level;
 import org.neo4j.logging.LogTimeZone;
+import org.neo4j.values.storable.DateTimeValue;
 
 import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
 import static org.neo4j.kernel.configuration.Settings.BYTES;
@@ -382,7 +385,7 @@ public class GraphDatabaseSettings implements LoadableConfig
     public static final Setting<Level> store_internal_log_level = setting( "dbms.logs.debug.level",
             options( Level.class ), "INFO" );
 
-    @Description( "Database timezone." )
+    @Description( "Database timezone. This setting influences which timezone the logs use." )
     public static final Setting<LogTimeZone> db_timezone =
             setting( "dbms.db.timezone", options( LogTimeZone.class ), LogTimeZone.UTC.name() );
 
@@ -391,6 +394,11 @@ public class GraphDatabaseSettings implements LoadableConfig
     @ReplacedBy( "dbms.db.timezone" )
     public static final Setting<LogTimeZone> log_timezone =
             setting( "dbms.logs.timezone", options( LogTimeZone.class ), LogTimeZone.UTC.name() );
+
+    @Description( "Database timezone for temporal functions. All Time and DateTime values that are created without " +
+            "an explicit timezone will use the configured default timezone." )
+    public static final Setting<ZoneId> db_temporal_timezone =
+            setting( "db.temporal.timezone", DateTimeValue::parseZoneOffsetOrZoneName, ZoneOffset.UTC.toString() );
 
     @Description( "Maximum time to wait for active transaction completion when rotating counts store" )
     @Internal

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -385,7 +385,7 @@ public class GraphDatabaseSettings implements LoadableConfig
     public static final Setting<Level> store_internal_log_level = setting( "dbms.logs.debug.level",
             options( Level.class ), "INFO" );
 
-    @Description( "Database timezone. This setting influences which timezone the logs use." )
+    @Description( "Database timezone. Among other things, this setting influences which timezone the logs and monitoring procedures use." )
     public static final Setting<LogTimeZone> db_timezone =
             setting( "dbms.db.timezone", options( LogTimeZone.class ), LogTimeZone.UTC.name() );
 
@@ -396,7 +396,7 @@ public class GraphDatabaseSettings implements LoadableConfig
             setting( "dbms.logs.timezone", options( LogTimeZone.class ), LogTimeZone.UTC.name() );
 
     @Description( "Database timezone for temporal functions. All Time and DateTime values that are created without " +
-            "an explicit timezone will use the configured default timezone." )
+            "an explicit timezone will use this configured default timezone." )
     public static final Setting<ZoneId> db_temporal_timezone =
             setting( "db.temporal.timezone", DateTimeValue::parseZoneOffsetOrZoneName, ZoneOffset.UTC.toString() );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -262,10 +262,11 @@ public class DataSourceModule
         Log internalLog = platform.logging.getInternalLog( Procedures.class );
         EmbeddedProxySPI proxySPI = platform.dependencies.resolveDependency( EmbeddedProxySPI.class );
 
+        ProcedureConfig procedureConfig = new ProcedureConfig( platform.config );
         Procedures procedures = new Procedures( proxySPI,
                 new SpecialBuiltInProcedures( Version.getNeo4jVersion(),
                         platform.databaseInfo.edition.toString() ),
-                pluginDir, internalLog, new ProcedureConfig( platform.config ) );
+                pluginDir, internalLog, procedureConfig );
         platform.life.add( procedures );
         platform.dependencies.satisfyDependency( procedures );
 
@@ -300,7 +301,7 @@ public class DataSourceModule
         // Edition procedures
         try
         {
-            editionModule.registerProcedures( procedures );
+            editionModule.registerProcedures( procedures, procedureConfig );
         }
         catch ( KernelException e )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
@@ -43,6 +43,7 @@ import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory.Configuration;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.StatementLocksFactory;
 import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.proc.ProcedureConfig;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.id.BufferedIdController;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.id.DefaultIdController;
@@ -78,13 +79,13 @@ public abstract class EditionModule
     private static final boolean safeIdBuffering = FeatureToggles.flag(
             EditionModule.class, "safeIdBuffering", true );
 
-    void registerProcedures( Procedures procedures ) throws KernelException
+    void registerProcedures( Procedures procedures, ProcedureConfig procedureConfig ) throws KernelException
     {
         procedures.registerProcedure( org.neo4j.kernel.builtinprocs.BuiltInProcedures.class );
         procedures.registerProcedure( org.neo4j.kernel.builtinprocs.TokenProcedures.class );
         procedures.registerProcedure( org.neo4j.kernel.builtinprocs.BuiltInDbmsProcedures.class );
         procedures.registerBuiltInFunctions( org.neo4j.kernel.builtinprocs.BuiltInFunctions.class );
-        registerTemporalFunctions( procedures );
+        registerTemporalFunctions( procedures, procedureConfig );
 
         registerEditionSpecificProcedures( procedures );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureConfig.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureConfig.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.proc;
 
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
@@ -29,6 +30,7 @@ import java.util.stream.Stream;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.configuration.Config;
 
+import static java.time.ZoneOffset.UTC;
 import static java.util.Arrays.stream;
 
 public class ProcedureConfig
@@ -45,6 +47,7 @@ public class ProcedureConfig
     private final List<ProcMatcher> matchers;
     private final List<Pattern> accessPatterns;
     private final List<Pattern> whiteList;
+    private final ZoneId defaultTemporalTimeZone;
 
     private ProcedureConfig()
     {
@@ -52,6 +55,7 @@ public class ProcedureConfig
         this.matchers = Collections.emptyList();
         this.accessPatterns = Collections.emptyList();
         this.whiteList = Collections.singletonList( compilePattern( "*" ) );
+        this.defaultTemporalTimeZone = UTC;
     }
 
     public ProcedureConfig( Config config )
@@ -78,6 +82,7 @@ public class ProcedureConfig
         this.whiteList =
                 parseMatchers( GraphDatabaseSettings.procedure_whitelist.name(), config, PROCEDURE_DELIMITER,
                         ProcedureConfig::compilePattern );
+        this.defaultTemporalTimeZone = config.get( GraphDatabaseSettings.db_temporal_timezone );
     }
 
     private <T> List<T> parseMatchers( String configName, Config config, String delimiter, Function<String,T>
@@ -132,6 +137,11 @@ public class ProcedureConfig
     }
 
     static final ProcedureConfig DEFAULT = new ProcedureConfig();
+
+    public ZoneId getDefaultTemporalTimeZone()
+    {
+        return defaultTemporalTimeZone;
+    }
 
     private static class ProcMatcher
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/DateFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/DateFunction.java
@@ -36,15 +36,15 @@ import static org.neo4j.internal.kernel.api.procs.Neo4jTypes.NTDate;
 @Description( "Create a Date instant." )
 class DateFunction extends TemporalFunction<DateValue>
 {
-    DateFunction()
+    DateFunction( Supplier<ZoneId> defaultZone )
     {
-        super( NTDate );
+        super( NTDate, defaultZone );
     }
 
     @Override
-    protected DateValue now( Clock clock, String timezone )
+    protected DateValue now( Clock clock, String timezone, Supplier<ZoneId> defaultZone )
     {
-        return timezone == null ? DateValue.now( clock ) : DateValue.now( clock, timezone );
+        return timezone == null ? DateValue.now( clock, defaultZone ) : DateValue.now( clock, timezone );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/DateTimeFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/DateTimeFunction.java
@@ -49,15 +49,15 @@ import static org.neo4j.internal.kernel.api.procs.Neo4jTypes.NTDateTime;
 @Description( "Create a DateTime instant." )
 class DateTimeFunction extends TemporalFunction<DateTimeValue>
 {
-    DateTimeFunction()
+    DateTimeFunction( Supplier<ZoneId> defaultZone )
     {
-        super( NTDateTime );
+        super( NTDateTime, defaultZone );
     }
 
     @Override
-    protected DateTimeValue now( Clock clock, String timezone )
+    protected DateTimeValue now( Clock clock, String timezone, Supplier<ZoneId> defaultZone )
     {
-        return timezone == null ? DateTimeValue.now( clock ) : DateTimeValue.now( clock, timezone );
+        return timezone == null ? DateTimeValue.now( clock, defaultZone ) : DateTimeValue.now( clock, timezone );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/LocalDateTimeFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/LocalDateTimeFunction.java
@@ -36,15 +36,15 @@ import static org.neo4j.internal.kernel.api.procs.Neo4jTypes.NTLocalDateTime;
 @Description( "Create a LocalDateTime instant." )
 class LocalDateTimeFunction extends TemporalFunction<LocalDateTimeValue>
 {
-    LocalDateTimeFunction()
+    LocalDateTimeFunction( Supplier<ZoneId> defaultZone )
     {
-        super( NTLocalDateTime );
+        super( NTLocalDateTime, defaultZone );
     }
 
     @Override
-    protected LocalDateTimeValue now( Clock clock, String timezone )
+    protected LocalDateTimeValue now( Clock clock, String timezone, Supplier<ZoneId> defaultZone )
     {
-        return timezone == null ? LocalDateTimeValue.now( clock ) : LocalDateTimeValue.now( clock, timezone );
+        return timezone == null ? LocalDateTimeValue.now( clock, defaultZone ) : LocalDateTimeValue.now( clock, timezone );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/LocalTimeFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/LocalTimeFunction.java
@@ -36,15 +36,15 @@ import static org.neo4j.internal.kernel.api.procs.Neo4jTypes.NTLocalTime;
 @Description( "Create a LocalTime instant." )
 class LocalTimeFunction extends TemporalFunction<LocalTimeValue>
 {
-    LocalTimeFunction()
+    LocalTimeFunction( Supplier<ZoneId> defaultZone )
     {
-        super( NTLocalTime );
+        super( NTLocalTime, defaultZone );
     }
 
     @Override
-    protected LocalTimeValue now( Clock clock, String timezone )
+    protected LocalTimeValue now( Clock clock, String timezone, Supplier<ZoneId> defaultZone  )
     {
-        return timezone == null ? LocalTimeValue.now( clock ) : LocalTimeValue.now( clock, timezone );
+        return timezone == null ? LocalTimeValue.now( clock, defaultZone ) : LocalTimeValue.now( clock, timezone );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/TimeFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/TimeFunction.java
@@ -36,15 +36,15 @@ import static org.neo4j.internal.kernel.api.procs.Neo4jTypes.NTTime;
 @Description( "Create a Time instant." )
 class TimeFunction extends TemporalFunction<TimeValue>
 {
-    TimeFunction()
+    TimeFunction( Supplier<ZoneId> defaultZone )
     {
-        super( NTTime );
+        super( NTTime, defaultZone );
     }
 
     @Override
-    protected TimeValue now( Clock clock, String timezone )
+    protected TimeValue now( Clock clock, String timezone, Supplier<ZoneId> defaultZone )
     {
-        return timezone == null ? TimeValue.now( clock ) : TimeValue.now( clock, timezone );
+        return timezone == null ? TimeValue.now( clock, defaultZone ) : TimeValue.now( clock, timezone );
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/DateTimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DateTimeValue.java
@@ -62,6 +62,7 @@ import static org.neo4j.values.storable.DateValue.DATE_PATTERN;
 import static org.neo4j.values.storable.DateValue.parseDate;
 import static org.neo4j.values.storable.IntegralValue.safeCastIntegral;
 import static org.neo4j.values.storable.LocalDateTimeValue.optTime;
+import static org.neo4j.values.storable.TimeValue.OFFSET;
 import static org.neo4j.values.storable.TimeValue.TIME_PATTERN;
 import static org.neo4j.values.storable.TimeValue.parseOffset;
 
@@ -160,6 +161,11 @@ public final class DateTimeValue extends TemporalValue<ZonedDateTime,DateTimeVal
     public static DateTimeValue now( Clock clock, String timezone )
     {
         return now( clock.withZone( parseZoneName( timezone ) ) );
+    }
+
+    public static DateTimeValue now( Clock clock, Supplier<ZoneId> defaultZone )
+    {
+        return now( clock.withZone( defaultZone.get() ) );
     }
 
     public static DateTimeValue build( MapValue map, Supplier<ZoneId> defaultZone )
@@ -629,6 +635,23 @@ public final class DateTimeValue extends TemporalValue<ZonedDateTime,DateTimeVal
             throw new TemporalParseException( e.getMessage(), e.getParsedString(), e.getErrorIndex(), e );
         }
         return parsedName;
+    }
+
+    public static ZoneId parseZoneOffsetOrZoneName( String zoneName )
+    {
+        Matcher matcher = OFFSET.matcher( zoneName );
+        if ( matcher.matches() )
+        {
+            return parseOffset( matcher );
+        }
+        try
+        {
+            return ZONE_NAME_PARSER.parse( zoneName.replace( ' ', '_' ) ).query( TemporalQueries.zoneId() );
+        }
+        catch ( DateTimeParseException e )
+        {
+            throw new TemporalParseException( e.getMessage(), e.getParsedString(), e.getErrorIndex(), e );
+        }
     }
 
     abstract static class DateTimeBuilder<Result> extends Builder<Result>

--- a/community/values/src/main/java/org/neo4j/values/storable/DateValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DateValue.java
@@ -105,6 +105,11 @@ public final class DateValue extends TemporalValue<LocalDate,DateValue>
         return now( clock.withZone( parseZoneName( timezone ) ) );
     }
 
+    public static DateValue now( Clock clock, Supplier<ZoneId> defaultZone )
+    {
+        return now( clock.withZone( defaultZone.get() ) );
+    }
+
     public static DateValue build( MapValue map, Supplier<ZoneId> defaultZone )
     {
         return StructureBuilder.build( builder( defaultZone ), map );

--- a/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
@@ -548,13 +548,16 @@ public final class DurationValue extends ScalarValue implements TemporalAmount, 
         int toNanos = to.isSupported( NANO_OF_SECOND ) ? to.get( NANO_OF_SECOND ) : 0;
         nanos = toNanos - fromNanos;
 
-        boolean specialZeroSecondCase = seconds == 0 && from.get( SECOND_OF_MINUTE ) != to.get( SECOND_OF_MINUTE );
+        boolean differenceIsLessThanOneSecond = seconds == 0
+                && from.isSupported( SECOND_OF_MINUTE )
+                && to.isSupported( SECOND_OF_MINUTE )
+                && from.get( SECOND_OF_MINUTE ) != to.get( SECOND_OF_MINUTE );
 
-        if ( nanos < 0 && ( seconds > 0 || specialZeroSecondCase ) )
+        if ( nanos < 0 && ( seconds > 0 || differenceIsLessThanOneSecond ) )
         {
             nanos = NANOS_PER_SECOND + nanos;
         }
-        else if ( nanos > 0 && ( seconds < 0 || specialZeroSecondCase ) )
+        else if ( nanos > 0 && ( seconds < 0 || differenceIsLessThanOneSecond ) )
         {
             nanos = nanos - NANOS_PER_SECOND;
         }

--- a/community/values/src/main/java/org/neo4j/values/storable/LocalDateTimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/LocalDateTimeValue.java
@@ -103,6 +103,11 @@ public final class LocalDateTimeValue extends TemporalValue<LocalDateTime,LocalD
         return now( clock.withZone( parseZoneName( timezone ) ) );
     }
 
+    public static LocalDateTimeValue now( Clock clock, Supplier<ZoneId> defaultZone )
+    {
+        return now( clock.withZone( defaultZone.get() ) );
+    }
+
     public static LocalDateTimeValue build( MapValue map, Supplier<ZoneId> defaultZone )
     {
         return StructureBuilder.build( builder( defaultZone ), map );

--- a/community/values/src/main/java/org/neo4j/values/storable/LocalTimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/LocalTimeValue.java
@@ -86,6 +86,11 @@ public final class LocalTimeValue extends TemporalValue<LocalTime,LocalTimeValue
         return now( clock.withZone( parseZoneName( timezone ) ) );
     }
 
+    public static LocalTimeValue now( Clock clock, Supplier<ZoneId> defaultZone )
+    {
+        return now( clock.withZone( defaultZone.get() ) );
+    }
+
     public static LocalTimeValue build( MapValue map, Supplier<ZoneId> defaultZone )
     {
         return StructureBuilder.build( builder( defaultZone ), map );

--- a/community/values/src/main/java/org/neo4j/values/storable/TimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TimeValue.java
@@ -112,6 +112,11 @@ public final class TimeValue extends TemporalValue<OffsetTime,TimeValue>
         return now( clock.withZone( parseZoneName( timezone ) ) );
     }
 
+    public static TimeValue now( Clock clock, Supplier<ZoneId> defaultZone )
+    {
+        return now( clock.withZone( defaultZone.get() ) );
+    }
+
     public static TimeValue build( MapValue map, Supplier<ZoneId> defaultZone )
     {
         return StructureBuilder.build( builder( defaultZone ), map );
@@ -381,7 +386,7 @@ public final class TimeValue extends TemporalValue<OffsetTime,TimeValue>
     private static final String OFFSET_PATTERN = "(?<zone>Z|[+-](?<zoneHour>[0-9]{2})(?::?(?<zoneMinute>[0-9]{2}))?)";
     static final String TIME_PATTERN = LocalTimeValue.TIME_PATTERN + "(?:" + OFFSET_PATTERN + ")?";
     private static final Pattern PATTERN = Pattern.compile( "(?:T)?" + TIME_PATTERN );
-    private static final Pattern OFFSET = Pattern.compile( OFFSET_PATTERN );
+    static final Pattern OFFSET = Pattern.compile( OFFSET_PATTERN );
 
     static ZoneOffset parseOffset( String offset )
     {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
@@ -168,3 +168,4 @@ Feature "DurationBetweenAcceptance": Scenario "Should compute negative duration 
 Feature "DurationBetweenAcceptance": Scenario "Should handle durations at daylight saving time day"
 Feature "DurationBetweenAcceptance": Scenario "Should handle large durations"
 Feature "DurationBetweenAcceptance": Scenario "Should handle when seconds and subseconds have different signs"
+Feature "DurationBetweenAcceptance": Scenario "Should compute durations with no difference"

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -293,3 +293,4 @@ Feature "DurationBetweenAcceptance": Scenario "Should compute negative duration 
 Feature "DurationBetweenAcceptance": Scenario "Should handle durations at daylight saving time day"
 Feature "DurationBetweenAcceptance": Scenario "Should handle large durations"
 Feature "DurationBetweenAcceptance": Scenario "Should handle when seconds and subseconds have different signs"
+Feature "DurationBetweenAcceptance": Scenario "Should compute durations with no difference"

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/DurationBetweenAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/DurationBetweenAcceptance.feature
@@ -380,3 +380,24 @@ Feature: DurationBetweenAcceptance
       | 'PT-1.6S'     |
       | 'PT1.6S'      |
     And no side effects
+
+  Scenario: Should compute durations with no difference
+    Given an empty graph
+    When executing query:
+    """
+    UNWIND[ duration.inSeconds(localtime(), localtime()),
+            duration.inSeconds(time(), time()),
+            duration.inSeconds(date(), date()),
+            duration.inSeconds(localdatetime(), localdatetime()),
+            duration.inSeconds(datetime(), datetime())
+          ] as d
+    RETURN d
+    """
+    Then the result should be, in order:
+      | d             |
+      | 'PT0S'        |
+      | 'PT0S'        |
+      | 'PT0S'        |
+      | 'PT0S'        |
+      | 'PT0S'        |
+    And no side effects

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TimeZoneAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TimeZoneAcceptanceTest.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import java.time.{ZoneId, ZonedDateTime}
+
+import org.neo4j.cypher._
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
+import org.neo4j.graphdb.config.Setting
+import org.neo4j.graphdb.factory.GraphDatabaseSettings
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
+import org.neo4j.test.TestGraphDatabaseFactory
+import org.neo4j.values.storable.DurationValue
+import org.neo4j.values.utils.TemporalParseException
+
+abstract class TimeZoneAcceptanceTest(timezone: String) extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with CypherComparisonSupport {
+
+  override def databaseConfig(): Map[Setting[_], String] = {
+    Map(
+      GraphDatabaseSettings.cypher_hints_error -> "true",
+      GraphDatabaseSettings.db_temporal_timezone -> timezone)
+  }
+
+  test("should use default timezone for current date and time") {
+    for (func <- Seq("date", "localtime", "time", "localdatetime", "datetime")) {
+      val query = s"RETURN duration.inSeconds($func.statement(), $func.statement('$timezone')) as diff"
+      val result = executeWith(Configs.Interpreted - Configs.Version2_3, query)
+      result.toList should equal(List(Map("diff" -> DurationValue.duration(0, 0, 0, 0))))
+    }
+  }
+
+  test("should get timezone for current datetime") {
+    val query = s"RETURN datetime().timezone as tz"
+    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    result.toList should equal(List(Map("tz" -> timezone)))
+  }
+
+  test("should get timezone for parse time") {
+    val query = s"RETURN time('12:00').timezone as tz"
+    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    result.toList should equal(List(Map("tz" -> ZonedDateTime.now(ZoneId.of(timezone)).getOffset.toString)))
+  }
+
+  test("should get timezone for parse datetime") {
+    val query = s"RETURN datetime('2018-01-01T12:00').timezone as tz"
+    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    result.toList should equal(List(Map("tz" -> timezone)))
+  }
+
+  test("should get timezone for select time") {
+    val query = s"RETURN time(localtime()).timezone as tz"
+    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    result.toList should equal(List(Map("tz" -> ZonedDateTime.now(ZoneId.of(timezone)).getOffset.toString)))
+  }
+
+  test("should get timezone for select datetime") {
+    val query = s"RETURN datetime({date: date(), time: localtime()}).timezone as tz"
+    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    result.toList should equal(List(Map("tz" -> timezone)))
+  }
+
+  test("should get timezone for build time") {
+    val query = s"RETURN time({hour: 12}).timezone as tz"
+    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    result.toList should equal(List(Map("tz" -> ZonedDateTime.now(ZoneId.of(timezone)).getOffset.toString)))
+  }
+
+  test("should get timezone for build datetime") {
+    val query = s"RETURN datetime({year: 2018}).timezone as tz"
+    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    result.toList should equal(List(Map("tz" -> timezone)))
+  }
+
+  test("should get timezone for truncate time") {
+    val query = s"RETURN time.truncate('minute', localtime()).timezone as tz"
+    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    result.toList should equal(List(Map("tz" -> ZonedDateTime.now(ZoneId.of(timezone)).getOffset.toString)))
+  }
+
+  test("should get timezone for truncate datetime") {
+    val query = s"RETURN datetime.truncate('minute', localdatetime()).timezone as tz"
+    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    result.toList should equal(List(Map("tz" -> timezone)))
+  }
+
+}
+
+class NamedTimeZoneAcceptanceTest extends TimeZoneAcceptanceTest("Europe/Berlin")
+
+class OffsetTimeZoneAcceptanceTest extends TimeZoneAcceptanceTest("+03:00")
+
+class InvalidTimeZoneConfigTest extends CypherFunSuite with GraphIcing {
+
+  import scala.collection.JavaConverters._
+
+  test("invalid timezone should fail startup") {
+    val invalidConfig: Map[Setting[_], String] = Map(GraphDatabaseSettings.db_temporal_timezone -> "Europe/Satia")
+    a[TemporalParseException] should be thrownBy {
+      new TestGraphDatabaseFactory().newImpermanentDatabase(invalidConfig.asJava)
+    }
+  }
+}


### PR DESCRIPTION
a) Fixes a bug when the duration between two equal dates was computed.
b) Enables to configure the default time zone for temporal values.

changelog: Adds the configuration option `db.temporal.timezone` to configure a default time zone affecting the creation of all temporal  values.