### PR TITLE
Close output stream in BoltMessageLog on shutdown

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
@@ -144,6 +144,7 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
 
         InternalLoggerFactory.setDefaultFactory( new Netty4LoggerFactory( logService.getInternalLogProvider() ) );
         BoltMessageLogging boltLogging = BoltMessageLogging.create( dependencies.fileSystem(), scheduler, config, log );
+        life.add( boltLogging );
 
         Authentication authentication = authentication( dependencies.authManager(), dependencies.userManagerSupplier() );
 

--- a/community/bolt/src/main/java/org/neo4j/bolt/logging/BoltMessageLoggerImpl.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/logging/BoltMessageLoggerImpl.java
@@ -21,9 +21,7 @@ package org.neo4j.bolt.logging;
 
 import io.netty.channel.Channel;
 import io.netty.util.AttributeKey;
-import org.codehaus.jackson.map.ObjectMapper;
 
-import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -44,7 +42,6 @@ import static java.lang.String.format;
  */
 class BoltMessageLoggerImpl implements BoltMessageLogger
 {
-    private static final ObjectMapper jsonObjectMapper = new ObjectMapper();
     private static final Supplier<String> PLACEHOLDER_DETAIL_SUPPLIER = () -> "-";
     private final BoltMessageLog messageLog;
 
@@ -207,18 +204,6 @@ class BoltMessageLoggerImpl implements BoltMessageLogger
         {
             SocketAddress remoteAddress = channel.remoteAddress();
             return remoteAddress.toString();
-        }
-    }
-
-    private static String json( Object arg )
-    {
-        try
-        {
-            return jsonObjectMapper.writeValueAsString( arg );
-        }
-        catch ( IOException e )
-        {
-            return "?";
         }
     }
 

--- a/community/bolt/src/main/java/org/neo4j/bolt/logging/BoltMessageLogging.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/logging/BoltMessageLogging.java
@@ -28,10 +28,11 @@ import java.util.concurrent.Executor;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.Log;
 import org.neo4j.scheduler.JobScheduler;
 
-public class BoltMessageLogging
+public class BoltMessageLogging extends LifecycleAdapter
 {
     private final BoltMessageLog boltMessageLog;
 
@@ -43,11 +44,6 @@ public class BoltMessageLogging
     public static BoltMessageLogging create( FileSystemAbstraction fs, JobScheduler scheduler, Config config, Log log )
     {
         return new BoltMessageLogging( createBoltMessageLog( fs, scheduler, config, log ) );
-    }
-
-    public static BoltMessageLogging none()
-    {
-        return new BoltMessageLogging( null );
     }
 
     public BoltMessageLogger newLogger( Channel channel )
@@ -74,5 +70,14 @@ public class BoltMessageLogging
             }
         }
         return null;
+    }
+
+    @Override
+    public void shutdown() throws Throwable
+    {
+        if ( boltMessageLog != null )
+        {
+            boltMessageLog.shutdown();
+        }
     }
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/logging/BoltMessageLoggingTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/logging/BoltMessageLoggingTest.java
@@ -96,12 +96,19 @@ public class BoltMessageLoggingTest
     }
 
     @Test
-    public void shouldCreateNullLoggerWhenNone()
+    public void shutdownLoggingWhenBoltLogEnabled() throws Throwable
     {
-        BoltMessageLogging logging = BoltMessageLogging.none();
-        BoltMessageLogger logger = logging.newLogger( channel );
+        Config config = newConfig( true );
+        BoltMessageLogging logging = BoltMessageLogging.create( fs, jobScheduler, config, log );
+        logging.shutdown();
+    }
 
-        assertThat( logger, instanceOf( NullBoltMessageLogger.class ) );
+    @Test
+    public void shutdownLoggingWhenBoltLogDisabled() throws Throwable
+    {
+        Config config = newConfig( false );
+        BoltMessageLogging logging = BoltMessageLogging.create( fs, jobScheduler, config, log );
+        logging.shutdown();
     }
 
     private static Config newConfig( boolean boltLogEnabled )

