### PR TITLE
Make buffer size configurable for `LOAD CSV`

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/BufferOverflowException.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/BufferOverflowException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.csv.reader;
+
+public class BufferOverflowException extends IllegalStateException
+{
+    public BufferOverflowException( String msg )
+    {
+        super( msg );
+    }
+}

--- a/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
@@ -22,11 +22,9 @@ package org.neo4j.csv.reader;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
-import java.util.Arrays;
 
 import org.neo4j.csv.reader.Source.Chunk;
 
-import static java.lang.Character.isWhitespace;
 import static java.lang.String.format;
 import static org.neo4j.csv.reader.Mark.END_OF_LINE_CHARACTER;
 
@@ -337,7 +335,9 @@ public class BufferedCharSeeker implements CharSeeker
                             dataLength + ". A common cause of this is that a field has an unterminated " +
                             "quote and so will try to seek until the next quote, which ever line it may be on." +
                             " This should not happen if multi-line fields are disabled, given that the fields contains " +
-                            "no new-line characters. This field started at " + sourceDescription() + ":" + lineNumber() );
+                            "no new-line characters. If you are running a `LOAD CSV query it may also be possible that " +
+                            "increasing the buffer size via `dbms.import.csv.buffer_size` could help. " +
+                            "This field started at " + sourceDescription() + ":" + lineNumber() );
                 }
             }
 

--- a/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
@@ -331,13 +331,11 @@ public class BufferedCharSeeker implements CharSeeker
                 currentChunk.close();
                 if ( bufferPos - seekStartPos >= dataCapacity )
                 {
-                    throw new IllegalStateException( "Tried to read a field larger than buffer size " +
+                    throw new BufferOverflowException( "Tried to read a field larger than buffer size " +
                             dataLength + ". A common cause of this is that a field has an unterminated " +
                             "quote and so will try to seek until the next quote, which ever line it may be on." +
                             " This should not happen if multi-line fields are disabled, given that the fields contains " +
-                            "no new-line characters. If you are running a `LOAD CSV query it may also be possible that " +
-                            "increasing the buffer size via `dbms.import.csv.buffer_size` could help. " +
-                            "This field started at " + sourceDescription() + ":" + lineNumber() );
+                            "no new-line characters. This field started at " + sourceDescription() + ":" + lineNumber() );
                 }
             }
 

--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/CypherCompiler.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/CypherCompiler.scala
@@ -98,5 +98,6 @@ case class CypherCompilerConfiguration(queryCacheSize: Int,
                                        errorIfShortestPathFallbackUsedAtRuntime: Boolean,
                                        errorIfShortestPathHasCommonNodesAtRuntime: Boolean,
                                        legacyCsvQuoteEscaping: Boolean,
+                                       csvBufferSize: Int,
                                        nonIndexedLabelWarningThreshold: Long,
                                        planWithMinimumCardinalityEstimates: Boolean)

--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/LogicalPlanningContext.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/LogicalPlanningContext.scala
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_3.planner.logical
 
+import org.neo4j.csv.reader.Configuration
 import org.neo4j.csv.reader.Configuration.DEFAULT_LEGACY_STYLE_QUOTING
 import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.Metrics.QueryGraphSolverInput
 import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.steps.LogicalPlanProducer
