### PR TITLE
Clean up PlanContext

### DIFF
--- a/community/cypher/cypher-planner-3.5/src/main/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/steps/AbstractIndexSeekLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.5/src/main/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/steps/AbstractIndexSeekLeafPlanner.scala
@@ -46,9 +46,6 @@ abstract class AbstractIndexSeekLeafPlanner extends LeafPlanner with LeafPlanFro
 
   protected def findIndexesForLabel(labelId: Int, context: LogicalPlanningContext): Iterator[IndexDescriptor]
 
-  protected def findIndexesFor(label: String, properties: Seq[String], context: LogicalPlanningContext): Option[IndexDescriptor]
-
-
   override def producePlanFor(predicates: Set[Expression],
                               qg: QueryGraph,
                               context: LogicalPlanningContext): Set[LeafPlansForVariable] = {

--- a/community/cypher/cypher-planner-3.5/src/main/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/steps/DynamicPropertyNotifier.scala
+++ b/community/cypher/cypher-planner-3.5/src/main/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/steps/DynamicPropertyNotifier.scala
@@ -39,6 +39,8 @@ object DynamicPropertyNotifier {
     }
   }
 
-  private def withIndex(labelName: LabelName, context: LogicalPlanningContext) =
-    context.planContext.indexExistsForLabel(labelName.name)
+  private def withIndex(labelName: LabelName, context: LogicalPlanningContext) = {
+    val maybeLabelId = context.semanticTable.id(labelName)
+    maybeLabelId.fold(false)(context.planContext.indexExistsForLabel(_))
+  }
 }

--- a/community/cypher/cypher-planner-3.5/src/main/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/steps/IndexSeekLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.5/src/main/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/steps/IndexSeekLeafPlanner.scala
@@ -37,16 +37,6 @@ object indexSeekLeafPlanner extends AbstractIndexSeekLeafPlanner {
       context.logicalPlanProducer.planNodeIndexSeek(idName, label, propertyKeys, valueExpr, solvedPredicates,
         predicatesForCardinalityEstimation, hint, argumentIds, context)
 
-  protected def findIndexesForLabel(labelId: Int, context: LogicalPlanningContext): Iterator[IndexDescriptor] =
+  override def findIndexesForLabel(labelId: Int, context: LogicalPlanningContext): Iterator[IndexDescriptor] =
     context.planContext.indexesGetForLabel(labelId)
-
-  protected def findIndexesFor(label: String, properties: Seq[String], context: LogicalPlanningContext): Option[IndexDescriptor] = {
-    if (uniqueIndexDefinedFor(label, properties, context).isDefined) None else anyIndex(label, properties, context)
-  }
-
-  private def anyIndex(label: String, properties: Seq[String], context: LogicalPlanningContext) =
-    context.planContext.indexGet(label, properties)
-
-  private def uniqueIndexDefinedFor(label: String, properties: Seq[String], context: LogicalPlanningContext) =
-    context.planContext.uniqueIndexGet(label, properties)
 }

