### PR TITLE
Move token holders from lifecycle.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DelegatingTokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DelegatingTokenHolder.java
@@ -31,7 +31,6 @@ import java.util.function.IntPredicate;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.ReadOnlyDbException;
-import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.storageengine.api.Token;
 import org.neo4j.storageengine.api.TokenFactory;
 
@@ -43,7 +42,7 @@ import static org.neo4j.function.Predicates.ALWAYS_TRUE_INT;
  * When asked for a token that isn't in the cache, delegates to a TokenCreator to create the token,
  * then stores it in the cache.
  */
-public abstract class DelegatingTokenHolder<TOKEN extends Token> extends LifecycleAdapter implements TokenHolder<TOKEN>
+public abstract class DelegatingTokenHolder<TOKEN extends Token> implements TokenHolder<TOKEN>
 {
     protected InMemoryTokenCache<TOKEN> tokenCache = new InMemoryTokenCache<>( tokenType() );
 
@@ -52,7 +51,7 @@ public abstract class DelegatingTokenHolder<TOKEN extends Token> extends Lifecyc
     private final TokenCreator tokenCreator;
     private final TokenFactory<TOKEN> tokenFactory;
 
-    public DelegatingTokenHolder( TokenCreator tokenCreator, TokenFactory<TOKEN> tokenFactory )
+    DelegatingTokenHolder( TokenCreator tokenCreator, TokenFactory<TOKEN> tokenFactory )
     {
         this.tokenCreator = tokenCreator;
         this.tokenFactory = tokenFactory;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
@@ -112,12 +112,14 @@ public class CommunityEditionModule extends EditionModule
         dependencies.satisfyDependency( idGeneratorFactory );
         dependencies.satisfyDependency( idController );
 
-        propertyKeyTokenHolder = life.add( dependencies.satisfyDependency( new DelegatingPropertyKeyTokenHolder(
-                createPropertyKeyCreator( config, dataSourceManager, idGeneratorFactory ) ) ) );
-        labelTokenHolder = life.add( dependencies.satisfyDependency(new DelegatingLabelTokenHolder( createLabelIdCreator( config,
-                dataSourceManager, idGeneratorFactory ) ) ));
-        relationshipTypeTokenHolder = life.add( dependencies.satisfyDependency(new DelegatingRelationshipTypeTokenHolder(
-                createRelationshipTypeCreator( config, dataSourceManager, idGeneratorFactory ) ) ));
+        propertyKeyTokenHolder = new DelegatingPropertyKeyTokenHolder( createPropertyKeyCreator( config, dataSourceManager, idGeneratorFactory ) );
+        labelTokenHolder = new DelegatingLabelTokenHolder( createLabelIdCreator( config, dataSourceManager, idGeneratorFactory ) );
+        relationshipTypeTokenHolder =
+                new DelegatingRelationshipTypeTokenHolder( createRelationshipTypeCreator( config, dataSourceManager, idGeneratorFactory ) );
+
+        dependencies.satisfyDependency( propertyKeyTokenHolder );
+        dependencies.satisfyDependency( labelTokenHolder );
+        dependencies.satisfyDependency( relationshipTypeTokenHolder );
 
         dependencies.satisfyDependency(
                 createKernelData( fileSystem, pageCache, storeDir, config, graphDatabaseFacade, life ) );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -27,7 +27,6 @@ import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
-import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.unsafe.impl.batchimport.input.Input;
 import org.neo4j.unsafe.impl.batchimport.staging.ExecutionMonitor;
 import org.neo4j.unsafe.impl.batchimport.store.BatchingNeoStores;
@@ -44,7 +43,7 @@ import static org.neo4j.unsafe.impl.batchimport.ImportLogic.instantiateNeoStores
  * Goes through multiple stages where each stage has one or more steps executing in parallel, passing
  * batches between these steps through each stage, i.e. passing batches downstream.
  */
-public class ParallelBatchImporter extends LifecycleAdapter implements BatchImporter
+public class ParallelBatchImporter implements BatchImporter
 {
     private final PageCache externalPageCache;
     private final File storeDir;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
@@ -185,9 +185,13 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
         dependencies.satisfyDependency( idController );
         dependencies.satisfyDependency( new IdBasedStoreEntityCounters( this.idGeneratorFactory ) );
 
-        propertyKeyTokenHolder = life.add( dependencies.satisfyDependency( new DelegatingPropertyKeyTokenHolder( new ReadOnlyTokenCreator() ) ) );
-        labelTokenHolder = life.add( dependencies.satisfyDependency( new DelegatingLabelTokenHolder( new ReadOnlyTokenCreator() ) ) );
-        relationshipTypeTokenHolder = life.add( dependencies.satisfyDependency( new DelegatingRelationshipTypeTokenHolder( new ReadOnlyTokenCreator() ) ) );
+        propertyKeyTokenHolder = new DelegatingPropertyKeyTokenHolder( new ReadOnlyTokenCreator() );
+        labelTokenHolder = new DelegatingLabelTokenHolder( new ReadOnlyTokenCreator() );
+        relationshipTypeTokenHolder = new DelegatingRelationshipTypeTokenHolder( new ReadOnlyTokenCreator() );
+
+        dependencies.satisfyDependency( propertyKeyTokenHolder );
+        dependencies.satisfyDependency( labelTokenHolder );
+        dependencies.satisfyDependency( relationshipTypeTokenHolder );
 
         life.add( dependencies.satisfyDependency( new DefaultKernelData( fileSystem, pageCache, storeDir, config, graphDatabaseFacade ) ) );
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchedDataMigrator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchedDataMigrator.java
@@ -27,18 +27,15 @@ import java.io.IOException;
 
 import org.neo4j.com.storecopy.StoreUtil;
 import org.neo4j.io.fs.FileUtils;
-import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
 public class BranchedDataMigrator extends LifecycleAdapter
 {
     private final File storeDir;
-    private final PageCache pageCache;
 
-    public BranchedDataMigrator( File storeDir, PageCache pageCache )
+    public BranchedDataMigrator( File storeDir )
     {
         this.storeDir = storeDir;
-        this.pageCache = pageCache;
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -225,7 +225,7 @@ public class HighlyAvailableEditionModule
         // Set Netty logger
         InternalLoggerFactory.setDefaultFactory( new NettyLoggerFactory( logging.getInternalLogProvider() ) );
 
-        life.add( new BranchedDataMigrator( platformModule.storeDir, platformModule.pageCache ) );
+        life.add( new BranchedDataMigrator( platformModule.storeDir ) );
         DelegateInvocationHandler<Master> masterDelegateInvocationHandler =
                 new DelegateInvocationHandler<>( Master.class );
         Master master = (Master) newProxyInstance( Master.class.getClassLoader(), new Class[]{Master.class},

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/CommitPusher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/CommitPusher.java
@@ -33,12 +33,11 @@ import java.util.concurrent.FutureTask;
 
 import org.neo4j.com.Response;
 import org.neo4j.kernel.ha.com.master.Slave;
-import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.scheduler.JobScheduler;
 
 import static org.neo4j.scheduler.JobScheduler.Groups.masterTransactionPushing;
 
-public class CommitPusher extends LifecycleAdapter
+public class CommitPusher
 {
     private static class PullUpdateFuture
             extends FutureTask<Object>


### PR DESCRIPTION
Previously token holders was part of lifecycle and it looks like there
was no reason for them be part of that. This PR move them away from
participating in life.