### PR TITLE
hasProperties and propertyType should be tx-state aware

### DIFF
--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTransactionStateTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTransactionStateTestBase.java
@@ -49,6 +49,7 @@ import static org.neo4j.internal.kernel.api.RelationshipTransactionStateTestBase
 import static org.neo4j.internal.kernel.api.RelationshipTransactionStateTestBase.RelationshipDirection.LOOP;
 import static org.neo4j.internal.kernel.api.RelationshipTransactionStateTestBase.RelationshipDirection.OUT;
 import static org.neo4j.values.storable.Values.NO_VALUE;
+import static org.neo4j.values.storable.Values.longValue;
 import static org.neo4j.values.storable.Values.stringValue;
 
 @SuppressWarnings( "Duplicates" )
@@ -1268,6 +1269,98 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
 
         return expectedCounts;
     }
+
+    @Test
+    public void hasPropertiesShouldSeeNewlyCreatedProperties() throws Exception
+    {
+        // Given
+        long relationship;
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            Write write = tx.dataWrite();
+            int token = tx.tokenWrite().relationshipTypeGetOrCreateForName( "R" );
+            relationship = write.relationshipCreate( write.nodeCreate(),
+                    token,
+                    write.nodeCreate() );
+            tx.success();
+        }
+
+        // Then
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            try ( RelationshipScanCursor cursor = tx.cursors().allocateRelationshipScanCursor() )
+            {
+                tx.dataRead().singleRelationship( relationship, cursor );
+                assertTrue( cursor.next() );
+                assertFalse( cursor.hasProperties() );
+                tx.dataWrite().relationshipSetProperty( relationship,
+                        tx.tokenWrite().propertyKeyGetOrCreateForName( "prop" ),
+                        stringValue( "foo" ) );
+                assertTrue( cursor.hasProperties() );
+            }
+        }
+    }
+
+    @Test
+    public void hasPropertiesShouldSeeNewlyCreatedPropertiesOnNewlyCreatedRelationship() throws Exception
+    {
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            Write write = tx.dataWrite();
+            int token = tx.tokenWrite().relationshipTypeGetOrCreateForName( "R" );
+            long relationship = write.relationshipCreate( write.nodeCreate(), token, write.nodeCreate() );
+            try ( RelationshipScanCursor cursor = tx.cursors().allocateRelationshipScanCursor() )
+            {
+                tx.dataRead().singleRelationship( relationship, cursor );
+                assertTrue( cursor.next() );
+                assertFalse( cursor.hasProperties() );
+                tx.dataWrite().relationshipSetProperty( relationship,
+                        tx.tokenWrite().propertyKeyGetOrCreateForName( "prop" ),
+                        stringValue( "foo" ) );
+                assertTrue( cursor.hasProperties() );
+            }
+        }
+    }
+
+    @Test
+    public void hasPropertiesShouldSeeNewlyRemovedProperties() throws Exception
+    {
+        // Given
+        long relationship;
+        int prop1, prop2, prop3;
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            Write write = tx.dataWrite();
+            int token = tx.tokenWrite().relationshipTypeGetOrCreateForName( "R" );
+            relationship = write.relationshipCreate( write.nodeCreate(), token, write.nodeCreate() );
+            prop1 = tx.tokenWrite().propertyKeyGetOrCreateForName( "prop1" );
+            prop2 = tx.tokenWrite().propertyKeyGetOrCreateForName( "prop2" );
+            prop3 = tx.tokenWrite().propertyKeyGetOrCreateForName( "prop3" );
+            tx.dataWrite().relationshipSetProperty( relationship, prop1, longValue( 1 ) );
+            tx.dataWrite().relationshipSetProperty( relationship, prop2, longValue( 2 ) );
+            tx.dataWrite().relationshipSetProperty( relationship, prop3, longValue( 3 ) );
+            tx.success();
+        }
+
+        // Then
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            try ( RelationshipScanCursor cursor = tx.cursors().allocateRelationshipScanCursor() )
+            {
+                tx.dataRead().singleRelationship( relationship, cursor );
+                assertTrue( cursor.next() );
+
+                assertTrue( cursor.hasProperties() );
+                tx.dataWrite().relationshipRemoveProperty( relationship, prop1 );
+                assertTrue( cursor.hasProperties() );
+                tx.dataWrite().relationshipRemoveProperty( relationship, prop2 );
+                assertTrue( cursor.hasProperties() );
+                tx.dataWrite().relationshipRemoveProperty( relationship, prop3 );
+                assertFalse( cursor.hasProperties() );
+            }
+        }
+    }
+
 
     private void relateNTimes( int nRelationshipsInStore, int type, long n1, long n2, Transaction tx )
             throws KernelException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultPropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultPropertyCursor.java
@@ -67,7 +67,7 @@ public class DefaultPropertyCursor extends PropertyRecord implements PropertyCur
     private AssertOpen assertOpen;
     private final DefaultCursors pool;
 
