### PR TITLE
Small cleanup around bolt tx state machine

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
@@ -47,12 +47,12 @@ import org.neo4j.bolt.v1.runtime.BoltFactory;
 import org.neo4j.bolt.v1.runtime.BoltFactoryImpl;
 import org.neo4j.configuration.Description;
 import org.neo4j.configuration.LoadableConfig;
-import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.ListenSocketAddress;
 import org.neo4j.helpers.Service;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
 import org.neo4j.kernel.api.security.AuthManager;
 import org.neo4j.kernel.api.security.UserManagerSupplier;
@@ -61,7 +61,6 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.ConnectorPortRegister;
 import org.neo4j.kernel.configuration.ssl.SslPolicyLoader;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
-import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.spi.KernelContext;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
@@ -96,7 +95,7 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
 
         Config config();
 
-        GraphDatabaseService db();
+        GraphDatabaseAPI db();
 
         JobScheduler scheduler();
 
@@ -104,7 +103,7 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
 
         Monitors monitors();
 
-        ThreadToStatementContextBridge txBridge();
+        AvailabilityGuard availabilityGuard();
 
         BoltConnectionTracker sessionTracker();
 
@@ -130,8 +129,6 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
     public Lifecycle newInstance( KernelContext context, Dependencies dependencies )
     {
         Config config = dependencies.config();
-        GraphDatabaseService gdb = dependencies.db();
-        GraphDatabaseAPI api = (GraphDatabaseAPI) gdb;
         LogService logService = dependencies.logService();
         Clock clock = dependencies.clock();
         SslPolicyLoader sslPolicyFactory = dependencies.sslPolicyFactory();
@@ -150,8 +147,8 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
 
         TransportThrottleGroup throttleGroup = new TransportThrottleGroup( config, clock );
 
-        BoltFactory boltFactory = life.add( new BoltFactoryImpl( api, dependencies.usageData(),
-                logService, dependencies.txBridge(), authentication, dependencies.sessionTracker(), config ) );
+        BoltFactory boltFactory = new BoltFactoryImpl( dependencies.db(), dependencies.usageData(), dependencies.availabilityGuard(),
+                authentication, dependencies.sessionTracker(), config, logService );
         BoltSchedulerProvider boltSchedulerProvider =
                 life.add( new ExecutorBoltSchedulerProvider( config, new CachedThreadPoolExecutorFactory( log ), scheduler, logService ) );
         BoltConnectionFactory boltConnectionFactory =

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineSPITest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineSPITest.java
@@ -124,17 +124,21 @@ public class TransactionStateMachineSPITest
     private static TransactionStateMachineSPI createTxSpi( Supplier<TransactionIdStore> txIdStore, Duration txAwaitDuration,
             AvailabilityGuard availabilityGuard, Clock clock )
     {
-        GraphDatabaseQueryService queryService = mock( GraphDatabaseQueryService.class );
-        DependencyResolver dependencyResolver = mock( DependencyResolver.class );
-        GraphDatabaseAPI db = mock( GraphDatabaseAPI.class );
+        QueryExecutionEngine queryExecutionEngine = mock( QueryExecutionEngine.class );
 
-        when( queryService.getDependencyResolver() ).thenReturn( dependencyResolver );
+        DependencyResolver dependencyResolver = mock( DependencyResolver.class );
+        ThreadToStatementContextBridge bridge = new ThreadToStatementContextBridge( availabilityGuard );
+        when( dependencyResolver.resolveDependency( ThreadToStatementContextBridge.class ) ).thenReturn( bridge );
+        when( dependencyResolver.resolveDependency( QueryExecutionEngine.class ) ).thenReturn( queryExecutionEngine );
+        when( dependencyResolver.provideDependency( TransactionIdStore.class ) ).thenReturn( txIdStore );
+
+        GraphDatabaseAPI db = mock( GraphDatabaseAPI.class );
         when( db.getDependencyResolver() ).thenReturn( dependencyResolver );
 
-        when(dependencyResolver.provideDependency( TransactionIdStore.class )).thenReturn( txIdStore );
+        GraphDatabaseQueryService queryService = mock( GraphDatabaseQueryService.class );
+        when( queryService.getDependencyResolver() ).thenReturn( dependencyResolver );
+        when( dependencyResolver.resolveDependency( GraphDatabaseQueryService.class ) ).thenReturn( queryService );
 
-        return new TransactionStateMachineSPI( db, new ThreadToStatementContextBridge( mock( AvailabilityGuard.class ) ),
-                mock( QueryExecutionEngine.class ), availabilityGuard, queryService, txAwaitDuration,
-                clock );
+        return new TransactionStateMachineSPI( db, availabilityGuard, txAwaitDuration, clock );
     }
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionRule.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionRule.java
@@ -40,11 +40,11 @@ import org.neo4j.bolt.v1.runtime.BoltStateMachine;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
 import org.neo4j.kernel.api.security.AuthManager;
 import org.neo4j.kernel.api.security.UserManagerSupplier;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
@@ -75,13 +75,12 @@ class SessionRule implements TestRule
                 boltFactory = new BoltFactoryImpl(
                                         gdb,
                                         new UsageData( null ),
-                                        NullLogService.getInstance(),
-                                        resolver.resolveDependency( ThreadToStatementContextBridge.class ),
+                                        resolver.resolveDependency( AvailabilityGuard.class ),
                                         authentication,
                                         BoltConnectionTracker.NOOP,
-                                        Config.defaults()
+                                        Config.defaults(),
+                                        NullLogService.getInstance()
                                     );
-                boltFactory.start();
                 try
                 {
                     base.evaluate();


### PR DESCRIPTION
Simplified lifecycle and removed dependency of `TransactionStateMachineSPI` on `GraphDatabaseQueryService`. It was unnecessary because component already had dependency on `GraphDatabaseAPI` which is essentially the same thing. SPI will also resolve all needed dependencies using the provided database.