### PR TITLE
Store only minimal splitter in internal nodes in GBPTree

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/Layout.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/Layout.java
@@ -109,6 +109,16 @@ public interface Layout<KEY, VALUE> extends Comparator<KEY>
      * @return true if keys and values are fixed size, otherwise true.
      */
     boolean fixedSize();
+
+    /**
+     * Find shortest key (best effort) that separate left from right in sort order
+     * and initialize into with result.
+     * @param left key that is less than right
+     * @param right key that is greater than left.
+     * @param into will be initialized with result.
+     */
+    void minimalSplitter( KEY left, KEY right, KEY into );
+
     /**
      * Used as verification when loading an index after creation, to verify that the same layout is used,
      * as the one it was initially created with.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/RightmostInChain.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/RightmostInChain.java
@@ -109,6 +109,6 @@ class RightmostInChain
     void assertLast()
     {
         assert currentRightmostRightSiblingPointer == NO_NODE_FLAG : "Expected rightmost right sibling to be " + NO_NODE_FLAG
-                + " but was " + currentRightmostRightSiblingPointer;
+                + " but was " + currentRightmostRightSiblingPointer + ". Current rightmost node is " + currentRightmostNode;
     }
 }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNodeDynamicSize.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNodeDynamicSize.java
@@ -97,6 +97,8 @@ public class TreeNodeDynamicSize<KEY, VALUE> extends TreeNode<KEY,VALUE>
     private final int[] newOffset = new int[maxKeyCount];
     private final int totalSpace;
     private final int halfSpace;
+    private final KEY tmpKeyLeft;
+    private final KEY tmpKeyRight;
 
     TreeNodeDynamicSize( int pageSize, Layout<KEY,VALUE> layout )
     {
@@ -112,6 +114,9 @@ public class TreeNodeDynamicSize<KEY, VALUE> extends TreeNode<KEY,VALUE>
                             "with current page size of %dB. We require this cap to be at least %dB.",
                     LEAST_NUMBER_OF_ENTRIES_PER_PAGE, keyValueSizeCap, pageSize, Long.SIZE );
         }
+
+        tmpKeyLeft = layout.newKey();
+        tmpKeyRight = layout.newKey();
     }
 
     @Override
@@ -622,11 +627,16 @@ public class TreeNodeDynamicSize<KEY, VALUE> extends TreeNode<KEY,VALUE>
 
         if ( middlePos == insertPos )
         {
-            layout.copyKey( newKey, newSplitter );
+            keyAt( leftCursor, tmpKeyLeft, middlePos - 1, LEAF );
+            layout.minimalSplitter( tmpKeyLeft, newKey, newSplitter );
         }
         else
         {
-            keyAt( leftCursor, newSplitter, insertPos < middlePos ? middlePos - 1 : middlePos, LEAF );
+            int rightPos = insertPos < middlePos ? middlePos - 1 : middlePos;
+            int leftPos = rightPos - 1;
+            keyAt( leftCursor, tmpKeyRight, rightPos, LEAF );
+            keyAt( leftCursor, tmpKeyLeft, leftPos, LEAF );
+            layout.minimalSplitter( tmpKeyLeft, tmpKeyRight, newSplitter );
         }
         int rightKeyCount = keyCountAfterInsert - middlePos;
 

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicDynamicSizeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicDynamicSizeTest.java
@@ -19,6 +19,13 @@
  */
 package org.neo4j.index.internal.gbptree;
 
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.index.internal.gbptree.TreeNode.Type.INTERNAL;
+
 public class InternalTreeLogicDynamicSizeTest extends InternalTreeLogicTestBase<RawBytes,RawBytes>
 {
     private SimpleByteArrayLayout layout = new SimpleByteArrayLayout();
@@ -44,5 +51,24 @@ public class InternalTreeLogicDynamicSizeTest extends InternalTreeLogicTestBase<
     protected TestLayout<RawBytes,RawBytes> getLayout()
     {
         return layout;
+    }
+
+    @Test
+    public void storeOnlyMinimalKeyDividerInInternal() throws IOException
+    {
+        // given
+        initialize();
+        long key = 0;
+        while ( numberOfRootSplits == 0 )
+        {
+            insert( key( key ), value( key ) );
+            key++;
+        }
+
+        // when
+        RawBytes rawBytes = keyAt( rootId, 0, INTERNAL );
+
+        // then
+        assertEquals( "expected no tail on internal key but was " + rawBytes.toString(), Long.BYTES, rawBytes.bytes.length );
     }
 }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTestBase.java
