### PR TITLE
Update java 9 profile to be java 9 and later

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <lucene.version>5.5.5</lucene.version>
     <bouncycastle.version>1.59</bouncycastle.version>
     <generate-config-docs-phase>prepare-package</generate-config-docs-phase>
-    <java9.exports/>
+    <java.exports/>
     <test.runner.jvm/>
     <test.runner.jvm.settings.additional/>
     <test.runner.jvm.settings>-Xmx2G -XX:+UseG1GC -XX:-OmitStackTraceInFastThrow -XX:+HeapDumpOnOutOfMemoryError -XX:+ExitOnOutOfMemoryError
@@ -77,7 +77,7 @@
       -Dorg.neo4j.io.pagecache.impl.muninn.usePreciseCursorErrorStackTraces=true
       -Dorg.neo4j.kernel.impl.api.KernelStatement.trackStatements=true
       -Dorg.org.neo4j.kernel.impl.newapi.DefaultCursors.trackCursors=true
-      -XX:+UnlockExperimentalVMOptions -XX:+TrustFinalNonStaticFields ${java9.exports} ${test.runner.jvm.settings.additional}
+      -XX:+UnlockExperimentalVMOptions -XX:+TrustFinalNonStaticFields ${java.exports} ${test.runner.jvm.settings.additional}
     </test.runner.jvm.settings>
     <jetty.version>9.4.8.v20171121</jetty.version>
     <findbugs.version>3.0.1</findbugs.version>
@@ -94,7 +94,7 @@
     <asm.version>6.1.1</asm.version>
     <metrics.version>4.0.2</metrics.version>
     <scala.target.vm>1.8</scala.target.vm>
-    <scala.java9.arg/>
+    <scala.java.additional.args/>
     <jersey.version>1.19.3</jersey.version>
     <checkstyle.strict>true</checkstyle.strict>
   </properties>
@@ -536,7 +536,7 @@
               <arg>100</arg>
               <arg>-Xlint</arg>
               <arg>-target:jvm-${scala.target.vm}</arg>
-              <arg>${scala.java9.arg}</arg>
+              <arg>${scala.java.additional.args}</arg>
             </args>
             <jvmArgs>
               <jvmArg>-Xms64m</jvmArg>
@@ -595,7 +595,7 @@
           <configuration>
             <showDeprecation>true</showDeprecation>
             <showWarnings>true</showWarnings>
-            <compilerArgument>${java9.exports}</compilerArgument>
+            <compilerArgument>${java.exports}</compilerArgument>
           </configuration>
         </plugin>
         <plugin>
@@ -923,15 +923,15 @@
     </profile>
 
     <profile>
-      <id>java9</id>
+      <id>java9AndLater</id>
       <activation>
         <activeByDefault>false</activeByDefault>
-        <jdk>9</jdk>
+        <jdk>[9, )</jdk>
       </activation>
       <properties>
-        <java9.exports>--add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-modules java.xml.bind</java9.exports>
+        <java.exports>--add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-modules java.xml.bind</java.exports>
         <maven.javadoc.skip>true</maven.javadoc.skip>
-        <scala.java9.arg>-nobootcp</scala.java9.arg>
+        <scala.java.additional.args>-nobootcp</scala.java.additional.args>
       </properties>
     </profile>
 


### PR DESCRIPTION
Update java 9 maven profile to be activated on VM's that are 9 and later.
Rename properties to much more generic profile usage.