### PR TITLE
Ability to override discoverable bolt URI

### DIFF
--- a/community/server-api/src/main/java/org/neo4j/server/plugins/Injectable.java
+++ b/community/server-api/src/main/java/org/neo4j/server/plugins/Injectable.java
@@ -19,6 +19,11 @@
  */
 package org.neo4j.server.plugins;
 
+/**
+ * Used to allow custom values to be injected into JAX-RS classes.
+ *
+ * @param <T> the type of the value, or an interface the value implements.
+ */
 public interface Injectable<T>
 {
     /**
@@ -28,6 +33,38 @@ public interface Injectable<T>
      */
     T getValue();
 
+    /**
+     * The type that resources should ask for to get this value;
+     * this can either be the concrete class, or some interface the
+     * value instance implements.
+     *
+     * @return a class that methods that want this value injected should ask for
+     */
     Class<T> getType();
 
+    /**
+     * Utility to wrap a singleton value as an injectable.
+     *
+     * @param type the type that JAX-RS classes should ask for
+     * @param obj the value
+     * @param <T> same as type
+     * @return
+     */
+    static <T> Injectable<T> injectable( Class<T> type, T obj )
+    {
+        return new Injectable<T>()
+        {
+            @Override
+            public T getValue()
+            {
+                return obj;
+            }
+
+            @Override
+            public Class<T> getType()
+            {
+                return type;
+            }
+        };
+    }
 }

--- a/community/server-api/src/main/java/org/neo4j/server/rest/repr/MappingSerializer.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/repr/MappingSerializer.java
@@ -31,9 +31,18 @@ public class MappingSerializer extends Serializer
         this.writer = writer;
     }
 
+    /**
+     * @deprecated please use {@link #putAbsoluteUri(String, URI)}
+     */
+    @Deprecated
     void putAbsoluteUri( String key, String path )
     {
         writer.writeValue( RepresentationType.URI, key, path );
+    }
+
+    void putAbsoluteUri( String key, URI path )
+    {
+        writer.writeValue( RepresentationType.URI, key, path.toASCIIString() );
     }
 
     public void putRelativeUri( String key, String path )

--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -138,8 +138,7 @@ public abstract class AbstractNeoServer implements NeoServer
 
     private TransactionHandleRegistry transactionRegistry;
     private boolean initialized;
-    private LifecycleAdapter serverComponents;
-    protected ConnectorPortRegister connectorPortRegister;
+    private ConnectorPortRegister connectorPortRegister;
     private HttpConnector httpConnector;
     private Optional<HttpConnector> httpsConnector;
     private AsyncRequestLog requestLog;
@@ -196,8 +195,7 @@ public abstract class AbstractNeoServer implements NeoServer
             registerModule( moduleClass );
         }
 
-        serverComponents = new ServerComponentsLifecycleAdapter();
-        life.add( serverComponents );
+        life.add( new ServerComponentsLifecycleAdapter() );
 
         this.initialized = true;
     }