@@ -1386,7 +1386,7 @@ public abstract class InternalTreeLogicTestBase<KEY,VALUE>
     public void shouldOverwriteInheritedSuccessorOnSuccessor() throws Exception
     {
         // GIVEN
-        assumeTrue( isCheckpointing );
+        assumeTrue( "No checkpointing, no successor", isCheckpointing );
         initialize();
         long originalNodeId = rootId;
         generationManager.checkpoint();
@@ -1417,7 +1417,7 @@ public abstract class InternalTreeLogicTestBase<KEY,VALUE>
     {
         // GIVEN
         // root with two children
-        assumeTrue( isCheckpointing );
+        assumeTrue( "No checkpointing, no successor", isCheckpointing );
         initialize();
         long someHighMultiplier = 1000;
         for ( int i = 1; numberOfRootSplits < 1; i++ )

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTestBase.java
@@ -982,9 +982,7 @@ public abstract class InternalTreeLogicTestBase<KEY,VALUE>
 
         // then
         goTo( readCursor, rootId );
-        ConsistencyChecker<KEY> consistencyChecker =
-                new ConsistencyChecker<>( node, layout, stableGeneration, unstableGeneration );
-        consistencyChecker.check( readCursor, rootGeneration );
+        consistencyCheck();
     }
 
     @Test
@@ -1005,10 +1003,7 @@ public abstract class InternalTreeLogicTestBase<KEY,VALUE>
         }
 
         // then
-        goTo( readCursor, rootId );
-        ConsistencyChecker<KEY> consistencyChecker =
-                new ConsistencyChecker<>( node, layout, stableGeneration, unstableGeneration );
-        consistencyChecker.check( readCursor, rootGeneration );
+        consistencyCheck();
     }
 
     /* TEST VALUE MERGER */
@@ -1444,6 +1439,16 @@ public abstract class InternalTreeLogicTestBase<KEY,VALUE>
             // THEN
             assertThat( e.getMessage(), containsString( PointerChecking.WRITER_TRAVERSE_OLD_STATE_MESSAGE ) );
         }
+    }
+
+    private void consistencyCheck() throws IOException
+    {
+        long currentPageId = readCursor.getCurrentPageId();
+        goTo( readCursor, rootId );
+        ConsistencyChecker<KEY> consistencyChecker =
+                new ConsistencyChecker<>( node, layout, stableGeneration, unstableGeneration );
+        consistencyChecker.check( readCursor, rootGeneration );
+        goTo( readCursor, currentPageId );
     }
 
     private void remove( KEY toRemove, List<KEY> list, Comparator<KEY> comparator )

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTestBase.java
@@ -94,9 +94,9 @@ public abstract class InternalTreeLogicTestBase<KEY,VALUE>
     @Rule
     public RandomRule random = new RandomRule();
 
-    private long rootId;
+    long rootId;
+    int numberOfRootSplits;
     private long rootGeneration;
-    private int numberOfRootSplits;
     private int numberOfRootSuccessors;
 
     @Before
@@ -581,14 +581,14 @@ public abstract class InternalTreeLogicTestBase<KEY,VALUE>
         insert( key( i ), value( i ) ); // And an extra to not cause rebalance
 
         // when key to remove exists in internal
-        KEY keyToRemove = structurePropagation.rightKey;
-        assertEqualsKey( keyAt( rootId, 0, INTERNAL ), keyToRemove );
+        long currentRightChild = structurePropagation.rightChild;
+        KEY keyToRemove = keyAt( currentRightChild, 0, LEAF );
+        assertEquals( getSeed( keyAt( rootId, 0, INTERNAL ) ), getSeed( keyToRemove ) );
 
         // and as first key in right child
-        long currentRightChild = structurePropagation.rightChild;
         goTo( readCursor, currentRightChild );
         int keyCountInRightChild = keyCount();
-        assertEqualsKey( keyAt( 0, LEAF ), keyToRemove );
+        assertEquals( "same seed", getSeed( keyToRemove ), getSeed( keyAt( 0, LEAF ) ) );
 
         // and we remove it
         generationManager.checkpoint();
