### PR TITLE
VarExpand: Detect dependencies on path in inner predicates

### DIFF
--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/idp/expandSolverStep.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/idp/expandSolverStep.scala
@@ -90,7 +90,7 @@ object expandSolverStep {
           qg.selections.predicatesGiven(availableSymbols + patternRel.name)
         val tempNode = patternRel.name + "_NODES"
         val tempEdge = patternRel.name + "_RELS"
-        val (nodePredicates: Seq[Expression], edgePredicates: Seq[Expression], solvedPredicates: Seq[Expression]) =
+        val (nodePredicates: Seq[Expression], edgePredicates: Seq[Expression], legacyPredicates: Seq[(Variable,Expression)], solvedPredicates: Seq[Expression]) =
           extractPredicates(
             availablePredicates,
             originalEdgeName = patternRel.name,
@@ -99,7 +99,6 @@ object expandSolverStep {
             originalNodeName = nodeId)
         val nodePredicate = Ands.create(nodePredicates.toSet)
         val relationshipPredicate = Ands.create(edgePredicates.toSet)
-        val legacyPredicates: Seq[(Variable, Expression)] = transformToLegacy(nodePredicate, relationshipPredicate, tempNode, tempEdge)
 
         context.logicalPlanProducer.planVarExpand(
           left = sourcePlan,
@@ -116,9 +115,5 @@ object expandSolverStep {
           legacyPredicates = legacyPredicates)
     }
   }
-
-  private def transformToLegacy(nodePredicate: Expression, edgePredicate: Expression, tempNode: String, tempEdge: String): Seq[(Variable, Expression)] =
-    (Seq(Variable(tempNode)(InputPosition.NONE), Variable(tempEdge)(InputPosition.NONE)) zip Seq(nodePredicate, edgePredicate)).
-      filterNot(_._2.getClass == classOf[True])
 
 }

--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/idp/expandSolverStep.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/idp/expandSolverStep.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_3.planner.logical.idp
 
 import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.LogicalPlanningContext
+import org.neo4j.cypher.internal.frontend.v3_3.InputPosition
 import org.neo4j.cypher.internal.frontend.v3_3.ast._
 import org.neo4j.cypher.internal.ir.v3_3._
 import org.neo4j.cypher.internal.v3_3.logical.plans.{ExpandAll, ExpandInto, LogicalPlan}
@@ -98,7 +99,7 @@ object expandSolverStep {
             originalNodeName = nodeId)
         val nodePredicate = Ands.create(nodePredicates.toSet)
         val relationshipPredicate = Ands.create(edgePredicates.toSet)
-        val legacyPredicates = extractLegacyPredicates(availablePredicates, patternRel, nodeId)
+        val legacyPredicates: Seq[(Variable, Expression)] = transformToLegacy(nodePredicate, relationshipPredicate, tempNode, tempEdge)
 
         context.logicalPlanProducer.planVarExpand(
           left = sourcePlan,
@@ -116,33 +117,8 @@ object expandSolverStep {
     }
   }
 
-  def extractLegacyPredicates(availablePredicates: Seq[Expression], patternRel: PatternRelationship,
-                              nodeId: String): Seq[(Variable, Expression)] = {
-    availablePredicates.collect {
-      //MATCH ()-[r* {prop:1337}]->()
-      case all@AllIterablePredicate(FilterScope(variable, Some(innerPredicate)), relId@Variable(patternRel.name))
-        if variable == relId || !innerPredicate.dependencies(relId) =>
-        (variable, innerPredicate) -> all
-      //MATCH p = ... WHERE all(n in nodes(p)... or all(r in relationships(p)
-      case all@AllIterablePredicate(FilterScope(variable, Some(innerPredicate)),
-      FunctionInvocation(_, FunctionName(fname), false,
-      Seq(PathExpression(
-      NodePathStep(startNode, MultiRelationshipPathStep(rel, _, NilPathStep) ))) ))
-        if (fname  == "nodes" || fname == "relationships")
-          && startNode.name == nodeId
-          && rel.name == patternRel.name =>
-        (variable, innerPredicate) -> all
-
-      //MATCH p = ... WHERE all(n in nodes(p)... or all(r in relationships(p)
-      case none@NoneIterablePredicate(FilterScope(variable, Some(innerPredicate)),
-      FunctionInvocation(_, FunctionName(fname), false,
-      Seq(PathExpression(
-      NodePathStep(startNode, MultiRelationshipPathStep(rel, _, NilPathStep) ))) ))
-        if (fname  == "nodes" || fname == "relationships")
-          && startNode.name == nodeId
-          && rel.name == patternRel.name =>
-        (variable, Not(innerPredicate)(innerPredicate.position)) -> none
-    }.unzip._1
-  }
+  private def transformToLegacy(nodePredicate: Expression, edgePredicate: Expression, tempNode: String, tempEdge: String): Seq[(Variable, Expression)] =
+    (Seq(Variable(tempNode)(InputPosition.NONE), Variable(tempEdge)(InputPosition.NONE)) zip Seq(nodePredicate, edgePredicate)).
+      filterNot(_._2.getClass == classOf[True])
 
 }

