### PR TITLE
Parallel flushing and forcing of pages

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
@@ -575,7 +575,7 @@ public class FullCheckIntegrationTest
                     }
                 }
             }
-            accessor.force( IOLimiter.unlimited() );
+            accessor.force( IOLimiter.UNLIMITED );
             accessor.close();
         }
 
@@ -602,7 +602,7 @@ public class FullCheckIntegrationTest
             IndexUpdater updater = accessor.newUpdater( IndexUpdateMode.ONLINE );
             updater.process( IndexEntryUpdate.add( 42, indexRule.schema(), values( indexRule ) ) );
             updater.close();
-            accessor.force( IOLimiter.unlimited() );
+            accessor.force( IOLimiter.UNLIMITED );
             accessor.close();
         }
 

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -488,7 +488,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
         changesSinceLastCheckpoint = true;
 
         // Checkpoint to make the created root node stable. Forcing tree state also piggy-backs on this.
-        checkpoint( IOLimiter.unlimited(), headerWriter );
+        checkpoint( IOLimiter.UNLIMITED, headerWriter );
         clean = true;
     }
 

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/FormatCompatibilityTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/FormatCompatibilityTest.java
@@ -264,7 +264,7 @@ public class FormatCompatibilityTest
                     put( writer, key );
                 }
             }
-            tree.checkpoint( IOLimiter.unlimited() );
+            tree.checkpoint( IOLimiter.UNLIMITED );
         }
         ZipUtils.zip( fsRule.get(), storeFile, directory.file( zipName ) );
     }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyITBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyITBase.java
@@ -584,7 +584,7 @@ public abstract class GBPTreeConcurrencyITBase<KEY,VALUE>
             {
                 try
                 {
-                    index.checkpoint( IOLimiter.unlimited() );
+                    index.checkpoint( IOLimiter.UNLIMITED );
                     // Sleep a little in between checkpoints
                     MILLISECONDS.sleep( 20L );
                 }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeITBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeITBase.java
@@ -140,7 +140,7 @@ public abstract class GBPTreeITBase<KEY,VALUE>
                     }
                 }
 
-                index.checkpoint( IOLimiter.unlimited() );
+                index.checkpoint( IOLimiter.UNLIMITED );
                 randomlyModifyIndex( index, data, random.random(), (double) round / totalNumberOfRounds );
             }
 

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryITBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryITBase.java
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.rules.RuleChain.outerRule;
 import static org.neo4j.index.internal.gbptree.ThrowingRunnable.throwing;
-import static org.neo4j.io.pagecache.IOLimiter.unlimited;
+import static org.neo4j.io.pagecache.IOLimiter.UNLIMITED;
 import static org.neo4j.test.rule.PageCacheRule.config;
 
 public abstract class GBPTreeRecoveryITBase<KEY,VALUE>
@@ -585,7 +585,7 @@ public abstract class GBPTreeRecoveryITBase<KEY,VALUE>
         @Override
         public void execute( GBPTree<KEY,VALUE> index ) throws IOException
         {
-            index.checkpoint( unlimited() );
+            index.checkpoint( UNLIMITED );
         }
 
         @Override

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
@@ -83,7 +83,7 @@ import static org.junit.rules.RuleChain.outerRule;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_READER;
 import static org.neo4j.index.internal.gbptree.SimpleLongLayout.longLayout;
 import static org.neo4j.index.internal.gbptree.ThrowingRunnable.throwing;
-import static org.neo4j.io.pagecache.IOLimiter.unlimited;
+import static org.neo4j.io.pagecache.IOLimiter.UNLIMITED;
 import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_WRITE_LOCK;
 import static org.neo4j.test.rule.PageCacheRule.config;
 
@@ -321,7 +321,7 @@ public class GBPTreeTest
                     writer.put( key, value );
                 }
             }
-            index.checkpoint( unlimited() );
+            index.checkpoint( UNLIMITED );
         }
 
         // THEN
@@ -483,7 +483,7 @@ public class GBPTreeTest
         BiConsumer<GBPTree<MutableLong,MutableLong>,byte[]> beforeClose = ( index, expected ) ->
         {
             ThrowingRunnable throwingRunnable = () ->
-                    index.checkpoint( unlimited(), cursor -> cursor.putBytes( expected ) );
+                    index.checkpoint( UNLIMITED, cursor -> cursor.putBytes( expected ) );
             ThrowingRunnable.throwing( throwingRunnable ).run();
         };
         verifyHeaderDataAfterClose( beforeClose );
@@ -496,12 +496,12 @@ public class GBPTreeTest
         {
             ThrowingRunnable throwingRunnable = () ->
             {
-                index.checkpoint( unlimited(), cursor -> cursor.putBytes( expected ) );
+                index.checkpoint( UNLIMITED, cursor -> cursor.putBytes( expected ) );
                 insert( index, 0, 1 );
 
                 // WHEN
                 // Should carry over header data
-                index.checkpoint( unlimited() );
+                index.checkpoint( UNLIMITED );
             };
             ThrowingRunnable.throwing( throwingRunnable ).run();
         };