@@ -598,12 +598,12 @@ public abstract class InternalTreeLogicTestBase<KEY,VALUE>
 
         // then we should still find it in internal
         assertThat( keyCount(), is( 1 ) );
-        assertEqualsKey( keyAt( 0, INTERNAL ), keyToRemove );
+        assertEquals( "same seed", getSeed( keyAt( 0, INTERNAL ) ), getSeed( keyToRemove ) );
 
         // but not in right leaf
         goTo( readCursor, currentRightChild );
         assertThat( keyCount(), is( keyCountInRightChild - 1 ) );
-        assertEqualsKey( keyAt( 0, LEAF ), key( getSeed( keyToRemove ) + 1 ) );
+        assertEquals( "same seed", getSeed( keyAt( 0, LEAF ) ), getSeed( key( getSeed( keyToRemove ) + 1 ) ) );
 
         // and when we remove same key again, nothing should change
         assertNull( remove( keyToRemove, dontCare ) );
@@ -655,7 +655,7 @@ public abstract class InternalTreeLogicTestBase<KEY,VALUE>
         // ... no keys should have moved from right sibling
         int actualKeyCount = TreeNode.keyCount( readCursor );
         assertEquals( "actualKeyCount=" + actualKeyCount + ", expectedKeyCount=" + expectedKeyCount, expectedKeyCount, actualKeyCount );
-        assertEqualsKey( keyAt( 0, LEAF ), primKey );
+        assertEquals( "same seed", getSeed( primKey ), getSeed( keyAt( 0, LEAF ) ) );
     }
 
     @Test
@@ -745,6 +745,7 @@ public abstract class InternalTreeLogicTestBase<KEY,VALUE>
         }
         goTo( readCursor, rootId );
         assertEquals( 2, keyCount() );
+        long oldRootId = readCursor.getCurrentPageId();
         long oldLeftChild = childAt( readCursor, 0, stableGeneration, unstableGeneration );
         long oldMiddleChild = childAt( readCursor, 1, stableGeneration, unstableGeneration );
         long oldRightChild = childAt( readCursor, 2, stableGeneration, unstableGeneration );
@@ -752,12 +753,13 @@ public abstract class InternalTreeLogicTestBase<KEY,VALUE>
 
         // WHEN
         generationManager.checkpoint();
-        KEY middleKey = keyAt( 0, INTERNAL ); // Should be located in middle leaf
+        KEY middleKey = keyAt( oldMiddleChild,0, LEAF ); // Should be located in middle leaf
         remove( middleKey, dontCare );
         allKeys.remove( middleKey );
 
         // THEN
         // old root should still have 2 keys
+        goTo( readCursor, oldRootId );
         assertEquals( 2, keyCount() );
 
         // new root should have only 1 key
@@ -1593,7 +1595,7 @@ public abstract class InternalTreeLogicTestBase<KEY,VALUE>
         return TreeNode.keyCount( readCursor );
     }
 
-    private void initialize()
+    void initialize()
     {
         node.initializeLeaf( cursor, stableGeneration, unstableGeneration );
         updateRoot();
@@ -1659,12 +1661,12 @@ public abstract class InternalTreeLogicTestBase<KEY,VALUE>
         cursor.next( currentPageId );
     }
 
-    private KEY key( long seed )
+    KEY key( long seed )
     {
         return layout.key( seed );
     }
 
-    private VALUE value( long seed )
+    VALUE value( long seed )
     {
         return layout.value( seed );
     }
@@ -1707,7 +1709,7 @@ public abstract class InternalTreeLogicTestBase<KEY,VALUE>
         goTo( readCursor, currentPageId );
     }
 
-    private KEY keyAt( long nodeId, int pos, TreeNode.Type type )
+    KEY keyAt( long nodeId, int pos, TreeNode.Type type )
     {
         KEY readKey = layout.newKey();
         long prevId = readCursor.getCurrentPageId();
@@ -1732,7 +1734,7 @@ public abstract class InternalTreeLogicTestBase<KEY,VALUE>
         return node.valueAt( readCursor, layout.newValue(), pos );
     }
 
-    private void insert( KEY key, VALUE value ) throws IOException
+    void insert( KEY key, VALUE value ) throws IOException
     {
         insert( key, value, overwrite() );
     }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleByteArrayLayout.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleByteArrayLayout.java