--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/idp/extractPredicates.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/idp/extractPredicates.scala
@@ -25,16 +25,17 @@ import org.neo4j.cypher.internal.frontend.v3_3.{Rewriter, bottomUp}
 object extractPredicates {
 
   // Using type predicates to make this more readable.
-  type NodePredicates = List[Expression]
-  type EdgePredicates = List[Expression]
-  type SolvedPredicates = List[Expression]
+  type NodePredicates = List[Expression] // for slotted runtime
+  type EdgePredicates = List[Expression] // for slotted runtime
+  type LegacyPredicates = List[(Variable, Expression)] // for interpreted runtime
+  type SolvedPredicates = List[Expression] // for marking predicates as solved
 
   def apply(availablePredicates: Seq[Expression],
             originalEdgeName: String,
             tempEdge: String,
             tempNode: String,
             originalNodeName: String)
-    : (NodePredicates, EdgePredicates, SolvedPredicates) = {
+    : (NodePredicates, EdgePredicates, LegacyPredicates, SolvedPredicates) = {
 
     /*
     We extract predicates that we can evaluate eagerly during the traversal, which allows us to abort traversing
@@ -43,8 +44,8 @@ object extractPredicates {
 
     During the folding, we also accumulate the original predicate, which we can mark as solved by this plan.
      */
-    val seed: (NodePredicates, EdgePredicates, SolvedPredicates) =
-      (List.empty, List.empty, List.empty)
+    val seed: (NodePredicates, EdgePredicates, LegacyPredicates, SolvedPredicates) =
+      (List.empty, List.empty, List.empty, List.empty)
 
     /**
       * Checks if an inner predicate depends on the path (i.e. the original start node or edge). In that case
@@ -55,47 +56,49 @@ object extractPredicates {
       */
     def pathDependent(innerPredicate: Expression) = {
       val names = innerPredicate.dependencies.map(_.name)
-      names.contains(originalEdgeName) || names.contains(originalNodeName)
+      names.contains(originalEdgeName)
     }
 
     availablePredicates.foldLeft(seed) {
 
       //MATCH ()-[r* {prop:1337}]->()
       case (
-          (n, e, s),
+          (n, e, l, s),
           p @ AllRelationships(variable, `originalEdgeName`, innerPredicate)) =>
         val rewrittenPredicate = innerPredicate.endoRewrite(replaceVariable(variable, tempEdge))
-        (n, e :+ rewrittenPredicate, s :+ p)
+        (n, e :+ rewrittenPredicate, l :+ (variable,innerPredicate), s :+ p)
 
       //MATCH p = (a)-[x*]->(b) WHERE ALL(r in rels(p) WHERE r.prop > 5)
-      case ((n, e, s),
+      case ((n, e, l, s),
             p @ AllRelationshipsInPath(`originalNodeName`, `originalEdgeName`, variable, innerPredicate))
             if !pathDependent(innerPredicate) =>
         val rewrittenPredicate = innerPredicate.endoRewrite(replaceVariable(variable, tempEdge))
-        (n, e :+ rewrittenPredicate, s :+ p)
+        (n, e :+ rewrittenPredicate, l :+ (variable,innerPredicate), s :+ p)
 
       //MATCH p = ()-[*]->() WHERE NONE(r in rels(p) WHERE <innerPredicate>)
-      case ((n, e, s),
+      case ((n, e, l, s),
             p @ NoRelationshipInPath(`originalNodeName`, `originalEdgeName`, variable, innerPredicate))
             if !pathDependent(innerPredicate) =>
         val rewrittenPredicate = innerPredicate.endoRewrite(replaceVariable(variable, tempEdge))
+        val negatedLegacyPredicate = Not(innerPredicate)(innerPredicate.position)
         val negatedPredicate = Not(rewrittenPredicate)(innerPredicate.position)
-        (n, e :+ negatedPredicate, s :+ p)
+        (n, e :+ negatedPredicate, l :+ (variable,negatedLegacyPredicate), s :+ p)
 
       //MATCH p = ()-[*]->() WHERE ALL(r in nodes(p) WHERE <innerPredicate>)
-      case ((n, e, s),
+      case ((n, e, l, s),
             p @ AllNodesInPath(`originalNodeName`, `originalEdgeName`, variable, innerPredicate))
             if !pathDependent(innerPredicate) =>
         val rewrittenPredicate = innerPredicate.endoRewrite(replaceVariable(variable, tempNode))
-        (n :+ rewrittenPredicate, e, s :+ p)
+        (n :+ rewrittenPredicate, e, l :+ (variable,innerPredicate), s :+ p)
 
       //MATCH p = ()-[*]->() WHERE NONE(r in nodes(p) WHERE <innerPredicate>)
-      case ((n, e, s),
+      case ((n, e, l, s),
             p @ NoNodeInPath(`originalNodeName`, `originalEdgeName`, variable, innerPredicate))
             if !pathDependent(innerPredicate) =>
         val rewrittenPredicate = innerPredicate.endoRewrite(replaceVariable(variable, tempNode))
+        val negatedLegacyPredicate = Not(innerPredicate)(innerPredicate.position)
         val negatedPredicate = Not(rewrittenPredicate)(innerPredicate.position)
-        (n :+ negatedPredicate, e, s :+ p)
+        (n :+ negatedPredicate, e, l :+ (variable,negatedLegacyPredicate), s :+ p)
 
       case (acc, _) =>
         acc

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/WithPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/WithPlanningIntegrationTest.scala
@@ -165,7 +165,7 @@ class WithPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
     plan.toString should equal(
       """Apply() {
         |  LHS -> Limit(SignedDecimalIntegerLiteral(1), DoNotIncludeTies) {
-        |    LHS -> VarExpand(a, OUTGOING, OUTGOING, List(), b, r, VarPatternLength(1,None), ExpandAll, r_NODES, r_RELS, True(), True(), Vector()) {
+        |    LHS -> VarExpand(a, OUTGOING, OUTGOING, List(), b, r, VarPatternLength(1,None), ExpandAll, r_NODES, r_RELS, True(), True(), List()) {
         |      LHS -> AllNodesScan(a, Set()) {}
         |    }
         |  }

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/idp/extractPredicatesTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/idp/extractPredicatesTest.scala
@@ -90,4 +90,105 @@ class extractPredicatesTest extends CypherFunSuite with AstConstructionTestSuppo
     edgePredicates shouldBe List(Not(LessThan(Property(varFor("x-edge"), PropertyKeyName("prop")(pos))(pos), literalInt(4))(pos))(pos))
     solvedPredicates shouldBe List(rewrittenRelPredicate, rewrittenNodePredicate)
   }
+
+  test("p = (n)-[r*1]->() WHERE ALL (x IN nodes(p) WHERE x.prop = n.prop") {
+    val pathExpression = PathExpression(
+      NodePathStep(
+        varFor("n"),
+        MultiRelationshipPathStep(varFor("r"),SemanticDirection.OUTGOING,NilPathStep)))(pos)
+
+    val nodePredicate = Equals(prop("x", "prop"), prop("n", "prop"))(pos)
+    val rewrittenPredicate = AllIterablePredicate(
+      FilterScope(varFor("x"), Some(nodePredicate))(pos),
+      FunctionInvocation(
+        FunctionName("nodes")(pos),
+        pathExpression)(pos))(pos)
+
+    val (nodePredicates: Seq[Expression], edgePredicates: Seq[Expression], solvedPredicates: Seq[Expression]) =
+      extractPredicates(Seq(rewrittenPredicate), "r", "r-edge", "r-node", "n")
+
+    nodePredicates shouldBe empty
+    edgePredicates shouldBe empty
+    solvedPredicates shouldBe empty
+  }
+
+  test("p = (n)-[r*1]->() WHERE ALL (x IN nodes(p) WHERE length(p) = 1)") {
+    val pathExpression = PathExpression(
+      NodePathStep(
+        varFor("n"),
+        MultiRelationshipPathStep(varFor("r"),SemanticDirection.OUTGOING,NilPathStep)))(pos)
+
+    val rewrittenPredicate = AllIterablePredicate(
+      FilterScope(varFor("x"), Some(Equals(FunctionInvocation(FunctionName("length")(pos), pathExpression)(pos), literalInt(1))(pos)))(pos),
+      FunctionInvocation(
+        FunctionName("nodes")(pos),
+        pathExpression)(pos))(pos)
+
+    val (nodePredicates: Seq[Expression], edgePredicates: Seq[Expression], solvedPredicates: Seq[Expression]) =
+      extractPredicates(Seq(rewrittenPredicate), "r", "r-edge", "r-node", "n")
+
+    nodePredicates shouldBe empty
+    edgePredicates shouldBe empty
+    solvedPredicates shouldBe empty
+  }
+
+  test("p = (n)-[r*1]->() WHERE ALL (x IN rels(p) WHERE length(p) = 1)") {
+    val pathExpression = PathExpression(
+      NodePathStep(
+        varFor("n"),
+        MultiRelationshipPathStep(varFor("r"),SemanticDirection.OUTGOING,NilPathStep)))(pos)
+
+    val rewrittenPredicate = AllIterablePredicate(
+      FilterScope(varFor("x"), Some(Equals(FunctionInvocation(FunctionName("length")(pos), pathExpression)(pos), literalInt(1))(pos)))(pos),
+      FunctionInvocation(
+        FunctionName("relationships")(pos),
+        pathExpression)(pos))(pos)
+
+    val (nodePredicates: Seq[Expression], edgePredicates: Seq[Expression], solvedPredicates: Seq[Expression]) =
+      extractPredicates(Seq(rewrittenPredicate), "r", "r-edge", "r-node", "n")
+
+    nodePredicates shouldBe empty
+    edgePredicates shouldBe empty
+    solvedPredicates shouldBe empty
+  }
+
+  test("p = (n)-[r*1]->() WHERE NONE (x IN nodes(p) WHERE length(p) = 1)") {
+    val pathExpression = PathExpression(
+      NodePathStep(
+        varFor("n"),
+        MultiRelationshipPathStep(varFor("r"),SemanticDirection.OUTGOING,NilPathStep)))(pos)
+
+    val rewrittenPredicate = NoneIterablePredicate(
+      FilterScope(varFor("x"), Some(Equals(FunctionInvocation(FunctionName("length")(pos), pathExpression)(pos), literalInt(1))(pos)))(pos),
+      FunctionInvocation(
+        FunctionName("nodes")(pos),
+        pathExpression)(pos))(pos)
+
+    val (nodePredicates: Seq[Expression], edgePredicates: Seq[Expression], solvedPredicates: Seq[Expression]) =
+      extractPredicates(Seq(rewrittenPredicate), "r", "r-edge", "r-node", "n")
+
+    nodePredicates shouldBe empty
+    edgePredicates shouldBe empty
+    solvedPredicates shouldBe empty
+  }
+
+  test("p = (n)-[r*1]->() WHERE NONE (x IN rels(p) WHERE length(p) = 1)") {
+    val pathExpression = PathExpression(
+      NodePathStep(
+        varFor("n"),
+        MultiRelationshipPathStep(varFor("r"),SemanticDirection.OUTGOING,NilPathStep)))(pos)
+
+    val rewrittenPredicate = NoneIterablePredicate(
+      FilterScope(varFor("x"), Some(Equals(FunctionInvocation(FunctionName("length")(pos), pathExpression)(pos), literalInt(1))(pos)))(pos),
+      FunctionInvocation(
+        FunctionName("relationships")(pos),
+        pathExpression)(pos))(pos)
+
+    val (nodePredicates: Seq[Expression], edgePredicates: Seq[Expression], solvedPredicates: Seq[Expression]) =
+      extractPredicates(Seq(rewrittenPredicate), "r", "r-edge", "r-node", "n")
+
+    nodePredicates shouldBe empty
+    edgePredicates shouldBe empty
+    solvedPredicates shouldBe empty
+  }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/VarLengthExpandQueryPlanAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/VarLengthExpandQueryPlanAcceptanceTest.scala
@@ -20,6 +20,7 @@
 package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.ExecutionEngineFunSuite
+import org.neo4j.graphdb.Path
 import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
 
 class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
@@ -139,6 +140,203 @@ class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite wit
       ComparePlansWithAssertion( plan => {
         plan should useOperators("VarLengthExpand(All)")
       }, expectPlansToFail = ignoreConfiguration))
+  }
+
+  test("AllNodesInPath with inner predicate using labelled nodes of the path") {
+    val node1 = createLabeledNode("NODE")
+    val node2 = createLabeledNode("NODE")
+    relate(node1,node2)
+
+    val query =
+      """ MATCH p = (:NODE)-[*1]->(:NODE)
+        | WHERE ALL(x IN nodes(p) WHERE single(y IN nodes(p) WHERE y = x))
+        | RETURN p
+      """.stripMargin
+
+    val configs = Configs.CommunityInterpreted - Configs.Cost3_2 - Configs.Cost3_1
+
+    val result = executeWith(configs, query)
+    val path = result.toList.head("p").asInstanceOf[Path]
+    path.startNode() should equal(node1)
+    path.endNode() should equal(node2)
+  }
+
+  test("AllNodesInPath with inner predicate using labelled named nodes of the path") {
+    val node1 = createLabeledNode("NODE")
+    val node2 = createLabeledNode("NODE")
+    relate(node1,node2)
+
+    val query =
+      """ MATCH p = (start:NODE)-[rel*1]->(end:NODE)
+        | WHERE ALL(x IN nodes(p) WHERE single(y IN nodes(p) WHERE y = x))
+        | RETURN p
+      """.stripMargin
+
+    val configs = Configs.CommunityInterpreted - Configs.Cost3_2 - Configs.Cost3_1
+
+    val result = executeWith(configs, query)
+    val path = result.toList.head("p").asInstanceOf[Path]
+    path.startNode() should equal(node1)
+    path.endNode() should equal(node2)
+  }
+
+  test("AllNodesInPath with inner predicate using nodes of the path") {
+    val node1 = createNode()
+    val node2 = createNode()
+    relate(node1,node2)
+
+    val query =
+      """
+        | MATCH p = ()-[*1]->()
+        | WHERE ALL(x IN nodes(p) WHERE single(y IN nodes(p) WHERE y = x))
+        | RETURN p
+      """.stripMargin
+
+    val configs = Configs.CommunityInterpreted - Configs.Cost3_2 - Configs.Cost3_1
+
+    val result = executeWith(configs, query)
+    val path = result.toList.head("p").asInstanceOf[Path]
+    path.startNode() should equal(node1)
+    path.endNode() should equal(node2)
+  }
+
+
+  test("AllNodesInPath with complex inner predicate using the start node and end node") {
+    val node1 = createLabeledNode(Map("prop" -> 1), "NODE")
+    val node2 = createLabeledNode(Map("prop" -> 1),"NODE")
+    relate(node1,node2)
+
+    val query =
+      """
+        | MATCH p = (start:NODE)-[*1..2]->(end:NODE)
+        | WHERE ALL(x IN nodes(p) WHERE x.prop = nodes(p)[0].prop AND x.prop = nodes(p)[1].prop)
+        | RETURN p
+      """.stripMargin
+
+    val configs = Configs.CommunityInterpreted - Configs.Cost3_2 - Configs.Cost3_1 - Configs.Version2_3
+
+    val result = executeWith(configs, query)
+    val path = result.toList.head("p").asInstanceOf[Path]
+    path.startNode() should equal(node1)
+    path.endNode() should equal(node2)
+  }
+
+  test("AllNodesInPath with simple inner predicate") {
+    val node1 = createLabeledNode("NODE")
+    val node2 = createLabeledNode("NODE")
+    relate(node1,node2)
+
+    val query =
+      """ MATCH p = (:NODE)-[*1]->(:NODE)
+        | WHERE ALL(x IN nodes(p) WHERE length(p) = 1)
+        | RETURN p
+      """.stripMargin
+
+    val configs = Configs.CommunityInterpreted - Configs.Cost3_2 - Configs.Cost3_1
+
+    val result = executeWith(configs, query)
+    val path = result.toList.head("p").asInstanceOf[Path]
+    path.startNode() should equal(node1)
+    path.endNode() should equal(node2)
+  }
+
+  test("AllNodesInPath with inner predicate only using start node") {
+    val node1 = createLabeledNode(Map("prop" -> 5),"NODE")
+    val node2 = createLabeledNode(Map("prop" -> 5),"NODE")
+    relate(node1,node2)
+
+    val query =
+      """ MATCH p = (n)-[r*1]->()
+        | WHERE ALL(x IN nodes(p) WHERE x.prop = n.prop)
+        | RETURN p
+      """.stripMargin
+
+    val configs = Configs.CommunityInterpreted
+
+    val result = executeWith(configs, query)
+    val path = result.toList.head("p").asInstanceOf[Path]
+    path.startNode() should equal(node1)
+    path.endNode() should equal(node2)
+  }
+
+  test("AllRelationshipsInPath with inner predicate using rels of the path") {
+    val node1 = createLabeledNode("NODE")
+    val node2 = createLabeledNode("NODE")
+    relate(node1,node2)
+
+    val query =
+      """
+        | MATCH p = (:NODE)-[*1]->(:NODE)
+        | WHERE ALL(x IN rels(p) WHERE single(y IN rels(p) WHERE y = x))
+        | RETURN p
+      """.stripMargin
+
+    val configs = Configs.CommunityInterpreted - Configs.Cost3_2 - Configs.Cost3_1
+
+    val result = executeWith(configs, query)
+    val path = result.toList.head("p").asInstanceOf[Path]
+    path.startNode() should equal(node1)
+    path.endNode() should equal(node2)
+  }
+
+  test("AllRelationshipsInPath with simple inner predicate") {
+    val node1 = createLabeledNode("NODE")
+    val node2 = createLabeledNode("NODE")
+    relate(node1,node2)
+
+    val query =
+      """
+        | MATCH p = (:NODE)-[*1]->(:NODE)
+        | WHERE ALL(x IN rels(p) WHERE length(p) = 1)
+        | RETURN p
+      """.stripMargin
+
+    val configs = Configs.CommunityInterpreted - Configs.Cost3_2 - Configs.Cost3_1
+
+    val result = executeWith(configs, query)
+    val path = result.toList.head("p").asInstanceOf[Path]
+    path.startNode() should equal(node1)
+    path.endNode() should equal(node2)
+  }
+
+  test("NoNodesInPath with simple inner predicate") {
+    val node1 = createLabeledNode("NODE")
+    val node2 = createLabeledNode("NODE")
+    relate(node1,node2)
+
+    val query =
+      """
+        | MATCH p = (:NODE)-[*1..2]->(:NODE)
+        | WHERE NONE(x IN nodes(p) WHERE length(p) = 2)
+        | RETURN p
+      """.stripMargin
+
+    val configs = Configs.CommunityInterpreted - Configs.Cost3_2 - Configs.Cost3_1
+
+    val result = executeWith(configs, query)
+    val path = result.toList.head("p").asInstanceOf[Path]
+    path.startNode() should equal(node1)
+    path.endNode() should equal(node2)
+  }
+
+  test("NoRelationshipsInPath with simple inner predicate") {
+    val node1 = createLabeledNode("NODE")
+    val node2 = createLabeledNode("NODE")
+    relate(node1,node2)
+
+    val query =
+      """
+        | MATCH p = (:NODE)-[*1..2]->(:NODE)
+        | WHERE NONE(x IN rels(p) WHERE length(p) = 2)
+        | RETURN p
+      """.stripMargin
+
+    val configs = Configs.CommunityInterpreted - Configs.Cost3_2 - Configs.Cost3_1
+
+    val result = executeWith(configs, query)
+    val path = result.toList.head("p").asInstanceOf[Path]
+    path.startNode() should equal(node1)
+    path.endNode() should equal(node2)
   }
 
   //  test("Do not plan pruning var expand when path is needed") {


### PR DESCRIPTION
In the cases where the inner predicate has a dependency on the path
(and not just the current node/relationship), we must evaluate the
predicates after the VarExpand.

Fixes #11653