@@ -40,6 +41,7 @@ case class LogicalPlanningContext(planContext: PlanContext,
                                   errorIfShortestPathFallbackUsedAtRuntime: Boolean = false,
                                   errorIfShortestPathHasCommonNodesAtRuntime: Boolean = true,
                                   legacyCsvQuoteEscaping: Boolean = DEFAULT_LEGACY_STYLE_QUOTING,
+                                  csvBufferSize: Int = 2 * Configuration.MB,
                                   config: QueryPlannerConfiguration = QueryPlannerConfiguration.default,
                                   leafPlanUpdater: LogicalPlan => LogicalPlan = identity) {
   def withStrictness(strictness: StrictnessMode) = copy(input = input.withPreferredStrictness(strictness))

--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/QueryPlanner.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/QueryPlanner.scala
@@ -48,7 +48,8 @@ case class QueryPlanner(planSingleQuery: LogicalPlanningFunction1[PlannerQuery, 
       errorIfShortestPathFallbackUsedAtRuntime = context.config.errorIfShortestPathFallbackUsedAtRuntime,
       errorIfShortestPathHasCommonNodesAtRuntime = context.config.errorIfShortestPathHasCommonNodesAtRuntime,
       config = QueryPlannerConfiguration.default.withUpdateStrategy(context.updateStrategy),
-      legacyCsvQuoteEscaping = context.config.legacyCsvQuoteEscaping
+      legacyCsvQuoteEscaping = context.config.legacyCsvQuoteEscaping,
+      csvBufferSize = context.config.csvBufferSize
     )
 
     val (perCommit, logicalPlan) = plan(from.unionQuery)(logicalPlanningContext)

--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/plans/rewriter/cleanUpEager.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/plans/rewriter/cleanUpEager.scala
@@ -35,7 +35,7 @@ case object cleanUpEager extends Rewriter {
       unwind.copy(left = eager.copy(inner = source)(eager.solved))(eager.solved)
 
     // E LCSV => LCSV E
-    case eager@Eager(loadCSV@LoadCSV(source, _, _, _, _, _)) =>
+    case eager@Eager(loadCSV@LoadCSV(source, _, _, _, _, _, _)) =>
       loadCSV.copy(source = eager.copy(inner = source)(eager.solved))(eager.solved)
 
     // LIMIT E => E LIMIT

--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/steps/LogicalPlanProducer.scala
@@ -427,7 +427,7 @@ case class LogicalPlanProducer(cardinalityModel: CardinalityModel) extends ListS
   def planLoadCSV(inner: LogicalPlan, variableName: String, url: Expression, format: CSVFormat, fieldTerminator: Option[StringLiteral])
                  (implicit context: LogicalPlanningContext): LogicalPlan = {
     val solved = inner.solved.updateTailOrSelf(_.withHorizon(LoadCSVProjection(variableName, url, format, fieldTerminator)))
-    LoadCSVPlan(inner, url, variableName, format, fieldTerminator.map(_.value), context.legacyCsvQuoteEscaping)(solved)
+    LoadCSVPlan(inner, url, variableName, format, fieldTerminator.map(_.value), context.legacyCsvQuoteEscaping, context.csvBufferSize)(solved)
   }
 
   def planUnwind(inner: LogicalPlan, name: String, expression: Expression, reported: Expression)(implicit context: LogicalPlanningContext): LogicalPlan = {

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/LogicalPlanningTestSupport.scala
@@ -21,6 +21,7 @@ package org.neo4j.cypher.internal.compiler.v3_3.planner
 
 import org.mockito.Matchers._
 import org.mockito.Mockito._
+import org.neo4j.csv.reader.Configuration
 import org.neo4j.cypher.internal.compiler.v3_3._
 import org.neo4j.cypher.internal.compiler.v3_3.ast.rewriters.namePatternPredicatePatternElements
 import org.neo4j.cypher.internal.compiler.v3_3.phases._
@@ -113,7 +114,8 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
     LogicalPlanningContext(planContext, LogicalPlanProducer(metrics.cardinality), metrics, semanticTable,
       strategy, QueryGraphSolverInput(Map.empty, cardinality, strictness),
       notificationLogger = notificationLogger, useErrorsOverWarnings = useErrorsOverWarnings,
-      legacyCsvQuoteEscaping = config.legacyCsvQuoteEscaping, config = QueryPlannerConfiguration.default)
+      legacyCsvQuoteEscaping = config.legacyCsvQuoteEscaping, csvBufferSize = config.csvBufferSize,
+                           config = QueryPlannerConfiguration.default)
 
   def newMockedStatistics = mock[GraphStatistics]
   def hardcodedStatistics = HardcodedGraphStatistics
@@ -158,6 +160,7 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
     errorIfShortestPathFallbackUsedAtRuntime = false,
     errorIfShortestPathHasCommonNodesAtRuntime = true,
     legacyCsvQuoteEscaping = false,
+    csvBufferSize = Configuration.DEFAULT_BUFFER_SIZE_4MB,
     nonIndexedLabelWarningThreshold = 10000,
     planWithMinimumCardinalityEstimates = false
   )

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/LogicalPlanningTestSupport2.scala
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_3.planner
 
+import org.neo4j.csv.reader.Configuration
 import org.neo4j.cypher.internal.compiler.v3_3._
 import org.neo4j.cypher.internal.compiler.v3_3.ast.rewriters._
 import org.neo4j.cypher.internal.compiler.v3_3.phases._
@@ -69,6 +70,7 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
     errorIfShortestPathFallbackUsedAtRuntime = false,
     errorIfShortestPathHasCommonNodesAtRuntime = true,
     legacyCsvQuoteEscaping = false,
+    csvBufferSize = Configuration.DEFAULT_BUFFER_SIZE_4MB,
     nonIndexedLabelWarningThreshold = 10000,
     planWithMinimumCardinalityEstimates = false
   )

--- a/community/cypher/cypher-logical-plans-3.3/src/main/scala/org/neo4j/cypher/internal/v3_3/logical/plans/LoadCSV.scala
+++ b/community/cypher/cypher-logical-plans-3.3/src/main/scala/org/neo4j/cypher/internal/v3_3/logical/plans/LoadCSV.scala
@@ -27,8 +27,9 @@ case class LoadCSV(source: LogicalPlan,
                    variableName: String,
                    format: CSVFormat,
                    fieldTerminator: Option[String],
-                   legacyCsvQuoteEscaping: Boolean)
-                  (val solved: PlannerQuery with CardinalityEstimation) extends LogicalPlan {
+                   legacyCsvQuoteEscaping: Boolean,
+                   csvBufferSize: Int
+                  )(val solved: PlannerQuery with CardinalityEstimation) extends LogicalPlan {
 
   override val availableSymbols = source.availableSymbols + variableName
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CompilerEngineDelegator.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CompilerEngineDelegator.scala
@@ -87,6 +87,7 @@ class CompilerEngineDelegator(graph: GraphDatabaseQueryService,
                               errorIfShortestPathFallbackUsedAtRuntime: Boolean,
                               errorIfShortestPathHasCommonNodesAtRuntime: Boolean,
                               legacyCsvQuoteEscaping: Boolean,
+                              csvBufferSize: Int,
                               planWithMinimumCardinalityEstimates: Boolean,
                               logProvider: LogProvider,
                               compatibilityFactory: CompatibilityFactory) {
@@ -104,6 +105,7 @@ class CompilerEngineDelegator(graph: GraphDatabaseQueryService,
     errorIfShortestPathFallbackUsedAtRuntime = errorIfShortestPathFallbackUsedAtRuntime,
     errorIfShortestPathHasCommonNodesAtRuntime = errorIfShortestPathHasCommonNodesAtRuntime,
     legacyCsvQuoteEscaping = legacyCsvQuoteEscaping,
+    csvBufferSize = csvBufferSize,
     nonIndexedLabelWarningThreshold = getNonIndexedLabelWarningThreshold,
     planWithMinimumCardinalityEstimates = planWithMinimumCardinalityEstimates
   )

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
@@ -304,6 +304,10 @@ class ExecutionEngine(val queryService: GraphDatabaseQueryService,
       queryService, GraphDatabaseSettings.csv_legacy_quote_escaping,
       GraphDatabaseSettings.csv_legacy_quote_escaping.getDefaultValue.toBoolean
     )
+    val csvBufferSize = optGraphSetting[java.lang.Integer](
+      queryService, GraphDatabaseSettings.csv_buffer_size,
+      GraphDatabaseSettings.csv_buffer_size.getDefaultValue.toInt
+    )
     val planWithMinimumCardinalityEstimates = optGraphSetting[java.lang.Boolean](
       queryService, GraphDatabaseSettings.cypher_plan_with_minimum_cardinality_estimates,
       GraphDatabaseSettings.cypher_plan_with_minimum_cardinality_estimates.getDefaultValue.toBoolean
@@ -320,7 +324,7 @@ class ExecutionEngine(val queryService: GraphDatabaseQueryService,
     val compatibilityCache = new CompatibilityCache(compatibilityFactory)
     new CompilerEngineDelegator(queryService, kernel, kernelMonitors, version, planner, runtime,
       useErrorsOverWarnings, idpMaxTableSize, idpIterationDuration, errorIfShortestPathFallbackUsedAtRuntime,
-      errorIfShortestPathHasCommonNodesAtRuntime, legacyCsvQuoteEscaping, planWithMinimumCardinalityEstimates,
+      errorIfShortestPathHasCommonNodesAtRuntime, legacyCsvQuoteEscaping, csvBufferSize, planWithMinimumCardinalityEstimates,
       logProvider, compatibilityCache)
   }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/CommunityPipeBuilder.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/CommunityPipeBuilder.scala
@@ -228,8 +228,8 @@ case class CommunityPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe
         val rowProcessing = ProcedureCallRowProcessing(signature)
         ProcedureCallPipe(source, signature, callMode, callArgumentCommands, rowProcessing, call.callResultTypes, call.callResultIndices)(id = id)
 
-      case LoadCSVPlan(_, url, variableName, format, fieldTerminator, legacyCsvQuoteEscaping) =>
-        LoadCSVPipe(source, format, buildExpression(url), variableName, fieldTerminator, legacyCsvQuoteEscaping)(id = id)
+      case LoadCSVPlan(_, url, variableName, format, fieldTerminator, legacyCsvQuoteEscaping, bufferSize) =>
+        LoadCSVPipe(source, format, buildExpression(url), variableName, fieldTerminator, legacyCsvQuoteEscaping, bufferSize)(id = id)
 
       case ProduceResult(columns, _) =>
         ProduceResultsPipe(source, columns)(id = id)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/LoadCsvPeriodicCommitObserver.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/LoadCsvPeriodicCommitObserver.scala
@@ -31,8 +31,9 @@ class LoadCsvPeriodicCommitObserver(batchRowCount: Long, resources: ExternalCSVR
   val updateCounter = new UpdateCounter
   var outerLoadCSVIterator: Option[LoadCsvIterator] = None
 
-  def getCsvIterator(url: URL, fieldTerminator: Option[String], legacyCsvQuoteEscaping: Boolean, headers: Boolean = false): Iterator[Array[String]] = {
-    val innerIterator = resources.getCsvIterator(url, fieldTerminator, legacyCsvQuoteEscaping, headers)
+  override def getCsvIterator(url: URL, fieldTerminator: Option[String], legacyCsvQuoteEscaping: Boolean, bufferSize: Int,
+                              headers: Boolean = false): Iterator[Array[String]] = {
+    val innerIterator = resources.getCsvIterator(url, fieldTerminator, legacyCsvQuoteEscaping, bufferSize, headers)
     if (outerLoadCSVIterator.isEmpty) {
       if (headers)
         updateCounter.offsetForHeaders()

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/ExternalCSVResource.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/ExternalCSVResource.scala
@@ -22,12 +22,14 @@ package org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes
 import java.net.URL
 
 trait ExternalCSVResource {
-  def getCsvIterator(url: URL, fieldTerminator: Option[String], legacyCsvQuoteEscaping: Boolean, headers: Boolean = false): Iterator[Array[String]]
+  def getCsvIterator(url: URL, fieldTerminator: Option[String], legacyCsvQuoteEscaping: Boolean, bufferSize: Int,
+                     headers: Boolean = false): Iterator[Array[String]]
 }
 
 object ExternalCSVResource {
   def empty: ExternalCSVResource = new ExternalCSVResource {
-    override def getCsvIterator(url: URL, fieldTerminator: Option[String], legacyCsvQuoteEscaping: Boolean, headers: Boolean = false): Iterator[Array[String]] =
+    override def getCsvIterator(url: URL, fieldTerminator: Option[String], legacyCsvQuoteEscaping: Boolean, bufferSize: Int,
+                                headers: Boolean = false): Iterator[Array[String]] =
       Iterator.empty
   }
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/LoadCSVPipe.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/LoadCSVPipe.scala
@@ -24,10 +24,10 @@ import java.net.URL
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.ExecutionContext
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.commands.expressions.Expression
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.helpers.ArrayBackedMap
-import org.neo4j.cypher.internal.v3_3.logical.plans.LogicalPlanId
 import org.neo4j.cypher.internal.frontend.v3_3.LoadExternalResourceException
 import org.neo4j.cypher.internal.ir.v3_3.{CSVFormat, HasHeaders, NoHeaders}
 import org.neo4j.cypher.internal.spi.v3_3.QueryContext
+import org.neo4j.cypher.internal.v3_3.logical.plans.LogicalPlanId
 import org.neo4j.values._
 import org.neo4j.values.storable.{TextValue, Value, Values}
 import org.neo4j.values.virtual.VirtualValues
@@ -39,7 +39,8 @@ case class LoadCSVPipe(source: Pipe,
                        urlExpression: Expression,
                        variable: String,
                        fieldTerminator: Option[String],
-                       legacyCsvQuoteEscaping: Boolean)
+                       legacyCsvQuoteEscaping: Boolean,
+                       bufferSize: Int)
                       (val id: LogicalPlanId = LogicalPlanId.DEFAULT)
   extends PipeWithSource(source) {
 
@@ -106,12 +107,12 @@ case class LoadCSVPipe(source: Pipe,
 
       format match {
         case HasHeaders =>
-          val iterator: Iterator[Array[Value]] = state.resources.getCsvIterator(url, fieldTerminator, legacyCsvQuoteEscaping, headers = true)
+          val iterator: Iterator[Array[Value]] = state.resources.getCsvIterator(url, fieldTerminator, legacyCsvQuoteEscaping, bufferSize, headers = true)
             .map(_.map(s => Values.stringOrNoValue(s)))
           val headers = if (iterator.nonEmpty) iterator.next().toIndexedSeq else IndexedSeq.empty // First row is headers
           new IteratorWithHeaders(headers, context, iterator)
         case NoHeaders =>
-          val iterator: Iterator[Array[Value]] = state.resources.getCsvIterator(url, fieldTerminator, legacyCsvQuoteEscaping, headers = false)
+          val iterator: Iterator[Array[Value]] = state.resources.getCsvIterator(url, fieldTerminator, legacyCsvQuoteEscaping, bufferSize, headers = false)
             .map(_.map(s => Values.stringOrNoValue(s)))
           new IteratorWithoutHeaders(context, iterator)
       }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/CSVResources.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/CSVResources.scala
@@ -82,10 +82,8 @@ class CSVResources(cleaner: TaskCloser) extends ExternalCSVResource {
             if (mark.isEndOfLine) return if (buffer.isEmpty) null else buffer.toArray
           }
         } catch {
-          case e: BufferOverflowException => throw new CypherExecutionException(
-            """Tried to read a field larger than the current buffer size.
-              | Make sure that the field doesn't have an unterminated quote,
-              | if it doesn't you can try increasing the buffer size via `dbms.import.csv.buffer_size`.""".stripMargin, e)
+          //TODO change to error message mentioning `dbms.import.csv.buffer_size` in 3.5
+          case e: BufferOverflowException => throw new CypherExecutionException(e.getMessage, e)
         }
 
         if (buffer.isEmpty) {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/CSVResources.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/CSVResources.scala
@@ -40,10 +40,10 @@ object CSVResources {
   val DEFAULT_BUFFER_SIZE: Int = 2 * 1024 * 1024
   val DEFAULT_QUOTE_CHAR: Char = '"'
 
-  private def config(legacyCsvQuoteEscaping: Boolean) = new Configuration {
+  private def config(legacyCsvQuoteEscaping: Boolean, csvBufferSize: Int) = new Configuration {
     override def quotationCharacter(): Char = DEFAULT_QUOTE_CHAR
 
-    override def bufferSize(): Int = DEFAULT_BUFFER_SIZE
+    override def bufferSize(): Int = csvBufferSize
 
     override def multilineFields(): Boolean = true
 
@@ -57,11 +57,12 @@ object CSVResources {
 
 class CSVResources(cleaner: TaskCloser) extends ExternalCSVResource {
 
-  def getCsvIterator(url: URL, fieldTerminator: Option[String], legacyCsvQuoteEscaping: Boolean, headers: Boolean = false): Iterator[Array[String]] = {
+  def getCsvIterator(url: URL, fieldTerminator: Option[String], legacyCsvQuoteEscaping: Boolean, bufferSize: Int,
+                     headers: Boolean = false): Iterator[Array[String]] = {
 
     val reader: CharReadable = getReader(url)
     val delimiter: Char = fieldTerminator.map(_.charAt(0)).getOrElse(CSVResources.DEFAULT_FIELD_TERMINATOR)
-    val seeker = CharSeekers.charSeeker(reader, CSVResources.config(legacyCsvQuoteEscaping), true)
+    val seeker = CharSeekers.charSeeker(reader, CSVResources.config(legacyCsvQuoteEscaping, bufferSize), true)
     val extractor = new Extractors(delimiter).string()
     val intDelimiter = delimiter.toInt
     val mark = new Mark

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher
 
 import org.mockito.Mockito.when
+import org.neo4j.csv.reader.Configuration
 import org.neo4j.cypher.internal.compiler.v3_3.CypherCompilerConfiguration
 import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.idp.DefaultIDPSolverConfig
 import org.neo4j.cypher.internal.compiler.v3_3.spi.PlanContext
@@ -281,6 +282,7 @@ trait GraphDatabaseTestSupport extends CypherTestSupport with GraphIcing {
     errorIfShortestPathFallbackUsedAtRuntime = false,
     errorIfShortestPathHasCommonNodesAtRuntime = true,
     legacyCsvQuoteEscaping = false,
+    csvBufferSize = Configuration.DEFAULT_BUFFER_SIZE_4MB,
     planWithMinimumCardinalityEstimates = false
   )
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/CypherCompilerAstCacheAcceptanceTest.scala
@@ -31,6 +31,7 @@ import org.neo4j.cypher.internal.frontend.v3_3.DummyPosition
 import org.neo4j.cypher.internal.frontend.v3_3.ast.Statement
 import org.neo4j.cypher.internal.frontend.v3_3.phases.{CompilationPhaseTracer, StatsDivergenceCalculator, Transformer}
 import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.spi.v3_3.CSVResources.DEFAULT_BUFFER_SIZE
 import org.neo4j.cypher.internal.spi.v3_3.TransactionalContextWrapper
 import org.neo4j.cypher.internal.{CypherExecutionMode, PreParsedQuery}
 import org.neo4j.graphdb.config.Setting
@@ -55,6 +56,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
       errorIfShortestPathFallbackUsedAtRuntime = false,
       errorIfShortestPathHasCommonNodesAtRuntime = true,
       legacyCsvQuoteEscaping = false,
+      csvBufferSize = DEFAULT_BUFFER_SIZE,
       nonIndexedLabelWarningThreshold = 10000L,
       planWithMinimumCardinalityEstimates = false
     )

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/CheckForEagerLoadCsvTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/CheckForEagerLoadCsvTest.scala
@@ -24,17 +24,20 @@ import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes.{AllNodesScanP
 import org.neo4j.cypher.internal.frontend.v3_3.notification.EagerLoadCsvNotification
 import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.ir.v3_3.HasHeaders
+import org.neo4j.cypher.internal.spi.v3_3.CSVResources.DEFAULT_BUFFER_SIZE
 
 class CheckForEagerLoadCsvTest extends CypherFunSuite {
 
   test("should notify for EagerPipe on top of LoadCsvPipe") {
-    val pipe = EagerPipe(LoadCSVPipe(AllNodesScanPipe("a")(), HasHeaders, Literal("foo"), "bar", None, false)())()
+    val pipe = EagerPipe(LoadCSVPipe(AllNodesScanPipe("a")(), HasHeaders, Literal("foo"), "bar", None,
+                                     legacyCsvQuoteEscaping = false, DEFAULT_BUFFER_SIZE)())()
 
     checkForEagerLoadCsv(pipe) should equal(Some(EagerLoadCsvNotification))
   }
 
   test("should not notify for LoadCsv on top of eager pipe") {
-    val pipe = LoadCSVPipe(EagerPipe(AllNodesScanPipe("a")())(), HasHeaders, Literal("foo"), "bar", None, false)()
+    val pipe = LoadCSVPipe(EagerPipe(AllNodesScanPipe("a")())(), HasHeaders, Literal("foo"), "bar", None,
+                           legacyCsvQuoteEscaping = false, DEFAULT_BUFFER_SIZE)()
 
     checkForEagerLoadCsv(pipe) should equal(None)
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/CheckForLoadCsvAndMatchOnLargeLabelTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/CheckForLoadCsvAndMatchOnLargeLabelTest.scala
@@ -31,6 +31,7 @@ import org.neo4j.cypher.internal.frontend.v3_3.LabelId
 import org.neo4j.cypher.internal.frontend.v3_3.notification.LargeLabelWithLoadCsvNotification
 import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.ir.v3_3.{Cardinality, HasHeaders}
+import org.neo4j.cypher.internal.spi.v3_3.CSVResources.DEFAULT_BUFFER_SIZE
 
 class CheckForLoadCsvAndMatchOnLargeLabelTest extends CypherFunSuite {
   private val THRESHOLD = 100
@@ -51,7 +52,8 @@ class CheckForLoadCsvAndMatchOnLargeLabelTest extends CypherFunSuite {
   private val checker = CheckForLoadCsvAndMatchOnLargeLabel(planContext, THRESHOLD)
 
   test("should notify when doing LoadCsv on top of large label scan") {
-    val loadCsvPipe = LoadCSVPipe(SingleRowPipe()(), HasHeaders, Literal("foo"), "bar", None, false)()
+    val loadCsvPipe = LoadCSVPipe(SingleRowPipe()(), HasHeaders, Literal("foo"), "bar", None,
+                                  legacyCsvQuoteEscaping = false, DEFAULT_BUFFER_SIZE)()
     val pipe = NodeStartPipe(loadCsvPipe, "foo",
       NodeByLabelEntityProducer(NodeByLabel("bar", labelOverThreshold), indexFor(labelOverThreshold)))()
 
@@ -59,7 +61,8 @@ class CheckForLoadCsvAndMatchOnLargeLabelTest extends CypherFunSuite {
   }
 
   test("should not notify when doing LoadCsv on top of a large label scan") {
-    val loadCsvPipe = LoadCSVPipe(SingleRowPipe()(), HasHeaders, Literal("foo"), "bar", None, false)()
+    val loadCsvPipe = LoadCSVPipe(SingleRowPipe()(), HasHeaders, Literal("foo"), "bar", None,
+                                  legacyCsvQuoteEscaping = false, DEFAULT_BUFFER_SIZE)()
     val pipe = NodeStartPipe(loadCsvPipe, "foo",
       NodeByLabelEntityProducer(NodeByLabel("bar", labelUnderThrehsold), indexFor(labelUnderThrehsold)))()
 
@@ -68,7 +71,8 @@ class CheckForLoadCsvAndMatchOnLargeLabelTest extends CypherFunSuite {
 
   test("should not notify when doing LoadCsv on top of large label scan") {
     val startPipe = NodeStartPipe(SingleRowPipe()(), "foo", NodeByLabelEntityProducer(NodeByLabel("bar", labelOverThreshold), indexFor(labelOverThreshold)))()
-    val pipe = LoadCSVPipe(startPipe, HasHeaders, Literal("foo"), "bar", None, false)()
+    val pipe = LoadCSVPipe(startPipe, HasHeaders, Literal("foo"), "bar", None, legacyCsvQuoteEscaping = false,
+                           DEFAULT_BUFFER_SIZE)()
 
     checker(pipe) should equal(None)
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/LoadCsvPeriodicCommitObserverTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/LoadCsvPeriodicCommitObserverTest.scala
@@ -106,7 +106,7 @@ class LoadCsvPeriodicCommitObserverTest extends CypherFunSuite {
 
     // When
     verify(resource, times(1)).getCsvIterator(url, Some(";"), legacyCsvQuoteEscaping = false,
-                                              DEFAULT_BUFFER_SIZE)
+                                              DEFAULT_BUFFER_SIZE, false)
   }
 
   override protected def beforeEach() {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_3/CSVResourcesTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_3/CSVResourcesTest.scala
@@ -28,6 +28,7 @@ import org.neo4j.cypher.internal.compatibility.v3_3.runtime.TaskCloser
 import org.neo4j.cypher.internal.compiler.v3_3.test_helpers.CreateTempFileTestSupport
 import org.neo4j.cypher.internal.frontend.v3_3.LoadExternalResourceException
 import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.spi.v3_3.CSVResources.DEFAULT_BUFFER_SIZE
 import org.neo4j.io.fs.FileUtils
 
 class CSVResourcesTest extends CypherFunSuite with CreateTempFileTestSupport {
@@ -51,7 +52,8 @@ class CSVResourcesTest extends CypherFunSuite with CreateTempFileTestSupport {
     }
 
     //when
-    val result: List[Array[String]] = resources.getCsvIterator(new URL(url), None, false).toList
+    val result: List[Array[String]] = resources.getCsvIterator(new URL(url), None, legacyCsvQuoteEscaping = false,
+                                                               DEFAULT_BUFFER_SIZE).toList
 
     (result zip List(
       Array[String]("1"),
@@ -74,7 +76,8 @@ class CSVResourcesTest extends CypherFunSuite with CreateTempFileTestSupport {
     }
 
     //when
-    val result = resources.getCsvIterator(new URL(url), None, false).toList
+    val result = resources.getCsvIterator(new URL(url), None, legacyCsvQuoteEscaping = false,
+                                          DEFAULT_BUFFER_SIZE).toList
 
     //then
     (result zip List(
@@ -97,7 +100,8 @@ class CSVResourcesTest extends CypherFunSuite with CreateTempFileTestSupport {
     }
 
     //when
-    val result = resources.getCsvIterator(new URL(url), None, false).toList
+    val result = resources.getCsvIterator(new URL(url), None, legacyCsvQuoteEscaping = false,
+                                          DEFAULT_BUFFER_SIZE).toList
 
     //then
     (result zip List(
@@ -115,7 +119,8 @@ class CSVResourcesTest extends CypherFunSuite with CreateTempFileTestSupport {
     val url = createCSVTempFileURL(_ => {})
 
     //when
-    val result = resources.getCsvIterator(new URL(url), None, false).toList
+    val result = resources.getCsvIterator(new URL(url), None, legacyCsvQuoteEscaping = false,
+                                          DEFAULT_BUFFER_SIZE).toList
 
     result should equal(List.empty)
   }
@@ -130,7 +135,7 @@ class CSVResourcesTest extends CypherFunSuite with CreateTempFileTestSupport {
     }
 
     // when
-    resources.getCsvIterator(new URL(url), None, false)
+    resources.getCsvIterator(new URL(url), None, legacyCsvQuoteEscaping = false, DEFAULT_BUFFER_SIZE)
 
     // then
     verify(cleaner, times(1)).addTask(any(classOf[Boolean => Unit]))
@@ -147,7 +152,8 @@ class CSVResourcesTest extends CypherFunSuite with CreateTempFileTestSupport {
     }
 
     //when
-    val result: List[Array[String]] = resources.getCsvIterator(new URL(url), Some("\t"), false).toList
+    val result: List[Array[String]] = resources.getCsvIterator(new URL(url), Some("\t"), legacyCsvQuoteEscaping = false,
+                                                               DEFAULT_BUFFER_SIZE).toList
 
     (result zip List(
       Array[String]("122", "foo"),
@@ -169,7 +175,8 @@ class CSVResourcesTest extends CypherFunSuite with CreateTempFileTestSupport {
     }
 
     //when
-    val result: List[Array[String]] = resources.getCsvIterator(new URL(url), None, false).toList
+    val result: List[Array[String]] = resources.getCsvIterator(new URL(url), None, legacyCsvQuoteEscaping = false,
+                                                               DEFAULT_BUFFER_SIZE).toList
 
     (result zip List(
       Array[String]("Malm\u0246"),
@@ -191,7 +198,8 @@ class CSVResourcesTest extends CypherFunSuite with CreateTempFileTestSupport {
     }
 
     // when
-    val e = intercept[IllegalStateException](resources.getCsvIterator(new URL(url), None, false))
+    val e = intercept[IllegalStateException](resources.getCsvIterator(new URL(url), None, legacyCsvQuoteEscaping = false,
+                                                                      DEFAULT_BUFFER_SIZE))
 
     var path = url.replace("file:", "")
     if (SystemUtils.IS_OS_WINDOWS) {
@@ -204,8 +212,12 @@ class CSVResourcesTest extends CypherFunSuite with CreateTempFileTestSupport {
   }
 
   test("should handle local missing file") {
-    intercept[LoadExternalResourceException](resources.getCsvIterator(new URL("file:///this/file/url/probably/doesnt/exist"), None, legacyCsvQuoteEscaping = false).toList)
-    intercept[LoadExternalResourceException](resources.getCsvIterator(new URL("http://127.0.0.1/url/probably/doesnt/exist"), None, legacyCsvQuoteEscaping = false).toList)
+    intercept[LoadExternalResourceException](resources.getCsvIterator(
+      new URL("file:///this/file/url/probably/doesnt/exist"), None, legacyCsvQuoteEscaping = false,
+      DEFAULT_BUFFER_SIZE).toList)
+    intercept[LoadExternalResourceException](resources.getCsvIterator(
+      new URL("http://127.0.0.1/url/probably/doesnt/exist"), None, legacyCsvQuoteEscaping = false,
+      DEFAULT_BUFFER_SIZE).toList)
   }
 
   test("should parse multiline fields") {
@@ -219,7 +231,8 @@ class CSVResourcesTest extends CypherFunSuite with CreateTempFileTestSupport {
     }
 
     //when
-    val result: List[Array[String]] = resources.getCsvIterator(new URL(url), Some("\t"), false).toList
+    val result: List[Array[String]] = resources.getCsvIterator(new URL(url), Some("\t"), legacyCsvQuoteEscaping = false,
+                                                               DEFAULT_BUFFER_SIZE).toList
 
     (result zip List(
       Array[String]("a", "b"),

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -303,6 +303,12 @@ public class GraphDatabaseSettings implements LoadableConfig
             setting( "dbms.import.csv.legacy_quote_escaping", BOOLEAN,
                     Boolean.toString( Configuration.DEFAULT_LEGACY_STYLE_QUOTING ) );
 
+    @Description( "The size of the internal buffer in bytes used by `LOAD CSV`. If the csv file contains huge fields " +
+                  "this value may have to be increased." )
+    public static Setting<Integer> csv_buffer_size =
+            buildSetting( "dbms.import.csv.buffer_size", INTEGER, Integer.toString( 2 * Configuration.MB ) )
+                    .constraint( min( 1 ) ).build();
+
     @Description( "Enables or disables tracking of how much time a query spends actively executing on the CPU." )
     public static Setting<Boolean> track_query_cpu_time = setting( "dbms.track_query_cpu_time", BOOLEAN, TRUE );
     @Description( "Enables or disables tracking of how many bytes are allocated by the execution of a query." )

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CartesianProductNotificationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CartesianProductNotificationAcceptanceTest.scala
@@ -34,6 +34,7 @@ import org.neo4j.cypher.internal.frontend.v3_3.helpers.rewriting.RewriterStepSeq
 import org.neo4j.cypher.internal.frontend.v3_3.notification.CartesianProductNotification
 import org.neo4j.cypher.internal.frontend.v3_3.phases.{CompilationPhaseTracer, InternalNotificationLogger, StatsDivergenceCalculator}
 import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.spi.v3_3.CSVResources
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge
 
 class CartesianProductNotificationAcceptanceTest extends CypherFunSuite with GraphDatabaseTestSupport {
@@ -120,8 +121,9 @@ class CartesianProductNotificationAcceptanceTest extends CypherFunSuite with Gra
     errorIfShortestPathFallbackUsedAtRuntime = false,
     errorIfShortestPathHasCommonNodesAtRuntime = true,
     legacyCsvQuoteEscaping = false,
+    csvBufferSize = CSVResources.DEFAULT_BUFFER_SIZE,
     nonIndexedLabelWarningThreshold = 10000L,
-    false
+    planWithMinimumCardinalityEstimates = false
   )
   private lazy val monitors = WrappedMonitors(kernelMonitors)
   private val metricsFactory = CachedMetricsFactory(SimpleMetricsFactory)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceTest.scala
@@ -606,14 +606,12 @@ class LoadCsvAcceptanceTest
           writer.println(longName)
       })
       for (url <- urls) {
-
+        //TODO this message should mention `dbms.import.csv.buffer_size` in 3.5
         val error = intercept[QueryExecutionException](db.execute(
           s"""LOAD CSV WITH HEADERS FROM '$url' AS row
              |RETURN row.prop""".stripMargin).next().get("row.prop"))
-        error.getMessage should equal(
-          """Tried to read a field larger than the current buffer size.
-            | Make sure that the field doesn't have an unterminated quote,
-            | if it doesn't you can try increasing the buffer size via `dbms.import.csv.buffer_size`.""".stripMargin)
+        error.getMessage should startWith(
+          """Tried to read a field larger than buffer size 1048576.""".stripMargin)
       }
     }
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceTest.scala
@@ -40,7 +40,7 @@ import scala.collection.JavaConverters._
 
 class LoadCsvAcceptanceTest
   extends ExecutionEngineFunSuite with BeforeAndAfterAll
-  with QueryStatisticsTestSupport with CreateTempFileTestSupport with CypherComparisonSupport{
+  with QueryStatisticsTestSupport with CreateTempFileTestSupport with CypherComparisonSupport with RunWithConfigTestSupport {
 
   val expectedToSucceed = Configs.CommunityInterpreted - Configs.Cost2_3
   val expectedToFail = Configs.CommunityInterpreted - Configs.Cost2_3 + TestConfiguration(Versions.Default, Planners.Default,
@@ -594,6 +594,23 @@ class LoadCsvAcceptanceTest
       )
 
       result.toList should equal(List(Map("count(*)" -> 0)))
+    }
+  }
+
+  test("should be able to configure db to handle huge fields") {
+    runWithConfig(GraphDatabaseSettings.csv_buffer_size -> (4 * 1024 * 1024).toString) { db =>
+      val longName  = "f"* 6000000
+      val urls = csvUrls({
+        writer =>
+          writer.println("\"prop\"")
+          writer.println(longName)
+      })
+      for (url <- urls) {
+        val result = db.execute(
+          s"""LOAD CSV WITH HEADERS FROM '$url' AS row
+             |RETURN row.prop""".stripMargin)
+        result.next().get("row.prop") should equal(longName)
+      }
     }
   }
 


### PR DESCRIPTION
If csv-file contains huge fields we will overflow the internal buffer and  throw an error without users able to do much. This PR adds a db configuration - `dbms.import.csv.buffer_size` - that allows the internal buffer to be increased.
Fixes #11687

changelog: Add db-setting: `dbms.import.csv.buffer_size` allowing for increasing the internal buffer in order to handle csv-files with huge fields.