### PR TITLE
Cheat with test directory for the cluster-related test to not fail.

### DIFF
--- a/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIT.java
+++ b/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIT.java
@@ -31,6 +31,7 @@ import org.junit.runners.Parameterized;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -235,7 +236,7 @@ public class StoreUpgradeIT
             assertConsistentStore( dir );
 
             // start the cluster with the db migrated from the old instance
-            File haDir = new File( dir.getParentFile(), "ha-stuff" );
+            File haDir = Files.createTempDirectory("ha-stuff" ).toFile();
             FileUtils.deleteRecursively( haDir );
             ClusterManager clusterManager = new ClusterManager.Builder( haDir )
                     .withSeedDir( dir ).withCluster( clusterOfSize( 2 ) ).build();


### PR DESCRIPTION
During the switch to master file descriptors to id files can leak.
Because of ha lifecycles, and ha in general just cheat with directory
for the test to avoid any ha related work.