### PR TITLE
Make SharedDiscovery canBeBootstrapped logic more deterministic

### DIFF
--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryCoreClient.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryCoreClient.java
@@ -32,7 +32,7 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 
-class SharedDiscoveryCoreClient extends AbstractTopologyService implements CoreTopologyService, Comparable<SharedDiscoveryCoreClient>
+class SharedDiscoveryCoreClient extends AbstractTopologyService implements CoreTopologyService
 {
     private final SharedDiscoveryService sharedDiscoveryService;
     private final MemberId myself;
@@ -56,12 +56,6 @@ class SharedDiscoveryCoreClient extends AbstractTopologyService implements CoreT
         this.log = logProvider.getLog( getClass() );
         this.refusesToBeLeader = config.get( CausalClusteringSettings.refuse_to_be_leader );
         this.localDBName = config.get( CausalClusteringSettings.database );
-    }
-
-    @Override
-    public int compareTo( SharedDiscoveryCoreClient o )
-    {
-        return Optional.ofNullable( o ).map( c -> c.myself.getUuid().compareTo( this.myself.getUuid() ) ).orElse( -1 );
     }
 
     @Override

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryService.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryService.java
@@ -20,12 +20,13 @@
 package org.neo4j.causalclustering.discovery;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -41,7 +42,7 @@ public final class SharedDiscoveryService
 
     private final ConcurrentMap<MemberId,CoreServerInfo> coreMembers;
     private final ConcurrentMap<MemberId,ReadReplicaInfo> readReplicas;
-    private final Set<SharedDiscoveryCoreClient> listeningClients;
+    private final List<SharedDiscoveryCoreClient> listeningClients;
     private final ConcurrentMap<String,ClusterId> clusterIdDbNames;
     private final ConcurrentMap<String,LeaderInfo> leaderMap;
     private final CountDownLatch enoughMembers;
@@ -50,7 +51,7 @@ public final class SharedDiscoveryService
     {
         coreMembers = new ConcurrentHashMap<>();
         readReplicas = new ConcurrentHashMap<>();
-        listeningClients = new ConcurrentSkipListSet<>();
+        listeningClients = new CopyOnWriteArrayList<>();
         clusterIdDbNames = new ConcurrentHashMap<>();
         leaderMap = new ConcurrentHashMap<>();
         enoughMembers = new CountDownLatch( MIN_DISCOVERY_MEMBERS );
@@ -95,6 +96,7 @@ public final class SharedDiscoveryService
         CoreServerInfo previousMember = coreMembers.putIfAbsent( client.getMemberId(), client.getCoreServerInfo() );
         if ( previousMember == null )
         {
+
             listeningClients.add( client );
             enoughMembers.countDown();
             notifyCoreClients();


### PR DESCRIPTION
In the `SharedDiscoveryService`, `canBeBootstrapped` was calculated for each member by iterating through `listeningClients` and performing the standard `isFirstAppropriate` logic. However the ordering was **not** insertion based, as with `HazelcastClusterTopology`, but instead based upon the uuid of the members. 

In very rare cases, with unfortunate timings, this allowed two members to think they were both bootstrappable and would lead to tests failing with the error: `Failed to publish: ClusterId{uuid=f89319d1-6031-4bef-8975-059eeff01ba1}`. I hope this will fix much flakiness .. 