### PR TITLE
Fix NPE in ForsetiClient on locks count

### DIFF
--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/DeadlockStrategies.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/DeadlockStrategies.java
@@ -42,8 +42,8 @@ public enum DeadlockStrategies implements ForsetiLockManager.DeadlockResolutionS
                         return true;
                     }
 
-                    int ourCount = clientThatsAsking.lockCount();
-                    int otherCount = clientWereDeadlockedWith.lockCount();
+                    long ourCount = clientThatsAsking.activeLockCount();
+                    long otherCount = clientWereDeadlockedWith.activeLockCount();
                     if ( ourCount > otherCount )
                     {
                         // We hold more locks than the other client, we stay the course!


### PR DESCRIPTION
Newly introduced eclipse collections where failing during size evaluation
due to racy nature of locks counting in forseti.
PRs update used map implementation to avoid NPE.
Also as part of PR duplicated lock counting code in ForsetiClient was removed
and test class was rewritten for junit 5 and cleaned up.