### PR TITLE
Avoid using finalization in GrabAllocator. Switch to use cleaner instead.

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/mem/MemoryAllocator.java
+++ b/community/io/src/main/java/org/neo4j/io/mem/MemoryAllocator.java
@@ -50,4 +50,9 @@ public interface MemoryAllocator
      * @throws OutOfMemoryError if the requested memory could not be allocated.
      */
     long allocateAligned( long bytes, long alignment );
+
+    /**
+     * Close all allocated resources and free all allocated memory.
+     */
+    void close();
 }

--- a/community/io/src/main/java/org/neo4j/io/mem/MemoryAllocator.java
+++ b/community/io/src/main/java/org/neo4j/io/mem/MemoryAllocator.java
@@ -23,7 +23,7 @@ import org.neo4j.io.ByteUnit;
 import org.neo4j.memory.MemoryAllocationTracker;
 
 /**
- * A MemoryAllocator is simple: it only allocates memory, until it itself is finalizable and frees it all in one go.
+ * A MemoryAllocator is simple: it only allocates memory, until it is closed and frees it all in one go.
  */
 public interface MemoryAllocator
 {
@@ -53,6 +53,9 @@ public interface MemoryAllocator
 
     /**
      * Close all allocated resources and free all allocated memory.
+     * Closing can happen by calling close explicitly or by GC as soon as allocator will become phantom reachable.
+     * It's up to implementations to guarantee correctness in scenario when multiple attempts will be made to release allocator resources.
+     * As soon as allocated resources will be cleaned any code that will try to access previously available memory will not gonna be able to do so.
      */
     void close();
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/PageList.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/PageList.java
@@ -535,9 +535,4 @@ class PageList
         sb.append( ", usageCounter = " ).append( getUsageCounter( pageRef ) );
         sb.append( " ] " ).append( OffHeapPageLock.toString( offLock( pageRef ) ) );
     }
-
-    public void close()
-    {
-        memoryAllocator.close();
-    }
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/PageList.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/PageList.java
@@ -535,4 +535,9 @@ class PageList
         sb.append( ", usageCounter = " ).append( getUsageCounter( pageRef ) );
         sb.append( " ] " ).append( OffHeapPageLock.toString( offLock( pageRef ) ) );
     }
+
+    public void close()
+    {
+        memoryAllocator.close();
+    }
 }

--- a/community/io/src/test/java/org/neo4j/io/mem/MemoryAllocatorTest.java
+++ b/community/io/src/test/java/org/neo4j/io/mem/MemoryAllocatorTest.java
@@ -170,7 +170,7 @@ public class MemoryAllocatorTest
         assertEquals( ByteUnit.mebiBytes( 1 ), memoryTracker.usedDirectMemory() );
 
         //noinspection FinalizeCalledExplicitly
-        allocator.finalize();
+        allocator.close();
         assertEquals( 0, memoryTracker.usedDirectMemory() );
     }
 }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -2798,7 +2798,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         PageCursor cursor = pagedFile.io( 0, PF_SHARED_WRITE_LOCK );
         assertTrue( cursor.next() );
 
-        Thread unmapper = fork( $close( pagedFile ) );
+        Thread unmapper = fork( closePageFile( pagedFile ) );
         unmapper.join( 100 );
 
         cursor.close();
@@ -2816,7 +2816,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         PageCursor cursor = pagedFile.io( 0, PF_SHARED_READ_LOCK );
         assertTrue( cursor.next() ); // Got a read lock
 
-        fork( $close( pagedFile ) ).join();
+        fork( closePageFile( pagedFile ) ).join();
 
         cursor.close();
     }
@@ -2832,7 +2832,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         PageCursor cursor = pagedFile.io( 0, PF_SHARED_READ_LOCK );
         assertTrue( cursor.next() ); // Got a pessimistic read lock
 
-        fork( $close( pagedFile ) ).join();
+        fork( closePageFile( pagedFile ) ).join();
 
         expectedException.expect( FileIsNotMappedException.class );
         cursor.next();
@@ -2851,7 +2851,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         assertTrue( cursor.next() );    // fault + unpin page 0
         assertTrue( cursor.next( 0 ) ); // potentially optimistic read lock page 0
 
-        fork( $close( pagedFile ) ).join();
+        fork( closePageFile( pagedFile ) ).join();
 
         try
         {
@@ -2877,7 +2877,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         assertTrue( cursor.next() );    // fault + unpin page 0
         assertTrue( cursor.next( 0 ) ); // potentially optimistic read lock page 0
 
-        fork( $close( pagedFile ) ).join();
+        fork( closePageFile( pagedFile ) ).join();
         pageCache.close();
         pageCache = null;
 

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTestSupport.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTestSupport.java
@@ -350,7 +350,7 @@ public abstract class PageCacheTestSupport<T extends PageCache>
         }
     }
 
-    protected Runnable $close( final PagedFile file )
+    protected Runnable closePageFile( final PagedFile file )
     {
         return () ->
         {


### PR DESCRIPTION
Update grabs to be cleaned using Cleaner.
Add possibility to close page list.
Small renaming in page cache tests.