### PR TITLE
percentileDisc should handle empty data

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/aggregation/DistinctFunction.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/aggregation/DistinctFunction.scala
@@ -26,21 +26,12 @@ import org.neo4j.values.AnyValue
 
 class DistinctFunction(value: Expression, inner: AggregationFunction) extends AggregationFunction {
   private val seen = scala.collection.mutable.Set[AnyValue]()
-  private var seenNull = false
 
   override def apply(ctx: ExecutionContext, state: QueryState) {
     val data = value(ctx, state)
-
-    if (data == null) {
-      if (!seenNull) {
-        seenNull = true
-        inner(ctx, state)
-      }
-    } else {
-      if (!seen.contains(data)) {
-        seen += data
-        inner(ctx, state)
-      }
+    if (!seen.contains(data)) {
+      seen += data
+      inner(ctx, state)
     }
   }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/aggregation/PercentileFunction.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/aggregation/PercentileFunction.scala
@@ -88,7 +88,7 @@ class PercentileDiscFunction(value: Expression, percentile: Expression)
       else idx - 1
       temp(idx)
     } else {
-      null
+      Values.NO_VALUE
     }
   }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -193,6 +193,7 @@ min() over integers
 max() over floats
 min() over floats
 Multiple aggregations should work
+percentileDisc on empty data should return null
 
 //MatchAcceptance.feature
 difficult to plan query number 1

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/AggregationAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/AggregationAcceptance.feature
@@ -229,3 +229,13 @@ Feature: AggregationAcceptance
       | 'prop1' | 'prop2' | 'prop3' | 'prop4' | 'prop5' | '8' | 'prop7' | 'prop8' | 'prop9' |
       | 'prop1' | 'prop2' | 'prop3' | 'prop4' | 'prop5' | '9' | 'prop7' | 'prop8' | 'prop9' |
     And no side effects
+
+  Scenario: percentileDisc on empty data should return null
+    When executing query:
+      """
+       MATCH (n:FAKE) RETURN percentileDisc(n.x, 0.9) AS result
+      """
+    Then the result should be:
+      | result |
+      | null   |
+    And no side effects


### PR DESCRIPTION
changelog: fixes #11663, Using percentileDisc with empty data should return null 