### PR TITLE
Fix toString for db.temporal.timezone setting

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -61,6 +61,7 @@ import static org.neo4j.kernel.configuration.Settings.NO_DEFAULT;
 import static org.neo4j.kernel.configuration.Settings.PATH;
 import static org.neo4j.kernel.configuration.Settings.STRING;
 import static org.neo4j.kernel.configuration.Settings.STRING_LIST;
+import static org.neo4j.kernel.configuration.Settings.TIMEZONE;
 import static org.neo4j.kernel.configuration.Settings.TRUE;
 import static org.neo4j.kernel.configuration.Settings.advertisedAddress;
 import static org.neo4j.kernel.configuration.Settings.buildSetting;
@@ -398,7 +399,7 @@ public class GraphDatabaseSettings implements LoadableConfig
     @Description( "Database timezone for temporal functions. All Time and DateTime values that are created without " +
             "an explicit timezone will use this configured default timezone." )
     public static final Setting<ZoneId> db_temporal_timezone =
-            setting( "db.temporal.timezone", DateTimeValue::parseZoneOffsetOrZoneName, ZoneOffset.UTC.toString() );
+            setting( "db.temporal.timezone", TIMEZONE, ZoneOffset.UTC.toString() );
 
     @Description( "Maximum time to wait for active transaction completion when rotating counts store" )
     @Internal

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Settings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Settings.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -54,6 +55,7 @@ import org.neo4j.helpers.TimeUtil;
 import org.neo4j.helpers.collection.CollectorsUtil;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.io.ByteUnit;
+import org.neo4j.values.storable.DateTimeValue;
 
 import static java.lang.Character.isDigit;
 import static java.lang.Long.parseLong;
@@ -529,6 +531,21 @@ public class Settings
         public String toString()
         {
             return "a duration (" + TimeUtil.VALID_TIME_DESCRIPTION + ")";
+        }
+    };
+
+    public static final Function<String,ZoneId> TIMEZONE = new Function<String,ZoneId>()
+    {
+        @Override
+        public ZoneId apply( String value )
+        {
+            return DateTimeValue.parseZoneOffsetOrZoneName(value);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "a string describing a timezone, either described by offset (e.g. '+02:00') or by name (e.g. 'Europe/Stockholm')";
         }
     };
 


### PR DESCRIPTION
Addendum to #11721
so that we get a correct textual description of valid values in the ops manual.