### PR TITLE
Fixes serialization issue in InputCache

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/ValueType.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/ValueType.java
@@ -216,7 +216,7 @@ public abstract class ValueType
             @Override
             public int length( Object value )
             {
-                return Integer.BYTES + ((String)value).length() * Character.BYTES; // pessimistic
+                return Integer.BYTES + UTF8.encode( (String)value ).length * Character.BYTES; // pessimistic
             }
 
             @Override
@@ -481,9 +481,9 @@ public abstract class ValueType
         public int length( Object value )
         {
             ValueType componentType = typeOf( value.getClass().getComponentType() );
-            int arrayLlength = Array.getLength( value );
+            int arrayLength = Array.getLength( value );
             int length = Integer.BYTES; // array length
-            for ( int i = 0; i < arrayLlength; i++ )
+            for ( int i = 0; i < arrayLength; i++ )
             {
                 length += componentType.length( Array.get( value, i ) );
             }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/InputCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/InputCacheTest.java
@@ -227,26 +227,9 @@ public class InputCacheTest
         }
     }
 
-    //TODO this should use random.nextValue but cannot since there is a bug here somewhere
-    //that fails when using non-ascii strings
     private Object nextProperty( RandomValues randomValues )
     {
-        int type = randomValues.nextInt( 5 );
-        switch ( type )
-        {
-        case 0:
-            return randomValues.nextNumberValue().asObject();
-        case 1:
-            return randomValues.nextBoolean();
-        case 2:
-            return randomValues.nextAsciiTextValue().stringValue();
-        case 3:
-            return randomValues.nextPointValue().asObject();
-        case 4:
-            return randomValues.nextTemporalValue().asObject();
-        default:
-            throw new IllegalArgumentException( type + " is not an expected type" );
-        }
+        return randomValues.nextValue().asObject();
     }
 
     private String randomType( RandomValues random )


### PR DESCRIPTION
Where it would calculate the length wrong and so potentially
run into buffer underflow when writing to the buffer.

InputCacheTest also now serializes all types of random values,
something which would previously would have failed.