### PR TITLE
 Store only minimal splitter in internal nodes in GBPTree

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/Layout.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/Layout.java
@@ -109,6 +109,16 @@ public interface Layout<KEY, VALUE> extends Comparator<KEY>
      * @return true if keys and values are fixed size, otherwise true.
      */
     boolean fixedSize();
+
+    /**
+     * Find shortest key (best effort) that separate left from right in sort order
+     * and initialize into with result.
+     * @param left key that is less than right
+     * @param right key that is greater than left.
+     * @param into will be initialized with result.
+     */
+    void minimalSplitter( KEY left, KEY right, KEY into );
+
     /**
      * Used as verification when loading an index after creation, to verify that the same layout is used,
      * as the one it was initially created with.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/RightmostInChain.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/RightmostInChain.java
@@ -109,6 +109,6 @@ class RightmostInChain
     void assertLast()
     {
         assert currentRightmostRightSiblingPointer == NO_NODE_FLAG : "Expected rightmost right sibling to be " + NO_NODE_FLAG
-                + " but was " + currentRightmostRightSiblingPointer;
+                + " but was " + currentRightmostRightSiblingPointer + ". Current rightmost node is " + currentRightmostNode;
     }
 }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicDynamicSizeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicDynamicSizeTest.java
@@ -19,6 +19,13 @@
  */
 package org.neo4j.index.internal.gbptree;
 
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.index.internal.gbptree.TreeNode.Type.INTERNAL;
+
 public class InternalTreeLogicDynamicSizeTest extends InternalTreeLogicTestBase<RawBytes,RawBytes>
 {
     private SimpleByteArrayLayout layout = new SimpleByteArrayLayout();
@@ -44,5 +51,24 @@ public class InternalTreeLogicDynamicSizeTest extends InternalTreeLogicTestBase<
     protected TestLayout<RawBytes,RawBytes> getLayout()
     {
         return layout;
+    }
+
+    @Test
+    public void storeOnlyMinimalKeyDividerInInternal() throws IOException
+    {
+        // given
+        initialize();
+        long key = 0;
+        while ( numberOfRootSplits == 0 )
+        {
+            insert( key( key ), value( key ) );
+            key++;
+        }
+
+        // when
+        RawBytes rawBytes = keyAt( rootId, 0, INTERNAL );
+
+        // then
+        assertEquals( "expected no tail on internal key but was " + rawBytes.toString(), Long.BYTES, rawBytes.bytes.length );
     }
 }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTestBase.java
@@ -1386,7 +1386,7 @@ public abstract class InternalTreeLogicTestBase<KEY,VALUE>
     public void shouldOverwriteInheritedSuccessorOnSuccessor() throws Exception
     {
         // GIVEN
-        assumeTrue( isCheckpointing );
+        assumeTrue( "No checkpointing, no successor", isCheckpointing );
         initialize();
         long originalNodeId = rootId;
         generationManager.checkpoint();
@@ -1417,7 +1417,7 @@ public abstract class InternalTreeLogicTestBase<KEY,VALUE>
     {
         // GIVEN
         // root with two children
-        assumeTrue( isCheckpointing );
+        assumeTrue( "No checkpointing, no successor", isCheckpointing );
         initialize();
         long someHighMultiplier = 1000;
         for ( int i = 1; numberOfRootSplits < 1; i++ )

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTestBase.java
@@ -982,9 +982,7 @@ public abstract class InternalTreeLogicTestBase<KEY,VALUE>
 
         // then
         goTo( readCursor, rootId );
-        ConsistencyChecker<KEY> consistencyChecker =
-                new ConsistencyChecker<>( node, layout, stableGeneration, unstableGeneration );
-        consistencyChecker.check( readCursor, rootGeneration );
+        consistencyCheck();
     }
 
     @Test
@@ -1005,10 +1003,7 @@ public abstract class InternalTreeLogicTestBase<KEY,VALUE>
         }
 
         // then
-        goTo( readCursor, rootId );
-        ConsistencyChecker<KEY> consistencyChecker =
-                new ConsistencyChecker<>( node, layout, stableGeneration, unstableGeneration );
-        consistencyChecker.check( readCursor, rootGeneration );
+        consistencyCheck();
     }
 
     /* TEST VALUE MERGER */
@@ -1444,6 +1439,16 @@ public abstract class InternalTreeLogicTestBase<KEY,VALUE>
             // THEN
             assertThat( e.getMessage(), containsString( PointerChecking.WRITER_TRAVERSE_OLD_STATE_MESSAGE ) );
         }
+    }
+
+    private void consistencyCheck() throws IOException
+    {
+        long currentPageId = readCursor.getCurrentPageId();
+        goTo( readCursor, rootId );
+        ConsistencyChecker<KEY> consistencyChecker =
+                new ConsistencyChecker<>( node, layout, stableGeneration, unstableGeneration );
+        consistencyChecker.check( readCursor, rootGeneration );
+        goTo( readCursor, currentPageId );
     }
 
     private void remove( KEY toRemove, List<KEY> list, Comparator<KEY> comparator )

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleByteArrayLayout.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleByteArrayLayout.java
@@ -34,9 +34,14 @@ public class SimpleByteArrayLayout extends TestLayout<RawBytes,RawBytes>
     @Override
     public RawBytes copyKey( RawBytes rawBytes, RawBytes into )
     {
+        return copyKey( rawBytes, into, rawBytes.bytes.length );
+    }
+
+    private RawBytes copyKey( RawBytes rawBytes, RawBytes into, int length )
+    {
         byte[] src = rawBytes.bytes;
-        byte[] target = new byte[src.length];
-        System.arraycopy( src, 0, target, 0, src.length );
+        byte[] target = new byte[length];
+        System.arraycopy( src, 0, target, 0, length );
         into.bytes = target;
         return into;
     }
