### PR TITLE
Handle property access for non-existing property

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/helpers/MapSupport.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/helpers/MapSupport.scala
@@ -72,7 +72,8 @@ class LazyMap[T <: PropertyContainer](ctx: QueryContext, ops: Operations[T], id:
 
   override def putAll(m: util.Map[_ <: String, _ <: AnyValue]): Unit = throw new UnsupportedOperationException()
 
-  override def get(key: scala.Any): AnyValue = ops.getProperty(id, ctx.getPropertyKeyId(key.asInstanceOf[String]))
+  override def get(key: scala.Any): AnyValue =
+    ctx.getOptPropertyKeyId(key.asInstanceOf[String]).flatMap( (pkId: Int) => Option(ops.getProperty(id, pkId)) ).orNull
 
   override def keySet(): util.Set[String] = allProps.keySet()
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/expressions/ContainerIndexTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/expressions/ContainerIndexTest.scala
@@ -86,8 +86,8 @@ class ContainerIndexTest extends CypherFunSuite {
     val node = mock[Node]
     when(node.getId).thenReturn(0)
     implicit val expression = Literal(node)
-    when(qtx.getPropertyKeyId("v")).thenReturn(0)
-    when(qtx.getPropertyKeyId("c")).thenReturn(1)
+    when(qtx.getOptPropertyKeyId("v")).thenReturn(Some(0))
+    when(qtx.getOptPropertyKeyId("c")).thenReturn(Some(1))
     val nodeOps = mock[Operations[Node]]
     when(nodeOps.getProperty(0, 0)).thenAnswer(new Answer[Value] {
       override def answer(invocation: InvocationOnMock): Value = Values.longValue(1)
@@ -105,8 +105,8 @@ class ContainerIndexTest extends CypherFunSuite {
     val rel = mock[Relationship]
     when(rel.getId).thenReturn(0)
     implicit val expression = Literal(rel)
-    when(qtx.getPropertyKeyId("v")).thenReturn(0)
-    when(qtx.getPropertyKeyId("c")).thenReturn(1)
+    when(qtx.getOptPropertyKeyId("v")).thenReturn(Some(0))
+    when(qtx.getOptPropertyKeyId("c")).thenReturn(Some(1))
     val relOps = mock[Operations[Relationship]]
     when(relOps.getProperty(0, 0)).thenAnswer(new Answer[Value] {
       override def answer(invocation: InvocationOnMock): Value = Values.longValue(1)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -151,6 +151,7 @@ Accessing a list with null should return null
 Accessing a list with null as lower bound should return null
 Accessing a list with null as upper bound should return null
 Accessing a map with null should return null
+Accessing a non-existing property with string should work
 
 Should allow AND and OR with equality predicates
 Should allow AND and OR with inequality predicates

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/ReturnAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/ReturnAcceptance.feature
@@ -96,3 +96,34 @@ Feature: ReturnAcceptance
       | result |
       | null   |
     And no side effects
+
+  Scenario: Accessing a non-existing property with string should work
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()
+      """
+    When executing query:
+      """
+      WITH 'prop' AS prop
+      MATCH (n) RETURN n[prop] AS result
+      """
+    Then the result should be:
+      | result |
+      | null   |
+    And no side effects
+
+  Scenario: Accessing a non-existing property with literal should work
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()
+      """
+    When executing query:
+      """
+      MATCH (n) RETURN n['prop'] AS result
+      """
+    Then the result should be:
+      | result |
+      | null   |
+    And no side effects


### PR DESCRIPTION
Fixes #11764
changelog: Return null when trying to access a non-existing property from
a string instead of throwing error.