### PR TITLE
Uses Configuration.Overridden in neo4j-admin import

### DIFF
--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/config/WrappedBatchImporterConfigurationForNeo4jAdmin.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/config/WrappedBatchImporterConfigurationForNeo4jAdmin.java
@@ -20,58 +20,21 @@
 package org.neo4j.commandline.dbms.config;
 
 import org.neo4j.unsafe.impl.batchimport.Configuration;
+
 /**
  * Provides a wrapper around {@link Configuration} with overridden defaults for neo4j-admin import
  * Use all available processors
  */
-public class WrappedBatchImporterConfigurationForNeo4jAdmin implements Configuration
+public class WrappedBatchImporterConfigurationForNeo4jAdmin extends Configuration.Overridden
 {
-    private Configuration defaults;
-
     public WrappedBatchImporterConfigurationForNeo4jAdmin( Configuration defaults )
     {
-        this.defaults = defaults;
-    }
-
-    @Override
-    public int batchSize()
-    {
-        return defaults.batchSize();
-    }
-
-    @Override
-    public int movingAverageSize()
-    {
-        return defaults.movingAverageSize();
+        super( defaults );
     }
 
     @Override
     public int maxNumberOfProcessors()
     {
         return Configuration.allAvailableProcessors();
-    }
-
-    @Override
-    public int denseNodeThreshold()
-    {
-        return defaults.denseNodeThreshold();
-    }
-
-    @Override
-    public long pageCacheMemory()
-    {
-        return defaults.pageCacheMemory();
-    }
-
-    @Override
-    public long maxMemoryUsage()
-    {
-        return defaults.maxMemoryUsage();
-    }
-
-    @Override
-    public boolean sequentialBackgroundFlushing()
-    {
-        return defaults.sequentialBackgroundFlushing();
     }
 }

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/config/WrappedCsvInputConfigurationForNeo4jAdmin.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/config/WrappedCsvInputConfigurationForNeo4jAdmin.java
@@ -27,43 +27,17 @@ import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration;
  * Buffer size is set to 4MB
  */
 
