### PR TITLE
Update timeout messages to include corresponding properties name.

### DIFF
--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -142,7 +142,7 @@ public interface Status
                 "Transaction was marked as both successful and failed. Failure takes precedence and so this " +
                 "transaction was rolled back although it may have looked like it was going to be committed" ),
         TransactionTimedOut( ClientError,
-                "The transaction has not completed within the specified timeout. You may want to retry with a longer " +
+                "The transaction has not completed within the specified timeout (dbms.transaction.timeout). You may want to retry with a longer " +
                 "timeout." ),
         InvalidBookmark( ClientError,
                 "Supplied bookmark cannot be interpreted. You should only supply a bookmark previously that was " +
@@ -184,7 +184,7 @@ public interface Status
                 "transaction ran longer than the configured transaction timeout, or because a human operator manually " +
                 "terminated the transaction, or because the database is shutting down." ),
         LockAcquisitionTimeout( TransientError,
-                "Unable to acquire lock within configured timeout." ),
+                "Unable to acquire lock within configured timeout (dbms.lock.acquisition.timeout)." ),
         Terminated( TransientError,
                 "Explicitly terminated by the user." ),
         Interrupted( TransientError,

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -47,7 +47,6 @@ import org.neo4j.kernel.configuration.Title;
 import org.neo4j.kernel.configuration.ssl.SslPolicyConfigValidator;
 import org.neo4j.logging.Level;
 import org.neo4j.logging.LogTimeZone;
-import org.neo4j.values.storable.DateTimeValue;
 
 import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
 import static org.neo4j.kernel.configuration.Settings.BYTES;
@@ -350,11 +349,13 @@ public class GraphDatabaseSettings implements LoadableConfig
     public static final Setting<Boolean> execution_guard_enabled =
             setting( "unsupported.dbms.executiontime_limit.enabled", BOOLEAN, FALSE );
 
+     // @see Status.Transaction#TransactionTimedOut
     @Description( "The maximum time interval of a transaction within which it should be completed." )
     @Dynamic
     public static final Setting<Duration> transaction_timeout = setting( "dbms.transaction.timeout", DURATION, String
             .valueOf( UNSPECIFIED_TIMEOUT ) );
 
+     // @see Status.Transaction#LockAcquisitionTimeout
     @Description( "The maximum time interval within which lock should be acquired." )
     public static final Setting<Duration> lock_acquisition_timeout = setting( "dbms.lock.acquisition.timeout", DURATION,
             String.valueOf( UNSPECIFIED_TIMEOUT ) );

--- a/community/neo4j/src/test/java/org/neo4j/locking/CommunityLockAcquisitionTimeoutIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/locking/CommunityLockAcquisitionTimeoutIT.java
@@ -117,7 +117,7 @@ public class CommunityLockAcquisitionTimeoutIT
         expectedException.expect( new RootCauseMatcher<>( LockAcquisitionTimeoutException.class,
                 "The transaction has been terminated. " +
                         "Retry your operation in a new transaction, and you should see a successful result. " +
-                        "Unable to acquire lock within configured timeout. " +
+                        "Unable to acquire lock within configured timeout (dbms.lock.acquisition.timeout). " +
                         "Unable to acquire lock for resource: NODE with id: 0 within 2000 millis." ) );
 
         try ( Transaction ignored = database.beginTx() )
@@ -154,7 +154,7 @@ public class CommunityLockAcquisitionTimeoutIT
         expectedException.expect( new RootCauseMatcher<>( LockAcquisitionTimeoutException.class,
                 "The transaction has been terminated. " +
                         "Retry your operation in a new transaction, and you should see a successful result. " +
-                        "Unable to acquire lock within configured timeout. " +
+                        "Unable to acquire lock within configured timeout (dbms.lock.acquisition.timeout). " +
                         "Unable to acquire lock for resource: LABEL with id: 1 within 2000 millis." ) );
 
         try ( Transaction ignored = database.beginTx() )

--- a/integrationtests/src/test/java/org/neo4j/TransactionGuardIT.java
+++ b/integrationtests/src/test/java/org/neo4j/TransactionGuardIT.java
@@ -79,7 +79,6 @@ import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.ports.allocation.PortAuthority;
 import org.neo4j.server.CommunityNeoServer;
-import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.database.LifecycleManagingDatabase;
 import org.neo4j.server.enterprise.OpenEnterpriseNeoServer;
 import org.neo4j.server.enterprise.helpers.EnterpriseServerBuilder;
@@ -278,8 +277,7 @@ public class TransactionGuardIT
         }
         catch ( ShellException e )
         {
-            assertThat( e.getMessage(), containsString( "The transaction has not completed within " +
-                    "the specified timeout." ) );
+            assertThat( e.getMessage(), containsString( "The transaction has not completed within the specified timeout (dbms.transaction.timeout)" ) );
         }
 
         assertDatabaseDoesNotHaveNodes( database );


### PR DESCRIPTION
Lock acquisition timeout and transaction timeouts are confusing and
would be good to include the name of the property that can be tuned.
This PR update status messages to include corresponding property names.