@@ -515,7 +515,7 @@ public class GBPTreeTest
         {
             ThrowingRunnable throwingRunnable = () ->
             {
-                index.checkpoint( unlimited(), cursor -> cursor.putBytes( expected ) );
+                index.checkpoint( UNLIMITED, cursor -> cursor.putBytes( expected ) );
                 insert( index, 0, 1 );
 
                 // No checkpoint
@@ -532,9 +532,9 @@ public class GBPTreeTest
         {
             ThrowingRunnable throwingRunnable = () ->
             {
-                index.checkpoint( unlimited(), cursor -> cursor.putBytes( expected ) );
+                index.checkpoint( UNLIMITED, cursor -> cursor.putBytes( expected ) );
                 ThreadLocalRandom.current().nextBytes( expected );
-                index.checkpoint( unlimited(), cursor -> cursor.putBytes( expected ) );
+                index.checkpoint( UNLIMITED, cursor -> cursor.putBytes( expected ) );
             };
             ThrowingRunnable.throwing( throwingRunnable ).run();
         };
@@ -613,7 +613,7 @@ public class GBPTreeTest
         Consumer<PageCursor> headerWriter = pc -> pc.putBytes( "failed".getBytes() );
         try ( GBPTree<MutableLong,MutableLong> index = index( pageCache ).with( RecoveryCleanupWorkCollector.IGNORE ).build() )
         {
-            index.checkpoint( IOLimiter.unlimited(), headerWriter );
+            index.checkpoint( UNLIMITED, headerWriter );
         }
 
         verifyHeader( pageCache, "failed".getBytes() );
@@ -811,7 +811,7 @@ public class GBPTreeTest
 
             // WHEN
             monitor.enabled = true;
-            Future<?> checkpoint = executor.submit( throwing( () -> index.checkpoint( unlimited() ) ) );
+            Future<?> checkpoint = executor.submit( throwing( () -> index.checkpoint( UNLIMITED ) ) );
             monitor.barrier.awaitUninterruptibly();
             // now we're in the smack middle of a checkpoint
             Future<?> writerClose = executor.submit( throwing( () -> index.writer().close() ) );
@@ -842,7 +842,7 @@ public class GBPTreeTest
                 }
             } ) );
             barrier.awaitUninterruptibly();
-            Future<?> checkpoint = executor.submit( throwing( () -> index.checkpoint( unlimited() ) ) );
+            Future<?> checkpoint = executor.submit( throwing( () -> index.checkpoint( UNLIMITED ) ) );
             shouldWait( checkpoint );
 
             // THEN
@@ -963,7 +963,7 @@ public class GBPTreeTest
             {
                 writer.put( new MutableLong( 1L ), new MutableLong( 2L ) );
             }
-            index.checkpoint( IOLimiter.unlimited() );
+            index.checkpoint( UNLIMITED );
         }
         try ( GBPTree<MutableLong,MutableLong> index = index().build() )
         {
@@ -987,7 +987,7 @@ public class GBPTreeTest
             index.writer().close();
 
             // THEN
-            Future<?> checkpoint = executor.submit( throwing( () -> index.checkpoint( IOLimiter.unlimited() ) ) );
+            Future<?> checkpoint = executor.submit( throwing( () -> index.checkpoint( UNLIMITED ) ) );
             shouldWait( checkpoint );
 
             monitor.barrier.release();
@@ -1011,7 +1011,7 @@ public class GBPTreeTest
             monitor.barrier.awaitUninterruptibly();
 
             // THEN
-            Future<?> checkpoint = executor.submit( throwing( () -> index.checkpoint( IOLimiter.unlimited() ) ) );
+            Future<?> checkpoint = executor.submit( throwing( () -> index.checkpoint( UNLIMITED ) ) );
             shouldWait( checkpoint );
 
             monitor.barrier.release();
@@ -1213,7 +1213,7 @@ public class GBPTreeTest
             Future<?> cleanup = executor.submit( throwing( collector::start ) );
             shouldWait( cleanup );
 
-            Future<?> checkpoint = executor.submit( throwing( () -> index.checkpoint( IOLimiter.unlimited() ) ) );
+            Future<?> checkpoint = executor.submit( throwing( () -> index.checkpoint( UNLIMITED ) ) );
             shouldWait( checkpoint );
 
             cleanupMonitor.barrier.release();
@@ -1262,7 +1262,7 @@ public class GBPTreeTest
             {
                 writer.put( new MutableLong( 0 ), new MutableLong( 1 ) );
             }
-            index.checkpoint( unlimited() );
+            index.checkpoint( UNLIMITED );
             assertEquals( 1, checkpointCounter.count() );
         }
 