--- a/community/bolt/src/test/java/org/neo4j/bolt/runtime/DefaultBoltConnectionTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/runtime/DefaultBoltConnectionTest.java
@@ -32,7 +32,7 @@ import java.util.concurrent.Future;
 import org.neo4j.bolt.BoltChannel;
 import org.neo4j.bolt.BoltKernelExtension;
 import org.neo4j.bolt.logging.BoltMessageLogger;
-import org.neo4j.bolt.logging.BoltMessageLogging;
+import org.neo4j.bolt.logging.NullBoltMessageLogger;
 import org.neo4j.bolt.testing.Jobs;
 import org.neo4j.bolt.v1.packstream.PackOutput;
 import org.neo4j.bolt.v1.runtime.BoltConnectionAuthFatality;
@@ -70,7 +70,7 @@ public class DefaultBoltConnectionTest
     private final BoltConnectionLifetimeListener connectionListener = mock( BoltConnectionLifetimeListener.class );
     private final BoltConnectionQueueMonitor queueMonitor = mock( BoltConnectionQueueMonitor.class );
     private final EmbeddedChannel channel = new EmbeddedChannel();
-    private final BoltMessageLogger messageLogger = BoltMessageLogging.none().newLogger( channel );
+    private final BoltMessageLogger messageLogger = NullBoltMessageLogger.getInstance();
 
     private BoltChannel boltChannel;
     private BoltStateMachine stateMachine;
@@ -82,7 +82,7 @@ public class DefaultBoltConnectionTest
     public void setup()
     {
         boltChannel = BoltChannel.open( connector, channel, messageLogger );
-        stateMachine = mock( BoltStateMachine.class ); // MachineRoom.newMachineWithOwner( BoltStateMachine.State.READY, "neo4j" );
+        stateMachine = mock( BoltStateMachine.class );
         when( stateMachine.owner() ).thenReturn( "neo4j" );
         when( stateMachine.shouldStickOnThread() ).thenReturn( false );
         when( stateMachine.hasOpenStatement() ).thenReturn( false );

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/MachineRoom.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/MachineRoom.java
@@ -65,14 +65,6 @@ public class MachineRoom
         return machine;
     }
 
-    public static BoltStateMachine newMachineWithOwner( BoltStateMachine.State state, String owner ) throws AuthenticationException, BoltConnectionFatality
-    {
-        BoltStateMachine machine = newMachine();
-        init( machine, owner );
-        machine.state = state;
-        return machine;
-    }
-
     public static BoltStateMachine newMachineWithTransaction( BoltStateMachine.State state )
             throws AuthenticationException, BoltConnectionFatality
     {

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineTest.java
@@ -46,7 +46,6 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -567,19 +566,6 @@ public class TransactionStateMachineTest
     private MapValue map( Object... keyValues )
     {
         return ValueUtils.asMapValue( MapUtil.map( keyValues ) );
-    }
-
-    private static TransactionStateMachineSPI newFailingTransactionStateMachineSPI( Status failureStatus ) throws KernelException
-    {
-        TransactionStateMachine.BoltResultHandle resultHandle = newResultHandle();
-        TransactionStateMachineSPI stateMachineSPI = mock( TransactionStateMachineSPI.class );
-
-        KernelTransaction kernelTransaction = mock( KernelTransaction.class );
-        when( stateMachineSPI.beginTransaction( any() ) ).thenReturn( kernelTransaction );
-        when( stateMachineSPI.executeQuery( any(), any(), anyString(), any() ) ).thenReturn( resultHandle );
-        when( stateMachineSPI.executeQuery( any(), any(), eq( "FAIL" ), any() ) ).thenThrow( new TransactionTerminatedException( failureStatus ) );
-
-        return stateMachineSPI;
     }
 
     private static TransactionStateMachineSPI newTransactionStateMachineSPI( KernelTransaction transaction ) throws KernelException


### PR DESCRIPTION
Before BoltMessageLog was not closing instance of RotatingFileOutputStreamSupplier
that was used for logging. This PR will close it as part of
bolt extension shutdown.

Small unused test code cleanup.