-public class WrappedCsvInputConfigurationForNeo4jAdmin implements Configuration
+public class WrappedCsvInputConfigurationForNeo4jAdmin extends Configuration.Overridden
 {
-    private Configuration defaults;
-
     public WrappedCsvInputConfigurationForNeo4jAdmin( Configuration defaults )
     {
-        this.defaults = defaults;
-    }
-
-    @Override
-    public char delimiter()
-    {
-        return defaults.delimiter();
-    }
-
-    @Override
-    public char arrayDelimiter()
-    {
-        return defaults.arrayDelimiter();
-    }
-
-    @Override
-    public char quotationCharacter()
-    {
-        return defaults.quotationCharacter();
+        super( defaults );
     }
 
     @Override
     public int bufferSize()
     {
         return DEFAULT_BUFFER_SIZE_4MB;
-    }
-
-    @Override
-    public boolean multilineFields()
-    {
-        return defaults.multilineFields();
     }
 
     @Override

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/config/WrappedBatchImporterConfigurationForNeo4jAdminTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/config/WrappedBatchImporterConfigurationForNeo4jAdminTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2002-2018 "Neo Technology,"
- * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
  *
  * This file is part of Neo4j.
  *
@@ -20,34 +20,181 @@
 package org.neo4j.commandline.dbms.config;
 
 import org.junit.Test;
+import org.omg.CORBA.COMM_FAILURE;
+
+import java.util.function.Function;
 
 import org.neo4j.unsafe.impl.batchimport.Configuration;
 
 import static org.junit.Assert.assertEquals;
+import static org.neo4j.io.ByteUnit.kibiBytes;
+import static org.neo4j.unsafe.impl.batchimport.Configuration.DEFAULT;
 
 public class WrappedBatchImporterConfigurationForNeo4jAdminTest
 {
     @Test
+    public void shouldDelegateDenseNodeThreshold()
+    {
+        shouldDelegate( expected -> new Configuration()
+        {
+            @Override
+            public int denseNodeThreshold()
+            {
+                return expected;
+            }
+        }, Configuration::denseNodeThreshold, 1, 20 );
+    }
+
+    @Test
+    public void shouldDelegateMovingAverageSize()
+    {
+        shouldDelegate( expected -> new Configuration()
+        {
+            @Override
+            public int movingAverageSize()
+            {
+                return expected;
+            }
+        }, Configuration::movingAverageSize, 100, 200 );
+    }
+
+    @Test
+    public void shouldDelegateSequentialBackgroundFlushing()
+    {
+        shouldDelegate( expected -> new Configuration()
+        {
+            @Override
+            public boolean sequentialBackgroundFlushing()
+            {
+                return expected;
+            }
+        }, Configuration::sequentialBackgroundFlushing, true, false );
+    }
+
+    @Test
+    public void shouldDelegateBatchSize()
+    {
+        shouldDelegate( expected -> new Configuration()
+        {
+            @Override
+            public int batchSize()
+            {
+                return expected;
+            }
+        }, Configuration::batchSize, 100, 200 );
+    }
+
+    @Test
+    public void shouldOverrideMaxNumberOfProcessors()
+    {
+        shouldOverride( expected -> new Configuration()
+        {
+            @Override
+            public int batchSize()
+            {
+                return expected;
+            }
+        }, Configuration::maxNumberOfProcessors, DEFAULT.maxNumberOfProcessors() + 1, DEFAULT.maxNumberOfProcessors() + 10 );
+    }
+
+    @Test
+    public void shouldDelegateParallelRecordWrites()
+    {
+        shouldDelegate( expected -> new Configuration()
+        {
+            @Override
+            public boolean parallelRecordWrites()
+            {
+                return expected;
+            }
+        }, Configuration::parallelRecordWrites, true, false );
+    }
+
+    @Test
+    public void shouldDelegateParallelRecordReads()
+    {
+        shouldDelegate( expected -> new Configuration()
+        {
+            @Override
+            public boolean parallelRecordReads()
+            {
+                return expected;
+            }
+        }, Configuration::parallelRecordReads, true, false );
+    }
+
+    @Test
     public void shouldDelegateHighIO()
     {
-        for ( boolean value : new boolean[]{true, false} )
+        shouldDelegate( expected -> new Configuration()
+        {
+            @Override
+            public boolean highIO()
+            {
+                return expected;
+            }
+        }, Configuration::highIO, true, false );
+    }
+
+    @Test
+    public void shouldDelegateMaxMemoryUsage()
+    {
+        shouldDelegate( expected -> new Configuration()
+        {
+            @Override
+            public long maxMemoryUsage()
+            {
+                return expected;
+            }
+        }, Configuration::maxMemoryUsage, kibiBytes( 10 ), kibiBytes( 20 ) );
+    }
+
+    @Test
+    public void shouldDelegateAllowCacheAllocationOnHeap()
+    {
+        shouldDelegate( expected -> new Configuration()
+        {
+            @Override
+            public boolean allowCacheAllocationOnHeap()
+            {
+                return expected;
+            }
+        }, Configuration::allowCacheAllocationOnHeap, true, false );
+    }
+
+    @SafeVarargs
+    private final <T> void shouldDelegate( Function<T,Configuration> configFactory, Function<Configuration,T> getter, T... expectedValues )
+    {
+        for ( T expectedValue : expectedValues )
         {
             // given
-            boolean expected = value;
-            Configuration configuration = new Configuration()
-            {
-                @Override
-                public boolean highIO()
-                {
-                    return expected;
-                }
-            };
+            Configuration configuration = configFactory.apply( expectedValue );
 
             // when
             WrappedBatchImporterConfigurationForNeo4jAdmin wrapped = new WrappedBatchImporterConfigurationForNeo4jAdmin( configuration );
 
             // then
-            assertEquals( expected, wrapped.highIO() );
+            assertEquals( expectedValue, getter.apply( wrapped ) );
+        }
+
+        // then
+        assertEquals( getter.apply( DEFAULT ), getter.apply( new WrappedBatchImporterConfigurationForNeo4jAdmin( DEFAULT ) ) );
+    }
+
+    @SafeVarargs
+    private final <T> void shouldOverride( Function<T,Configuration> configFactory, Function<Configuration,T> getter, T... values )
+    {
+        for ( T value : values )
+        {
+            // given
+            Configuration configuration = configFactory.apply( value );
+            WrappedBatchImporterConfigurationForNeo4jAdmin vanilla = new WrappedBatchImporterConfigurationForNeo4jAdmin( DEFAULT );
+
+            // when
+            WrappedBatchImporterConfigurationForNeo4jAdmin wrapped = new WrappedBatchImporterConfigurationForNeo4jAdmin( configuration );
+
+            // then
+            assertEquals( getter.apply( vanilla ), getter.apply( wrapped ) );
         }
     }
 }

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/config/WrappedBatchImporterConfigurationForNeo4jAdminTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/config/WrappedBatchImporterConfigurationForNeo4jAdminTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms.config;
+
+import org.junit.Test;
+
+import org.neo4j.unsafe.impl.batchimport.Configuration;
+
+import static org.junit.Assert.assertEquals;
+
+public class WrappedBatchImporterConfigurationForNeo4jAdminTest
+{
+    @Test
+    public void shouldDelegateHighIO()
+    {
+        for ( boolean value : new boolean[]{true, false} )
+        {
+            // given
+            boolean expected = value;
+            Configuration configuration = new Configuration()
+            {
+                @Override
+                public boolean highIO()
+                {
+                    return expected;
+                }
+            };
+
+            // when
+            WrappedBatchImporterConfigurationForNeo4jAdmin wrapped = new WrappedBatchImporterConfigurationForNeo4jAdmin( configuration );
+
+            // then
+            assertEquals( expected, wrapped.highIO() );
+        }
+    }
+}

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/config/WrappedCsvInputConfigurationForNeo4jAdminTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/config/WrappedCsvInputConfigurationForNeo4jAdminTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms.config;
+
+import org.junit.Test;
+
+import java.util.function.Function;
+
+import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.unsafe.impl.batchimport.input.csv.Configuration.COMMAS;
+
+public class WrappedCsvInputConfigurationForNeo4jAdminTest
+{
+    @Test
+    public void shouldDelegateArrayDelimiter()
+    {
+        shouldDelegate( expected -> new Configuration.Overridden( COMMAS )
+        {
+            @Override
+            public char arrayDelimiter()
+            {
+                return expected;
+            }
+        }, Configuration::arrayDelimiter, 'a', 'b' );
+    }
+
+    @Test
+    public void shouldDelegateDelimiter()
+    {
+        shouldDelegate( expected -> new Configuration.Overridden( COMMAS )
+        {
+            @Override
+            public char delimiter()
+            {
+                return expected;
+            }
+        }, Configuration::delimiter, 'a', 'b' );
+    }
+
+    @Test
+    public void shouldDelegateQuoteCharacter()
+    {
+        shouldDelegate( expected -> new Configuration.Overridden( COMMAS )
+        {
+            @Override
+            public char quotationCharacter()
+            {
+                return expected;
+            }
+        }, Configuration::quotationCharacter, 'a', 'b' );
+    }
+
+    @Test
+    public void shouldOverrideTrimStrings()
+    {
+        shouldOverride( expected -> new Configuration.Overridden( COMMAS )
+        {
+            @Override
+            public boolean trimStrings()
+            {
+                return expected;
+            }
+        }, Configuration::trimStrings, true, false );
+    }
+
+    @Test
+    public void shouldOverrideBufferSize()
+    {
+        shouldOverride( expected -> new Configuration.Overridden( COMMAS )
+        {
+            @Override
+            public int bufferSize()
+            {
+                return expected;
+            }
+        }, Configuration::bufferSize, 100, 200 );
+    }
+
+    @Test
+    public void shouldDelegateMultiLineFields()
+    {
+        shouldDelegate( expected -> new Configuration.Overridden( COMMAS )
+        {
+            @Override
+            public boolean multilineFields()
+            {
+                return expected;
+            }
+        }, Configuration::multilineFields, true, false );
+    }
+
+    @Test
+    public void shouldOverrideEmptyQuotedStringsAsNull()
+    {
+        shouldOverride( expected -> new Configuration.Overridden( COMMAS )
+        {
+            @Override
+            public boolean emptyQuotedStringsAsNull()
+            {
+                return expected;
+            }
+        }, Configuration::emptyQuotedStringsAsNull, true, false );
+    }
+
+    @Test
+    public void shouldOverrideLegacyStyleQuoting()
+    {
+        shouldOverride( expected -> new Configuration.Overridden( COMMAS )
+        {
+            @Override
+            public boolean legacyStyleQuoting()
+            {
+                return expected;
+            }
+        }, Configuration::legacyStyleQuoting, true, false );
+    }
+
+    @SafeVarargs
+    private final <T> void shouldDelegate( Function<T,Configuration> configFactory, Function<Configuration,T> getter, T... expectedValues )
+    {
+        for ( T expectedValue : expectedValues )
+        {
+            // given
+            Configuration configuration = configFactory.apply( expectedValue );
+
+            // when
+            WrappedCsvInputConfigurationForNeo4jAdmin wrapped = new WrappedCsvInputConfigurationForNeo4jAdmin( configuration );
+
+            // then
+            assertEquals( expectedValue, getter.apply( wrapped ) );
+        }
+
+        // then
+        assertEquals( getter.apply( COMMAS ), getter.apply( new WrappedCsvInputConfigurationForNeo4jAdmin( COMMAS ) ) );
+    }
+
+    @SafeVarargs
+    private final <T> void shouldOverride( Function<T,Configuration> configFactory, Function<Configuration,T> getter, T... values )
+    {
+        for ( T value : values )
+        {
+            // given
+            Configuration configuration = configFactory.apply( value );
+            WrappedCsvInputConfigurationForNeo4jAdmin vanilla = new WrappedCsvInputConfigurationForNeo4jAdmin( COMMAS );
+
+            // when
+            WrappedCsvInputConfigurationForNeo4jAdmin wrapped = new WrappedCsvInputConfigurationForNeo4jAdmin( configuration );
+
+            // then
+            assertEquals( getter.apply( vanilla ), getter.apply( wrapped ) );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
@@ -212,7 +212,9 @@ public interface Configuration
         @Override
         public int denseNodeThreshold()
         {
-            return config.get( dense_node_threshold );
+            return config.getRaw().containsKey( dense_node_threshold.name() )
+                   ? config.get( dense_node_threshold )
+                   : defaults.denseNodeThreshold();
         }
 
         @Override


### PR DESCRIPTION
So that all the configuration flags from the defaults gets delegated
to the wrapped configuration.