@@ -1280,7 +1280,7 @@ public class GBPTreeTest
         try ( GBPTree<MutableLong,MutableLong> index = index().with( checkpointCounter ).build() )
         {
             checkpointCounter.reset();
-            index.checkpoint( unlimited() );
+            index.checkpoint( UNLIMITED );
 
             // THEN
             assertEquals( 1, checkpointCounter.count() );
@@ -1322,7 +1322,7 @@ public class GBPTreeTest
             insert( index, key, value );
 
             // WHEN
-            index.checkpoint( unlimited() );
+            index.checkpoint( UNLIMITED );
         }
 
         // THEN
@@ -1408,7 +1408,7 @@ public class GBPTreeTest
         {
             insert( index, 0, 1 );
 
-            index.checkpoint( unlimited() );
+            index.checkpoint( UNLIMITED );
         }
 
         // WHEN
@@ -1501,7 +1501,7 @@ public class GBPTreeTest
         {
             insert( index, 0, 1 );
 
-            index.checkpoint( IOLimiter.unlimited() );
+            index.checkpoint( UNLIMITED );
         }
 
         // WHEN

--- a/community/io/src/main/java/org/neo4j/io/IOUtils.java
+++ b/community/io/src/main/java/org/neo4j/io/IOUtils.java
@@ -42,7 +42,7 @@ public final class IOUtils
      */
     public static <T extends AutoCloseable> void closeAll( Collection<T> closeables ) throws IOException
     {
-        closeAll( closeables.toArray( new AutoCloseable[closeables.size()] ) );
+        closeAll( closeables.toArray( new AutoCloseable[0] ) );
     }
 
     /**

--- a/community/io/src/main/java/org/neo4j/io/pagecache/IOLimiter.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/IOLimiter.java
@@ -107,27 +107,13 @@ public interface IOLimiter
      * An IOPSLimiter implementation that does not restrict the rate of IO. Use this implementation if you want the
      * flush to go as fast as possible.
      */
-    IOLimiter UNLIMITED = new IOLimiter()
-    {
-        @Override
-        public long maybeLimitIO( long previousStamp, int recentlyCompletedIOs, Flushable flushable )
-        {
-            return previousStamp;
-        }
-
-        @Override
-        public boolean isLimited()
-        {
-            return false;
-        }
-    };
-
+    IOLimiter UNLIMITED = ( previousStamp, recentlyCompletedIOs, flushable ) -> previousStamp;
 
     /**
      * @return {@code true} if IO is currently limited
      */
     default boolean isLimited()
     {
-        return true;
+        return false;
     }
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/IOLimiter.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/IOLimiter.java
@@ -107,8 +107,27 @@ public interface IOLimiter
      * An IOPSLimiter implementation that does not restrict the rate of IO. Use this implementation if you want the
      * flush to go as fast as possible.
      */
-    static IOLimiter unlimited()
+    IOLimiter UNLIMITED = new IOLimiter()
     {
-        return ( previousStamp, recentlyCompletedIOs, flushable ) -> previousStamp;
+        @Override
+        public long maybeLimitIO( long previousStamp, int recentlyCompletedIOs, Flushable flushable )
+        {
+            return previousStamp;
+        }
+
+        @Override
+        public boolean isLimited()
+        {
+            return false;
+        }
+    };
+
+
+    /**
+     * @return {@code true} if IO is currently limited
+     */
+    default boolean isLimited()
+    {
+        return true;
     }
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/BackgroundThreadExecutor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/BackgroundThreadExecutor.java
@@ -20,13 +20,15 @@
 package org.neo4j.io.pagecache.impl.muninn;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 /**
  * An executor for the background threads for the page caches.
- *
+ * <p>
  * This is similar to an unbounded cached thread pool, except it uses daemon threads.
- *
+ * <p>
  * There are only one of these (it's a singleton) to facilitate reusing the threads of closed page caches.
  * This is useful for making tests run faster.
  */
