### PR TITLE
Fix flaky BinaryLatchTest.releaseMustUnblockAwaiters.

### DIFF
--- a/community/concurrent/src/test/java/org/neo4j/util/concurrent/BinaryLatchTest.java
+++ b/community/concurrent/src/test/java/org/neo4j/util/concurrent/BinaryLatchTest.java
@@ -58,7 +58,7 @@ class BinaryLatchTest
     @Test
     void releaseMustUnblockAwaiters()
     {
-        assertTimeout( ofSeconds( 1 ), () ->
+        assertTimeout( ofSeconds( 10 ), () ->
         {
             final BinaryLatch latch = new BinaryLatch();
             Runnable awaiter = latch::await;


### PR DESCRIPTION
The fix is to reinstate the 10 second timeout the test had prior to being converted to JUnit 5.