### PR TITLE
Abort replication on missing leader or leader switch

### DIFF
--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -503,6 +503,9 @@ public interface Status
         NoLeaderAvailable( TransientError,
                 "No leader available at the moment. Retrying your request at a later time may succeed." ),
 
+        ReplicationFailure( TransientError,
+                "Replication failure." ),
+
         NotALeader( ClientError,
                 "The request cannot be processed by this server. Write requests can only be processed by the leader." ),
                 ;

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/KernelException.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/KernelException.java
@@ -34,6 +34,12 @@ public abstract class KernelException extends Exception implements Status.HasSta
         initCause( cause );
     }
 
+    protected KernelException( Status statusCode, Throwable cause )
+    {
+        super( cause );
+        this.statusCode = statusCode;
+    }
+
     protected KernelException( Status statusCode, String message, Object... parameters )
     {
         super( String.format( message, parameters ) );

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/TransactionFailureException.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/exceptions/TransactionFailureException.java
@@ -36,6 +36,11 @@ public class TransactionFailureException extends KernelException
         super( statusCode, cause, message, parameters );
     }
 
+    public TransactionFailureException( Status statusCode, Throwable cause )
+    {
+        super( statusCode, cause );
+    }
+
     public TransactionFailureException( Status statusCode, String message, Object... parameters )
     {
         super( statusCode, message, parameters );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/ReplicationFailureException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/ReplicationFailureException.java
@@ -22,22 +22,15 @@
  */
 package org.neo4j.causalclustering.core.replication;
 
-import java.util.concurrent.Future;
-
-/**
- * Replicate content across a cluster of servers.
-  */
-public interface Replicator
+public class ReplicationFailureException extends Exception
 {
-    /**
-     * Submit content for replication. This method does not guarantee that the content
-     * actually gets replicated, it merely makes an attempt at replication. Other
-     * mechanisms must be used to achieve required delivery semantics.
-     *
-     * @param content      The content to replicated.
-     * @param trackResult  Whether to track the result for this operation.
-     *
-     * @return A future that will receive the result when available. Only valid if trackResult is set.
-     */
-    Future<Object> replicate( ReplicatedContent content, boolean trackResult ) throws ReplicationFailureException;
+    ReplicationFailureException( String message, Throwable cause )
+    {
+        super( message, cause );
+    }
+
+    ReplicationFailureException( String message )
+    {
+        super( message );
+    }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdRangeAcquirer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdRangeAcquirer.java
@@ -23,7 +23,6 @@
 package org.neo4j.causalclustering.core.state.machines.id;
 
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 import org.neo4j.causalclustering.core.replication.Replicator;
 import org.neo4j.causalclustering.identity.MemberId;
@@ -85,9 +84,9 @@ public class ReplicatedIdRangeAcquirer
         {
             return (Boolean) replicator.replicate( idAllocationRequest, true ).get();
         }
-        catch ( InterruptedException | ExecutionException e )
+        catch ( Exception e )
         {
-            log.error( format( "Failed to acquire id range for idType %s", idType ), e );
+            log.warn( format( "Failed to acquire id range for idType %s", idType ), e );
             throw new IdGenerationException( e );
         }
     }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManager.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManager.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 
 import org.neo4j.causalclustering.core.consensus.LeaderLocator;
 import org.neo4j.causalclustering.core.consensus.NoLeaderFoundException;
+import org.neo4j.causalclustering.core.replication.ReplicationFailureException;
 import org.neo4j.causalclustering.core.replication.Replicator;
 import org.neo4j.causalclustering.core.state.machines.tx.ReplicatedTransactionStateMachine;
 import org.neo4j.causalclustering.identity.MemberId;
@@ -39,6 +40,7 @@ import org.neo4j.storageengine.api.lock.ResourceType;
 
 import static org.neo4j.kernel.api.exceptions.Status.Cluster.NoLeaderAvailable;
 import static org.neo4j.kernel.api.exceptions.Status.Cluster.NotALeader;
+import static org.neo4j.kernel.api.exceptions.Status.Cluster.ReplicationFailure;
 import static org.neo4j.kernel.api.exceptions.Status.Transaction.Interrupted;
 
 /**
@@ -114,9 +116,9 @@ public class LeaderOnlyLockManager implements Locks
         {
             future = replicator.replicate( lockTokenRequest, true );
         }
-        catch ( InterruptedException e )
+        catch ( ReplicationFailureException e )
         {
-            throw new AcquireLockTimeoutException( e, "Interrupted acquiring token.", Interrupted );
+            throw new AcquireLockTimeoutException( e, "Replication failure acquiring lock token.", ReplicationFailure );
         }
 
         try

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedTokenHolder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedTokenHolder.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import org.neo4j.causalclustering.core.replication.ReplicationFailureException;
 import org.neo4j.causalclustering.core.replication.Replicator;
 import org.neo4j.internal.kernel.api.exceptions.schema.ConstraintValidationException;
 import org.neo4j.internal.kernel.api.exceptions.TransactionFailureException;
@@ -101,7 +102,7 @@ abstract class ReplicatedTokenHolder<TOKEN extends Token> implements TokenHolder
             Future<Object> future = replicator.replicate( tokenRequest, true );
             return (int) future.get();
         }
-        catch ( InterruptedException e )
+        catch ( ReplicationFailureException | InterruptedException e )
         {
             throw new org.neo4j.graphdb.TransactionFailureException( "Could not create token", e );
         }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransactionCommitProcess.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransactionCommitProcess.java
@@ -25,6 +25,7 @@ package org.neo4j.causalclustering.core.state.machines.tx;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import org.neo4j.causalclustering.core.replication.ReplicationFailureException;
 import org.neo4j.causalclustering.core.replication.Replicator;
 import org.neo4j.internal.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
@@ -33,6 +34,7 @@ import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
 import org.neo4j.storageengine.api.TransactionApplicationMode;
 
 import static org.neo4j.causalclustering.core.state.machines.tx.ReplicatedTransactionFactory.createImmutableReplicatedTransaction;
+import static org.neo4j.kernel.api.exceptions.Status.Cluster.ReplicationFailure;
 
 public class ReplicatedTransactionCommitProcess implements TransactionCommitProcess
 {
@@ -54,9 +56,9 @@ public class ReplicatedTransactionCommitProcess implements TransactionCommitProc
         {
             futureTxId = replicator.replicate( transaction, true );
         }
-        catch ( InterruptedException e )
+        catch ( ReplicationFailureException e )
         {
-            throw new TransactionFailureException( "Interrupted replicating transaction.", e );
+            throw new TransactionFailureException( ReplicationFailure, e );
         }
 
         try


### PR DESCRIPTION
When there is a lot of data queued up behind the replicator, it makes sense
to make a sweeping abort of it all when there is a leader switch or a leader
is missing altogether. A leader switch generally implies, for transactional
work, that the work has to be thrown away anyway due to the switch of lock token.

To keep the safety aspect of exactly-once semantics, we cannot abort once
replication has been attempted, but the replication limit of the Throttler
limits the amount of in-flight replication data which must be finalized.