@@ -34,7 +36,7 @@ final class BackgroundThreadExecutor implements Executor
 {
     static final BackgroundThreadExecutor INSTANCE = new BackgroundThreadExecutor();
 
-    private final Executor executor;
+    private final ExecutorService executor;
 
     private BackgroundThreadExecutor()
     {
@@ -47,4 +49,8 @@ final class BackgroundThreadExecutor implements Executor
         executor.execute( command );
     }
 
+    public Future<?> submit( Runnable command )
+    {
+        return executor.submit( command );
+    }
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
@@ -258,7 +258,7 @@ final class MuninnPagedFile extends PageList implements PagedFile, Flushable
     @Override
     public void flushAndForce() throws IOException
     {
-        flushAndForce( IOLimiter.unlimited() );
+        flushAndForce( IOLimiter.UNLIMITED );
     }
 
     @Override
@@ -288,7 +288,7 @@ final class MuninnPagedFile extends PageList implements PagedFile, Flushable
         }
         try ( MajorFlushEvent flushEvent = pageCacheTracer.beginFileFlush( swapper ) )
         {
-            flushAndForceInternal( flushEvent.flushEventOpportunity(), true, IOLimiter.unlimited() );
+            flushAndForceInternal( flushEvent.flushEventOpportunity(), true, IOLimiter.UNLIMITED );
             syncDevice();
         }
         pageCache.clearEvictorException();

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCacheTest.java
@@ -25,6 +25,8 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.function.IntSupplier;
@@ -32,13 +34,17 @@ import java.util.function.LongSupplier;
 
 import org.neo4j.graphdb.mockfs.DelegatingFileSystemAbstraction;
 import org.neo4j.graphdb.mockfs.DelegatingStoreChannel;
+import org.neo4j.io.IOUtils;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.OpenMode;
 import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.io.pagecache.PageCacheTest;
 import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.io.pagecache.PageSwapper;
 import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.io.pagecache.tracing.ConfigurablePageCursorTracerSupplier;
+import org.neo4j.io.pagecache.tracing.DefaultPageCacheTracer;
 import org.neo4j.io.pagecache.tracing.DelegatingPageCacheTracer;
 import org.neo4j.io.pagecache.tracing.EvictionRunEvent;
 import org.neo4j.io.pagecache.tracing.MajorFlushEvent;
@@ -676,6 +682,56 @@ public class MuninnPageCacheTest extends PageCacheTest<MuninnPageCache>
                     }
                 }
             }