@@ -34,9 +34,14 @@ public class SimpleByteArrayLayout extends TestLayout<RawBytes,RawBytes>
     @Override
     public RawBytes copyKey( RawBytes rawBytes, RawBytes into )
     {
+        return copyKey( rawBytes, into, rawBytes.bytes.length );
+    }
+
+    private RawBytes copyKey( RawBytes rawBytes, RawBytes into, int length )
+    {
         byte[] src = rawBytes.bytes;
-        byte[] target = new byte[src.length];
-        System.arraycopy( src, 0, target, 0, src.length );
+        byte[] target = new byte[length];
+        System.arraycopy( src, 0, target, 0, length );
         into.bytes = target;
         return into;
     }
@@ -97,6 +102,13 @@ public class SimpleByteArrayLayout extends TestLayout<RawBytes,RawBytes>
     public boolean fixedSize()
     {
         return false;
+    }
+
+    @Override
+    public void minimalSplitter( RawBytes left, RawBytes right, RawBytes into )
+    {
+        // Minimal splitter will always be the first 8B
+        copyKey( right, into, Long.BYTES );
     }
 
     @Override

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleLongLayout.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleLongLayout.java
@@ -175,6 +175,12 @@ class SimpleLongLayout extends TestLayout<MutableLong,MutableLong>
     }
 
     @Override
+    public void minimalSplitter( MutableLong left, MutableLong right, MutableLong into )
+    {
+        copyKey( right, into );
+    }
+
+    @Override
     public long identifier()
     {
         return identifier;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanLayout.java
@@ -136,6 +136,12 @@ class LabelScanLayout extends Layout.Adapter<LabelScanKey,LabelScanValue>
     }
 
     @Override
+    public void minimalSplitter( LabelScanKey left, LabelScanKey right, LabelScanKey into )
+    {
+        copyKey( right, into );
+    }
+
+    @Override
     public long identifier()
     {
         return Layout.namedIdentifier( IDENTIFIER_NAME, LabelScanValue.RANGE_SIZE );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SchemaLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SchemaLayout.java
@@ -72,6 +72,12 @@ abstract class SchemaLayout<KEY extends NativeSchemaKey<KEY>> extends Layout.Ada
     }
 
     @Override
+    public void minimalSplitter( KEY left, KEY right, KEY into )
+    {
+        copyKey( right, into );
+    }
+
+    @Override
     public long identifier()
     {
         return identifier;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringLayout.java
@@ -83,6 +83,24 @@ class StringLayout extends SchemaLayout<StringSchemaKey>
     }
 
     @Override
+    public void minimalSplitter( StringSchemaKey left, StringSchemaKey right, StringSchemaKey into )
+    {
+        int maxLength = Math.min( left.bytesLength, right.bytesLength );
+        int targetLength = 0;
+        boolean foundDiffer = false;
+        for ( int i = 0; i < maxLength; i++ )
+        {
+            targetLength++;
+            if ( left.bytes[i] != right.bytes[i] )
+            {
+                foundDiffer = true;
+                break;
+            }
+        }
+        into.copyFrom( right, targetLength );
+    }
+
+    @Override
     public String toString()
     {
         return format( "%s[version:%d.%d, identifier:%d]", getClass().getSimpleName(), majorVersion(), minorVersion(), identifier() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringSchemaKey.java
@@ -189,8 +189,13 @@ class StringSchemaKey extends NativeSchemaKey<StringSchemaKey>
 
     void copyFrom( StringSchemaKey key )
     {
-        setBytesLength( key.bytesLength );
-        System.arraycopy( key.bytes, 0, bytes, 0, key.bytesLength );
+        copyFrom( key, key.bytesLength );
+    }
+
+    void copyFrom( StringSchemaKey key, int targetLength )
+    {
+        setBytesLength( targetLength );
+        System.arraycopy( key.bytes, 0, bytes, 0, targetLength );
         setEntityId( key.getEntityId() );
         setCompareId( key.getCompareId() );
     }


### PR DESCRIPTION
Keys in internal nodes only act as guide posts for search and thus we
only need to store just enough to separate the sub ranges from each
other.

For keys with dynamic layout such as strings this can be used to save
space within internal nodes and instead of storing full string we may
only need to store the first few characters depending on the nature
of the strings.