### PR TITLE
Use EnumMap instead of T[] in fusion index

### DIFF
--- a/community/collections/src/main/java/org/neo4j/helpers/collection/Iterables.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/Iterables.java
@@ -249,7 +249,7 @@ public final class Iterables
         return concat( Arrays.asList( (Iterable<T>[]) iterables ) );
     }
 
-    public static <T> Iterable<T> concat( final Iterable<Iterable<T>> iterables )
+    public static <T> Iterable<T> concat( final Iterable<? extends Iterable<T>> iterables )
     {
         return new CombiningIterable<>( iterables );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexPopulator.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.StreamSupport;
 
 import org.neo4j.gis.spatial.index.curves.SpaceFillingCurveConfiguration;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -136,10 +135,12 @@ class SpatialIndexPopulator extends SpatialIndexCache<SpatialIndexPopulator.Part
     @Override
     public IndexSample sampleResult()
     {
-        IndexSample[] indexSamples = StreamSupport.stream( this.spliterator(), false )
-                .map( PartPopulator::sampleResult )
-                .toArray( IndexSample[]::new );
-        return combineSamples( indexSamples );
+        List<IndexSample> samples = new ArrayList<>();
+        for ( PartPopulator partPopulator : this )
+        {
+            samples.add( partPopulator.sampleResult() );
+        }
+        return combineSamples( samples );
     }
 
     static class PartPopulator extends NativeSchemaIndexPopulator<SpatialSchemaKey, NativeSchemaValue>

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SpatialIndexReader.java
@@ -19,9 +19,11 @@
  */
 package org.neo4j.kernel.impl.index.schema;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.neo4j.collection.PrimitiveLongResourceIterator;
 import org.neo4j.graphdb.Resource;
-import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.internal.kernel.api.IndexOrder;
 import org.neo4j.internal.kernel.api.IndexQuery;
 import org.neo4j.internal.kernel.api.IndexQuery.ExistsPredicate;
@@ -64,7 +66,12 @@ class SpatialIndexReader extends SpatialIndexCache<SpatialIndexPartReader<Native
     @Override
     public IndexSampler createSampler()
     {
-        return new FusionIndexSampler( Iterators.stream( iterator() ).map( IndexReader::createSampler ).toArray( IndexSampler[]::new ) );
+        List<IndexSampler> samplers = new ArrayList<>();
+        for ( SpatialIndexPartReader<NativeSchemaValue> partReader : this )
+        {
+            samplers.add( partReader.createSampler() );
+        }
+        return new FusionIndexSampler( samplers );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexPopulator.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.StreamSupport;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
@@ -131,10 +130,12 @@ class TemporalIndexPopulator extends TemporalIndexCache<TemporalIndexPopulator.P
     @Override
     public IndexSample sampleResult()
     {
-        IndexSample[] indexSamples = StreamSupport.stream( this.spliterator(), false )
-                .map( PartPopulator::sampleResult )
-                .toArray( IndexSample[]::new );
-        return combineSamples( indexSamples );
+        List<IndexSample> samples = new ArrayList<>();
+        for ( PartPopulator<?> partPopulator : this )
+        {
+            samples.add( partPopulator.sampleResult() );
+        }
+        return combineSamples( samples );
     }
 
     static class PartPopulator<KEY extends NativeSchemaKey<KEY>> extends NativeSchemaIndexPopulator<KEY, NativeSchemaValue>

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TemporalIndexReader.java
@@ -19,9 +19,11 @@
  */
 package org.neo4j.kernel.impl.index.schema;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.neo4j.collection.PrimitiveLongResourceIterator;
 import org.neo4j.graphdb.Resource;
-import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.internal.kernel.api.IndexOrder;
 import org.neo4j.internal.kernel.api.IndexQuery;
 import org.neo4j.internal.kernel.api.IndexQuery.ExistsPredicate;
@@ -62,7 +64,12 @@ class TemporalIndexReader extends TemporalIndexCache<TemporalIndexPartReader<?>>
     @Override
     public IndexSampler createSampler()
     {
-        return new FusionIndexSampler( Iterators.stream( iterator() ).map( IndexReader::createSampler ).toArray( IndexSampler[]::new ) );
+        List<IndexSampler> samplers = new ArrayList<>();
+        for ( TemporalIndexPartReader<?> partReader : this )
+        {
+            samplers.add( partReader.createSampler() );
+        }
+        return new FusionIndexSampler( samplers );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexAccessor.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.index.schema.fusion;
 import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.stream.StreamSupport;
 
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.collection.BoundedIterable;
@@ -150,8 +149,7 @@ class FusionIndexAccessor extends FusionIndexBase<IndexAccessor> implements Inde
     @Override
     public boolean isDirty()
     {
-        return StreamSupport.stream( instanceSelector.flatMap( IndexAccessor::isDirty ).spliterator(), false )
-                .anyMatch( Boolean::booleanValue );
+        return Iterables.stream( instanceSelector.flatMap( IndexAccessor::isDirty ) ).anyMatch( Boolean::booleanValue );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexAccessor.java
@@ -96,7 +96,7 @@ class FusionIndexAccessor extends FusionIndexBase<IndexAccessor> implements Inde
     @Override
     public BoundedIterable<Long> newAllEntriesReader()
     {
-        Iterable<BoundedIterable<Long>> entries = instanceSelector.flatMap( IndexAccessor::newAllEntriesReader );
+        Iterable<BoundedIterable<Long>> entries = instanceSelector.transform( IndexAccessor::newAllEntriesReader );
         return new BoundedIterable<Long>()
         {
             @Override
@@ -133,7 +133,7 @@ class FusionIndexAccessor extends FusionIndexBase<IndexAccessor> implements Inde
     @Override
     public ResourceIterator<File> snapshotFiles() throws IOException
     {
-        return concatResourceIterators( instanceSelector.flatMap( IndexAccessor::snapshotFiles ).iterator() );
+        return concatResourceIterators( instanceSelector.transform( IndexAccessor::snapshotFiles ).iterator() );
     }
 
     @Override
@@ -149,7 +149,7 @@ class FusionIndexAccessor extends FusionIndexBase<IndexAccessor> implements Inde
     @Override
     public boolean isDirty()
     {
-        return Iterables.stream( instanceSelector.flatMap( IndexAccessor::isDirty ) ).anyMatch( Boolean::booleanValue );
+        return Iterables.stream( instanceSelector.transform( IndexAccessor::isDirty ) ).anyMatch( Boolean::booleanValue );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulator.java
@@ -122,6 +122,6 @@ class FusionIndexPopulator extends FusionIndexBase<IndexPopulator> implements In
     @Override
     public IndexSample sampleResult()
     {
-        return combineSamples( instanceSelector.flatMap( IndexPopulator::sampleResult ) );
+        return combineSamples( instanceSelector.transform( IndexPopulator::sampleResult ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexProvider.java
@@ -193,7 +193,6 @@ public class FusionIndexProvider extends IndexProvider
          *
          * @param indexId the index id, for which directory to drop.
          * @param archiveExistentIndex create archive with content of dropped directories
-         * @throws IOException on I/O error.
          * @see GraphDatabaseSettings#archive_failed_index
          */
         void drop( long indexId, boolean archiveExistentIndex );
@@ -202,7 +201,6 @@ public class FusionIndexProvider extends IndexProvider
          * Deletes the index directory and everything in it, as last part of dropping an index.
          *
          * @param indexId the index id, for which directory to drop.
-         * @throws IOException on I/O error.
          */
         default void drop( long indexId )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexProvider.java
@@ -142,7 +142,7 @@ public class FusionIndexProvider extends IndexProvider
     @Override
     public InternalIndexState getInitialState( StoreIndexDescriptor descriptor )
     {
-        Iterable<InternalIndexState> statesIterable = providers.flatMap( p -> p.getInitialState( descriptor ) );
+        Iterable<InternalIndexState> statesIterable = providers.transform( p -> p.getInitialState( descriptor ) );
         List<InternalIndexState> states = Iterables.asList( statesIterable );
         if ( states.contains( FAILED ) )
         {
@@ -161,7 +161,7 @@ public class FusionIndexProvider extends IndexProvider
     @Override
     public IndexCapability getCapability()
     {
-        Iterable<IndexCapability> capabilities = providers.flatMap( IndexProvider::getCapability );
+        Iterable<IndexCapability> capabilities = providers.transform( IndexProvider::getCapability );
         return new UnionIndexCapability( capabilities )
         {
             @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexReader.java
@@ -62,7 +62,7 @@ class FusionIndexReader extends FusionIndexBase<IndexReader> implements IndexRea
     @Override
     public IndexSampler createSampler()
     {
-        return new FusionIndexSampler( instanceSelector.flatMap( IndexReader::createSampler ) );
+        return new FusionIndexSampler( instanceSelector.transform( IndexReader::createSampler ) );
     }
 
     @Override
@@ -71,7 +71,7 @@ class FusionIndexReader extends FusionIndexBase<IndexReader> implements IndexRea
         IndexSlot slot = slotSelector.selectSlot( predicates, IndexQuery::valueGroup );
         return slot != null
                ? instanceSelector.select( slot ).query( predicates )
-               : concat( instanceSelector.flatMap( reader -> reader.query( predicates ) ) );
+               : concat( instanceSelector.transform( reader -> reader.query( predicates ) ) );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexSampler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexSampler.java
@@ -19,15 +19,18 @@
  */
 package org.neo4j.kernel.impl.index.schema.fusion;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.storageengine.api.schema.IndexSample;
 import org.neo4j.storageengine.api.schema.IndexSampler;
 
 public class FusionIndexSampler implements IndexSampler
 {
-    private final IndexSampler[] samplers;
+    private final Iterable<IndexSampler> samplers;
 
-    public FusionIndexSampler( IndexSampler... samplers )
+    public FusionIndexSampler( Iterable<IndexSampler> samplers )
     {
         this.samplers = samplers;
     }
@@ -35,15 +38,15 @@ public class FusionIndexSampler implements IndexSampler
     @Override
     public IndexSample sampleIndex() throws IndexNotFoundKernelException
     {
-        IndexSample[] samples = new IndexSample[samplers.length];
-        for ( int i = 0; i < samplers.length; i++ )
+        List<IndexSample> samples = new ArrayList<>();
+        for ( IndexSampler sampler : samplers )
         {
-            samples[i] = samplers[i].sampleIndex();
+            samples.add( sampler.sampleIndex() );
         }
         return combineSamples( samples );
     }
 
-    public static IndexSample combineSamples( IndexSample... samples )
+    public static IndexSample combineSamples( Iterable<IndexSample> samples )
     {
         long indexSize = 0;
         long uniqueValues = 0;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSlotSelector00.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSlotSelector00.java
@@ -24,6 +24,10 @@ import java.util.function.Function;
 import org.neo4j.kernel.api.index.IndexProvider;
 import org.neo4j.values.storable.ValueGroup;
 
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.LUCENE;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.SPATIAL;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.TEMPORAL;
+
 /**
  * Selector for index provider "lucene-1.x".
  * The version name "00" comes from lucene-1.x originally not being a fusion index.
@@ -31,13 +35,13 @@ import org.neo4j.values.storable.ValueGroup;
 public class FusionSlotSelector00 implements SlotSelector
 {
     @Override
-    public void validateSatisfied( IndexProvider[] instances )
+    public void validateSatisfied( InstanceSelector<IndexProvider> instances )
     {
         SlotSelector.validateSelectorInstances( instances, LUCENE, SPATIAL, TEMPORAL );
     }
 
     @Override
-    public <V> int selectSlot( V[] values, Function<V,ValueGroup> groupOf )
+    public <V> IndexSlot selectSlot( V[] values, Function<V,ValueGroup> groupOf )
     {
         if ( values.length > 1 )
         {
@@ -52,7 +56,7 @@ public class FusionSlotSelector00 implements SlotSelector
         case TEMPORAL:
             return TEMPORAL;
         case UNKNOWN:
-            return UNKNOWN;
+            return null;
         default:
             return LUCENE;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSlotSelector10.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSlotSelector10.java
@@ -24,6 +24,11 @@ import java.util.function.Function;
 import org.neo4j.kernel.api.index.IndexProvider;
 import org.neo4j.values.storable.ValueGroup;
 
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.LUCENE;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.NUMBER;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.SPATIAL;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.TEMPORAL;
+
 /**
  * Selector for "lucene+native-1.x".
  * Separates numbers into native index.
@@ -31,13 +36,13 @@ import org.neo4j.values.storable.ValueGroup;
 public class FusionSlotSelector10 implements SlotSelector
 {
     @Override
-    public void validateSatisfied( IndexProvider[] instances )
+    public void validateSatisfied( InstanceSelector<IndexProvider> instances )
     {
         SlotSelector.validateSelectorInstances( instances, NUMBER, LUCENE, SPATIAL, TEMPORAL );
     }
 
     @Override
-    public <V> int selectSlot( V[] values, Function<V,ValueGroup> groupOf )
+    public <V> IndexSlot selectSlot( V[] values, Function<V,ValueGroup> groupOf )
     {
         if ( values.length > 1 )
         {
@@ -54,7 +59,7 @@ public class FusionSlotSelector10 implements SlotSelector
         case TEMPORAL:
             return TEMPORAL;
         case UNKNOWN:
-            return UNKNOWN;
+            return null;
         default:
             return LUCENE;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSlotSelector20.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSlotSelector20.java
@@ -24,6 +24,12 @@ import java.util.function.Function;
 import org.neo4j.kernel.api.index.IndexProvider;
 import org.neo4j.values.storable.ValueGroup;
 
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.LUCENE;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.NUMBER;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.SPATIAL;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.STRING;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.TEMPORAL;
+
 
 /**
  * Selector for "lucene+native-2.x".
@@ -32,13 +38,13 @@ import org.neo4j.values.storable.ValueGroup;
 public class FusionSlotSelector20 implements SlotSelector
 {
     @Override
-    public void validateSatisfied( IndexProvider[] instances )
+    public void validateSatisfied( InstanceSelector<IndexProvider> instances )
     {
         SlotSelector.validateSelectorInstances( instances, STRING, NUMBER, SPATIAL, TEMPORAL, LUCENE );
     }
 
     @Override
-    public <V> int selectSlot( V[] values, Function<V,ValueGroup> groupOf )
+    public <V> IndexSlot selectSlot( V[] values, Function<V,ValueGroup> groupOf )
     {
         if ( values.length > 1 )
         {
@@ -57,7 +63,7 @@ public class FusionSlotSelector20 implements SlotSelector
         case TEMPORAL:
             return TEMPORAL;
         case UNKNOWN:
-            return UNKNOWN;
+            return null;
         default:
             return LUCENE;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/IndexSlot.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/IndexSlot.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2002-2018 "Neo Technology,"
- * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
  *
  * This file is part of Neo4j.
  *

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/IndexSlot.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/IndexSlot.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema.fusion;
+
+public enum IndexSlot
+{
+    STRING,
+    NUMBER,
+    SPATIAL,
+    TEMPORAL,
+    LUCENE;
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/InstanceSelector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/InstanceSelector.java
@@ -110,7 +110,7 @@ class InstanceSelector<T>
      * @throws E exception from converter.
      */
     @SuppressWarnings( "unchecked" )
-    <R,E extends Exception> Iterable<R> flatMap( ThrowingFunction<T,R,E> converter ) throws E
+    <R,E extends Exception> Iterable<R> transform( ThrowingFunction<T,R,E> converter ) throws E
     {
         List<R> result = new ArrayList<>();
         for ( IndexSlot slot : IndexSlot.values() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/LazyInstanceSelector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/LazyInstanceSelector.java
@@ -60,12 +60,11 @@ class LazyInstanceSelector<T> extends InstanceSelector<T>
     @Override
     T select( IndexSlot slot )
     {
-        if ( !instances.containsKey( slot ) )
+        return instances.computeIfAbsent( slot, s ->
         {
             assertOpen();
-            instances.put( slot, factory.apply( slot ) );
-        }
-        return super.select( slot );
+            return factory.apply( s );
+        } );
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/UnionIndexCapability.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/UnionIndexCapability.java
@@ -35,10 +35,10 @@ import org.neo4j.values.storable.ValueCategory;
  */
 public class UnionIndexCapability implements IndexCapability
 {
-    private final IndexCapability[] capabilities;
+    private final Iterable<IndexCapability> capabilities;
     private final IndexLimitation[] limitationsUnion;
 
-    public UnionIndexCapability( IndexCapability... capabilities )
+    protected UnionIndexCapability( Iterable<IndexCapability> capabilities )
     {
         this.capabilities = capabilities;
         this.limitationsUnion = limitationsUnion( capabilities );
@@ -76,7 +76,7 @@ public class UnionIndexCapability implements IndexCapability
         return limitationsUnion;
     }
 
-    private IndexLimitation[] limitationsUnion( IndexCapability[] capabilities )
+    private IndexLimitation[] limitationsUnion( Iterable<IndexCapability> capabilities )
     {
         HashSet<IndexLimitation> union = new HashSet<>();
         for ( IndexCapability capability : capabilities )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexProviderTest.java
@@ -27,6 +27,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.List;
 
 import org.neo4j.internal.kernel.api.InternalIndexState;
@@ -55,15 +56,15 @@ import static org.neo4j.kernel.api.index.IndexDirectoryStructure.NONE;
 import static org.neo4j.kernel.api.schema.SchemaDescriptorFactory.forLabel;
 import static org.neo4j.kernel.impl.api.index.TestIndexProviderDescriptor.PROVIDER_DESCRIPTOR;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexBase.GROUP_OF;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexTestHelp.fill;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionVersion.v00;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionVersion.v10;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionVersion.v20;
-import static org.neo4j.kernel.impl.index.schema.fusion.SlotSelector.INSTANCE_COUNT;
-import static org.neo4j.kernel.impl.index.schema.fusion.SlotSelector.LUCENE;
-import static org.neo4j.kernel.impl.index.schema.fusion.SlotSelector.NUMBER;
-import static org.neo4j.kernel.impl.index.schema.fusion.SlotSelector.SPATIAL;
-import static org.neo4j.kernel.impl.index.schema.fusion.SlotSelector.STRING;
-import static org.neo4j.kernel.impl.index.schema.fusion.SlotSelector.TEMPORAL;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.LUCENE;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.NUMBER;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.SPATIAL;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.STRING;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.TEMPORAL;
 
 @RunWith( Parameterized.class )
 public class FusionIndexProviderTest
@@ -72,7 +73,7 @@ public class FusionIndexProviderTest
     public static final StoreIndexDescriptor AN_INDEX =
             IndexDescriptorFactory.forSchema( forLabel( 0, 0 ), PROVIDER_DESCRIPTOR ).withId( 0 );
 
-    private IndexProvider[] providers;
+    private EnumMap<IndexSlot,IndexProvider> providers;
     private IndexProvider[] aliveProviders;
     private IndexProvider fusionIndexProvider;
     private SlotSelector slotSelector;
@@ -100,23 +101,79 @@ public class FusionIndexProviderTest
     @Rule
     public RandomRule random = new RandomRule();
 
+    private void setupMocks()
+    {
+        IndexSlot[] aliveSlots = fusionVersion.aliveSlots();
+        aliveProviders = new IndexProvider[aliveSlots.length];
+        providers = new EnumMap<>( IndexSlot.class );
+        fill( providers, IndexProvider.EMPTY );
+        for ( int i = 0; i < aliveSlots.length; i++ )
+        {
+            switch ( aliveSlots[i] )
+            {
+            case STRING:
+                IndexProvider string = mockProvider( StringIndexProvider.class, "string" );
+                providers.put( STRING, string );
+                aliveProviders[i] = string;
+                break;
+            case NUMBER:
+                IndexProvider number = mockProvider( NumberIndexProvider.class, "number" );
+                providers.put( NUMBER, number );
+                aliveProviders[i] = number;
+                break;
+            case SPATIAL:
+                IndexProvider spatial = mockProvider( SpatialIndexProvider.class, "spatial" );
+                providers.put( SPATIAL, spatial );
+                aliveProviders[i] = spatial;
+                break;
+            case TEMPORAL:
+                IndexProvider temporal = mockProvider( TemporalIndexProvider.class, "temporal" );
+                providers.put( TEMPORAL, temporal );
+                aliveProviders[i] = temporal;
+                break;
+            case LUCENE:
+                IndexProvider lucene = mockProvider( IndexProvider.class, "lucene" );
+                providers.put( LUCENE, lucene );
+                aliveProviders[i] = lucene;
+                break;
+            default:
+                throw new RuntimeException();
+            }
+        }
+        fusionIndexProvider = new FusionIndexProvider(
+                providers.get( STRING ),
+                providers.get( NUMBER ),
+                providers.get( SPATIAL ),
+                providers.get( TEMPORAL ),
+                providers.get( LUCENE ),
+                fusionVersion.slotSelector(), DESCRIPTOR, 10, NONE, mock( FileSystemAbstraction.class ), false );
+        instanceSelector = new InstanceSelector<>( providers );
+    }
+
+    private IndexProvider mockProvider( Class<? extends IndexProvider> providerClass, String name )
+    {
+        IndexProvider mock = mock( providerClass );
+        when( mock.getProviderDescriptor() ).thenReturn( new IndexProvider.Descriptor( name, "1" ) );
+        return mock;
+    }
+
     @Test
     public void mustSelectCorrectTargetForAllGivenValueCombinations()
     {
         // given
-        Value[][] values = FusionIndexTestHelp.valuesByGroup();
+        EnumMap<IndexSlot,Value[]> values = FusionIndexTestHelp.valuesByGroup();
         Value[] allValues = FusionIndexTestHelp.allValues();
 
-        for ( int i = 0; i < values.length; i++ )
+        for ( IndexSlot slot : IndexSlot.values() )
         {
-            Value[] group = values[i];
+            Value[] group = values.get( slot );
             for ( Value value : group )
             {
                 // when
                 IndexProvider selected = instanceSelector.select( slotSelector.selectSlot( array( value ), GROUP_OF ) );
 
                 // then
-                assertSame( orLucene( providers[i] ), selected );
+                assertSame( orLucene( providers.get( slot ) ), selected );
             }
         }
 
@@ -129,7 +186,7 @@ public class FusionIndexProviderTest
                 IndexProvider selected = instanceSelector.select( slotSelector.selectSlot( array( firstValue, secondValue ), GROUP_OF ) );
 
                 // then
-                assertSame( providers[LUCENE], selected );
+                assertSame( providers.get( LUCENE ), selected );
             }
         }
     }
@@ -141,7 +198,7 @@ public class FusionIndexProviderTest
         int sumIndexSize = 0;
         int sumUniqueValues = 0;
         int sumSampleSize = 0;
-        IndexSample[] samples = new IndexSample[providers.length];
+        IndexSample[] samples = new IndexSample[providers.size()];
         for ( int i = 0; i < samples.length; i++ )
         {
             int indexSize = random.nextInt( 0, 1_000_000 );
@@ -154,7 +211,7 @@ public class FusionIndexProviderTest
         }
 
         // when
-        IndexSample fusionSample = FusionIndexSampler.combineSamples( samples );
+        IndexSample fusionSample = FusionIndexSampler.combineSamples( Arrays.asList( samples ) );
 
         // then
         assertEquals( sumIndexSize, fusionSample.indexSize() );
@@ -273,62 +330,6 @@ public class FusionIndexProviderTest
         }
     }
 
-    private void setupMocks()
-    {
-        int[] aliveSlots = fusionVersion.aliveSlots();
-        aliveProviders = new IndexProvider[aliveSlots.length];
-        providers = new IndexProvider[INSTANCE_COUNT];
-        Arrays.fill( providers, IndexProvider.EMPTY );
-        for ( int i = 0; i < aliveSlots.length; i++ )
-        {
-            switch ( aliveSlots[i] )
-            {
-            case STRING:
-                IndexProvider string = mockProvider( StringIndexProvider.class, "string" );
-                providers[STRING] = string;
-                aliveProviders[i] = string;
-                break;
-            case NUMBER:
-                IndexProvider number = mockProvider( NumberIndexProvider.class, "number" );
-                providers[NUMBER] = number;
-                aliveProviders[i] = number;
-                break;
-            case SPATIAL:
-                IndexProvider spatial = mockProvider( SpatialIndexProvider.class, "spatial" );
-                providers[SPATIAL] = spatial;
-                aliveProviders[i] = spatial;
-                break;
-            case TEMPORAL:
-                IndexProvider temporal = mockProvider( TemporalIndexProvider.class, "temporal" );
-                providers[TEMPORAL] = temporal;
-                aliveProviders[i] = temporal;
-                break;
-            case LUCENE:
-                IndexProvider lucene = mockProvider( IndexProvider.class, "lucene" );
-                providers[LUCENE] = lucene;
-                aliveProviders[i] = lucene;
-                break;
-            default:
-                throw new RuntimeException();
-            }
-        }
-        fusionIndexProvider = new FusionIndexProvider(
-                providers[STRING],
-                providers[NUMBER],
-                providers[SPATIAL],
-                providers[TEMPORAL],
-                providers[LUCENE],
-                fusionVersion.slotSelector(), DESCRIPTOR, 10, NONE, mock( FileSystemAbstraction.class ), false );
-        instanceSelector = new InstanceSelector<>( providers );
-    }
-
-    private IndexProvider mockProvider( Class<? extends IndexProvider> providerClass, String name )
-    {
-        IndexProvider mock = mock( providerClass );
-        when( mock.getProviderDescriptor() ).thenReturn( new IndexProvider.Descriptor( name, "1" ) );
-        return mock;
-    }
-
     private void setInitialState( IndexProvider mockedProvider, InternalIndexState state )
     {
         when( mockedProvider.getInitialState( any( StoreIndexDescriptor.class ) ) ).thenReturn( state );
@@ -336,6 +337,6 @@ public class FusionIndexProviderTest
 
     private IndexProvider orLucene( IndexProvider provider )
     {
-        return provider != IndexProvider.EMPTY ? provider : providers[LUCENE];
+        return provider != IndexProvider.EMPTY ? provider : providers.get( LUCENE );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexTestHelp.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexTestHelp.java
@@ -25,6 +25,7 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -43,6 +44,11 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.LUCENE;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.NUMBER;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.SPATIAL;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.STRING;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.TEMPORAL;
 
 class FusionIndexTestHelp
 {
@@ -119,23 +125,22 @@ class FusionIndexTestHelp
     static Value[] allValues()
     {
         List<Value> values = new ArrayList<>();
-        for ( Value[] group : valuesByGroup() )
+        for ( Value[] group : valuesByGroup().values() )
         {
             values.addAll( Arrays.asList( group ) );
         }
         return values.toArray( new Value[values.size()] );
     }
 
-    static Value[][] valuesByGroup()
+    static EnumMap<IndexSlot,Value[]> valuesByGroup()
     {
-        return new Value[][]
-                {
-                        FusionIndexTestHelp.valuesSupportedByString(),
-                        FusionIndexTestHelp.valuesSupportedByNumber(),
-                        FusionIndexTestHelp.valuesSupportedBySpatial(),
-                        FusionIndexTestHelp.valuesSupportedByTemporal(),
-                        FusionIndexTestHelp.valuesNotSupportedBySpecificIndex()
-                };
+        EnumMap<IndexSlot,Value[]> values = new EnumMap<>( IndexSlot.class );
+        values.put( STRING, FusionIndexTestHelp.valuesSupportedByString() );
+        values.put( NUMBER, FusionIndexTestHelp.valuesSupportedByNumber() );
+        values.put( SPATIAL, FusionIndexTestHelp.valuesSupportedBySpatial() );
+        values.put( TEMPORAL, FusionIndexTestHelp.valuesSupportedByTemporal() );
+        values.put( LUCENE, FusionIndexTestHelp.valuesNotSupportedBySpecificIndex() );
+        return values;
     }
 
     static void verifyCallFail( Exception expectedFailure, Callable failingCall )
@@ -251,6 +256,14 @@ class FusionIndexTestHelp
                 matchers.add( sameInstance( failure ) );
             }
             assertThat( e, anyOf( matchers ) );
+        }
+    }
+
+    static <T> void fill( EnumMap<IndexSlot,T> map, T instance )
+    {
+        for ( IndexSlot slot : IndexSlot.values() )
+        {
+            map.put( slot, instance );
         }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexUpdaterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexUpdaterTest.java
@@ -26,8 +26,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.function.IntFunction;
+import java.util.EnumMap;
+import java.util.function.Function;
 
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
@@ -47,22 +47,22 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.neo4j.helpers.ArrayUtil.without;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexTestHelp.add;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexTestHelp.change;
+import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexTestHelp.fill;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexTestHelp.remove;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionVersion.v00;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionVersion.v10;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionVersion.v20;
-import static org.neo4j.kernel.impl.index.schema.fusion.SlotSelector.INSTANCE_COUNT;
-import static org.neo4j.kernel.impl.index.schema.fusion.SlotSelector.LUCENE;
-import static org.neo4j.kernel.impl.index.schema.fusion.SlotSelector.NUMBER;
-import static org.neo4j.kernel.impl.index.schema.fusion.SlotSelector.SPATIAL;
-import static org.neo4j.kernel.impl.index.schema.fusion.SlotSelector.STRING;
-import static org.neo4j.kernel.impl.index.schema.fusion.SlotSelector.TEMPORAL;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.LUCENE;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.NUMBER;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.SPATIAL;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.STRING;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.TEMPORAL;
 
 @RunWith( Parameterized.class )
 public class FusionIndexUpdaterTest
 {
     private IndexUpdater[] aliveUpdaters;
-    private IndexUpdater[] updaters;
+    private EnumMap<IndexSlot,IndexUpdater> updaters;
     private FusionIndexUpdater fusionIndexUpdater;
 
     @Rule
@@ -87,9 +87,9 @@ public class FusionIndexUpdaterTest
 
     private void initiateMocks()
     {
-        int[] activeSlots = fusionVersion.aliveSlots();
-        updaters = new IndexUpdater[INSTANCE_COUNT];
-        Arrays.fill( updaters, SwallowingIndexUpdater.INSTANCE );
+        IndexSlot[] activeSlots = fusionVersion.aliveSlots();
+        updaters = new EnumMap<>( IndexSlot.class );
+        fill( updaters, SwallowingIndexUpdater.INSTANCE );
         aliveUpdaters = new IndexUpdater[activeSlots.length];
         for ( int i = 0; i < activeSlots.length; i++ )
         {
@@ -98,19 +98,19 @@ public class FusionIndexUpdaterTest
             switch ( activeSlots[i] )
             {
             case STRING:
-                updaters[STRING] = mock;
+                updaters.put( STRING, mock );
                 break;
             case NUMBER:
-                updaters[NUMBER] = mock;
+                updaters.put( NUMBER, mock );
                 break;
             case SPATIAL:
-                updaters[SPATIAL] = mock;
+                updaters.put( SPATIAL, mock );
                 break;
             case TEMPORAL:
-                updaters[TEMPORAL] = mock;
+                updaters.put( TEMPORAL, mock );
                 break;
             case LUCENE:
-                updaters[LUCENE] = mock;
+                updaters.put( LUCENE, mock );
                 break;
             default:
                 throw new RuntimeException();
@@ -119,7 +119,7 @@ public class FusionIndexUpdaterTest
         fusionIndexUpdater = new FusionIndexUpdater( fusionVersion.slotSelector(), new LazyInstanceSelector<>( updaters, throwingFactory() ) );
     }
 
-    private IntFunction<IndexUpdater> throwingFactory()
+    private Function<IndexSlot,IndexUpdater> throwingFactory()
     {
         return i ->
         {
@@ -141,15 +141,15 @@ public class FusionIndexUpdaterTest
     public void processMustSelectCorrectForAdd() throws Exception
     {
         // given
-        Value[][] values = FusionIndexTestHelp.valuesByGroup();
+        EnumMap<IndexSlot,Value[]> values = FusionIndexTestHelp.valuesByGroup();
         Value[] allValues = FusionIndexTestHelp.allValues();
 
-        for ( int i = 0; i < updaters.length; i++ )
+        for ( IndexSlot slot : IndexSlot.values() )
         {
-            for ( Value value : values[i] )
+            for ( Value value : values.get( slot ) )
             {
                 // then
-                verifyAddWithCorrectUpdater( orLucene( updaters[i] ), value );
+                verifyAddWithCorrectUpdater( orLucene( updaters.get( slot ) ), value );
             }
         }
 
@@ -158,7 +158,7 @@ public class FusionIndexUpdaterTest
         {
             for ( Value secondValue : allValues )
             {
-                verifyAddWithCorrectUpdater( updaters[LUCENE], firstValue, secondValue );
+                verifyAddWithCorrectUpdater( updaters.get( LUCENE ), firstValue, secondValue );
             }
         }
     }
@@ -167,15 +167,15 @@ public class FusionIndexUpdaterTest
     public void processMustSelectCorrectForRemove() throws Exception
     {
         // given
-        Value[][] values = FusionIndexTestHelp.valuesByGroup();
+        EnumMap<IndexSlot,Value[]> values = FusionIndexTestHelp.valuesByGroup();
         Value[] allValues = FusionIndexTestHelp.allValues();
 
-        for ( int i = 0; i < updaters.length; i++ )
+        for ( IndexSlot slot : IndexSlot.values() )
         {
-            for ( Value value : values[i] )
+            for ( Value value : values.get( slot ) )
             {
                 // then
-                verifyRemoveWithCorrectUpdater( orLucene( updaters[i] ), value );
+                verifyRemoveWithCorrectUpdater( orLucene( updaters.get( slot ) ), value );
             }
         }
 
@@ -184,7 +184,7 @@ public class FusionIndexUpdaterTest
         {
             for ( Value secondValue : allValues )
             {
-                verifyRemoveWithCorrectUpdater( updaters[LUCENE], firstValue, secondValue );
+                verifyRemoveWithCorrectUpdater( updaters.get( LUCENE ), firstValue, secondValue );
             }
         }
     }
@@ -193,16 +193,16 @@ public class FusionIndexUpdaterTest
     public void processMustSelectCorrectForChange() throws Exception
     {
         // given
-        Value[][] values = FusionIndexTestHelp.valuesByGroup();
+        EnumMap<IndexSlot,Value[]> values = FusionIndexTestHelp.valuesByGroup();
 
         // when
-        for ( int i = 0; i < updaters.length; i++ )
+        for ( IndexSlot slot : IndexSlot.values() )
         {
-            for ( Value before : values[i] )
+            for ( Value before : values.get( slot ) )
             {
-                for ( Value after : values[i] )
+                for ( Value after : values.get( slot ) )
                 {
-                    verifyChangeWithCorrectUpdaterNotMixed( orLucene( updaters[i] ), before, after );
+                    verifyChangeWithCorrectUpdaterNotMixed( orLucene( updaters.get( slot ) ), before, after );
                 }
             }
         }
@@ -211,20 +211,21 @@ public class FusionIndexUpdaterTest
     @Test
     public void processMustSelectCorrectForChangeFromOneGroupToAnother() throws Exception
     {
-        Value[][] values = FusionIndexTestHelp.valuesByGroup();
-        for ( int f = 0; f < values.length; f++ )
+        EnumMap<IndexSlot,Value[]> values = FusionIndexTestHelp.valuesByGroup();
+        for ( IndexSlot from : IndexSlot.values() )
         {
             // given
-            for ( int t = 0; t < values.length; t++ )
+            for ( IndexSlot to : IndexSlot.values() )
             {
-                if ( f != t )
+                if ( from != to )
                 {
                     // when
-                    verifyChangeWithCorrectUpdaterMixed( orLucene( updaters[f] ), orLucene( updaters[t] ), values[f], values[t] );
+                    verifyChangeWithCorrectUpdaterMixed(
+                            orLucene( updaters.get( from ) ), orLucene( updaters.get( to ) ), values.get( from ), values.get( to ) );
                 }
                 else
                 {
-                    verifyChangeWithCorrectUpdaterNotMixed( orLucene( updaters[f] ), values[f] );
+                    verifyChangeWithCorrectUpdaterNotMixed( orLucene( updaters.get( from ) ), values.get( from ) );
                 }
                 resetMocks();
             }
@@ -233,7 +234,7 @@ public class FusionIndexUpdaterTest
 
     private IndexUpdater orLucene( IndexUpdater updater )
     {
-        return updater != SwallowingIndexUpdater.INSTANCE ? updater : updaters[LUCENE];
+        return updater != SwallowingIndexUpdater.INSTANCE ? updater : updaters.get( LUCENE );
     }
 
     private void verifyAddWithCorrectUpdater( IndexUpdater correctPopulator, Value... numberValues )
@@ -336,10 +337,9 @@ public class FusionIndexUpdaterTest
     @Test
     public void closeMustThrowIfAnyThrow() throws Exception
     {
-        for ( int i = 0; i < aliveUpdaters.length; i++ )
+        for ( IndexSlot indexSlot : fusionVersion.aliveSlots() )
         {
-            IndexUpdater updater = aliveUpdaters[i];
-            FusionIndexTestHelp.verifyFusionCloseThrowOnSingleCloseThrow( updater, fusionIndexUpdater );
+            FusionIndexTestHelp.verifyFusionCloseThrowOnSingleCloseThrow( updaters.get( indexSlot ), fusionIndexUpdater );
             initiateMocks();
         }
     }
@@ -347,10 +347,10 @@ public class FusionIndexUpdaterTest
     @Test
     public void closeMustCloseOthersIfAnyThrow() throws Exception
     {
-        for ( int i = 0; i < aliveUpdaters.length; i++ )
+        for ( IndexSlot indexSlot : fusionVersion.aliveSlots() )
         {
-            IndexUpdater updater = aliveUpdaters[i];
-            FusionIndexTestHelp.verifyOtherIsClosedOnSingleThrow( updater, fusionIndexUpdater, without( aliveUpdaters, updater ) );
+            IndexUpdater failingUpdater = updaters.get( indexSlot );
+            FusionIndexTestHelp.verifyOtherIsClosedOnSingleThrow( failingUpdater, fusionIndexUpdater, without( aliveUpdaters, failingUpdater ) );
             initiateMocks();
         }
     }
@@ -365,26 +365,26 @@ public class FusionIndexUpdaterTest
     public void shouldInstantiatePartLazilyForSpecificValueGroupUpdates() throws IOException, IndexEntryConflictException
     {
         // given
-        Value[][] values = FusionIndexTestHelp.valuesByGroup();
-        for ( int i = 0; i < updaters.length; i++ )
+        EnumMap<IndexSlot,Value[]> values = FusionIndexTestHelp.valuesByGroup();
+        for ( IndexSlot i : IndexSlot.values() )
         {
-            if ( updaters[i] != SwallowingIndexUpdater.INSTANCE )
+            if ( updaters.get( i ) != SwallowingIndexUpdater.INSTANCE )
             {
                 // when
-                Value value = values[i][0];
+                Value value = values.get( i )[0];
                 fusionIndexUpdater.process( add( value ) );
-                for ( int j = 0; j < updaters.length; j++ )
+                for ( IndexSlot j : IndexSlot.values() )
                 {
                     // then
-                    if ( updaters[j] != SwallowingIndexUpdater.INSTANCE )
+                    if ( updaters.get( j ) != SwallowingIndexUpdater.INSTANCE )
                     {
                         if ( i == j )
                         {
-                            verify( updaters[i] ).process( any( IndexEntryUpdate.class ) );
+                            verify( updaters.get( i ) ).process( any( IndexEntryUpdate.class ) );
                         }
                         else
                         {
-                            verifyNoMoreInteractions( updaters[j] );
+                            verifyNoMoreInteractions( updaters.get( j ) );
                         }
                     }
                 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSlotSelectorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSlotSelectorTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2002-2018 "Neo Technology,"
- * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
  *
  * This file is part of Neo4j.
  *

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSlotSelectorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSlotSelectorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema.fusion;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumMap;
+
+import org.neo4j.kernel.api.index.IndexProvider;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.NUMBER;
+import static org.neo4j.kernel.impl.index.schema.fusion.SlotSelector.validateSelectorInstances;
+
+class FusionSlotSelectorTest
+{
+    @Test
+    void throwIfToFewInstances()
+    {
+        // given
+        EnumMap<IndexSlot,IndexProvider> instances = new EnumMap<>( IndexSlot.class );
+        for ( IndexSlot indexSlot : IndexSlot.values() )
+        {
+            instances.put( indexSlot, IndexProvider.EMPTY );
+        }
+        InstanceSelector<IndexProvider> instanceSelector = new InstanceSelector<>( instances );
+
+        // when, then
+        assertThrows( IllegalArgumentException.class, () -> validateSelectorInstances( instanceSelector, NUMBER ) );
+    }
+
+    @Test
+    void throwIfToManyInstances()
+    {
+        // given
+        EnumMap<IndexSlot,IndexProvider> instances = new EnumMap<>( IndexSlot.class );
+        for ( IndexSlot indexSlot : IndexSlot.values() )
+        {
+            instances.put( indexSlot, IndexProvider.EMPTY );
+        }
+        IndexProvider mockedIndxProvider = mock( IndexProvider.class );
+        instances.put( NUMBER, mockedIndxProvider );
+        InstanceSelector<IndexProvider> instanceSelector = new InstanceSelector<>( instances );
+
+        // when, then
+        assertThrows( IllegalArgumentException.class, () -> validateSelectorInstances( instanceSelector ) );
+    }
+
+    @Test
+    void shouldValidateSelectorInstances()
+    {
+        // given
+        EnumMap<IndexSlot,IndexProvider> instances = new EnumMap<>( IndexSlot.class );
+        for ( IndexSlot indexSlot : IndexSlot.values() )
+        {
+            instances.put( indexSlot, IndexProvider.EMPTY );
+        }
+        IndexProvider mockedIndxProvider = mock( IndexProvider.class );
+        instances.put( NUMBER, mockedIndxProvider );
+        InstanceSelector<IndexProvider> selector = new InstanceSelector<>( instances );
+
+        // when
+        validateSelectorInstances( selector, NUMBER );
+
+        // then this should be fine
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionVersion.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionVersion.java
@@ -19,20 +19,20 @@
  */
 package org.neo4j.kernel.impl.index.schema.fusion;
 
-import static org.neo4j.kernel.impl.index.schema.fusion.SlotSelector.LUCENE;
-import static org.neo4j.kernel.impl.index.schema.fusion.SlotSelector.NUMBER;
-import static org.neo4j.kernel.impl.index.schema.fusion.SlotSelector.SPATIAL;
-import static org.neo4j.kernel.impl.index.schema.fusion.SlotSelector.STRING;
-import static org.neo4j.kernel.impl.index.schema.fusion.SlotSelector.TEMPORAL;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.LUCENE;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.NUMBER;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.SPATIAL;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.STRING;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.TEMPORAL;
 
 enum FusionVersion
 {
     v00
             {
                 @Override
-                int[] aliveSlots()
+                IndexSlot[] aliveSlots()
                 {
-                    return new int[]{LUCENE, SPATIAL, TEMPORAL};
+                    return new IndexSlot[]{LUCENE, SPATIAL, TEMPORAL};
                 }
 
                 @Override
@@ -44,9 +44,9 @@ enum FusionVersion
     v10
             {
                 @Override
-                int[] aliveSlots()
+                IndexSlot[] aliveSlots()
                 {
-                    return new int[]{NUMBER, LUCENE, SPATIAL, TEMPORAL};
+                    return new IndexSlot[]{NUMBER, LUCENE, SPATIAL, TEMPORAL};
                 }
 
                 @Override
@@ -58,9 +58,9 @@ enum FusionVersion
     v20
             {
                 @Override
-                int[] aliveSlots()
+                IndexSlot[] aliveSlots()
                 {
-                    return new int[]{STRING, NUMBER, SPATIAL, TEMPORAL, LUCENE};
+                    return new IndexSlot[]{STRING, NUMBER, SPATIAL, TEMPORAL, LUCENE};
                 }
 
                 @Override
@@ -70,7 +70,7 @@ enum FusionVersion
                 }
             };
 
-    abstract int[] aliveSlots();
+    abstract IndexSlot[] aliveSlots();
 
     abstract SlotSelector slotSelector();
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/InstanceSelectorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/InstanceSelectorTest.java
@@ -84,7 +84,7 @@ public class InstanceSelectorTest
         // when
         try
         {
-            selector.flatMap( Integer::parseInt );
+            selector.transform( Integer::parseInt );
             fail( "Should have failed" );
         }
         catch ( IllegalStateException e )
@@ -120,7 +120,7 @@ public class InstanceSelectorTest
         InstanceSelector<String> selector = selectorFilledWithOrdinal();
 
         // when
-        List<Integer> actual = Iterables.asList( selector.flatMap( Integer::parseInt ) );
+        List<Integer> actual = Iterables.asList( selector.transform( Integer::parseInt ) );
         List<Integer> expected = Arrays.stream( IndexSlot.values() ).map( Enum::ordinal ).collect( Collectors.toList() );
 
         // then

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/InstanceSelectorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/InstanceSelectorTest.java
@@ -30,8 +30,8 @@ import java.util.stream.Collectors;
 import org.neo4j.helpers.collection.Iterables;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.NUMBER;
 import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.STRING;
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/LazyInstanceSelectorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/LazyInstanceSelectorTest.java
@@ -21,19 +21,22 @@ package org.neo4j.kernel.impl.index.schema.fusion;
 
 import org.junit.Test;
 
-import java.util.function.IntFunction;
+import java.util.function.Function;
 
 import org.neo4j.function.ThrowingConsumer;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static org.neo4j.kernel.impl.index.schema.fusion.SlotSelector.INSTANCE_COUNT;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.NUMBER;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.STRING;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.TEMPORAL;
+import static org.neo4j.kernel.impl.index.schema.fusion.IndexSlot.values;
 
 public class LazyInstanceSelectorTest
 {
@@ -41,17 +44,16 @@ public class LazyInstanceSelectorTest
     public void shouldInstantiateLazilyOnFirstSelect()
     {
         // given
-        IntFunction<String> factory = mock( IntFunction.class );
-        when( factory.apply( anyInt() ) ).then( invocationOnMock -> String.valueOf( (Integer) invocationOnMock.getArgument( 0 ) ) );
-        LazyInstanceSelector<String> selector = new LazyInstanceSelector<>( new String[INSTANCE_COUNT], factory );
+        Function<IndexSlot,String> factory = slotToStringFunction();
+        LazyInstanceSelector<String> selector = new LazyInstanceSelector<>( factory );
 
         // when
-        for ( int slot = 0; slot < INSTANCE_COUNT; slot++ )
+        for ( IndexSlot slot : values() )
         {
-            for ( int candidate = 0; candidate < INSTANCE_COUNT; candidate++ )
+            for ( IndexSlot candidate : values() )
             {
                 // then
-                if ( candidate < slot )
+                if ( candidate.ordinal() < slot.ordinal() )
                 {
                     verify( factory, times( 1 ) ).apply( candidate );
                     selector.select( candidate );
@@ -75,17 +77,16 @@ public class LazyInstanceSelectorTest
     public void shouldPerformActionOnAll()
     {
         // given
-        IntFunction<String> factory = mock( IntFunction.class );
-        when( factory.apply( anyInt() ) ).then( invocationOnMock -> String.valueOf( (Integer) invocationOnMock.getArgument( 0 ) ) );
-        LazyInstanceSelector<String> selector = new LazyInstanceSelector<>( new String[INSTANCE_COUNT], factory );
-        selector.select( 1 );
+        Function<IndexSlot,String> factory = slotToStringFunction();
+        LazyInstanceSelector<String> selector = new LazyInstanceSelector<>( factory );
+        selector.select( STRING );
 
         // when
         ThrowingConsumer<String,RuntimeException> consumer = mock( ThrowingConsumer.class );
         selector.forAll( consumer );
 
         // then
-        for ( int slot = 0; slot < INSTANCE_COUNT; slot++ )
+        for ( IndexSlot slot : IndexSlot.values() )
         {
             verify( consumer, times( 1 ) ).accept( String.valueOf( slot ) );
         }
@@ -96,19 +97,18 @@ public class LazyInstanceSelectorTest
     public void shouldCloseAllInstantiated()
     {
         // given
-        IntFunction<String> factory = mock( IntFunction.class );
-        when( factory.apply( anyInt() ) ).then( invocationOnMock -> String.valueOf( (Integer) invocationOnMock.getArgument( 0 ) ) );
-        LazyInstanceSelector<String> selector = new LazyInstanceSelector<>( new String[INSTANCE_COUNT], factory );
-        selector.select( 1 );
-        selector.select( 3 );
+        Function<IndexSlot,String> factory = slotToStringFunction();
+        LazyInstanceSelector<String> selector = new LazyInstanceSelector<>( factory );
+        selector.select( NUMBER );
+        selector.select( STRING );
 
         // when
         ThrowingConsumer<String,RuntimeException> consumer = mock( ThrowingConsumer.class );
         selector.close( consumer );
 
         // then
-        verify( consumer, times( 1 ) ).accept( "1" );
-        verify( consumer, times( 1 ) ).accept( "3" );
+        verify( consumer, times( 1 ) ).accept( String.valueOf( NUMBER ) );
+        verify( consumer, times( 1 ) ).accept( String.valueOf( STRING ) );
         verifyNoMoreInteractions( consumer );
     }
 
@@ -116,11 +116,10 @@ public class LazyInstanceSelectorTest
     public void shouldPreventInstantiationAfterClose()
     {
         // given
-        IntFunction<String> factory = mock( IntFunction.class );
-        when( factory.apply( anyInt() ) ).then( invocationOnMock -> String.valueOf( (Integer) invocationOnMock.getArgument( 0 ) ) );
-        LazyInstanceSelector<String> selector = new LazyInstanceSelector<>( new String[INSTANCE_COUNT], factory );
-        selector.select( 1 );
-        selector.select( 3 );
+        Function<IndexSlot,String> factory = slotToStringFunction();
+        LazyInstanceSelector<String> selector = new LazyInstanceSelector<>( factory );
+        selector.select( NUMBER );
+        selector.select( STRING );
 
         // when
         selector.close( mock( ThrowingConsumer.class ) );
@@ -128,12 +127,19 @@ public class LazyInstanceSelectorTest
         // then
         try
         {
-            selector.select( 0 );
+            selector.select( TEMPORAL );
             fail( "Should have failed" );
         }
         catch ( IllegalStateException e )
         {
             // then good
         }
+    }
+
+    private Function<IndexSlot,String> slotToStringFunction()
+    {
+        Function<IndexSlot,String> factory = mock( Function.class );
+        when( factory.apply( any( IndexSlot.class ) ) ).then( invocationOnMock -> String.valueOf( (IndexSlot) invocationOnMock.getArgument( 0 ) ) );
+        return factory;
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/UnionIndexCapabilityTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/UnionIndexCapabilityTest.java
@@ -22,6 +22,8 @@ package org.neo4j.kernel.impl.newapi;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.neo4j.helpers.ArrayUtil;
 import org.neo4j.internal.kernel.api.IndexCapability;
@@ -146,12 +148,12 @@ public class UnionIndexCapabilityTest
         assertEquals( asSet( IndexLimitation.SLOW_CONTAINS ), asSet( union.limitations() ) );
     }
 
-    private UnionIndexCapability unionOfIndexLimitations( IndexLimitation[]... limitiations )
+    private UnionIndexCapability unionOfIndexLimitations( IndexLimitation[]... limitations )
     {
-        IndexCapability[] capabilities = new IndexCapability[limitiations.length];
-        for ( int i = 0; i < limitiations.length; i++ )
+        List<IndexCapability> capabilities = new ArrayList<>();
+        for ( IndexLimitation[] limitation : limitations )
         {
-            capabilities[i] = capabilityWithIndexLimitations( limitiations[i] );
+            capabilities.add( capabilityWithIndexLimitations( limitation ) );
         }
         return new UnionIndexCapability( capabilities );
     }
@@ -165,20 +167,20 @@ public class UnionIndexCapabilityTest
 
     private UnionIndexCapability unionOfValueCapabilities( IndexValueCapability... valueCapabilities )
     {
-        IndexCapability[] capabilities = new IndexCapability[valueCapabilities.length];
-        for ( int i = 0; i < valueCapabilities.length; i++ )
+        List<IndexCapability> capabilities = new ArrayList<>( valueCapabilities.length );
+        for ( IndexValueCapability valueCapability : valueCapabilities )
         {
-            capabilities[i] = capabilityWithValue( valueCapabilities[i] );
+            capabilities.add( capabilityWithValue( valueCapability ) );
         }
         return new UnionIndexCapability( capabilities );
     }
 
     private UnionIndexCapability unionOfOrderCapabilities( IndexOrder[]... indexOrders )
     {
-        IndexCapability[] capabilities = new IndexCapability[indexOrders.length];
-        for ( int i = 0; i < indexOrders.length; i++ )
+        List<IndexCapability> capabilities = new ArrayList<>( indexOrders.length );
+        for ( IndexOrder[] indexOrder : indexOrders )
         {
-            capabilities[i] = capabilityWithOrder( indexOrders[i] );
+            capabilities.add( capabilityWithOrder( indexOrder ) );
         }
         return new UnionIndexCapability( capabilities );
     }


### PR DESCRIPTION
This way the mapping from sub index type to actual instance is much
more explicit and we get rid of all magic int.

co-author: @klaren 