+        }
+    }
+
+    @Test( timeout = SEMI_LONG_TIMEOUT_MILLIS )
+    public void unlimitedShouldFlushInParallel() throws Exception
+    {
+        List<File> mappedFiles = new ArrayList<>();
+        mappedFiles.add( existingFile( "a" ) );
+        mappedFiles.add( existingFile( "b" ) );
+        getPageCache( fs, maxPages, new FlushRendezvousTracer( mappedFiles.size() ), PageCursorTracerSupplier.NULL );
+
+        List<PagedFile> mappedPagedFiles = new ArrayList<>();
+        for ( File mappedFile : mappedFiles )
+        {
+            PagedFile pagedFile = pageCache.map( mappedFile, filePageSize );
+            mappedPagedFiles.add( pagedFile );
+            try ( PageCursor cursor = pagedFile.io( 0, PF_SHARED_WRITE_LOCK ) )
+            {
+                assertTrue( cursor.next() );
+                cursor.putInt( 1 );
+            }
+        }
+
+        pageCache.flushAndForce( IOLimiter.UNLIMITED );
+
+        IOUtils.closeAll( mappedPagedFiles );
+    }
+
+    private static class FlushRendezvousTracer extends DefaultPageCacheTracer
+    {
+        private final CountDownLatch latch;
+
+        FlushRendezvousTracer( int fileCountToWaitFor )
+        {
+            latch = new CountDownLatch( fileCountToWaitFor );
+        }
+
+        @Override
+        public MajorFlushEvent beginFileFlush( PageSwapper swapper )
+        {
+            latch.countDown();
+            try
+            {
+                latch.await();
+            }
+            catch ( InterruptedException e )
+            {
+                e.printStackTrace();
+            }
+            return MajorFlushEvent.NULL;
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
@@ -136,7 +136,7 @@ public class CommunityEditionModule extends EditionModule
 
         coreAPIAvailabilityGuard = new CoreAPIAvailabilityGuard( platformModule.availabilityGuard, transactionStartTimeout );
 
-        ioLimiter = IOLimiter.unlimited();
+        ioLimiter = IOLimiter.UNLIMITED;
 
         registerRecovery( platformModule.databaseInfo, life, dependencies );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
@@ -433,7 +433,7 @@ public class NativeLabelScanStore implements LabelScanStore
                 numberOfNodes = fullStoreChangeStream.applyTo( writer );
             }
 
-            index.checkpoint( IOLimiter.unlimited(), writeClean );
+            index.checkpoint( IOLimiter.UNLIMITED, writeClean );
 
             monitor.rebuilt( numberOfNodes );
             needsRebuild = false;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexPopulator.java
@@ -302,12 +302,12 @@ public abstract class NativeSchemaIndexPopulator<KEY extends NativeSchemaKey<KEY
         {
             failureBytes = new byte[0];
         }
-        tree.checkpoint( IOLimiter.unlimited(), new FailureHeaderWriter( failureBytes ) );
+        tree.checkpoint( IOLimiter.UNLIMITED, new FailureHeaderWriter( failureBytes ) );
     }
 
     void markTreeAsOnline() throws IOException
     {
-        tree.checkpoint( IOLimiter.unlimited(), pc -> pc.putByte( BYTE_ONLINE ) );
+        tree.checkpoint( IOLimiter.UNLIMITED, pc -> pc.putByte( BYTE_ONLINE ) );
     }
 
     static class IndexUpdateApply<KEY extends NativeSchemaKey<KEY>, VALUE extends NativeSchemaValue>

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPopulator.java
@@ -170,7 +170,7 @@ class SpatialIndexPopulator extends SpatialIndexCache<SpatialIndexPopulator.Part
         @Override
         void markTreeAsOnline() throws IOException
         {
-            tree.checkpoint( IOLimiter.unlimited(), settings.headerWriter( BYTE_ONLINE ) );
+            tree.checkpoint( IOLimiter.UNLIMITED, settings.headerWriter( BYTE_ONLINE ) );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
@@ -981,7 +981,7 @@ public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvide
         try
         {
             repopulateAllIndexes();
-            labelScanStore.force( IOLimiter.unlimited() );
+            labelScanStore.force( IOLimiter.UNLIMITED );
         }
         catch ( IOException | IndexEntryConflictException e )
         {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
@@ -74,7 +74,7 @@ import static org.neo4j.graphdb.factory.GraphDatabaseSettings.dense_node_thresho
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.io.IOUtils.closeAll;
-import static org.neo4j.io.pagecache.IOLimiter.unlimited;
+import static org.neo4j.io.pagecache.IOLimiter.UNLIMITED;
 import static org.neo4j.kernel.impl.index.labelscan.NativeLabelScanStore.getLabelScanStoreFile;
 import static org.neo4j.kernel.impl.store.MetaDataStore.DEFAULT_NAME;
 import static org.neo4j.kernel.impl.store.StoreType.PROPERTY;
@@ -456,17 +456,17 @@ public class BatchingNeoStores implements AutoCloseable, MemoryStatsVisitor.Visi
         }
         if ( neoStores != null )
         {
-            neoStores.flush( unlimited() );
+            neoStores.flush( UNLIMITED );
             flushIdFiles( neoStores, StoreType.values() );
         }
         if ( temporaryNeoStores != null )
         {
-            temporaryNeoStores.flush( unlimited() );
+            temporaryNeoStores.flush( UNLIMITED );
             flushIdFiles( temporaryNeoStores, TEMP_STORE_TYPES );
         }
         if ( labelScanStore != null )
         {
-            labelScanStore.force( unlimited() );
+            labelScanStore.force( UNLIMITED );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/graphdb/NativeLabelScanStoreStartupIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/NativeLabelScanStoreStartupIT.java
@@ -82,7 +82,7 @@ public class NativeLabelScanStoreStartupIT
         createTestNode();
         long[] labels = readNodesForLabel( labelScanStore );
         assertEquals( "Label scan store see 1 label for node", 1, labels.length );
-        labelScanStore.force( IOLimiter.unlimited() );
+        labelScanStore.force( IOLimiter.UNLIMITED );
         labelScanStore.shutdown();
         workCollector.shutdown();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/NeoStoreDataSourceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/NeoStoreDataSourceTest.java
@@ -118,7 +118,7 @@ public class NeoStoreDataSourceTest
 
         ds.stop();
         ds.shutdown();
-        verify( pageCache ).flushAndForce( IOLimiter.unlimited() );
+        verify( pageCache ).flushAndForce( IOLimiter.UNLIMITED );
     }
 
     @Test
@@ -134,7 +134,7 @@ public class NeoStoreDataSourceTest
 
         ds.stop();
         ds.shutdown();
-        verify( pageCache ).flushAndForce( IOLimiter.unlimited() );
+        verify( pageCache ).flushAndForce( IOLimiter.UNLIMITED );
     }
 
     @Test
@@ -154,7 +154,7 @@ public class NeoStoreDataSourceTest
 
         ds.stop();
         ds.shutdown();
-        verify( pageCache, never() ).flushAndForce( IOLimiter.unlimited() );
+        verify( pageCache, never() ).flushAndForce( IOLimiter.UNLIMITED );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/RecoveryIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/RecoveryIT.java
@@ -517,7 +517,7 @@ public class RecoveryIT
 
     private void flush( GraphDatabaseService db )
     {
-        ((GraphDatabaseAPI)db).getDependencyResolver().resolveDependency( StorageEngine.class ).flushAndForce( IOLimiter.unlimited() );
+        ((GraphDatabaseAPI)db).getDependencyResolver().resolveDependency( StorageEngine.class ).flushAndForce( IOLimiter.UNLIMITED );
     }
 
     private void checkPoint( GraphDatabaseService db ) throws IOException

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreTest.java
@@ -125,7 +125,7 @@ public abstract class LabelScanStoreTest
     public void forceShouldNotForceWriterOnReadOnlyScanStore()
     {
         createAndStartReadOnly();
-        store.force( IOLimiter.unlimited() );
+        store.force( IOLimiter.UNLIMITED );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/ContractCheckingIndexProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/ContractCheckingIndexProxyTest.java
@@ -151,7 +151,7 @@ public class ContractCheckingIndexProxyTest
         IndexProxy outer = newContractCheckingIndexProxy( inner );
 
         // WHEN
-        outer.force( IOLimiter.unlimited() );
+        outer.force( IOLimiter.UNLIMITED );
     }
 
     @Test( expected = IllegalStateException.class )
