### PR TITLE
Move ThreadToStatementContextBridge out of lifecycle.

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltFactoryImplTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltFactoryImplTest.java
@@ -26,6 +26,7 @@ import java.time.Clock;
 import org.neo4j.bolt.BoltChannel;
 import org.neo4j.bolt.security.auth.Authentication;
 import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
 import org.neo4j.kernel.configuration.Config;
@@ -121,7 +122,7 @@ public class BoltFactoryImplTest
     private static BoltFactoryImpl newBoltFactory( GraphDatabaseAPI db )
     {
         return new BoltFactoryImpl( db, new UsageData( new OnDemandJobScheduler() ), NullLogService.getInstance(),
-                new ThreadToStatementContextBridge(), mock( Authentication.class ), BoltConnectionTracker.NOOP,
+                new ThreadToStatementContextBridge( mock( AvailabilityGuard.class ) ), mock( Authentication.class ), BoltConnectionTracker.NOOP,
                 Config.defaults() );
     }
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineSPITest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineSPITest.java
@@ -29,9 +29,9 @@ import java.util.concurrent.Future;
 import java.util.function.Supplier;
 
 import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.internal.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.GraphDatabaseQueryService;
-import org.neo4j.internal.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
@@ -133,7 +133,7 @@ public class TransactionStateMachineSPITest
 
         when(dependencyResolver.provideDependency( TransactionIdStore.class )).thenReturn( txIdStore );
 
