### PR TITLE
Don't dump stack on cluster bootstrap timeout

### DIFF
--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -497,6 +497,12 @@ public interface Status
 
     enum Cluster implements Status
     {
+        IntraClusterConnectionTimeout( DatabaseError,
+                "This instance is failing to establish connections to other cluster members. You should " +
+                "ensure other cluster members are operational, listening to the ports this instance is " +
+                "configured to connect to, and that there are no firewalls or other network equipment " +
+                "preventing connections." ),
+
         // transient errors
         NoLeaderAvailable( TransientError,
                 "No leader available at the moment. Retrying your request at a later time may succeed." ),

--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -95,7 +95,7 @@ import static org.neo4j.server.configuration.ServerSettings.http_logging_rotatio
 import static org.neo4j.server.configuration.ServerSettings.http_logging_rotation_size;
 import static org.neo4j.server.database.InjectableProvider.providerForSingleton;
 import static org.neo4j.server.database.InjectableProvider.providerFromSupplier;
-import static org.neo4j.server.exception.ServerStartupErrors.translateToServerStartupError;
+import static org.neo4j.server.exception.CommunityStartupErrors.translateCommunityStartupError;
 
 public abstract class AbstractNeoServer implements NeoServer
 {
@@ -216,8 +216,13 @@ public abstract class AbstractNeoServer implements NeoServer
             // If the database has been started, attempt to cleanly shut it down to avoid unclean shutdowns.
             life.shutdown();
 
-            throw translateToServerStartupError( t );
+            throw translateStartupError( t );
         }
+    }
+
+    protected ServerStartupException translateStartupError( Throwable cause )
+    {
+        return translateCommunityStartupError( cause );
     }
 
     public DependencyResolver getDependencyResolver()

--- a/community/server/src/main/java/org/neo4j/server/ServerStartupException.java
+++ b/community/server/src/main/java/org/neo4j/server/ServerStartupException.java
@@ -37,8 +37,6 @@ public class ServerStartupException extends RuntimeException
 
     public void describeTo( Log log )
     {
-        // By default, log the full error. The intention is that sub classes can override this and
-        // specify less extreme logging options.
         log.error( format( "Failed to start Neo4j: %s", getMessage() ), this );
     }
 }

--- a/community/server/src/main/java/org/neo4j/server/exception/WellKnownStartupException.java
+++ b/community/server/src/main/java/org/neo4j/server/exception/WellKnownStartupException.java
@@ -19,14 +19,16 @@
  */
 package org.neo4j.server.exception;
 
-import org.neo4j.kernel.impl.storemigration.UpgradeNotAllowedByConfigurationException;
-import org.neo4j.kernel.impl.storemigration.UpgradeNotAllowedException;
 import org.neo4j.logging.Log;
 import org.neo4j.server.ServerStartupException;
 
-public class UpgradeDisallowedStartupException extends ServerStartupException
+/**
+ * Wrapper around well-known startup exceptions that have useful messages
+ * and can be logged without stack traces.
+ */
+public class WellKnownStartupException extends ServerStartupException
 {
-    public UpgradeDisallowedStartupException( UpgradeNotAllowedException cause )
+    public WellKnownStartupException( Throwable cause )
     {
         super( cause.getMessage(), cause );
     }
@@ -34,14 +36,6 @@ public class UpgradeDisallowedStartupException extends ServerStartupException
     @Override
     public void describeTo( Log log )
     {
-        Throwable cause = getCause();
-        if ( cause instanceof UpgradeNotAllowedByConfigurationException )
-        {
-            log.error( cause.getMessage() );
-        }
-        else
-        {
-            super.describeTo( log );
-        }
+        log.error( getCause().getMessage() );
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/exception/CommunityStartupErrorsTest.java
+++ b/community/server/src/test/java/org/neo4j/server/exception/CommunityStartupErrorsTest.java
@@ -29,9 +29,9 @@ import org.neo4j.logging.AssertableLogProvider;
 import static org.neo4j.kernel.lifecycle.LifecycleStatus.STARTED;
 import static org.neo4j.kernel.lifecycle.LifecycleStatus.STARTING;
 import static org.neo4j.logging.AssertableLogProvider.inLog;
-import static org.neo4j.server.exception.ServerStartupErrors.translateToServerStartupError;
+import static org.neo4j.server.exception.CommunityStartupErrors.translateCommunityStartupError;
 
-public class ServerStartupErrorsTest
+public class CommunityStartupErrorsTest
 {
     @Test
     public void shouldDescribeUpgradeFailureInAFriendlyWay()
@@ -45,7 +45,7 @@ public class ServerStartupErrorsTest
                                         new UpgradeNotAllowedByConfigurationException() ) ) ) );
 
         // when
