### PR TITLE
Aggregation (SUM, AVG) for Durations

### DIFF
--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/AvgFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/AvgFunction.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher.internal.runtime.interpreted.pipes.aggregation
 
+import java.time.temporal.ChronoUnit
+
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Expression
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.QueryState
@@ -37,27 +39,35 @@ class AvgFunction(val value: Expression)
 
   private var count: Long = 0L
 
+  private var monthsRunningAvg = 0d
+  private var daysRunningAvg = 0d
+  private var secondsRunningAvg = 0d
+  private var nanosRunningAvg = 0d
+
   override def result(state: QueryState): Value = aggregatingType match {
     case None =>
       Values.NO_VALUE
     case Some(AggregatingNumbers) =>
       sumNumber
     case Some(AggregatingDurations) =>
-      sumDuration.div(Values.longValue(count))
+      DurationValue.approximate(monthsRunningAvg, daysRunningAvg, secondsRunningAvg, nanosRunningAvg)
   }
 
   override def apply(data: ExecutionContext, state: QueryState) {
     val vl = value(data, state)
     actOnNumberOrDuration(vl,
       number => {
-      count += 1
+        count += 1
         val diff = number.minus(sumNumber)
         val next = diff.dividedBy(count.toDouble)
         sumNumber = overflowSafeAdd(sumNumber, next)
       },
       duration => {
         count += 1
-        sumDuration = sumDuration.add(duration)
+        monthsRunningAvg += (duration.get(ChronoUnit.MONTHS).asInstanceOf[Double] - monthsRunningAvg) / count
+        daysRunningAvg += (duration.get(ChronoUnit.DAYS).asInstanceOf[Double] - daysRunningAvg) / count
+        secondsRunningAvg += (duration.get(ChronoUnit.SECONDS).asInstanceOf[Double] - secondsRunningAvg) / count
+        nanosRunningAvg += (duration.get(ChronoUnit.NANOS).asInstanceOf[Double] - nanosRunningAvg) / count
       }
     )
   }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/NumericOrDurationAggregationExpression.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/NumericOrDurationAggregationExpression.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2002-2018 "Neo Technology,"
- * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
  *
  * This file is part of Neo4j.
  *

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/NumericOrDurationAggregationExpression.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/NumericOrDurationAggregationExpression.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.runtime.interpreted.pipes.aggregation
+
+import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Expression
+import org.neo4j.values.AnyValue
+import org.neo4j.values.storable.{DurationValue, NumberValue, Values}
+import org.opencypher.v9_0.util.CypherTypeException
+
+trait NumericOrDurationAggregationExpression {
+  trait AggregatingType
+  case object AggregatingNumbers extends AggregatingType
+  case object AggregatingDurations extends AggregatingType
+
+  protected var sumNumber: NumberValue = Values.ZERO_INT
+  protected var sumDuration: DurationValue = DurationValue.ZERO
+  protected var aggregatingType: Option[AggregatingType] = None
+
+  def name: String
+
+  def value: Expression
+
+  protected def actOnNumberOrDuration(vl: AnyValue, aggNumber: NumberValue => Unit, aggDuration: DurationValue => Unit) = {
+    vl match {
+      case Values.NO_VALUE =>
+      case number: NumberValue =>
+        aggregatingType match {
+          case None =>
+            aggregatingType = Some(AggregatingNumbers)
+          case Some(AggregatingDurations) =>
+            throw new CypherTypeException("%s(%s) cannot mix number and durations".format(name, value))
+          case _ =>
+        }
+        aggNumber(number)
+      case dur: DurationValue =>
+        aggregatingType match {
+          case None =>
+            aggregatingType = Some(AggregatingDurations)
+          case Some(AggregatingNumbers) =>
+            throw new CypherTypeException("%s(%s) cannot mix number and durations".format(name, value))
+          case _ =>
+        }
+        aggDuration(dur)
+      case _ =>
+        throw new CypherTypeException("%s(%s) can only handle numerical values, duration, or null.".format(name, value))
+    }
+  }
+}

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/SumFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/SumFunction.scala
@@ -23,21 +23,32 @@ import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Expression
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.QueryState
 import org.neo4j.values.AnyValue
-import org.neo4j.values.storable.{NumberValue, Values}
 import org.neo4j.values.utils.ValueMath.overflowSafeAdd
 
 class SumFunction(val value: Expression)
   extends AggregationFunction
