### PR TITLE
Use NeoStoreDataSource dependency resolver instead of platform's resolver

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -375,7 +375,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
     @Override
     public void start() throws IOException
     {
-        dependencies = new Dependencies();
+        dependencies = new Dependencies( dependencyResolver );
         life = new LifeSupport();
 
         life.add( recoveryCleanupWorkCollector );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/ClassicCoreSPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/ClassicCoreSPI.java
@@ -92,7 +92,7 @@ class ClassicCoreSPI implements GraphDatabaseFacade.SPI
     @Override
     public DependencyResolver resolver()
     {
-        return platform.dependencies;
+        return dataSource.neoStoreDataSource.getDependencyResolver();
     }
 
     @Override


### PR DESCRIPTION
In the hierarchy of resolvers, we need to use the last resolver in a chain
to get a natural hierarchical component resolution