### PR TITLE
Don't use ReferenceFromSlot in plan description

### DIFF
--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/SlottedRewriter.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/SlottedRewriter.scala
@@ -140,7 +140,7 @@ class SlottedRewriter(tokenContext: TokenContext) {
             else
               propExpression
 
-          case RefSlot(offset, _, _, _) => prop.copy(map = ReferenceFromSlot(offset))(prop.position)
+          case RefSlot(offset, _, _, name) => prop.copy(map = ReferenceFromSlot(offset, name))(prop.position)
         }
 
       case e@Equals(Variable(k1), Variable(k2)) => // TODO: Handle nullability
@@ -167,7 +167,7 @@ class SlottedRewriter(tokenContext: TokenContext) {
             case LongSlot(offset, true, CTNode, name) => NullCheck(offset, NodeFromSlot(offset, name))
             case LongSlot(offset, false, CTRelationship, name) => RelationshipFromSlot(offset, name)
             case LongSlot(offset, true, CTRelationship, name) => NullCheck(offset, RelationshipFromSlot(offset, name))
-            case RefSlot(offset, _, _, _) => ReferenceFromSlot(offset)
+            case RefSlot(offset, _, _, name) => ReferenceFromSlot(offset, name)
             case _ =>
               throw new CantCompileQueryException("Unknown type for `" + k + "` in the pipeline information")
           }

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/ast/ReferenceFromSlot.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/ast/ReferenceFromSlot.scala
@@ -19,4 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_3.runtime.ast
 
-case class ReferenceFromSlot(offset: Int) extends RuntimeExpression
+case class ReferenceFromSlot(offset: Int, name: String) extends RuntimeExpression {
+
+  override def toString: String = name
+}

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/ExecutionPlanDescriptionTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/ExecutionPlanDescriptionTest.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compatibility.v3_3.runtime
+
+import org.neo4j.cypher.internal.compatibility.v3_3.runtime.ast.ReferenceFromSlot
+import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.InternalPlanDescription.Arguments.{DbHits, EstimatedRows, Expression, Rows}
+import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.{NoChildren, PlanDescriptionImpl, renderAsTreeTable}
+import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.v3_3.logical.plans.LogicalPlanId
+
+class ExecutionPlanDescriptionTest extends CypherFunSuite {
+
+  test("use variable name instead of ReferenceFromSlot") {
+
+    val arguments = Seq(
+      Rows(42),
+      DbHits(33),
+      Expression(ReferenceFromSlot(42, "  id@23")),
+      EstimatedRows(1))
+
+    val plan = PlanDescriptionImpl(LogicalPlanId.DEFAULT, "NAME", NoChildren, arguments, Set("  n@76"))
+
+    val details = renderAsTreeTable(plan)
+    details should equal(
+      """+----------+----------------+------+---------+-----------+-------+
+        || Operator | Estimated Rows | Rows | DB Hits | Variables | Other |
+        |+----------+----------------+------+---------+-----------+-------+
+        || +NAME    |              1 |   42 |      33 | n         | id    |
+        |+----------+----------------+------+---------+-----------+-------+
+        |""".stripMargin)
+  }
+
+}

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/ExecutionPlanDescriptionTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/ExecutionPlanDescriptionTest.scala
@@ -22,10 +22,11 @@ package org.neo4j.cypher.internal.compatibility.v3_3.runtime
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.ast.ReferenceFromSlot
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.InternalPlanDescription.Arguments.{DbHits, EstimatedRows, Expression, Rows}
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.{NoChildren, PlanDescriptionImpl, renderAsTreeTable}
-import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.{CypherFunSuite, WindowsStringSafe}
 import org.neo4j.cypher.internal.v3_3.logical.plans.LogicalPlanId
 
 class ExecutionPlanDescriptionTest extends CypherFunSuite {
+  implicit val windowsSafe = WindowsStringSafe
 
   test("use variable name instead of ReferenceFromSlot") {
 

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/SlottedRewriterTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/SlottedRewriterTest.scala
@@ -283,7 +283,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
 
     // then
 
-    val pr1BafterRewrite = Projection(pr1A, Map("xx" -> ReferenceFromSlot(0)))(solved)
+    val pr1BafterRewrite = Projection(pr1A, Map("xx" -> ReferenceFromSlot(0, "x")))(solved)
     val applyAfterRewrite = Apply(pr1BafterRewrite, pr2)(solved)
 
     resultPlan should equal(

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/SlottedPipeBuilder.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/SlottedPipeBuilder.scala
@@ -285,8 +285,8 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
           case LongSlot(offset, true, CTRelationship, _) =>
             k -> slottedExpressions.NullCheck(offset, slottedExpressions.RelationshipFromSlot(offset))
 
-          case RefSlot(offset, _, _, _) =>
-            k -> slottedExpressions.ReferenceFromSlot(offset)
+          case RefSlot(offset, _, _, name) =>
+            k -> slottedExpressions.ReferenceFromSlot(offset, name)
 
           case _ =>
             throw new InternalException(s"Did not find `$k` in the pipeline information")

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/expressions/ReferenceFromSlot.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/expressions/ReferenceFromSlot.scala
@@ -24,9 +24,10 @@ import org.neo4j.cypher.internal.compatibility.v3_3.runtime.commands.expressions
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes.QueryState
 import org.neo4j.values.AnyValue
 
-case class ReferenceFromSlot(offset: Int) extends Expression with SlottedExpression {
+case class ReferenceFromSlot(offset: Int, name: String) extends Expression with SlottedExpression {
 
   override def apply(ctx: ExecutionContext, state: QueryState): AnyValue =
     ctx.getRefAt(offset)
 
+  override def toString: String = name
 }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/expressions/SlottedExpressionConverters.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/expressions/SlottedExpressionConverters.scala
@@ -32,8 +32,8 @@ object SlottedExpressionConverters extends ExpressionConverter {
         Some(runtimeExpression.NodeFromSlot(offset))
       case runtimeAst.RelationshipFromSlot(offset, _) =>
         Some(runtimeExpression.RelationshipFromSlot(offset))
-      case runtimeAst.ReferenceFromSlot(offset) =>
-        Some(runtimeExpression.ReferenceFromSlot(offset))
+      case runtimeAst.ReferenceFromSlot(offset, name) =>
+        Some(runtimeExpression.ReferenceFromSlot(offset, name))
       case runtimeAst.NodeProperty(offset, token, _) =>
         Some(runtimeExpression.NodeProperty(offset, token))
       case runtimeAst.RelationshipProperty(offset, token, _) =>

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/pipes/UnwindSlottedPipeTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/pipes/UnwindSlottedPipeTest.scala
@@ -45,7 +45,7 @@ class UnwindSlottedPipeTest extends CypherFunSuite {
     val y = outputPipeline.getReferenceOffsetFor("y")
 
     val source = FakeSlottedPipe(data.toIterator, inputPipeline)
-    val unwindPipe = UnwindSlottedPipe(source, ReferenceFromSlot(x), y, outputPipeline)()
+    val unwindPipe = UnwindSlottedPipe(source, ReferenceFromSlot(x, "x"), y, outputPipeline)()
     unwindPipe.createResults(QueryStateHelper.empty).map {
       case c: PrimitiveExecutionContext =>
         Map("x" -> c.getRefAt(x), "y" -> c.getRefAt(y))


### PR DESCRIPTION
Having `ReferenceFromSlot` in the plan description is not particularly
helpful. Instead we should display it just as we display variables in the
interpreted runtime.

changelog: Fixes problems where variables were displayed as `ReferenceFromSlot` in plan descriptions.