### PR TITLE
Add access to propertiesReference to RelationshipSelectionCursor

### DIFF
--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledExpandUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledExpandUtils.java
@@ -279,6 +279,12 @@ public abstract class CompiledExpandUtils
             }
 
             @Override
+            public long propertiesReference()
+            {
+                return allRelationships.propertiesReference();
+            }
+
+            @Override
             public boolean next()
             {
                 while ( allRelationships.next() )

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/profiler/Profiler.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/profiler/Profiler.scala
@@ -184,6 +184,8 @@ final class ProfilingPipeQueryContext(inner: QueryContext, val p: Pipe)
     override def sourceNodeReference(): Long = inner.sourceNodeReference()
 
     override def targetNodeReference(): Long = inner.targetNodeReference()
+
+    override def propertiesReference(): Long = inner.propertiesReference()
   }
 
   class ProfilerOperations[T](inner: Operations[T]) extends DelegatingOperations[T](inner) {

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionCursor.java
@@ -65,4 +65,10 @@ public final class RelationshipDenseSelectionCursor extends RelationshipDenseSel
     {
         return relationshipCursor.targetNodeReference();
     }
+
+    @Override
+    public long propertiesReference()
+    {
+        return relationshipCursor.propertiesReference();
+    }
 }

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSelectionCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSelectionCursor.java
@@ -39,6 +39,8 @@ public interface RelationshipSelectionCursor extends AutoCloseable
 
     long targetNodeReference();
 
+    long propertiesReference();
+
     final class EMPTY implements RelationshipSelectionCursor
     {
         @Override
@@ -79,6 +81,12 @@ public interface RelationshipSelectionCursor extends AutoCloseable
 
         @Override
         public long targetNodeReference()
+        {
+            return -1;
+        }
+
+        @Override
+        public long propertiesReference()
         {
             return -1;
         }

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionCursor.java
@@ -65,4 +65,10 @@ public final class RelationshipSparseSelectionCursor extends RelationshipSparseS
     {
         return cursor.targetNodeReference();
     }
+
+    @Override
+    public long propertiesReference()
+    {
+        return cursor.propertiesReference();
+    }
 }


### PR DESCRIPTION
discussed with @fickludd on Slack, following neo4j-contrib/neo4j-graph-algorithms#610

Add access to the properties reference for `RelationshipSelectionCursor`s, so that we can read properties from relationships while scanning through the relationship store without having to go through an additional singleRelationship cursor. Although we don't expect additional IO from reading the single cursor, as the target page should be the same that has just been cached for the selection cursor, we would skip an additional decoding of the relationship store data.