### PR TITLE
Disable tracking of CPU time and memory allocation by default

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -47,7 +47,6 @@ import org.neo4j.kernel.configuration.Title;
 import org.neo4j.kernel.configuration.ssl.SslPolicyConfigValidator;
 import org.neo4j.logging.Level;
 import org.neo4j.logging.LogTimeZone;
-import org.neo4j.values.storable.DateTimeValue;
 
 import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
 import static org.neo4j.kernel.configuration.Settings.BYTES;
@@ -320,11 +319,11 @@ public class GraphDatabaseSettings implements LoadableConfig
 
     @Description( "Enables or disables tracking of how much time a query spends actively executing on the CPU." )
     @Dynamic
-    public static final Setting<Boolean> track_query_cpu_time = setting( "dbms.track_query_cpu_time", BOOLEAN, TRUE );
+    public static final Setting<Boolean> track_query_cpu_time = setting( "dbms.track_query_cpu_time", BOOLEAN, FALSE );
 
     @Description( "Enables or disables tracking of how many bytes are allocated by the execution of a query." )
     @Dynamic
-    public static final Setting<Boolean> track_query_allocation = setting( "dbms.track_query_allocation", BOOLEAN, TRUE );
+    public static final Setting<Boolean> track_query_allocation = setting( "dbms.track_query_allocation", BOOLEAN, FALSE );
 
     @Description( "The size of the morsels" )
     @Internal

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/ListQueriesProcedureTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/ListQueriesProcedureTest.java
@@ -40,7 +40,8 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.test.rule.DatabaseRule;
@@ -79,13 +80,11 @@ import static org.neo4j.test.rule.concurrent.ThreadingRule.waitingWhileIn;
 public class ListQueriesProcedureTest
 {
     private final DatabaseRule db = new ImpermanentEnterpriseDatabaseRule()
-    {
-        @Override
-        protected void configure( GraphDatabaseBuilder builder )
-        {
-            builder.setConfig( cypher_hints_error, "true" );
-        }
-    }.startLazily();
+            .withSetting( cypher_hints_error, Settings.TRUE )
+            .withSetting( GraphDatabaseSettings.track_query_allocation, Settings.TRUE )
+            .withSetting( track_query_cpu_time, Settings.TRUE )
+            .startLazily();
+
     private final ThreadingRule threads = new ThreadingRule();
 
     @Rule


### PR DESCRIPTION
Tracking of CPU time and memory allocations are expensive operations
and since most users will never need this information before they start
investigations of any sort we will disable keep settings disabled by default