-        translateToServerStartupError( error ).describeTo( logging.getLog( "console" ) );
+        translateCommunityStartupError( error ).describeTo( logging.getLog( "console" ) );
 
         // then
         logging.assertExactly( inLog( "console" )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/BootstrapConnectionTimeout.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/BootstrapConnectionTimeout.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j Enterprise Edition. The included source
+ * code can be redistributed and/or modified under the terms of the
+ * GNU AFFERO GENERAL PUBLIC LICENSE Version 3
+ * (http://www.fsf.org/licensing/licenses/agpl-3.0.html) with the
+ * Commons Clause, as found in the associated LICENSE.txt file.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * Neo4j object code can be licensed independently from the source
+ * under separate terms from the AGPL. Inquiries can be directed to:
+ * licensing@neo4j.com
+ *
+ * More information is also available at:
+ * https://neo4j.com/licensing/
+ */
+package org.neo4j.causalclustering.identity;
+
+import org.neo4j.internal.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.exceptions.Status;
+
+/**
+ * Failed to bootstrap, because this instance is unable to connect to other cluster members.
+ */
+public class BootstrapConnectionTimeout extends KernelException
+{
+    public BootstrapConnectionTimeout( String message, Object... parameters )
+    {
+        super( Status.Cluster.IntraClusterConnectionTimeout, message, parameters );
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/ClusterBinder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/ClusterBinder.java
@@ -167,9 +167,12 @@ public class ClusterBinder implements Supplier<Optional<ClusterId>>
 
         if ( clusterId == null )
         {
-            throw new TimeoutException( format(
-                    "Failed to join a cluster with members %s. Another member should have published " +
-                    "a clusterId but none was detected. Please restart the cluster.", topology ) );
+            throw new BootstrapConnectionTimeout( format(
+                    "Neo4j cannot be started because this instance is unable to reach other cluster members. " +
+                    "Waited %dms for another member in %s, giving up. This may be temporary and retrying may help. " +
+                    "It may also be a configuration or a firewall problem. Ensure that other members are listening " +
+                    "on the host/port you've configured this instance to connect to, and that there is no firewall " +
+                    "preventing connections.", timeoutMillis, topology ) );
         }
 
         clusterIdStorage.writeState( clusterId );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/identity/ClusterBinderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/identity/ClusterBinderTest.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.IntStream;
 
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
@@ -88,7 +87,7 @@ public class ClusterBinderTest
             binder.bindToCluster();
             fail( "Should have timed out" );
         }
-        catch ( TimeoutException e )
+        catch ( BootstrapConnectionTimeout e )
         {
             // expected
         }

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/OpenEnterpriseNeoServer.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/OpenEnterpriseNeoServer.java
@@ -22,13 +22,13 @@
  */
 package org.neo4j.server.enterprise;
 
+import org.eclipse.jetty.util.thread.ThreadPool;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
-
-import org.eclipse.jetty.util.thread.ThreadPool;
 
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.core.CoreGraphDatabase;
@@ -48,8 +48,10 @@ import org.neo4j.logging.LogProvider;
 import org.neo4j.metrics.source.server.ServerThreadView;
 import org.neo4j.metrics.source.server.ServerThreadViewSetter;
 import org.neo4j.server.CommunityNeoServer;
+import org.neo4j.server.ServerStartupException;
 import org.neo4j.server.database.Database;
 import org.neo4j.server.database.LifecycleManagingDatabase.GraphFactory;
+import org.neo4j.server.enterprise.exceptions.EnterpriseStartupErrors;
 import org.neo4j.server.enterprise.modules.EnterpriseAuthorizationModule;
 import org.neo4j.server.enterprise.modules.JMXManagementModule;
 import org.neo4j.server.modules.AuthorizationModule;
@@ -207,5 +209,11 @@ public class OpenEnterpriseNeoServer extends CommunityNeoServer
         }
 
         return uriWhitelist.toArray( new Pattern[uriWhitelist.size()] );
+    }
+
+    @Override
+    protected ServerStartupException translateStartupError( Throwable cause )
+    {
+        return EnterpriseStartupErrors.translateEnterpriseStartupError( cause );
     }
 }

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/exceptions/EnterpriseStartupErrors.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/exceptions/EnterpriseStartupErrors.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j Enterprise Edition. The included source
+ * code can be redistributed and/or modified under the terms of the
+ * GNU AFFERO GENERAL PUBLIC LICENSE Version 3
+ * (http://www.fsf.org/licensing/licenses/agpl-3.0.html) with the
+ * Commons Clause, as found in the associated LICENSE.txt file.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * Neo4j object code can be licensed independently from the source
+ * under separate terms from the AGPL. Inquiries can be directed to:
+ * licensing@neo4j.com
+ *
+ * More information is also available at:
+ * https://neo4j.com/licensing/
+ */
+package org.neo4j.server.enterprise.exceptions;
+
+import org.neo4j.causalclustering.identity.BootstrapConnectionTimeout;
+import org.neo4j.helpers.Exceptions;
+import org.neo4j.server.ServerStartupException;
+import org.neo4j.server.exception.CommunityStartupErrors;
+import org.neo4j.server.exception.WellKnownStartupException;
+
+/**
+ * Enterprise-specific startup errors, see {@link CommunityStartupErrors}.
+ */
+public class EnterpriseStartupErrors
+{
+    private EnterpriseStartupErrors()
+    {
+
+    }
+
+    public static ServerStartupException translateEnterpriseStartupError( Throwable cause )
+    {
+        Throwable rootCause = Exceptions.rootCause( cause );
+
+        if ( rootCause instanceof BootstrapConnectionTimeout )
+        {
+            return new WellKnownStartupException( rootCause );
+        }
+
+        // No idea, fall back to see if community edition knows
+        return CommunityStartupErrors.translateCommunityStartupError( cause );
+    }
+}

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/exceptions/EnterpriseStartupErrorsTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/exceptions/EnterpriseStartupErrorsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j Enterprise Edition. The included source
+ * code can be redistributed and/or modified under the terms of the
+ * GNU AFFERO GENERAL PUBLIC LICENSE Version 3
+ * (http://www.fsf.org/licensing/licenses/agpl-3.0.html) with the
+ * Commons Clause, as found in the associated LICENSE.txt file.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * Neo4j object code can be licensed independently from the source
+ * under separate terms from the AGPL. Inquiries can be directed to:
+ * licensing@neo4j.com
+ *
+ * More information is also available at:
+ * https://neo4j.com/licensing/
+ */
+package org.neo4j.server.enterprise.exceptions;
+
+import org.junit.Test;
+
+import org.neo4j.causalclustering.identity.BootstrapConnectionTimeout;
+import org.neo4j.kernel.lifecycle.LifecycleException;
+import org.neo4j.logging.AssertableLogProvider;
+
+import static org.neo4j.kernel.lifecycle.LifecycleStatus.STARTED;
+import static org.neo4j.kernel.lifecycle.LifecycleStatus.STARTING;
+import static org.neo4j.logging.AssertableLogProvider.inLog;
+
+public class EnterpriseStartupErrorsTest
+{
+    @Test
+    public void shouldDescribeCausalClusterBootstrapTimeout()
+    {
+        // given
+        AssertableLogProvider logging = new AssertableLogProvider();
+        LifecycleException error = new LifecycleException( new Object(), STARTING, STARTED,
+                new RuntimeException( "Error starting org.neo4j.kernel.ha.factory.EnterpriseFacadeFactory",
+                        new LifecycleException( new Object(), STARTING, STARTED,
+                                new LifecycleException( new Object(), STARTING, STARTED,
+                                        new BootstrapConnectionTimeout( "Bork bork" ) ) ) ) );
+
+        // when
+        EnterpriseStartupErrors.translateEnterpriseStartupError( error ).describeTo( logging.getLog( "console" ) );
+
+        // then
+        logging.assertExactly( inLog( "console" ).error( "Bork bork" ) );
+    }
+}


### PR DESCRIPTION
If an instance is bootstrapped and unable to reach it's peers,
dumping a large stack trace is unhelpful. This replaces the
stack trace with a shorter message that suggests paths for
debugging.

Same as prior PR, retargeted for 3.5