@@ -164,7 +164,7 @@ public class ContractCheckingIndexProxyTest
         // WHEN
         outer.start();
         outer.close();
-        outer.force( IOLimiter.unlimited() );
+        outer.force( IOLimiter.UNLIMITED );
     }
 
     @Test( expected = /* THEN */ IllegalStateException.class )
@@ -297,7 +297,7 @@ public class ContractCheckingIndexProxyTest
         actionThreadReference.set( actionThread );
 
         outer.start();
-        Thread thread = runInSeparateThread( () -> outer.force( IOLimiter.unlimited() ) );
+        Thread thread = runInSeparateThread( () -> outer.force( IOLimiter.UNLIMITED ) );
 
         ThreadTestUtils.awaitThreadState( actionThread, TEST_TIMEOUT, Thread.State.TIMED_WAITING );
         latch.countDown();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
@@ -1052,11 +1052,11 @@ public class IndexingServiceTest
 
         IndexingService indexingService = createIndexServiceWithCustomIndexMap( indexMapReference );
 
-        indexingService.forceAll( IOLimiter.unlimited() );
-        verify( validIndex1, times( 1 ) ).force( IOLimiter.unlimited() );
-        verify( validIndex2, times( 1 ) ).force( IOLimiter.unlimited() );
-        verify( validIndex3, times( 1 ) ).force( IOLimiter.unlimited() );
-        verify( validIndex4, times( 1 ) ).force( IOLimiter.unlimited() );
+        indexingService.forceAll( IOLimiter.UNLIMITED );
+        verify( validIndex1, times( 1 ) ).force( IOLimiter.UNLIMITED );
+        verify( validIndex2, times( 1 ) ).force( IOLimiter.UNLIMITED );
+        verify( validIndex3, times( 1 ) ).force( IOLimiter.UNLIMITED );
+        verify( validIndex4, times( 1 ) ).force( IOLimiter.UNLIMITED );
     }
 
     @Test
@@ -1080,7 +1080,7 @@ public class IndexingServiceTest
 
         expectedException.expectMessage( "Unable to force" );
         expectedException.expect( UnderlyingStorageException.class );
-        indexingService.forceAll( IOLimiter.unlimited() );
+        indexingService.forceAll( IOLimiter.UNLIMITED );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexAccessorTest.java
@@ -214,7 +214,7 @@ public abstract class NativeSchemaIndexAccessorTest<KEY extends NativeSchemaKey<
             applyUpdatesToExpectedData( expectedData, batch );
             // verifyUpdates
             forceAndCloseAccessor();
-            verifyUpdates( expectedData.toArray( new IndexEntryUpdate[expectedData.size()] ) );
+            verifyUpdates( expectedData.toArray( new IndexEntryUpdate[0] ) );
             setupAccessor();
         }
     }
@@ -551,7 +551,7 @@ public abstract class NativeSchemaIndexAccessorTest<KEY extends NativeSchemaKey<
         processAll( data );
 
         // when
-        accessor.force( IOLimiter.unlimited() );
+        accessor.force( IOLimiter.UNLIMITED );
         accessor.close();
 
         // then
@@ -878,7 +878,7 @@ public abstract class NativeSchemaIndexAccessorTest<KEY extends NativeSchemaKey<
     @SuppressWarnings( "unchecked" )
     private IndexEntryUpdate<IndexDescriptor> selectRandomItem( Set<IndexEntryUpdate<IndexDescriptor>> expectedData )
     {
-        return expectedData.toArray( new IndexEntryUpdate[expectedData.size()] )[random.nextInt( expectedData.size() )];
+        return expectedData.toArray( new IndexEntryUpdate[0] )[random.nextInt( expectedData.size() )];
     }
 
     @SafeVarargs
@@ -896,7 +896,7 @@ public abstract class NativeSchemaIndexAccessorTest<KEY extends NativeSchemaKey<
 
     private void forceAndCloseAccessor() throws IOException
     {
-        accessor.force( IOLimiter.unlimited() );
+        accessor.force( IOLimiter.UNLIMITED );
         closeAccessor();
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberFullScanNonUniqueIndexSamplerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NumberFullScanNonUniqueIndexSamplerTest.java
@@ -33,7 +33,6 @@ import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.storageengine.api.schema.IndexSample;
 
 import static org.junit.Assert.assertEquals;
-
 import static org.neo4j.kernel.impl.index.schema.LayoutTestUtil.countUniqueValues;
 import static org.neo4j.values.storable.Values.values;
 
@@ -90,7 +89,7 @@ public class NumberFullScanNonUniqueIndexSamplerTest extends NativeSchemaIndexTe
                     nodeId++;
                 }
             }
