### PR TITLE
Fix bug in DefaultRelationshipTraversalCursor filter state.

### DIFF
--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTestSupport.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTestSupport.java
@@ -248,6 +248,7 @@ public class RelationshipTestSupport
     }
 
     private static Function<Node,StartRelationship>[] sparseDenseRels = Iterators.array(
+            loop( "FOO" ), // loops are the hardest, let's have two to try to interfere with outgoing/incoming code
             outgoing( "FOO" ),
             outgoing( "BAR" ),
             outgoing( "BAR" ),

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
@@ -58,7 +58,7 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
                     @Override
                     boolean check( long source, long target, long origin )
                     {
-                        return origin == target;
+                        return origin == target && source != target;
                     }
                 },
         // allow only outgoing relationships
@@ -67,7 +67,7 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
                     @Override
                     boolean check( long source, long target, long origin )
                     {
-                        return origin == source;
+                        return origin == source && source != target;
                     }
                 },
         // allow only loop relationships


### PR DESCRIPTION
Fixes a bug which would occur when traversing a sparse node via groups. This is not reachable via public APIs.