@@ -97,6 +102,13 @@ public class SimpleByteArrayLayout extends TestLayout<RawBytes,RawBytes>
     public boolean fixedSize()
     {
         return false;
+    }
+
+    @Override
+    public void minimalSplitter( RawBytes left, RawBytes right, RawBytes into )
+    {
+        // Minimal splitter will always be the first 8B
+        copyKey( right, into, Long.BYTES );
     }
 
     @Override

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleLongLayout.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleLongLayout.java
@@ -175,6 +175,12 @@ public class SimpleLongLayout extends TestLayout<MutableLong,MutableLong>
     }
 
     @Override
+    public void minimalSplitter( MutableLong left, MutableLong right, MutableLong into )
+    {
+        copyKey( right, into );
+    }
+
+    @Override
     public long identifier()
     {
         return identifier;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanLayout.java
@@ -136,6 +136,12 @@ class LabelScanLayout extends Layout.Adapter<LabelScanKey,LabelScanValue>
     }
 
     @Override
+    public void minimalSplitter( LabelScanKey left, LabelScanKey right, LabelScanKey into )
+    {
+        copyKey( right, into );
+    }
+
+    @Override
     public long identifier()
     {
         return Layout.namedIdentifier( IDENTIFIER_NAME, LabelScanValue.RANGE_SIZE );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SchemaLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SchemaLayout.java
@@ -72,6 +72,12 @@ abstract class SchemaLayout<KEY extends NativeSchemaKey<KEY>> extends Layout.Ada
     }
 
     @Override
+    public void minimalSplitter( KEY left, KEY right, KEY into )
+    {
+        copyKey( right, into );
+    }
+
+    @Override
     public long identifier()
     {
         return identifier;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringLayout.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringLayout.java
@@ -83,6 +83,24 @@ class StringLayout extends SchemaLayout<StringSchemaKey>
     }
 
     @Override
+    public void minimalSplitter( StringSchemaKey left, StringSchemaKey right, StringSchemaKey into )
+    {
+        int maxLength = Math.min( left.bytesLength, right.bytesLength );
+        int targetLength = 0;
+        boolean foundDiffer = false;
+        for ( int i = 0; i < maxLength; i++ )
+        {
+            targetLength++;
+            if ( left.bytes[i] != right.bytes[i] )
+            {
+                foundDiffer = true;
+                break;
+            }
+        }
+        into.copyFrom( right, targetLength );
+    }
+
+    @Override
     public String toString()
     {
         return format( "%s[version:%d.%d, identifier:%d]", getClass().getSimpleName(), majorVersion(), minorVersion(), identifier() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringSchemaKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/StringSchemaKey.java
@@ -189,8 +189,13 @@ class StringSchemaKey extends NativeSchemaKey<StringSchemaKey>
 
     void copyFrom( StringSchemaKey key )
     {
-        setBytesLength( key.bytesLength );
-        System.arraycopy( key.bytes, 0, bytes, 0, key.bytesLength );
+        copyFrom( key, key.bytesLength );
+    }
+
+    void copyFrom( StringSchemaKey key, int targetLength )
+    {
+        setBytesLength( targetLength );
+        System.arraycopy( key.bytes, 0, bytes, 0, targetLength );
         setEntityId( key.getEntityId() );
         setCompareId( key.getCompareId() );
     }

--- a/community/neo4j/src/test/java/org/neo4j/kernel/impl/index/schema/NativeStringIndexingIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/kernel/impl/index/schema/NativeStringIndexingIT.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.schema.IndexCreator;
 import org.neo4j.internal.kernel.api.IndexOrder;
 import org.neo4j.internal.kernel.api.IndexQuery;
@@ -56,7 +57,8 @@ public class NativeStringIndexingIT
     private static final String KEY2 = "key2";
 
     @Rule
-    public final DatabaseRule db = new EmbeddedDatabaseRule();
+    public final DatabaseRule db = new EmbeddedDatabaseRule()
+            .withSetting( GraphDatabaseSettings.default_schema_provider, GraphDatabaseSettings.SchemaIndex.NATIVE20.providerName() );
     @Rule
     public final RandomRule random = new RandomRule();
 


### PR DESCRIPTION
Keys in internal nodes only act as guide posts for search and thus we
only need to store just enough to separate the sub ranges from each
other.

For keys with dynamic layout such as strings this can be used to save
space within internal nodes and instead of storing full string we may
only need to store the first few characters depending on the nature
of the strings.

Merge https://github.com/neo-technology/jmh-benchmarks/pull/90 when this is merged