-            gbpTree.checkpoint( IOLimiter.unlimited() );
+            gbpTree.checkpoint( IOLimiter.UNLIMITED );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngineTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngineTest.java
@@ -164,7 +164,7 @@ public class RecordStorageEngineTest
     @Test
     public void mustFlushStoresWithGivenIOLimiter()
     {
-        IOLimiter limiter = ( stamp, completedIOs, swapper ) -> 0;
+        IOLimiter limiter = IOLimiter.UNLIMITED;
         FileSystemAbstraction fs = fsRule.get();
         AtomicReference<IOLimiter> observedLimiter = new AtomicReference<>();
         PageCache pageCache = new DelegatingPageCache( pageCacheRule.getPageCache( fs ) )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresTest.java
@@ -607,7 +607,7 @@ public class NeoStoresTest
         assertEquals( 10L, metaDataStore.getLatestConstraintIntroducingTx() );
 
         // when
-        neoStores.flush( IOLimiter.unlimited() );
+        neoStores.flush( IOLimiter.UNLIMITED );
         neoStores.close();
         neoStores = sf.openAllNeoStores();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigratorTest.java
@@ -215,7 +215,7 @@ public class NativeLabelScanStoreMigratorTest
             {
                 labelScanWriter.write( NodeLabelUpdate.labelChanges( 1, new long[0], new long[]{1} ) );
             }
-            nativeLabelScanStore.force( IOLimiter.unlimited() );
+            nativeLabelScanStore.force( IOLimiter.UNLIMITED );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointSchedulerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointSchedulerTest.java
@@ -276,7 +276,7 @@ public class CheckPointSchedulerTest
         checkpointerStarter.get();
 
         assertTrue( "Checkpointer should be created.", checkPointer.isCheckpointCreated() );
-        assertTrue( "Limiter should be enabled in the end.", ioLimiter.isLimitEnabled() );
+        assertTrue( "Limiter should be enabled in the end.", ioLimiter.isLimited() );
     }
 
     @Test
@@ -366,7 +366,8 @@ public class CheckPointSchedulerTest
             limitEnabled = true;
         }
 
-        boolean isLimitEnabled()
+        @Override
+        public boolean isLimited()
         {
             return limitEnabled;
         }
@@ -389,7 +390,7 @@ public class CheckPointSchedulerTest
         public long checkPointIfNeeded( TriggerInfo triggerInfo )
         {
             latch.countDown();
-            while ( ioLimiter.isLimitEnabled() )
+            while ( ioLimiter.isLimited() )
             {
                 //spin while limiter enabled
             }

--- a/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoreDataSourceRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoreDataSourceRule.java
@@ -133,7 +133,7 @@ public class NeoStoreDataSourceRule extends ExternalResource
                 new StandardConstraintSemantics(), monitors,
                 new Tracers( "null", NullLog.getInstance(), monitors, jobScheduler, clock ),
                 mock( Procedures.class ),
-                IOLimiter.unlimited(),
+                IOLimiter.UNLIMITED,
                 availabilityGuard, clock,
                 new CanWrite(), new StoreCopyCheckPointMutex(),
                 RecoveryCleanupWorkCollector.IMMEDIATE,

--- a/community/lucene-index/src/test/java/org/neo4j/index/recovery/UniqueIndexRecoveryTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/recovery/UniqueIndexRecoveryTest.java
@@ -248,6 +248,6 @@ public class UniqueIndexRecoveryTest
 
     private void flushAll()
     {
-        db.getDependencyResolver().resolveDependency( StorageEngine.class ).flushAndForce( IOLimiter.unlimited() );
+        db.getDependencyResolver().resolveDependency( StorageEngine.class ).flushAndForce( IOLimiter.UNLIMITED );
     }
 }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexPopulationIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexPopulationIT.java
@@ -106,7 +106,7 @@ public class LuceneSchemaIndexPopulationIT
             try ( LuceneIndexAccessor indexAccessor = new LuceneIndexAccessor( uniqueIndex, descriptor ) )
             {
                 generateUpdates( indexAccessor, affectedNodes );
-                indexAccessor.force( IOLimiter.unlimited() );
+                indexAccessor.force( IOLimiter.UNLIMITED );
 
                 // now index is online and should contain updates data
                 assertTrue( uniqueIndex.isOnline() );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexProviderTest.java
@@ -117,7 +117,7 @@ public class LuceneIndexProviderTest
                 new DirectoryFactory.InMemoryDirectoryFactory(), fs, graphDbDir );
 
         // We assert that 'force' does not throw an exception