-    public DefaultPropertyCursor( DefaultCursors pool )
+    DefaultPropertyCursor( DefaultCursors pool )
     {
         super( NO_ID );
         this.pool = pool;
@@ -254,6 +254,11 @@ public class DefaultPropertyCursor extends PropertyRecord implements PropertyCur
     @Override
     public ValueGroup propertyType()
     {
+        if ( txStateValue != null )
+        {
+            return txStateValue.value().valueGroup();
+        }
+
         PropertyType type = type();
         if ( type == null )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipScanCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipScanCursor.java
@@ -37,7 +37,7 @@ class DefaultRelationshipScanCursor extends RelationshipCursor implements Relati
 
     DefaultRelationshipScanCursor( DefaultCursors pool )
     {
-        super(pool);
+        super( pool );
     }
 
     void scan( int type, Read read )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipScanCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipScanCursor.java
@@ -35,11 +35,9 @@ class DefaultRelationshipScanCursor extends RelationshipCursor implements Relati
     private PageCursor pageCursor;
     private Set<Long> addedRelationships;
 
-    private final DefaultCursors pool;
-
     DefaultRelationshipScanCursor( DefaultCursors pool )
     {
-        this.pool = pool;
+        super(pool);
     }
 
     void scan( int type, Read read )
@@ -142,6 +140,7 @@ class DefaultRelationshipScanCursor extends RelationshipCursor implements Relati
     @Override
     public void close()
     {
+        super.close();
         if ( !isClosed() )
         {
             read = null;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
@@ -122,7 +122,6 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
     private Record buffer;
     private PageCursor pageCursor;
     private final DefaultRelationshipGroupCursor group;
-    private final DefaultCursors pool;
     private GroupState groupState;
     private FilterState filterState;
     private boolean filterStore;
@@ -132,8 +131,8 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
 
     DefaultRelationshipTraversalCursor( DefaultRelationshipGroupCursor group, DefaultCursors pool )
     {
+        super(pool);
         this.group = group;
-        this.pool = pool;
     }
 
     /*
@@ -482,6 +481,7 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
     @Override
     public void close()
     {
+        super.close();
         if ( !isClosed() )
         {
             read = null;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
@@ -131,7 +131,7 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
 
     DefaultRelationshipTraversalCursor( DefaultRelationshipGroupCursor group, DefaultCursors pool )
     {
-        super(pool);
+        super( pool );
         this.group = group;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
@@ -60,7 +60,7 @@ abstract class RelationshipCursor extends RelationshipRecord implements Relation
     @Override
     public boolean hasProperties()
     {
-        if (read.hasTxStateWithChanges())
+        if ( read.hasTxStateWithChanges() )
         {
             PropertyCursor cursor = propertyCursor();
             properties( cursor );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
@@ -27,13 +27,16 @@ import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 
 abstract class RelationshipCursor extends RelationshipRecord implements RelationshipDataAccessor, RelationshipVisitor<RuntimeException>
 {
-    Read read;
     private boolean hasChanges;
     private boolean checkHasChanges;
+    private PropertyCursor propertyCursor;
+    final DefaultCursors pool;
+    Read read;
 
-    RelationshipCursor()
+    RelationshipCursor( DefaultCursors pool )
     {
         super( NO_ID );
+        this.pool = pool;
     }
 
     protected void init( Read read )
@@ -57,7 +60,16 @@ abstract class RelationshipCursor extends RelationshipRecord implements Relation
     @Override
     public boolean hasProperties()
     {
-        return nextProp != DefaultPropertyCursor.NO_ID;
+        if (read.hasTxStateWithChanges())
+        {
+            PropertyCursor cursor = propertyCursor();
+            properties( cursor );
+            return cursor.next();
+        }
+        else
+        {
+            return nextProp != DefaultPropertyCursor.NO_ID;
+        }
     }
 
     @Override
@@ -118,7 +130,7 @@ abstract class RelationshipCursor extends RelationshipRecord implements Relation
     }
 
     // Load transaction state using RelationshipVisitor
-    protected void loadFromTxState( long reference )
+    void loadFromTxState( long reference )
     {
         read.txState().relationshipVisit( reference, this );
     }
@@ -129,5 +141,23 @@ abstract class RelationshipCursor extends RelationshipRecord implements Relation
     {
         setId( relationshipId );
         initialize( true, NO_ID, startNodeId, endNodeId, typeId, NO_ID, NO_ID, NO_ID, NO_ID, false, false );
+    }
+
+    private PropertyCursor propertyCursor()
+    {
+        if ( propertyCursor == null )
+        {
+            propertyCursor = pool.allocatePropertyCursor();
+        }
+        return propertyCursor;
+    }
+
+    void close()
+    {
+        if ( propertyCursor != null )
+        {
+            propertyCursor.close();
+            propertyCursor = null;
+        }
     }
 }


### PR DESCRIPTION
The `hasProperties` method of `DefaultNodeCursor` and `DefaultRelationshipCursor`and `propertyType` of `DefaultPropertyCursor` weren't considering transaction state.