### PR TITLE
Move global platform components out to PlatformModule

### DIFF
--- a/community/common/src/main/java/org/neo4j/kernel/lifecycle/LifeSupport.java
+++ b/community/common/src/main/java/org/neo4j/kernel/lifecycle/LifeSupport.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import org.neo4j.helpers.Exceptions;
+
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 
@@ -184,14 +186,7 @@ public class LifeSupport implements Lifecycle
                 }
                 catch ( LifecycleException e )
                 {
-                    if ( ex != null )
-                    {
-                        ex.addSuppressed( e );
-                    }
-                    else
-                    {
-                        ex = e;
-                    }
+                    ex = Exceptions.chain( ex, e );
                 }
             }
 
@@ -267,14 +262,7 @@ public class LifeSupport implements Lifecycle
             }
             catch ( LifecycleException e )
             {
-                if ( ex != null )
-                {
-                    ex.addSuppressed( e );
-                }
-                else
-                {
-                    ex = e;
-                }
+                ex = Exceptions.chain( ex, e );
             }
         }
         return ex;

--- a/community/kernel/src/main/java/org/neo4j/kernel/AvailabilityGuard.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/AvailabilityGuard.java
@@ -41,12 +41,12 @@ import org.neo4j.logging.Log;
  */
 public class AvailabilityGuard
 {
-    public static final String DATABASE_AVAILABLE_MSG = "Fulfilling of requirement makes database available: ";
-    public static final String DATABASE_UNAVAILABLE_MSG = "Requirement makes database unavailable: ";
+    private static final String DATABASE_AVAILABLE_MSG = "Fulfilling of requirement makes database available: ";
+    private static final String DATABASE_UNAVAILABLE_MSG = "Requirement makes database unavailable: ";
 
     public static class UnavailableException extends Exception implements Status.HasStatus
     {
-        public UnavailableException( String message )
+        UnavailableException( String message )
         {
             super( message );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/DatabaseAvailability.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/DatabaseAvailability.java
@@ -22,7 +22,7 @@ package org.neo4j.kernel;
 import java.time.Clock;
 
 import org.neo4j.kernel.impl.transaction.TransactionStats;
-import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.time.Clocks;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -35,7 +35,7 @@ import static org.neo4j.kernel.AvailabilityGuard.availabilityRequirement;
  * As it runs as the last service in the lifecycle list, the stop() is called first
  * on stop, shutdown or restart, and thus blocks access to everything else for outsiders.
  */
-public class DatabaseAvailability implements Lifecycle
+public class DatabaseAvailability extends LifecycleAdapter
 {
     private static final AvailabilityRequirement AVAILABILITY_REQUIREMENT = availabilityRequirement( "Database available" );
     private final AvailabilityGuard availabilityGuard;
@@ -51,11 +51,6 @@ public class DatabaseAvailability implements Lifecycle
 
         // On initial setup, deny availability
         availabilityGuard.require( AVAILABILITY_REQUIREMENT );
-    }
-
-    @Override
-    public void init()
-    {
     }
 
     @Override
@@ -83,11 +78,5 @@ public class DatabaseAvailability implements Lifecycle
         {
             parkNanos( MILLISECONDS.toNanos( 10 ) );
         }
-    }
-
-    @Override
-    public void shutdown()
-    {
-        // TODO: Starting database. Make sure none can access it through lock or CAS
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -503,9 +503,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
             throw new RuntimeException( e );
         }
 
-        // NOTE: please make sure this is performed after having added everything to the life, in fact we would like
-        // to perform the checkpointing as first step when the life is shutdown.
-        life.add( lifecycleToTriggerCheckPointOnShutdown() );
+        life.addLast( lifecycleToTriggerCheckPointOnShutdown() );
 
         try
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/StartupWaiter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/StartupWaiter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel;
+
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+/**
+ * At end of startup, wait for instance to become available for transactions.
+ * <p>
+ * This helps users who expect to be able to access the instance after
+ * the constructor is run.
+ */
+public class StartupWaiter extends LifecycleAdapter
+{
+    private final AvailabilityGuard availabilityGuard;
+    private final long timeout;
+
+    public StartupWaiter( AvailabilityGuard availabilityGuard, long timeout )
+    {
+        this.availabilityGuard = availabilityGuard;
+        this.timeout = timeout;
+    }
+
+    @Override
+    public void start()
+    {
+        availabilityGuard.isAvailable( timeout );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/VmPauseMonitorComponent.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/VmPauseMonitorComponent.java
@@ -21,12 +21,12 @@ package org.neo4j.kernel.impl.cache;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.kernel.monitoring.VmPauseMonitor;
 import org.neo4j.logging.Log;
 import org.neo4j.scheduler.JobScheduler;
 
-public class VmPauseMonitorComponent implements Lifecycle
+public class VmPauseMonitorComponent extends LifecycleAdapter
 {
     private final Config config;
     private final Log log;
@@ -38,11 +38,6 @@ public class VmPauseMonitorComponent implements Lifecycle
         this.config = config;
         this.log = log;
         this.jobScheduler = jobScheduler;
-    }
-
-    @Override
-    public void init()
-    {
     }
 
     @Override
@@ -61,11 +56,6 @@ public class VmPauseMonitorComponent implements Lifecycle
     {
         vmPauseMonitor.stop();
         vmPauseMonitor = null;
-    }
-
-    @Override
-    public void shutdown()
-    {
     }
 
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/ClassicCoreSPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/ClassicCoreSPI.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.impl.factory;
 
 import java.io.File;
 import java.net.URL;
-import java.util.Map;
 
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.Result;
@@ -29,10 +28,10 @@ import org.neo4j.graphdb.event.KernelEventHandler;
 import org.neo4j.graphdb.event.TransactionEventHandler;
 import org.neo4j.graphdb.security.URLAccessValidationError;
 import org.neo4j.internal.kernel.api.Kernel;
+import org.neo4j.internal.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.internal.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.explicitindex.AutoIndexing;
 import org.neo4j.kernel.impl.coreapi.CoreAPIAvailabilityGuard;
 import org.neo4j.kernel.impl.query.QueryExecutionKernelException;
@@ -99,13 +98,13 @@ class ClassicCoreSPI implements GraphDatabaseFacade.SPI
     @Override
     public void registerKernelEventHandler( KernelEventHandler handler )
     {
-        dataSource.kernelEventHandlers.registerKernelEventHandler( handler );
+        platform.eventHandlers.registerKernelEventHandler( handler );
     }
 
     @Override
     public void unregisterKernelEventHandler( KernelEventHandler handler )
     {
-        dataSource.kernelEventHandlers.unregisterKernelEventHandler( handler );
+        platform.eventHandlers.unregisterKernelEventHandler( handler );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
@@ -28,13 +28,18 @@ import java.util.function.Supplier;
 import org.neo4j.configuration.Internal;
 import org.neo4j.configuration.LoadableConfig;
 import org.neo4j.graphdb.config.Setting;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.security.URLAccessRule;
 import org.neo4j.kernel.AvailabilityGuard;
+import org.neo4j.kernel.DatabaseAvailability;
 import org.neo4j.kernel.NeoStoreDataSource;
+import org.neo4j.kernel.StartupWaiter;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
+import org.neo4j.kernel.impl.cache.VmPauseMonitorComponent;
 import org.neo4j.kernel.impl.coreapi.CoreAPIAvailabilityGuard;
+import org.neo4j.kernel.impl.pagecache.PublishPageCacheTracerMetricsAfterStart;
 import org.neo4j.kernel.impl.query.QueryEngineProvider;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
 import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
@@ -160,6 +165,14 @@ public class GraphDatabaseFacadeFactory
         AtomicReference<QueryExecutionEngine> queryEngine = new AtomicReference<>( noEngine() );
 
         final DataSourceModule dataSource = createDataSource( platform, edition, queryEngine::get );
+
+        platform.life.add( new VmPauseMonitorComponent( config, platform.logging.getInternalLog( VmPauseMonitorComponent.class ), platform.jobScheduler ) );
+        platform.life.add( new PublishPageCacheTracerMetricsAfterStart( platform.tracers.pageCursorTracerSupplier ) );
+        platform.life.add( new DatabaseAvailability( platform.availabilityGuard, platform.transactionMonitor,
+                config.get( GraphDatabaseSettings.shutdown_transaction_end_timeout ).toMillis() ) );
+        platform.life.add( new StartupWaiter( platform.availabilityGuard, edition.transactionStartTimeout ) );
+        platform.life.addLast( platform.eventHandlers );
+
         Logger msgLog = platform.logging.getInternalLog( getClass() ).infoLogger();
         CoreAPIAvailabilityGuard coreAPIAvailabilityGuard = edition.coreAPIAvailabilityGuard;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/KernelEventHandlers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/KernelEventHandlers.java
@@ -24,14 +24,13 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.neo4j.graphdb.event.ErrorState;
 import org.neo4j.graphdb.event.KernelEventHandler;
-import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.Log;
 
 /**
  * Handle the collection of kernel event handlers, and fire events as needed.
  */
-public class KernelEventHandlers
-    implements Lifecycle
+public class KernelEventHandlers extends LifecycleAdapter
 {
     private final List<KernelEventHandler> kernelEventHandlers = new CopyOnWriteArrayList<>();
     private final Log log;
@@ -39,21 +38,6 @@ public class KernelEventHandlers
     public KernelEventHandlers( Log log )
     {
         this.log = log;
-    }
-
-    @Override
-    public void init()
-    {
-    }
-
-    @Override
-    public void start()
-    {
-    }
-
-    @Override
-    public void stop()
-    {
     }
 
     @Override

--- a/community/udc/src/main/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollector.java
+++ b/community/udc/src/main/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollector.java
@@ -84,7 +84,7 @@ public class DefaultUdcInformationCollector implements UdcInformationCollector
 
     private NeoStoreDataSource neoStoreDataSource;
 
-    public DefaultUdcInformationCollector( Config config, DataSourceManager xadsm,
+    public DefaultUdcInformationCollector( Config config, DataSourceManager dataSourceManager,
             IdGeneratorFactory idGeneratorFactory, StartupStatistics startupStats, UsageData usageData )
     {
         this.config = config;
@@ -92,9 +92,9 @@ public class DefaultUdcInformationCollector implements UdcInformationCollector
         this.idGeneratorFactory = idGeneratorFactory;
         final StartupStatistics startupStatistics = startupStats;
 
-        if ( xadsm != null )
+        if ( dataSourceManager != null )
         {
-            xadsm.addListener( new DataSourceManager.Listener()
+            dataSourceManager.addListener( new DataSourceManager.Listener()
             {
                 @Override
                 public void registered( NeoStoreDataSource ds )

--- a/community/udc/src/main/java/org/neo4j/ext/udc/impl/UdcKernelExtension.java
+++ b/community/udc/src/main/java/org/neo4j/ext/udc/impl/UdcKernelExtension.java
@@ -23,11 +23,11 @@ import java.util.Timer;
 
 import org.neo4j.ext.udc.UdcSettings;
 import org.neo4j.helpers.HostnamePort;
-import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.core.StartupStatistics;
+import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
-import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.udc.UsageData;
 
 /**
@@ -39,7 +39,7 @@ import org.neo4j.udc.UsageData;
  * testing and short-run applications. Subsequent updates are made at regular
  * intervals. Both times are specified in milliseconds.
  */
-public class UdcKernelExtension implements Lifecycle
+public class UdcKernelExtension extends LifecycleAdapter
 {
     private Timer timer;
     private IdGeneratorFactory idGeneratorFactory;
@@ -57,11 +57,6 @@ public class UdcKernelExtension implements Lifecycle
         this.startupStats = startupStats;
         this.usageData = usageData;
         this.timer = timer;
-    }
-
-    @Override
-    public void init()
-    {
     }
 
     @Override
@@ -93,8 +88,4 @@ public class UdcKernelExtension implements Lifecycle
         }
     }
 
-    @Override
-    public void shutdown()
-    {
-    }
 }


### PR DESCRIPTION
Move global components form DataSourceModule to PlatformModule.
Update components to extend LifecycleAdapter instead of implementing
interface with empty methods.
Cleanup assertions in Lifecycle.