-  with NumericExpressionOnly {
+    with NumericOrDurationAggregationExpression {
 
   def name = "SUM"
 
-  private var sum: NumberValue = Values.ZERO_INT
-  override def result(state: QueryState): AnyValue = sum
+  override def result(state: QueryState): AnyValue = aggregatingType match {
+    case None =>
+      sumNumber
+    case Some(AggregatingNumbers) =>
+      sumNumber
+    case Some(AggregatingDurations) =>
+      sumDuration
+  }
 
   override def apply(data: ExecutionContext, state: QueryState) {
-    actOnNumber(value(data, state), (number) => {
-      sum = overflowSafeAdd(sum, number)
-    })
+    val vl = value(data, state)
+    actOnNumberOrDuration(vl,
+      number => {
+        sumNumber = overflowSafeAdd(sumNumber, number)
+      },
+      duration => {
+        sumDuration = sumDuration.add(duration)
+      }
+    )
   }
 }

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/SumFunctionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/SumFunctionTest.scala
@@ -58,6 +58,13 @@ class SumFunctionTest extends CypherFunSuite with AggregateTest {
     }
   }
 
+  test("catches duration overflows") {
+    val durationValue = DurationValue.duration(0, 0, Long.MaxValue, 0)
+    an[ArithmeticException] shouldBe thrownBy{
+      aggregateOn(durationValue, durationValue)
+    }
+  }
+
   test("singleValueOfDecimalReturnsDecimal") {
     val result = aggregateOn(doubleValue(1.0d))
 

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/SumFunctionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/aggregation/SumFunctionTest.scala
@@ -23,7 +23,7 @@ import org.opencypher.v9_0.util.CypherTypeException
 import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Expression
 import org.opencypher.v9_0.util.test_helpers.CypherFunSuite
 import org.neo4j.values.storable.Values._
-import org.neo4j.values.storable.{DoubleValue, LongValue, Values}
+import org.neo4j.values.storable.{DoubleValue, DurationValue, LongValue, Values}
 
 class SumFunctionTest extends CypherFunSuite with AggregateTest {
   def createAggregator(inner: Expression) = new SumFunction(inner)
@@ -33,6 +33,29 @@ class SumFunctionTest extends CypherFunSuite with AggregateTest {
 
     result should equal(longValue(1))
     result shouldBe a [LongValue]
+  }
+
+  test("singleValueReturnsThatDuration") {
+    val durationValue = DurationValue.duration(0, 0, 0, 1)
+    val result = aggregateOn(durationValue)
+
+    result should equal(durationValue)
+  }
+
+  test("twoValuesReturnsDuration") {
+    val durationValue = DurationValue.duration(0, 0, 0, 1)
+    val durationValue2 = DurationValue.duration(0, 0, 1, 1)
+    val result = aggregateOn(durationValue, durationValue2)
+
+    result should equal(DurationValue.duration(0,0,1,2))
+  }
+
+  test("cantMixDurationAndNumber") {
+    val durationValue = DurationValue.duration(0, 0, 0, 1)
+    val numberValue = longValue(1)
+    a[CypherTypeException] shouldBe thrownBy{
+      aggregateOn(durationValue, numberValue)
+    }
   }
 
   test("singleValueOfDecimalReturnsDecimal") {

--- a/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
@@ -958,7 +958,11 @@ public final class DurationValue extends ScalarValue implements TemporalAmount, 
         return approximate( months / divisor, days / divisor, seconds / divisor, nanos / divisor );
     }
 
-    private static DurationValue approximate( double months, double days, double seconds, double nanos )
+    /**
+     * Returns an approximation of the provided values by rounding to whole units and recalculating
+     * the remainder into the smaller units.
+     */
+    public static DurationValue approximate( double months, double days, double seconds, double nanos )
     {
         long m = safeDoubleToLong( months );
         days += AVG_DAYS_PER_MONTH * (months - m);

--- a/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
@@ -177,7 +177,7 @@ public final class DurationValue extends ScalarValue implements TemporalAmount, 
     {
     }
 
-    private static final DurationValue ZERO = new DurationValue( 0, 0, 0, 0 );
+    public static final DurationValue ZERO = new DurationValue( 0, 0, 0, 0 );
     private static final List<TemporalUnit> UNITS = unmodifiableList( asList( MONTHS, DAYS, SECONDS, NANOS ) );
     // This comparator is safe until 292,271,023,045 years. After that, we have an overflow.
     private static final Comparator<DurationValue> COMPARATOR =

--- a/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
@@ -201,7 +201,7 @@ public final class DurationValue extends ScalarValue implements TemporalAmount, 
 
     private DurationValue( long months, long days, long seconds, long nanos )
     {
-        seconds += nanos / NANOS_PER_SECOND;
+        seconds = Math.addExact( seconds, nanos / NANOS_PER_SECOND);
         nanos %= NANOS_PER_SECOND;
         // normalize nanos to be between 0 and NANOS_PER_SECOND-1
         if ( nanos < 0 )
@@ -918,19 +918,19 @@ public final class DurationValue extends ScalarValue implements TemporalAmount, 
     public DurationValue add( DurationValue that )
     {
         return duration(
-                this.months + that.months,
-                this.days + that.days,
-                this.seconds + that.seconds,
-                this.nanos + that.nanos );
+                Math.addExact( this.months, that.months ),
+                Math.addExact( this.days, that.days ),
+                Math.addExact( this.seconds, that.seconds ),
+                Math.addExact( this.nanos, that.nanos ) );
     }
 
     public DurationValue sub( DurationValue that )
     {
         return duration(
-                this.months - that.months,
-                this.days - that.days,
-                this.seconds - that.seconds,
-                this.nanos - that.nanos );
+                Math.subtractExact( this.months, that.months ),
+                Math.subtractExact( this.days, that.days ),
+                Math.subtractExact( this.seconds, that.seconds ),
+                Math.subtractExact( this.nanos, that.nanos ) );
     }
 
     public DurationValue mul( NumberValue number )
@@ -938,7 +938,11 @@ public final class DurationValue extends ScalarValue implements TemporalAmount, 
         if ( number instanceof IntegralValue )
         {
             long factor = number.longValue();
-            return duration( months * factor, days * factor, seconds * factor, nanos * factor );
+            return duration(
+                    Math.multiplyExact( months, factor ),
+                    Math.multiplyExact( days, factor ),
+                    Math.multiplyExact( seconds, factor ),
+                    Math.multiplyExact( nanos, factor ) );
         }
         if ( number instanceof FloatingPointValue )
         {
@@ -956,14 +960,27 @@ public final class DurationValue extends ScalarValue implements TemporalAmount, 
 
     private static DurationValue approximate( double months, double days, double seconds, double nanos )
     {
-        long m = (long) months;
+        long m = safeDoubleToLong( months );
         days += AVG_DAYS_PER_MONTH * (months - m);
-        long d = (long) days;
+        long d = safeDoubleToLong( days );
         seconds += SECONDS_PER_DAY * (days - d);
-        long s = (long) seconds;
+        long s = safeDoubleToLong( seconds );
         nanos += NANOS_PER_SECOND * (seconds - s);
-        long n = (long) nanos;
+        long n = safeDoubleToLong( nanos );
         return duration( m, d, s, n );
+    }
+
+    /**
+     * Will cast a double to a long, but only if it is inside the limits of [Long.MIN_VALUE, LONG.MAX_VALUE]
+     * We need this to detect overflow errors, whereas normal truncation is OK while approximating.
+     */
+    private static long safeDoubleToLong( double d )
+    {
+        if ( d > Long.MAX_VALUE || d < Long.MIN_VALUE )
+        {
+            throw new ArithmeticException( "long overflow" );
+        }
+        return (long) d;
     }
 
     private static Temporal assertValidPlus( Temporal temporal, long amountToAdd, TemporalUnit unit )

--- a/community/values/src/test/java/org/neo4j/values/storable/DurationValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DurationValueTest.java
@@ -40,6 +40,7 @@ import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.helpers.collection.Pair.pair;
 import static org.neo4j.values.storable.DateTimeValue.datetime;
 import static org.neo4j.values.storable.DateValue.date;
@@ -378,6 +379,39 @@ public class DurationValueTest
         assertNotEquals(
                 duration( 1, 0, 0, 0 ).computeHash(),
                 duration( 0, 1, 0, 0 ).computeHash() );
+    }
+
+    @Test
+    public void shouldThrowExceptionOnAddOverflow()
+    {
+        DurationValue duration1 = duration( 0, 0, Long.MAX_VALUE, 500_000_000 );
+        DurationValue duration2 = duration( 0, 0, 1, 0 );
+        DurationValue duration3 = duration( 0, 0, 0, 500_000_000 );
+        assertThrows( ArithmeticException.class, () -> duration1.add( duration2 ) );
+        assertThrows( ArithmeticException.class, () -> duration1.add( duration3 ) );
+    }
+
+    @Test
+    public void shouldThrowExceptionOnSubtractOverflow()
+    {
+        DurationValue duration1 = duration( 0, 0, Long.MIN_VALUE, 0 );
+        DurationValue duration2 = duration( 0, 0, 1, 0 );
+        assertThrows( ArithmeticException.class, () -> duration1.sub( duration2 ) );
+    }
+
+    @Test
+    public void shouldThrowExceptionOnMultiplyOverflow()
+    {
+        DurationValue duration = duration( 0, 0, Long.MAX_VALUE, 0 );
+        assertThrows( ArithmeticException.class, () -> duration.mul( Values.intValue( 2 ) ) );
+        assertThrows( ArithmeticException.class, () -> duration.mul( Values.floatValue( 2 ) ) );
+    }
+
+    @Test
+    public void shouldThrowExceptionOnDivideOverflow()
+    {
+        DurationValue duration = duration( 0, 0, Long.MAX_VALUE, 0 );
+        assertThrows( ArithmeticException.class, () -> duration.div( Values.floatValue( 0.5f ) ) );
     }
 
     @Test


### PR DESCRIPTION
It is now possible to aggregate durations using SUM and AVG like
`UNWIND [duration('PT10S'), duration('P1D'), duration('PT30.5S')] as x RETURN sum(x)` or
`UNWIND [duration('PT10S'), duration('P1D'), duration('PT30.5S')] as x RETURN avg(x)`