### PR TITLE
Return correct HTTPS uri in Neo4jRule

### DIFF
--- a/community/neo4j-harness/pom.xml
+++ b/community/neo4j-harness/pom.xml
@@ -147,5 +147,11 @@
       <artifactId>neo4j-kernel</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+
   </dependencies>
 </project>

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/junit/Neo4jRule.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/junit/Neo4jRule.java
@@ -205,7 +205,7 @@ public class Neo4jRule implements TestRule, TestServerBuilder
         {
             throw new IllegalStateException( "Cannot access instance URI before or after the test runs." );
         }
-        return controls.httpURI();
+        return controls.httpsURI().orElseThrow( () -> new IllegalStateException( "HTTPS connector is not configured" ) );
     }
 
     public GraphDatabaseService getGraphDatabaseService()

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/junit/Neo4jRuleTest.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/junit/Neo4jRuleTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.harness.junit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.runners.model.Statement;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.neo4j.harness.ServerControls;
+import org.neo4j.harness.TestServerBuilder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.runner.Description.createTestDescription;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class Neo4jRuleTest
+{
+    @Test
+    void shouldReturnHttpsUriWhenConfigured() throws Throwable
+    {
+        URI configuredHttpsUri = URI.create( "https://localhost:7473" );
+        assertEquals( configuredHttpsUri, getHttpsUriFromNeo4jRule( configuredHttpsUri ) );
+    }
+
+    @Test
+    void shouldThrowWhenHttpsUriNotConfigured() throws Throwable
+    {
+        assertThrows( IllegalStateException.class, () -> getHttpsUriFromNeo4jRule( null ) );
+    }
+
+    private static URI getHttpsUriFromNeo4jRule( URI configuredHttpsUri ) throws Throwable
+    {
+        ServerControls serverControls = mock( ServerControls.class );
+        when( serverControls.httpsURI() ).thenReturn( Optional.ofNullable( configuredHttpsUri ) );
+        TestServerBuilder serverBuilder = mock( TestServerBuilder.class );
+        when( serverBuilder.newServer() ).thenReturn( serverControls );
+
+        Neo4jRule rule = new Neo4jRule( serverBuilder );
+
+        AtomicReference<URI> uriRef = new AtomicReference<>();
+        Statement statement = rule.apply( new Statement()
+        {
+            @Override
+            public void evaluate() throws Throwable
+            {
+                uriRef.set( rule.httpsURI() );
+            }
+        }, createTestDescription( Neo4jRuleTest.class, "test" ) );
+
+        statement.evaluate();
+        return uriRef.get();
+    }
+}


### PR DESCRIPTION
Previously rule returned HTTP uri instead from `Neo4jRule#httpsUri()` method. This method will now throw `IllegalStateException` when HTTPS connector is not configured.