--- a/community/cypher/cypher-planner-3.5/src/main/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/steps/indexScanLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.5/src/main/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/steps/indexScanLeafPlanner.scala
@@ -87,8 +87,7 @@ object indexScanLeafPlanner extends LeafPlanner with LeafPlanFromExpression {
     val idName = variableName
 
     for (labelPredicate <- labelPredicates.getOrElse(idName, Set.empty);
-         labelName <- labelPredicate.labels;
-         indexDescriptor <- findIndexesFor(labelName.name, propertyKeyName, context);
+         labelName <- labelPredicate.labels if context.planContext.indexExistsForLabelAndProperties(labelName.name, Seq(propertyKeyName));
          labelId <- semanticTable.id(labelName))
       yield {
         val hint = qg.hints.collectFirst {
@@ -101,7 +100,4 @@ object indexScanLeafPlanner extends LeafPlanner with LeafPlanFromExpression {
         planProducer(idName, labelToken, keyToken, predicates, hint, qg.argumentIds)
       }
   }
-
-  private def findIndexesFor(label: String, property: String, context: LogicalPlanningContext) =
-    context.planContext.indexGet(label, Seq(property)) orElse context.planContext.uniqueIndexGet(label, Seq(property))
 }

--- a/community/cypher/cypher-planner-3.5/src/main/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/steps/mergeUniqueIndexSeekLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.5/src/main/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/steps/mergeUniqueIndexSeekLeafPlanner.scala
@@ -66,7 +66,4 @@ object mergeUniqueIndexSeekLeafPlanner extends AbstractIndexSeekLeafPlanner {
 
   override def findIndexesForLabel(labelId: Int, context: LogicalPlanningContext): Iterator[IndexDescriptor] =
     context.planContext.uniqueIndexesGetForLabel(labelId)
-
-  override def findIndexesFor(label: String, properties: Seq[String], context: LogicalPlanningContext): Option[IndexDescriptor] =
-    context.planContext.uniqueIndexGet(label, properties)
 }

--- a/community/cypher/cypher-planner-3.5/src/main/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/steps/uniqueIndexSeekLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.5/src/main/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/steps/uniqueIndexSeekLeafPlanner.scala
@@ -36,9 +36,6 @@ object uniqueIndexSeekLeafPlanner extends AbstractIndexSeekLeafPlanner {
                              (solvedPredicates: Seq[Expression], predicatesForCardinalityEstimation: Seq[Expression]): LogicalPlan =
       context.logicalPlanProducer.planNodeUniqueIndexSeek(idName, label, propertyKeys, valueExpr, solvedPredicates, hint, argumentIds, context)
 
-  protected def findIndexesForLabel(labelId: Int, context: LogicalPlanningContext): Iterator[IndexDescriptor] =
+  override def findIndexesForLabel(labelId: Int, context: LogicalPlanningContext): Iterator[IndexDescriptor] =
     context.planContext.uniqueIndexesGetForLabel(labelId)
-
-  protected def findIndexesFor(label: String, properties: Seq[String], context: LogicalPlanningContext): Option[IndexDescriptor] =
-    context.planContext.uniqueIndexGet(label, properties)
 }

--- a/community/cypher/cypher-planner-3.5/src/main/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/steps/verifyBestPlan.scala
+++ b/community/cypher/cypher-planner-3.5/src/main/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/steps/verifyBestPlan.scala
@@ -110,8 +110,7 @@ object verifyBestPlan extends PlanTransformer[PlannerQuery] {
     query.allHints.flatMap {
       // using index name:label(property1,property2)
       case UsingIndexHint(_, LabelName(label), properties, _)
-        if planContext.indexGet(label, properties.map(_.name)).isDefined ||
-          planContext.uniqueIndexGet(label, properties.map(_.name)).isDefined => None
+        if planContext.indexExistsForLabelAndProperties(label, properties.map(_.name)) => None
       // no such index exists
       case hint: UsingIndexHint => Some(hint)
       // don't care about other hints

--- a/community/cypher/cypher-planner-3.5/src/main/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/steps/verifyBestPlan.scala
+++ b/community/cypher/cypher-planner-3.5/src/main/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/steps/verifyBestPlan.scala
@@ -19,15 +19,15 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_5.planner.logical.steps
 
-import org.neo4j.cypher.internal.util.v3_5.{HintException, IndexHintException, InternalException, JoinHintException}
 import org.neo4j.cypher.internal.compiler.v3_5.planner.logical.{LogicalPlanningContext, PlanTransformer}
 import org.neo4j.cypher.internal.frontend.v3_5.ast._
 import org.neo4j.cypher.internal.frontend.v3_5.notification.{IndexHintUnfulfillableNotification, JoinHintUnfulfillableNotification}
 import org.neo4j.cypher.internal.ir.v3_5.PlannerQuery
 import org.neo4j.cypher.internal.planner.v3_5.spi.PlanContext
 import org.neo4j.cypher.internal.planner.v3_5.spi.PlanningAttributes.{Cardinalities, Solveds}
-import org.neo4j.cypher.internal.v3_5.logical.plans.LogicalPlan
+import org.neo4j.cypher.internal.util.v3_5._
 import org.neo4j.cypher.internal.v3_5.expressions.LabelName
+import org.neo4j.cypher.internal.v3_5.logical.plans.LogicalPlan
 
 object verifyBestPlan extends PlanTransformer[PlannerQuery] {
   def apply(plan: LogicalPlan, expected: PlannerQuery, context: LogicalPlanningContext, solveds: Solveds, cardinalities: Cardinalities): LogicalPlan = {

--- a/community/cypher/cypher-planner-3.5/src/test/scala/org/neo4j/cypher/internal/compiler/v3_5/NotImplementedPlanContext.scala
+++ b/community/cypher/cypher-planner-3.5/src/test/scala/org/neo4j/cypher/internal/compiler/v3_5/NotImplementedPlanContext.scala
@@ -26,13 +26,11 @@ import org.neo4j.cypher.internal.v3_5.logical.plans.{ProcedureSignature, Qualifi
 class NotImplementedPlanContext extends PlanContext {
   override def indexesGetForLabel(labelId: Int): Iterator[IndexDescriptor] = ???
 
-  override def indexGet(labelName: String, propertyKeys: Seq[String]): Option[IndexDescriptor] = ???
-
   override def indexExistsForLabel(labelName: String): Boolean = ???
 
-  override def uniqueIndexesGetForLabel(labelId: Int): Iterator[IndexDescriptor] = ???
+  override def indexExistsForLabelAndProperties(labelName: String, propertyKey: Seq[String]): Boolean = ???
 
-  override def uniqueIndexGet(labelName: String, propertyKeys: Seq[String]): Option[IndexDescriptor] = ???
+  override def uniqueIndexesGetForLabel(labelId: Int): Iterator[IndexDescriptor] = ???
 
   override def hasPropertyExistenceConstraint(labelName: String, propertyKey: String): Boolean = ???
 

--- a/community/cypher/cypher-planner-3.5/src/test/scala/org/neo4j/cypher/internal/compiler/v3_5/NotImplementedPlanContext.scala
+++ b/community/cypher/cypher-planner-3.5/src/test/scala/org/neo4j/cypher/internal/compiler/v3_5/NotImplementedPlanContext.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.v3_5.logical.plans.{ProcedureSignature, Qualifi
 class NotImplementedPlanContext extends PlanContext {
   override def indexesGetForLabel(labelId: Int): Iterator[IndexDescriptor] = ???
 
-  override def indexExistsForLabel(labelName: String): Boolean = ???
+  override def indexExistsForLabel(labelId: Int): Boolean = ???
 
   override def indexExistsForLabelAndProperties(labelName: String, propertyKey: Seq[String]): Boolean = ???
 

--- a/community/cypher/cypher-planner-3.5/src/test/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-planner-3.5/src/test/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/LogicalPlanningTestSupport2.scala
@@ -122,8 +122,10 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
         else
           None
 
-      override def indexExistsForLabel(labelName: String): Boolean =
+      override def indexExistsForLabel(labelId: Int): Boolean = {
+        val labelName = config.labelsById(labelId)
         config.indexes.exists(_._1 == labelName) || config.uniqueIndexes.exists(_._1 == labelName)
+      }
 
       override def indexExistsForLabelAndProperties(labelName: String, propertyKey: Seq[String]): Boolean =
         config.indexes((labelName, propertyKey)) || config.uniqueIndexes((labelName, propertyKey))

--- a/community/cypher/cypher-planner-3.5/src/test/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-planner-3.5/src/test/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/LogicalPlanningTestSupport2.scala
@@ -104,7 +104,7 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
         config.uniqueIndexes.filter(p => p._1 == label).flatMap(p => uniqueIndexGet(p._1, p._2)).iterator
       }
 
-      override def uniqueIndexGet(labelName: String, propertyKeys: Seq[String]): Option[IndexDescriptor] =
+      private def uniqueIndexGet(labelName: String, propertyKeys: Seq[String]): Option[IndexDescriptor] =
         if (config.uniqueIndexes((labelName, propertyKeys)))
           Some(IndexDescriptor(
             semanticTable.resolvedLabelNames(labelName).id,
@@ -113,7 +113,7 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
         else
           None
 
-      override def indexGet(labelName: String, propertyKeys: Seq[String]): Option[IndexDescriptor] =
+      private def indexGet(labelName: String, propertyKeys: Seq[String]): Option[IndexDescriptor] =
         if (config.indexes((labelName, propertyKeys)) || config.uniqueIndexes((labelName, propertyKeys)))
           Some(IndexDescriptor(
             semanticTable.resolvedLabelNames(labelName).id,
@@ -124,6 +124,9 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
 
       override def indexExistsForLabel(labelName: String): Boolean =
         config.indexes.exists(_._1 == labelName) || config.uniqueIndexes.exists(_._1 == labelName)
+
+      override def indexExistsForLabelAndProperties(labelName: String, propertyKey: Seq[String]): Boolean =
+        config.indexes((labelName, propertyKey)) || config.uniqueIndexes((labelName, propertyKey))
 
       override def getOptPropertyKeyId(propertyKeyName: String) =
         semanticTable.resolvedPropertyKeyNames.get(propertyKeyName).map(_.id)

--- a/community/cypher/cypher-planner-3.5/src/test/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/steps/ExtractBestPlanTest.scala
+++ b/community/cypher/cypher-planner-3.5/src/test/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/steps/ExtractBestPlanTest.scala
@@ -52,14 +52,8 @@ class ExtractBestPlanTest extends CypherFunSuite with LogicalPlanningTestSupport
     ).addHints(Set(newJoinHint())))
 
   private def getPlanContext(hasIndex: Boolean): PlanContext = {
-
     val planContext = newMockedPlanContext
-    val indexDescriptor: Option[IndexDescriptor] =
-      if (hasIndex) Option(IndexDescriptor(0, 0))
-      else None
-
-    when(planContext.indexGet(anyString(),any())).thenReturn(indexDescriptor)
-    when(planContext.uniqueIndexGet(anyString(),any())).thenReturn(None)
+    when(planContext.indexExistsForLabelAndProperties(anyString(), any())).thenReturn(hasIndex)
     planContext
   }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_5/ExceptionTranslatingPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_5/ExceptionTranslatingPlanContext.scala
@@ -28,14 +28,11 @@ class ExceptionTranslatingPlanContext(inner: PlanContext) extends PlanContext wi
   override def indexesGetForLabel(labelId: Int): Iterator[IndexDescriptor] =
     translateException(inner.indexesGetForLabel(labelId))
 
-  override def indexGet(labelName: String, propertyKeys: Seq[String]): Option[IndexDescriptor] =
-    translateException(inner.indexGet(labelName, propertyKeys))
+  override def indexExistsForLabelAndProperties(labelName: String, propertyKey: Seq[String]): Boolean =
+    translateException(inner.indexExistsForLabelAndProperties(labelName, propertyKey))
 
   override def uniqueIndexesGetForLabel(labelId: Int): Iterator[IndexDescriptor] =
     translateException(inner.uniqueIndexesGetForLabel(labelId))
-
-  override def uniqueIndexGet(labelName: String, propertyKeys: Seq[String]): Option[IndexDescriptor] =
-    translateException(inner.uniqueIndexGet(labelName, propertyKeys))
 
   override def statistics: GraphStatistics =
     translateException(inner.statistics)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_5/ExceptionTranslatingPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_5/ExceptionTranslatingPlanContext.scala
@@ -51,8 +51,8 @@ class ExceptionTranslatingPlanContext(inner: PlanContext) extends PlanContext wi
   override def functionSignature(name: QualifiedName): Option[UserFunctionSignature] =
     translateException(inner.functionSignature(name))
 
-  override def indexExistsForLabel(labelName: String): Boolean =
-    translateException(inner.indexExistsForLabel(labelName))
+  override def indexExistsForLabel(labelId: Int): Boolean =
+    translateException(inner.indexExistsForLabel(labelId))
 
   override def hasPropertyExistenceConstraint(labelName: String, propertyKey: String): Boolean =
     translateException(inner.hasPropertyExistenceConstraint(labelName, propertyKey))

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundPlanContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundPlanContext.scala
@@ -56,21 +56,17 @@ class TransactionBoundPlanContext(tc: TransactionalContextWrapper, logger: Inter
       .flatMap(getOnlineIndex)
   }
 
-  override def indexExistsForLabel(labelName: String): Boolean = {
-    try {
-      val labelId = getLabelId(labelName)
-      val onlineIndexDescriptors = tc.schemaRead.indexesGetForLabel(labelId).asScala
-        .flatMap(getOnlineIndex)
-
-      onlineIndexDescriptors.nonEmpty
-    } catch {
-      case _: KernelException => false
-    }
+  override def indexExistsForLabel(labelId: Int): Boolean = {
+      tc.schemaRead.indexesGetForLabel(labelId).asScala.flatMap(getOnlineIndex).nonEmpty
   }
 
   override def indexExistsForLabelAndProperties(labelName: String, propertyKey: Seq[String]): Boolean = {
-    val descriptor = toLabelSchemaDescriptor(this, labelName, propertyKey)
-    getOnlineIndex(tc.schemaRead.index(descriptor.getLabelId, descriptor.getPropertyIds:_*)).isDefined
+    try {
+      val descriptor = toLabelSchemaDescriptor(this, labelName, propertyKey)
+      getOnlineIndex(tc.schemaRead.index(descriptor.getLabelId, descriptor.getPropertyIds:_*)).isDefined
+    } catch {
+      case _: KernelException => false
+    }
   }
 
   private def evalOrNone[T](f: => Option[T]): Option[T] =

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundPlanContextTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundPlanContextTest.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher.internal.runtime.interpreted
 
+import java.util.concurrent.TimeUnit.SECONDS
+
 import org.neo4j.cypher.internal.frontend.v3_5.phases.devNullLogger
 import org.neo4j.cypher.internal.javacompat.GraphDatabaseCypherService
 import org.neo4j.cypher.internal.planner.v3_5.spi.IndexDescriptor
@@ -129,6 +131,7 @@ class TransactionBoundPlanContextTest extends CypherFunSuite {
 
     val planContext = TransactionBoundPlanContext(TransactionalContextWrapper(transactionalContext), devNullLogger)
 
+    database.schema().awaitIndexesOnline(10, SECONDS)
     val l1id = planContext.getLabelId("L1")
     val prop1id = planContext.getPropertyKeyId("prop")
     val prop2id = planContext.getPropertyKeyId("prop2")
@@ -154,6 +157,7 @@ class TransactionBoundPlanContextTest extends CypherFunSuite {
 
     val planContext = TransactionBoundPlanContext(TransactionalContextWrapper(transactionalContext), devNullLogger)
 
+    database.schema().awaitIndexesOnline(10, SECONDS)
     val l1id = planContext.getLabelId("L1")
     val prop2id = planContext.getPropertyKeyId("prop2")
     planContext.uniqueIndexesGetForLabel(l1id).toSet should equal(Set(
@@ -180,6 +184,7 @@ class TransactionBoundPlanContextTest extends CypherFunSuite {
 
     val planContext = TransactionBoundPlanContext(TransactionalContextWrapper(transactionalContext), devNullLogger)
 
+    database.schema().awaitIndexesOnline(10, SECONDS)
     val l1id = planContext.getLabelId("L1")
     val l2id = planContext.getLabelId("L2")
     val l3id = planContext.getLabelId("L3")
@@ -207,6 +212,7 @@ class TransactionBoundPlanContextTest extends CypherFunSuite {
 
     val planContext = TransactionBoundPlanContext(TransactionalContextWrapper(transactionalContext), devNullLogger)
 
+    database.schema().awaitIndexesOnline(10, SECONDS)
     planContext.indexExistsForLabelAndProperties("L1", Seq("prop")) should be(true)
     planContext.indexExistsForLabelAndProperties("L1", Seq("prop2")) should be(false)
     planContext.indexExistsForLabelAndProperties("L2", Seq("prop")) should be(false)

--- a/community/cypher/planner-spi-3.5/src/main/scala/org/neo4j/cypher/internal/planner/v3_5/spi/PlanContext.scala
+++ b/community/cypher/planner-spi-3.5/src/main/scala/org/neo4j/cypher/internal/planner/v3_5/spi/PlanContext.scala
@@ -31,15 +31,25 @@ import org.neo4j.cypher.internal.v3_5.logical.plans.{ProcedureSignature, Qualifi
  */
 trait PlanContext extends TokenContext with ProcedureSignatureResolver {
 
+  /**
+    * Return all indexes (general and unique) for a given label
+    */
   def indexesGetForLabel(labelId: Int): Iterator[IndexDescriptor]
 
-  def indexGet(labelName: String, propertyKeys: Seq[String]): Option[IndexDescriptor]
-
-  def indexExistsForLabel(labelName: String): Boolean
-
+  /**
+    * Return all unique indexes for a given label
+    */
   def uniqueIndexesGetForLabel(labelId: Int): Iterator[IndexDescriptor]
 
-  def uniqueIndexGet(labelName: String, propertyKey: Seq[String]): Option[IndexDescriptor]
+  /**
+    * Checks if an index exists (general or unique) for a given label
+    */
+  def indexExistsForLabel(labelName: String): Boolean
+
+  /**
+    * Checks if an index exists (general or unique) for a given label and properties
+    */
+  def indexExistsForLabelAndProperties(labelName: String, propertyKey: Seq[String]): Boolean
 
   def hasPropertyExistenceConstraint(labelName: String, propertyKey: String): Boolean
 

--- a/community/cypher/planner-spi-3.5/src/main/scala/org/neo4j/cypher/internal/planner/v3_5/spi/PlanContext.scala
+++ b/community/cypher/planner-spi-3.5/src/main/scala/org/neo4j/cypher/internal/planner/v3_5/spi/PlanContext.scala
@@ -44,7 +44,7 @@ trait PlanContext extends TokenContext with ProcedureSignatureResolver {
   /**
     * Checks if an index exists (general or unique) for a given label
     */
-  def indexExistsForLabel(labelName: String): Boolean
+  def indexExistsForLabel(labelId: Int): Boolean
 
   /**
     * Checks if an index exists (general or unique) for a given label and properties


### PR DESCRIPTION
This cleans up the interface, usages, and implementation of PlanContext w.r.t. several methods around indexes. It adds scaladoc and tests.