-        return new TransactionStateMachineSPI( db, new ThreadToStatementContextBridge(),
+        return new TransactionStateMachineSPI( db, new ThreadToStatementContextBridge( mock( AvailabilityGuard.class ) ),
                 mock( QueryExecutionEngine.class ), availabilityGuard, queryService, txAwaitDuration,
                 clock );
     }

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionResultTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionResultTest.java
@@ -149,7 +149,7 @@ public class ExecutionResultTest
     {
         ThreadToStatementContextBridge bridge = db.getDependencyResolver().resolveDependency(
                 ThreadToStatementContextBridge.class );
-        KernelTransaction kernelTransaction = bridge.getTopLevelTransactionBoundToThisThread( false );
+        KernelTransaction kernelTransaction = bridge.getKernelTransactionBoundToThisThread( false );
         return kernelTransaction == null ? null : new TopLevelTransaction( kernelTransaction );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -120,7 +120,7 @@ public class DataSourceModule
         DiagnosticsManager diagnosticsManager = platformModule.diagnosticsManager;
         this.queryExecutor = queryExecutionEngineSupplier;
 
-        threadToTransactionBridge = deps.satisfyDependency( life.add( new ThreadToStatementContextBridge() ) );
+        threadToTransactionBridge = deps.satisfyDependency( new ThreadToStatementContextBridge( platformModule.availabilityGuard ) );
 
         deps.satisfyDependency( graphDatabaseFacade );
         transactionEventHandlers = new TransactionEventHandlers( graphDatabaseFacade );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -515,7 +515,7 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI, EmbeddedProxySPI
     private <T> ResourceIterable<T> allInUse( final TokenAccess<T> tokens )
     {
         assertTransactionOpen();
-        return () -> tokens.inUse( statementContext.getTopLevelTransactionBoundToThisThread( true ) );
+        return () -> tokens.inUse( statementContext.getKernelTransactionBoundToThisThread( true ) );
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueConstraintCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueConstraintCompatibility.java
@@ -945,7 +945,7 @@ public class UniqueConstraintCompatibility extends IndexProviderCompatibilityTes
     private void suspend( Transaction tx )
     {
         ThreadToStatementContextBridge txManager = getTransactionManager();
-        txMap.put( tx, txManager.getTopLevelTransactionBoundToThisThread( true ) );
+        txMap.put( tx, txManager.getKernelTransactionBoundToThisThread( true ) );
         txManager.unbindTransactionFromCurrentThread();
     }
 

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionStateChecker.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionStateChecker.java
@@ -40,7 +40,7 @@ public class TransactionStateChecker implements AutoCloseable
     public static TransactionStateChecker create( TransitionalPeriodTransactionMessContainer container )
     {
         KernelTransaction topLevelTransactionBoundToThisThread =
-                container.getBridge().getTopLevelTransactionBoundToThisThread( true );
+                container.getBridge().getKernelTransactionBoundToThisThread( true );
         KernelStatement kernelStatement = (KernelStatement) topLevelTransactionBoundToThisThread.acquireStatement();
 
         return new TransactionStateChecker(

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalTxManagementKernelTransaction.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalTxManagementKernelTransaction.java
@@ -22,9 +22,9 @@ package org.neo4j.server.rest.transactional;
 import java.util.concurrent.TimeUnit;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.internal.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.internal.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
@@ -54,7 +54,7 @@ class TransitionalTxManagementKernelTransaction
     void suspendSinceTransactionsAreStillThreadBound()
     {
         assert suspendedTransaction == null : "Can't suspend the transaction if it already is suspended.";
-        suspendedTransaction = bridge.getTopLevelTransactionBoundToThisThread( true );
+        suspendedTransaction = bridge.getKernelTransactionBoundToThisThread( true );
         bridge.unbindTransactionFromCurrentThread();
     }
 

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/TxStateCheckerTestSupport.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/TxStateCheckerTestSupport.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.server.rest.transactional;
 
+import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
@@ -26,35 +27,30 @@ import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class TxStateCheckerTestSupport
+class TxStateCheckerTestSupport
 {
-    protected static final TransitionalPeriodTransactionMessContainer TPTPMC =
-            mock( TransitionalPeriodTransactionMessContainer.class );
+    static final TransitionalPeriodTransactionMessContainer TPTPMC = mock( TransitionalPeriodTransactionMessContainer.class );
+    private static FakeBridge fakeBridge = new FakeBridge();
 
     static
     {
-        // a problem with Mockito prevents inlining
-        FakeBridge bridge = new FakeBridge();
-        when( TPTPMC.getBridge() ).thenReturn( bridge );
+        when( TPTPMC.getBridge() ).thenReturn( fakeBridge );
     }
 
-    protected TxStateCheckerTestSupport()
-    {
-    }
-
-    protected static class FakeBridge extends ThreadToStatementContextBridge
+    static class FakeBridge extends ThreadToStatementContextBridge
     {
         private final KernelTransaction tx = mock( KernelTransaction.class );
         private final KernelStatement statement = mock( KernelStatement.class );
 
-        public FakeBridge()
+        FakeBridge()
         {
+            super( mock( AvailabilityGuard.class ) );
             when( tx.acquireStatement() ).thenReturn( statement );
             when( statement.hasTxStateWithChanges() ).thenReturn( false );
         }
 
         @Override
-        public KernelTransaction getTopLevelTransactionBoundToThisThread( boolean strict )
+        public KernelTransaction getKernelTransactionBoundToThisThread( boolean strict )
         {
             return tx;
         }

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/GraphDatabaseShellServer.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/GraphDatabaseShellServer.java
@@ -128,7 +128,7 @@ public class GraphDatabaseShellServer extends AbstractAppServer
         if ( !clients.containsKey( clientId ) )
         {
             ThreadToStatementContextBridge threadToStatementContextBridge = getThreadToStatementContextBridge();
-            KernelTransaction tx = threadToStatementContextBridge.getTopLevelTransactionBoundToThisThread( false );
+            KernelTransaction tx = threadToStatementContextBridge.getKernelTransactionBoundToThisThread( false );
             clients.put( clientId, tx );
         }
     }
@@ -148,7 +148,7 @@ public class GraphDatabaseShellServer extends AbstractAppServer
         try
         {
             ThreadToStatementContextBridge threadToStatementContextBridge = getThreadToStatementContextBridge();
-            KernelTransaction tx = threadToStatementContextBridge.getTopLevelTransactionBoundToThisThread( false );
+            KernelTransaction tx = threadToStatementContextBridge.getKernelTransactionBoundToThisThread( false );
             threadToStatementContextBridge.unbindTransactionFromCurrentThread();
             if ( tx == null )
             {

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Begin.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Begin.java
@@ -29,7 +29,6 @@ import org.neo4j.shell.AppCommandParser;
 import org.neo4j.shell.Continuation;
 import org.neo4j.shell.Output;
 import org.neo4j.shell.Session;
-import org.neo4j.shell.ShellException;
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
 
 @Service.Implementation( App.class )
@@ -93,6 +92,6 @@ public class Begin extends NonTransactionProvidingApp
     public static KernelTransaction currentTransaction( GraphDatabaseShellServer server )
     {
         return server.getDb().getDependencyResolver().resolveDependency( ThreadToStatementContextBridge.class )
-                .getTopLevelTransactionBoundToThisThread( false );
+                .getKernelTransactionBoundToThisThread( false );
     }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MutatingIntegrationTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MutatingIntegrationTest.scala
@@ -309,7 +309,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
     failWithError(Configs.AbsolutelyAll, "RETURN 1 / 0", List("/ by zero", "divide by zero"))
 
     val contextBridge : ThreadToStatementContextBridge = graph.getDependencyResolver.resolveDependency(classOf[ThreadToStatementContextBridge])
-    contextBridge.getTopLevelTransactionBoundToThisThread( false ) should be(null)
+    contextBridge.getKernelTransactionBoundToThisThread( false ) should be(null)
   }
 
   test("full path in one create") {


### PR DESCRIPTION
Move ThreadToStatementContextBridge out of lifecycle that was wrongly
used to detect database shutdown. Simplify code around the bridge and
use availability guard instead to detect shutdown in a standard way.