-        getIndexAccessor( readOnlyConfig, readOnlyIndexProvider ).force( IOLimiter.unlimited() );
+        getIndexAccessor( readOnlyConfig, readOnlyIndexProvider ).force( IOLimiter.UNLIMITED );
     }
 
     private void createEmptySchemaIndex( DirectoryFactory directoryFactory ) throws IOException

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexIT.java
@@ -88,7 +88,7 @@ public class LuceneSchemaIndexIT
         try ( LuceneIndexAccessor indexAccessor = createDefaultIndexAccessor() )
         {
             generateUpdates( indexAccessor, 32 );
-            indexAccessor.force( IOLimiter.unlimited() );
+            indexAccessor.force( IOLimiter.UNLIMITED );
 
             // When & Then
             List<String> singlePartitionFileTemplates = Arrays.asList( ".cfe", ".cfs", ".si", "segments_1" );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceIntegrationTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceIntegrationTest.java
@@ -206,7 +206,7 @@ public class IndexingServiceIntegrationTest
 
         expectedException.expect( UnderlyingStorageException.class );
         expectedException.expectMessage( "Unable to force" );
-        indexingService.forceAll( IOLimiter.unlimited() );
+        indexingService.forceAll( IOLimiter.UNLIMITED );
     }
 
     private PropertyKeyTokenHolder getPropertyKeyTokenHolder( GraphDatabaseService database )

--- a/community/neo4j/src/test/java/recovery/TestRecoveryScenarios.java
+++ b/community/neo4j/src/test/java/recovery/TestRecoveryScenarios.java
@@ -262,7 +262,7 @@ public class TestRecoveryScenarios
                     @Override
                     void flush( GraphDatabaseAPI db )
                     {
-                        IOLimiter limiter = IOLimiter.unlimited();
+                        IOLimiter limiter = IOLimiter.UNLIMITED;
                         db.getDependencyResolver().resolveDependency( StorageEngine.class ).flushAndForce( limiter );
                     }
                 },

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupProtocolServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupProtocolServiceIT.java
@@ -144,7 +144,7 @@ public class BackupProtocolServiceIT
     private static final Label LABEL = Label.label( "LABEL" );
 
     private final Monitors monitors = new Monitors();
-    private final IOLimiter limiter = IOLimiter.unlimited();
+    private final IOLimiter limiter = IOLimiter.UNLIMITED;
     private FileSystemAbstraction fileSystem;
     private Path storeDir;
     private Path backupDir;

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ClusterManager.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ClusterManager.java
@@ -1354,7 +1354,7 @@ public class ClusterManager
             {
                 if ( !exceptSet.contains( db ) )
                 {
-                    IOLimiter limiter = IOLimiter.unlimited();
+                    IOLimiter limiter = IOLimiter.UNLIMITED;
                     db.getDependencyResolver().resolveDependency( StorageEngine.class ).flushAndForce( limiter );
                 }
             }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/transaction/log/checkpoint/ConfigurableIOLimiter.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/transaction/log/checkpoint/ConfigurableIOLimiter.java
@@ -188,6 +188,12 @@ public class ConfigurableIOLimiter implements IOLimiter
         while ( !stateUpdater.compareAndSet( this, currentState, newState ) );
     }
 
+    @Override
+    public boolean isLimited()
+    {
+        return getDisabledCounter( state ) > 0;
+    }
+
     private long currentTimeMillis()
     {
         return System.currentTimeMillis();

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/HalfAppliedConstraintRecoveryIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/HalfAppliedConstraintRecoveryIT.java
@@ -293,7 +293,7 @@ public class HalfAppliedConstraintRecoveryIT
     private static void flushStores( GraphDatabaseAPI db )
     {
         db.getDependencyResolver().resolveDependency( RecordStorageEngine.class )
-                .testAccessNeoStores().flush( IOLimiter.unlimited() );
+                .testAccessNeoStores().flush( IOLimiter.UNLIMITED );
     }
 
     private static void apply( GraphDatabaseAPI db, List<TransactionRepresentation> transactions )

--- a/tools/src/test/java/org/neo4j/tools/org/neo4j/index/GBPTreePlayground.java
+++ b/tools/src/test/java/org/neo4j/tools/org/neo4j/index/GBPTreePlayground.java
@@ -132,7 +132,7 @@ public class GBPTreePlayground
         @Override
         public void run( String[] args, PrintStream out ) throws Exception
         {
-            tree.checkpoint( IOLimiter.unlimited() );
+            tree.checkpoint( IOLimiter.UNLIMITED );
         }
         @Override
         public String toString()


### PR DESCRIPTION
If `IOLimiter` allows, flushing of pages will be done in parallel. 

This is true during a shutdown and for checkpointing when `dbms.checkpoint.iops.limit` is `-1`.