@@ -209,7 +207,6 @@ public abstract class AbstractNeoServer implements NeoServer
         try
         {
             life.start();
-
         }
         catch ( Throwable t )
         {
@@ -469,7 +466,6 @@ public abstract class AbstractNeoServer implements NeoServer
         singletons.add( new TransactionFilter( database ) );
         singletons.add( new LoggingProvider( logProvider ) );
         singletons.add( providerForSingleton( logProvider.getLog( NeoServer.class ), Log.class ) );
-
         singletons.add( providerForSingleton( resolveDependency( UsageData.class ), UsageData.class ) );
 
         return singletons;

--- a/community/server/src/main/java/org/neo4j/server/CommunityNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/CommunityNeoServer.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.configuration.ConnectorPortRegister;
 import org.neo4j.kernel.impl.factory.CommunityEditionModule;
 import org.neo4j.kernel.impl.factory.DatabaseInfo;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
@@ -48,6 +49,7 @@ import org.neo4j.server.web.Jetty9WebServer;
 import org.neo4j.server.web.WebServer;
 
 import static org.neo4j.server.database.LifecycleManagingDatabase.lifecycleManagingDatabase;
+import static org.neo4j.server.rest.discovery.CommunityDiscoverableURIs.communityDiscoverableURIs;
 
 public class CommunityNeoServer extends AbstractNeoServer
 {
@@ -74,7 +76,7 @@ public class CommunityNeoServer extends AbstractNeoServer
     protected Iterable<ServerModule> createServerModules()
     {
         return Arrays.asList(
-                new DBMSModule( webServer, getConfig() ),
+                createDBMSModule(),
                 new RESTApiModule( webServer, getConfig(), getDependencyResolver(), logProvider ),
                 new ManagementApiModule( webServer, getConfig() ),
                 new ThirdPartyJAXRSModule( webServer, getConfig(), logProvider, this ),
@@ -98,6 +100,12 @@ public class CommunityNeoServer extends AbstractNeoServer
         toReturn.add( new JmxService( null, null ) );
 
         return toReturn;
+    }
+
+    protected DBMSModule createDBMSModule()
+    {
+        ConnectorPortRegister ports = getDependencyResolver().resolveDependency( ConnectorPortRegister.class );
+        return new DBMSModule( webServer, getConfig(), communityDiscoverableURIs( getConfig(), ports ) );
     }
 
     protected AuthorizationModule createAuthorizationModule()

--- a/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
@@ -192,6 +192,14 @@ public class ServerSettings implements LoadableConfig
                   "Value is expected to contain dirictives like 'max-age', 'includeSubDomains' and 'preload'." )
     public static final Setting<String> http_strict_transport_security = setting( "dbms.security.http_strict_transport_security", STRING, NO_DEFAULT );
 
+    @Description( "Publicly discoverable bolt:// URI to use for Neo4j Drivers wanting to access the data in this " +
+            "particular database instance. Normally this is the same as the advertised address configured for the " +
+            "connector, but this allows manually overriding that default." )
+    @DocumentedDefaultValue(
+            "Defaults to a bolt://-schemed version of the advertised address " + "of the first found bolt connector." )
+    public static final Setting<URI> bolt_discoverable_address =
+            setting( "unsupported.dbms.discoverable_bolt_address", Settings.URI, "" );
+
     @SuppressWarnings( "unused" ) // accessed from the browser
     @Description( "Commands to be run when Neo4j Browser successfully connects to this server. Separate multiple " +
                   "commands with semi-colon." )

--- a/community/server/src/main/java/org/neo4j/server/modules/DBMSModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/DBMSModule.java
@@ -25,8 +25,12 @@ import java.util.List;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.server.rest.dbms.UserService;
+import org.neo4j.server.rest.discovery.DiscoverableURIs;
 import org.neo4j.server.rest.discovery.DiscoveryService;
 import org.neo4j.server.web.WebServer;
+
+import static java.util.Collections.singletonList;
+import static org.neo4j.server.plugins.Injectable.injectable;
 
 /**
  * Mounts the DBMS REST API.
@@ -37,24 +41,29 @@ public class DBMSModule implements ServerModule
 
     private final WebServer webServer;
     private final Config config;
+    private final DiscoverableURIs discoverableURIs;
 
-    public DBMSModule( WebServer webServer, Config config )
+    public DBMSModule( WebServer webServer, Config config, DiscoverableURIs discoverableURIs )
     {
         this.webServer = webServer;
         this.config = config;
+        this.discoverableURIs = discoverableURIs;
     }
 
     @Override
     public void start()
     {
+        webServer.addJAXRSClasses(
+                singletonList( DiscoveryService.class.getName() ), ROOT_PATH,
+                singletonList( injectable( DiscoverableURIs.class, discoverableURIs ) ) );
         webServer.addJAXRSClasses( getClassNames(), ROOT_PATH, null );
+
     }
 
     private List<String> getClassNames()
     {
         List<String> toReturn = new ArrayList<>( 2 );
 
-        toReturn.add( DiscoveryService.class.getName() );
         if ( config.get( GraphDatabaseSettings.auth_enabled ) )
         {
             toReturn.add( UserService.class.getName() );

--- a/community/server/src/main/java/org/neo4j/server/rest/discovery/CommunityDiscoverableURIs.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/discovery/CommunityDiscoverableURIs.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.discovery;
+
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.configuration.ConnectorPortRegister;
+import org.neo4j.server.configuration.ServerSettings;
+
+public class CommunityDiscoverableURIs
+{
+    /**
+     * URIs exposed at the root HTTP endpoint, to help clients discover the rest of the service.
+     */
+    public static DiscoverableURIs communityDiscoverableURIs( Config config, ConnectorPortRegister portRegister )
+    {
+        DiscoverableURIs repo = new DiscoverableURIs();
+        repo.addRelative( "data", config.get( ServerSettings.rest_api_path ).getPath() + "/" );
+        repo.addRelative( "management", config.get( ServerSettings.management_api_path ).getPath() + "/" );
+
+        DiscoverableURIs
+                .discoverableBoltUri("bolt", config, ServerSettings.bolt_discoverable_address, portRegister )
+                .ifPresent( uri -> repo.addAbsolute( "bolt", uri ) );
+        return repo;
+    }
+}

--- a/community/server/src/main/java/org/neo4j/server/rest/discovery/DiscoverableURIs.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/discovery/DiscoverableURIs.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.discovery;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+import org.neo4j.graphdb.config.InvalidSettingException;
+import org.neo4j.graphdb.config.Setting;
+import org.neo4j.helpers.AdvertisedSocketAddress;
+import org.neo4j.helpers.collection.Pair;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.configuration.ConnectorPortRegister;
+
+/**
+ * Repository of URIs that the REST API publicly advertises at the root endpoint.
+ */
+public class DiscoverableURIs
+{
+    private final Collection<Pair<String,String>> relativeUris = new ArrayList<>();
+    private final Collection<Pair<String,URI>> absoluteUris = new ArrayList<>();
+
+    public DiscoverableURIs addRelative( String key, String uri )
+    {
+        relativeUris.add( Pair.pair( key, uri ) );
+        return this;
+    }
+
+    public DiscoverableURIs addAbsolute( String key, URI uri )
+    {
+        absoluteUris.add( Pair.pair( key, uri ) );
+        return this;
+    }
+
+    public static Optional<URI> discoverableBoltUri( String scheme, Config config, Setting<URI> override,
+            ConnectorPortRegister connectorPortRegister )
+    {
+        // Note that this whole function would be much cleaner to implement as a default function for the
+        // bolt_discoverable_address setting; however the current config design makes it hard to do
+        // "find any bolt connector", it can only do "find exactly this config key".. Something to refactor
+        // when we refactor config API for 4.0.
+        if ( config.isConfigured( override ) )
+        {
+            return Optional.ofNullable( config.get( override ) );
+        }
+
+        return config.enabledBoltConnectors().stream().findFirst().map( c ->
+        {
+            AdvertisedSocketAddress advertisedSocketAddress = config.get( c.advertised_address );
+
+            // If port is 0 it's been assigned a random port from the OS, list this instead
+            if ( advertisedSocketAddress.getPort() == 0 )
+            {
+                int boltPort = connectorPortRegister.getLocalAddress( c.key() ).getPort();
+                return boltURI( scheme, advertisedSocketAddress.getHostname(), boltPort );
+            }
+
+            // Use the config verbatim since it seems sane
+            return boltURI( scheme, advertisedSocketAddress.getHostname(), advertisedSocketAddress.getPort() );
+        } );
+    }
+
+    public void forEachRelativeUri( BiConsumer<String,String> consumer )
+    {
+        relativeUris.forEach( p -> consumer.accept( p.first(), p.other() ) );
+    }
+
+    public void forEachAbsoluteUri( BiConsumer<String,URI> consumer )
+    {
+        absoluteUris.forEach( p -> consumer.accept( p.first(), p.other() ) );
+    }
+
+    private static URI boltURI( String scheme, String host, int port )
+    {
+        try
+        {
+            return new URI( scheme, null, host, port, null, null, null );
+        }
+        catch ( URISyntaxException e )
+        {
+            throw new InvalidSettingException(
+                    String.format( "Unable to construct bolt discoverable URI using '%s' as hostname: " + "%s", host,
+                            e.getMessage() ), e );
+        }
+    }
+}

--- a/community/server/src/main/java/org/neo4j/server/rest/discovery/DiscoveryService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/discovery/DiscoveryService.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.server.rest.discovery;
 
-import java.net.URISyntaxException;
-import java.util.Optional;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -29,10 +27,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
-import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.configuration.ConnectorPortRegister;
-import org.neo4j.server.NeoServer;
 import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.rest.repr.DiscoveryRepresentation;
 import org.neo4j.server.rest.repr.OutputFormat;
@@ -46,57 +41,21 @@ public class DiscoveryService
 {
     private final Config config;
     private final OutputFormat outputFormat;
-    private final ConnectorPortRegister connectorPortRegister;
+    private final DiscoverableURIs uris;
 
     // Your IDE might tell you to make this less visible than public. Don't. JAX-RS demands is to be public.
-    public DiscoveryService( @Context Config config, @Context OutputFormat outputFormat, @Context NeoServer neoServer )
+    public DiscoveryService( @Context Config config, @Context OutputFormat outputFormat, @Context DiscoverableURIs uris )
     {
         this.config = config;
         this.outputFormat = outputFormat;
-        connectorPortRegister = neoServer.getDatabase().getGraph().getDependencyResolver()
-                .resolveDependency( ConnectorPortRegister.class );
+        this.uris = uris;
     }
 
     @GET
     @Produces( MediaType.APPLICATION_JSON )
     public Response getDiscoveryDocument( @Context UriInfo uriInfo )
     {
-        String managementUri = config.get( ServerSettings.management_api_path ).getPath() + "/";
-        String dataUri = config.get( ServerSettings.rest_api_path ).getPath() + "/";
-
-        Optional<AdvertisedSocketAddress> boltAddress = config.enabledBoltConnectors().stream().findFirst()
-                .map( boltConnector -> config.get( boltConnector.advertised_address ) );
-
-        if ( boltAddress.isPresent() )
-        {
-            AdvertisedSocketAddress advertisedSocketAddress = boltAddress.get();
-
-            // If port is 0 it's been assigned a random port from the OS, list this instead
-            if ( advertisedSocketAddress.getPort() == 0 )
-            {
-                int boltPort = connectorPortRegister.getLocalAddress( "bolt" ).getPort();
-                advertisedSocketAddress = new AdvertisedSocketAddress( advertisedSocketAddress.getHostname(), boltPort );
-            }
-
-            if ( advertisedSocketAddress.getHostname().equals( "localhost" ) )
-            {
-                // Use the port specified in the config, but not the host
-                return outputFormat.ok( new DiscoveryRepresentation( managementUri, dataUri,
-                        new AdvertisedSocketAddress( uriInfo.getBaseUri().getHost(), advertisedSocketAddress.getPort() ) ) );
-            }
-            else
-            {
-                // Use the config verbatim since it seems sane
-                return outputFormat
-                        .ok( new DiscoveryRepresentation( managementUri, dataUri, advertisedSocketAddress ) );
-            }
-        }
-        else
-        {
-            // There's no config, compute possible endpoint using host header and default bolt port.
-            return outputFormat.ok( new DiscoveryRepresentation( managementUri, dataUri,
-                    new AdvertisedSocketAddress( uriInfo.getBaseUri().getHost(), 7687 ) ) );
-        }
+        return outputFormat.ok( new DiscoveryRepresentation( uris ) );
     }
 
     @GET

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/DiscoveryRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/DiscoveryRepresentation.java
@@ -19,32 +19,26 @@
  */
 package org.neo4j.server.rest.repr;
 
-import org.neo4j.helpers.AdvertisedSocketAddress;
+import org.neo4j.server.rest.discovery.DiscoverableURIs;
 
 public class DiscoveryRepresentation extends MappingRepresentation
 {
-
-    private static final String DATA_URI_KEY = "data";
-    private static final String MANAGEMENT_URI_KEY = "management";
-    private static final String BOLT_URI_KEY = "bolt";
     private static final String DISCOVERY_REPRESENTATION_TYPE = "discovery";
-    private final String managementUri;
-    private final String dataUri;
-    private final AdvertisedSocketAddress boltAddress;
+    private final DiscoverableURIs uris;
 
-    public DiscoveryRepresentation( String managementUri, String dataUri, AdvertisedSocketAddress boltAddress )
+    /**
+     * @param uris URIs that we want to make publicly discoverable.
+     */
+    public DiscoveryRepresentation( DiscoverableURIs uris )
     {
         super( DISCOVERY_REPRESENTATION_TYPE );
-        this.managementUri = managementUri;
-        this.dataUri = dataUri;
-        this.boltAddress = boltAddress;
+        this.uris = uris;
     }
 
     @Override
     protected void serialize( MappingSerializer serializer )
     {
-        serializer.putRelativeUri( MANAGEMENT_URI_KEY, managementUri );
-        serializer.putRelativeUri( DATA_URI_KEY, dataUri );
-        serializer.putAbsoluteUri( BOLT_URI_KEY, "bolt://" + boltAddress.getHostname() + ":" + boltAddress.getPort() );
+        uris.forEachRelativeUri(serializer::putRelativeUri);
+        uris.forEachAbsoluteUri( serializer::putAbsoluteUri );
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/BoltIT.java
+++ b/community/server/src/test/java/org/neo4j/server/BoltIT.java
@@ -39,7 +39,6 @@ import org.neo4j.test.server.ExclusiveServerTestBase;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertFalse;
 import static org.neo4j.server.helpers.CommunityServerBuilder.serverOnRandomPorts;
 
 public class BoltIT extends ExclusiveServerTestBase
@@ -86,30 +85,12 @@ public class BoltIT extends ExclusiveServerTestBase
     }
 
     @Test
-    public void boltAddressShouldAppearToComeFromTheSameOriginAsTheHttpAddressEvenThoughThisIsMorallyHazardous()
-            throws Throwable
-    {
-        // Given
-        String host = "neo4j.com";
-        startServerWithBoltEnabled();
-        RestRequest request = new RestRequest( server.baseUri() ).host( host );
-
-        // When
-        JaxRsResponse response = request.get();
-
-        // Then
-        Map<String,Object> map = JsonHelper.jsonToMap( response.getEntity() );
-        assertThat( String.valueOf( map.get( "bolt" ) ), containsString( "bolt://" + host ) );
-        assertFalse( String.valueOf( map.get( "bolt" ) ).contains( "bolt://bolt://" ) );
-    }
-
-    @Test
-    public void boltAddressShouldComeFromConfigWhenTheListenConfigIsNotLocalhost() throws Throwable
+    public void boltAddressShouldComeFromConnectorAdvertisedAddress() throws Throwable
     {
         // Given
         String host = "neo4j.com";
 
-        startServerWithBoltEnabled( host, 9999, "localhost", 7687 );
+        startServerWithBoltEnabled( host, 9999, "localhost", 0 );
         RestRequest request = new RestRequest( server.baseUri() ).host( host );
 
         // When
@@ -118,23 +99,6 @@ public class BoltIT extends ExclusiveServerTestBase
         // Then
         Map<String,Object> map = JsonHelper.jsonToMap( response.getEntity() );
         assertThat( String.valueOf( map.get( "bolt" ) ), containsString( "bolt://" + host + ":" + 9999 ) );
-    }
-
-    @Test
-    public void boltPortShouldComeFromConfigButHostShouldMatchHttpHostHeaderWhenConfigIsLocalhostOrEmptyEvenThoughThisIsMorallyHazardous()
-            throws Throwable
-    {
-        // Given
-        String host = "neo4j.com";
-        startServerWithBoltEnabled( "localhost", 9999, "localhost", 7687 );
-        RestRequest request = new RestRequest( server.baseUri() ).host( host );
-
-        // When
-        JaxRsResponse response = request.get();
-
-        // Then
-        Map<String,Object> map = JsonHelper.jsonToMap( response.getEntity() );
-        assertThat( String.valueOf( map.get( "bolt" ) ), containsString( "bolt://" + host + ":9999" ) );
     }
 
     private void startServerWithBoltEnabled() throws IOException

--- a/community/server/src/test/java/org/neo4j/server/modules/DBMSModuleTest.java
+++ b/community/server/src/test/java/org/neo4j/server/modules/DBMSModuleTest.java
@@ -30,6 +30,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.server.CommunityNeoServer;
 import org.neo4j.server.rest.dbms.UserService;
+import org.neo4j.server.rest.discovery.DiscoverableURIs;
 import org.neo4j.server.web.WebServer;
 import org.neo4j.test.rule.SuppressOutput;
 
@@ -61,7 +62,7 @@ public class DBMSModuleTest
         when( neoServer.getWebServer() ).thenReturn( webServer );
         when( config.get( GraphDatabaseSettings.auth_enabled ) ).thenReturn( true );
 
-        DBMSModule module = new DBMSModule( webServer, config );
+        DBMSModule module = new DBMSModule( webServer, config, new DiscoverableURIs() );
 
         module.start();
 
@@ -80,7 +81,7 @@ public class DBMSModuleTest
         when( neoServer.getWebServer() ).thenReturn( webServer );
         when( config.get( GraphDatabaseSettings.auth_enabled ) ).thenReturn( false );
 
-        DBMSModule module = new DBMSModule( webServer, config );
+        DBMSModule module = new DBMSModule( webServer, config, new DiscoverableURIs() );
 
         module.start();
 

--- a/community/server/src/test/java/org/neo4j/server/rest/discovery/CommunityDiscoverableURIsTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/discovery/CommunityDiscoverableURIsTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.discovery;
+
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.kernel.configuration.BoltConnector;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.configuration.ConnectorPortRegister;
+import org.neo4j.server.configuration.ServerSettings;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.neo4j.helpers.collection.MapUtil.map;
+import static org.neo4j.server.rest.discovery.CommunityDiscoverableURIs.communityDiscoverableURIs;
+
+public class CommunityDiscoverableURIsTest
+{
+    @Test
+    public void shouldAdvertiseDataAndManagementURIs() throws Exception
+    {
+        DiscoverableURIs uris = communityDiscoverableURIs( Config.defaults(), null );
+
+        assertEquals( map( "data", "/db/data/", "management", "/db/manage/" ), toMap(uris) );
+    }
+
+    @Test
+    public void shouldAdvertiseBoltIfExplicitlyConfigured() throws Exception
+    {
+        DiscoverableURIs uris = communityDiscoverableURIs(
+                Config.defaults( ServerSettings.bolt_discoverable_address, "bolt://banana.com:1234" ), null );
+
+        assertEquals( "bolt://banana.com:1234", toMap(uris).get("bolt") );
+    }
+
+    @Test
+    public void shouldLookupBoltPortInRegisterIfConfiguredTo0() throws Exception
+    {
+        BoltConnector bolt = new BoltConnector( "honestJakesBoltConnector" );
+        ConnectorPortRegister register = new ConnectorPortRegister();
+        register.register( bolt.key(), new InetSocketAddress( 1337 ) );
+
+        DiscoverableURIs uris = communityDiscoverableURIs(
+                Config.builder()
+                        .withSetting( bolt.advertised_address, "apple.com:0" )
+                        .withSetting( bolt.enabled, "true" )
+                        .withSetting( bolt.type, BoltConnector.ConnectorType.BOLT.name() )
+                        .build(), register );
+
+        assertEquals( "bolt://apple.com:1337", toMap(uris).get("bolt")  );
+    }
+
+    @Test
+    public void shouldOmitBoltIfNoConnectorConfigured() throws Exception
+    {
+        DiscoverableURIs uris = communityDiscoverableURIs( Config.builder().build(), null );
+
+        assertFalse( toMap( uris ).containsKey( "bolt" ) );
+    }
+
+    private Map<String,Object> toMap( DiscoverableURIs uris )
+    {
+        Map<String,Object> out = new HashMap<>();
+        uris.forEachAbsoluteUri( ( k, v ) -> out.put( k, v.toASCIIString() ) );
+        uris.forEachRelativeUri( out::put );
+        return out;
+    }
+}

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/DiscoveryRepresentationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/DiscoveryRepresentationTest.java
@@ -22,9 +22,10 @@ package org.neo4j.server.rest.repr;
 import org.junit.Test;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Map;
 
-import org.neo4j.helpers.AdvertisedSocketAddress;
+import org.neo4j.server.rest.discovery.DiscoverableURIs;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -32,12 +33,13 @@ import static org.junit.Assert.assertNotNull;
 public class DiscoveryRepresentationTest
 {
     @Test
-    public void shouldCreateAMapContainingDataAndManagementURIs()
+    public void shouldCreateAMapContainingDataAndManagementURIs() throws URISyntaxException
     {
         String managementUri = "/management";
         String dataUri = "/data";
-        AdvertisedSocketAddress boltAddress = new AdvertisedSocketAddress( "localhost", 7687 );
-        DiscoveryRepresentation dr = new DiscoveryRepresentation( managementUri, dataUri, boltAddress );
+        DiscoveryRepresentation dr = new DiscoveryRepresentation(
+                new DiscoverableURIs().addRelative( "management", managementUri ).addRelative( "data",
+                        dataUri ).addAbsolute( "bolt", new URI( "bolt://localhost:7687" ) ) );
 
         Map<String,Object> mapOfUris = RepresentationTestAccess.serialize( dr );
 
@@ -53,11 +55,6 @@ public class DiscoveryRepresentationTest
 
         assertEquals( mappedManagementUri.toString(), Serializer.joinBaseWithRelativePath( baseUri, managementUri ) );
         assertEquals( mappedDataUri.toString(), Serializer.joinBaseWithRelativePath( baseUri, dataUri ) );
-        assertEquals( mappedBoltUri.toString(), toBoltUri( boltAddress ) );
-    }
-
-    private String toBoltUri( AdvertisedSocketAddress boltAddress )
-    {
-        return "bolt://" + boltAddress.getHostname() + ":" + boltAddress.getPort();
+        assertEquals( mappedBoltUri.toString(), "bolt://localhost:7687" );
     }
 }

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseServerSettings.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseServerSettings.java
@@ -22,11 +22,14 @@
  */
 package org.neo4j.server.enterprise;
 
+import java.net.URI;
 import java.time.Duration;
 
 import org.neo4j.configuration.Description;
+import org.neo4j.configuration.DocumentedDefaultValue;
 import org.neo4j.configuration.LoadableConfig;
 import org.neo4j.graphdb.config.Setting;
+import org.neo4j.kernel.configuration.Settings;
 
 import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
 import static org.neo4j.kernel.configuration.Settings.DURATION;
@@ -51,4 +54,13 @@ public class EnterpriseServerSettings implements LoadableConfig
     @Description( "Configure the policy for outgoing Neo4j Browser connections." )
     public static final Setting<Boolean> browser_allowOutgoingBrowserConnections =
             setting( "browser.allow_outgoing_connections", BOOLEAN, TRUE );
+
+    @Description( "Publicly discoverable bolt+routing:// URI to use for Neo4j Drivers wanting to access a cluster " +
+            "that this instance is a member of. Only applicable to causal clusters." )
+    @DocumentedDefaultValue( "Defaults to empty on any deployment that is not a causal cluster core, and a " +
+            "bolt+routing://-schemed URI of the advertised address of the first found bolt connector if the " +
+            "instance is a core member of a causal cluster." )
+    public static final Setting<URI> bolt_routing_discoverable_address =
+            setting( "unsupported.dbms.discoverable_bolt_routing_address", Settings.URI, "" );
+
 }

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/OpenEnterpriseNeoServer.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/OpenEnterpriseNeoServer.java
@@ -22,13 +22,13 @@
  */
 package org.neo4j.server.enterprise;
 
+import org.eclipse.jetty.util.thread.ThreadPool;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
-
-import org.eclipse.jetty.util.thread.ThreadPool;
 
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.core.CoreGraphDatabase;
@@ -36,6 +36,7 @@ import org.neo4j.causalclustering.readreplica.ReadReplicaGraphDatabase;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.configuration.ConnectorPortRegister;
 import org.neo4j.kernel.enterprise.EnterpriseGraphDatabase;
 import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
@@ -53,8 +54,10 @@ import org.neo4j.server.database.LifecycleManagingDatabase.GraphFactory;
 import org.neo4j.server.enterprise.modules.EnterpriseAuthorizationModule;
 import org.neo4j.server.enterprise.modules.JMXManagementModule;
 import org.neo4j.server.modules.AuthorizationModule;
+import org.neo4j.server.modules.DBMSModule;
 import org.neo4j.server.modules.ServerModule;
 import org.neo4j.server.rest.DatabaseRoleInfoServerModule;
+import org.neo4j.server.rest.EnterpriseDiscoverableURIs;
 import org.neo4j.server.rest.MasterInfoService;
 import org.neo4j.server.rest.management.AdvertisableService;
 import org.neo4j.server.web.Jetty9WebServer;
@@ -161,6 +164,14 @@ public class OpenEnterpriseNeoServer extends CommunityNeoServer
     {
         return new EnterpriseAuthorizationModule( webServer, authManagerSupplier, logProvider, getConfig(),
                 getUriWhitelist() );
+    }
+
+    @Override
+    protected DBMSModule createDBMSModule()
+    {
+        ConnectorPortRegister ports = getDependencyResolver().resolveDependency( ConnectorPortRegister.class );
+        return new DBMSModule( webServer, getConfig(),
+                EnterpriseDiscoverableURIs.enterpriseDiscoverableURIs( getConfig(), ports ) );
     }
 
     @SuppressWarnings( "unchecked" )

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/EnterpriseDiscoverableURIs.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/EnterpriseDiscoverableURIs.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j Enterprise Edition. The included source
+ * code can be redistributed and/or modified under the terms of the
+ * GNU AFFERO GENERAL PUBLIC LICENSE Version 3
+ * (http://www.fsf.org/licensing/licenses/agpl-3.0.html) with the
+ * Commons Clause, as found in the associated LICENSE.txt file.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * Neo4j object code can be licensed independently from the source
+ * under separate terms from the AGPL. Inquiries can be directed to:
+ * licensing@neo4j.com
+ *
+ * More information is also available at:
+ * https://neo4j.com/licensing/
+ */
+package org.neo4j.server.rest;
+
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.configuration.ConnectorPortRegister;
+import org.neo4j.kernel.impl.enterprise.configuration.EnterpriseEditionSettings;
+import org.neo4j.server.enterprise.EnterpriseServerSettings;
+import org.neo4j.server.rest.discovery.DiscoverableURIs;
+
+import static org.neo4j.server.rest.discovery.CommunityDiscoverableURIs.communityDiscoverableURIs;
+
+public class EnterpriseDiscoverableURIs
+{
+    public static DiscoverableURIs enterpriseDiscoverableURIs( Config config, ConnectorPortRegister ports )
+    {
+        DiscoverableURIs uris = communityDiscoverableURIs( config, ports );
+        if ( config.get( EnterpriseEditionSettings.mode ) == EnterpriseEditionSettings.Mode.CORE )
+        {
+            DiscoverableURIs
+                    .discoverableBoltUri( "bolt+routing", config,
+                            EnterpriseServerSettings.bolt_routing_discoverable_address, ports )
+                    .ifPresent( uri -> uris.addAbsolute( "bolt_routing", uri ) );
+        }
+        return uris;
+    }
+}

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/functional/EnterpriseServerIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/functional/EnterpriseServerIT.java
@@ -35,6 +35,7 @@ import org.neo4j.ports.allocation.PortAuthority;
 import org.neo4j.server.NeoServer;
 import org.neo4j.server.enterprise.helpers.EnterpriseServerBuilder;
 import org.neo4j.test.rule.SuppressOutput;
+import org.neo4j.test.server.HTTP;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.hamcrest.CoreMatchers.is;
@@ -44,8 +45,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.neo4j.cluster.ClusterSettings.cluster_server;
 import static org.neo4j.cluster.ClusterSettings.initial_hosts;
-import static org.neo4j.kernel.impl.enterprise.configuration.EnterpriseEditionSettings.mode;
 import static org.neo4j.cluster.ClusterSettings.server_id;
+import static org.neo4j.kernel.impl.enterprise.configuration.EnterpriseEditionSettings.mode;
 
 public class EnterpriseServerIT
 {
@@ -73,13 +74,14 @@ public class EnterpriseServerIT
             server.start();
             server.getDatabase();
 
-            assertThat( server.getDatabase().getGraph(), is( instanceOf(HighlyAvailableGraphDatabase.class) ) );
+            assertThat( server.getDatabase().getGraph(), is( instanceOf( HighlyAvailableGraphDatabase.class ) ) );
 
-            Client client = Client.create();
-            ClientResponse r = client.resource( getHaEndpoint( server ) )
-                    .accept( APPLICATION_JSON ).get( ClientResponse.class );
-            assertEquals( 200, r.getStatus() );
-            assertThat( r.getEntity( String.class ), containsString( "master" ) );
+            HTTP.Response haEndpoint = HTTP.GET( getHaEndpoint( server ) );
+            assertEquals( 200, haEndpoint.status() );
+            assertThat( haEndpoint.rawContent(), containsString( "master" ) );
+
+            HTTP.Response discovery = HTTP.GET( server.baseUri().toASCIIString() );
+            assertEquals( 200, discovery.status() );
         }
         finally
         {

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/EnterpriseDiscoverableURIsTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/EnterpriseDiscoverableURIsTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j Enterprise Edition. The included source
+ * code can be redistributed and/or modified under the terms of the
+ * GNU AFFERO GENERAL PUBLIC LICENSE Version 3
+ * (http://www.fsf.org/licensing/licenses/agpl-3.0.html) with the
+ * Commons Clause, as found in the associated LICENSE.txt file.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * Neo4j object code can be licensed independently from the source
+ * under separate terms from the AGPL. Inquiries can be directed to:
+ * licensing@neo4j.com
+ *
+ * More information is also available at:
+ * https://neo4j.com/licensing/
+ */
+package org.neo4j.server.rest;
+
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.kernel.configuration.BoltConnector;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.configuration.ConnectorPortRegister;
+import org.neo4j.kernel.impl.enterprise.configuration.EnterpriseEditionSettings;
+import org.neo4j.server.rest.discovery.DiscoverableURIs;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class EnterpriseDiscoverableURIsTest
+{
+    @Test
+    public void shouldExposeBoltRoutingIfCore() throws Exception
+    {
+        // Given
+        BoltConnector bolt = new BoltConnector( "honestJakesBoltConnector" );
+        Config config = Config.builder()
+                .withSetting( EnterpriseEditionSettings.mode, EnterpriseEditionSettings.Mode.CORE.name() )
+                .withSetting( bolt.enabled, "true" )
+                .withSetting( bolt.type, BoltConnector.ConnectorType.BOLT.name() )
+                .build();
+
+        // When
+        Map<String,Object> asd = toMap(
+                EnterpriseDiscoverableURIs.enterpriseDiscoverableURIs( config, new ConnectorPortRegister() ) );
+
+        // Then
+        assertThat(asd.get("bolt_routing"), equalTo( "bolt+routing://localhost:7687" ));
+    }
+
+    @Test
+    public void shouldGrabPortFromRegisterIfSetTo0() throws Exception
+    {
+        // Given
+        BoltConnector bolt = new BoltConnector( "honestJakesBoltConnector" );
+        Config config = Config.builder()
+                .withSetting( EnterpriseEditionSettings.mode, EnterpriseEditionSettings.Mode.CORE.name() )
+                .withSetting( bolt.enabled, "true" )
+                .withSetting( bolt.type, BoltConnector.ConnectorType.BOLT.name() )
+                .withSetting( bolt.listen_address, ":0" )
+                .build();
+        ConnectorPortRegister ports = new ConnectorPortRegister();
+        ports.register( bolt.key(), new InetSocketAddress( 1337 ) );
+
+        // When
+        Map<String,Object> asd = toMap(
+                EnterpriseDiscoverableURIs.enterpriseDiscoverableURIs( config, ports ) );
+
+        // Then
+        assertThat(asd.get("bolt_routing"), equalTo( "bolt+routing://localhost:1337" ));
+    }
+
+    private Map<String,Object> toMap( DiscoverableURIs uris )
+    {
+        Map<String,Object> out = new HashMap<>();
+        uris.forEachAbsoluteUri( ( k, v ) -> out.put( k, v.toASCIIString() ) );
+        uris.forEachRelativeUri( out::put );
+        return out;
+    }
+}


### PR DESCRIPTION
This introduces a minor overhaul of the discovery
service, allowing arbitrary URLs to be published to it.
That functionality is leveraged to have the enterprise
edition of the server publish a `bolt+routing` URI.

Same PR as before, re targeted to 3.5, all comments addressed.