### PR TITLE
Fix bugs in morsel runtime for aggregation and sort

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MorselRuntimeAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MorselRuntimeAcceptanceTest.scala
@@ -342,6 +342,23 @@ class MorselRuntimeAcceptanceTest extends ExecutionEngineFunSuite {
    asScalaResult(result).toList should not be empty
   }
 
+  test("aggregation should not overflow morsel") {
+    // Given
+    graph.execute( """
+                     |CREATE (zadie: AUTHOR {name: "Zadie Smith"})
+                     |CREATE (zadie)-[:WROTE]->(:BOOK {book: "White teeth"})
+                     |CREATE (zadie)-[:WROTE]->(:BOOK {book: "The Autograph Man"})
+                     |CREATE (zadie)-[:WROTE]->(:BOOK {book: "On Beauty"})
+                     |CREATE (zadie)-[:WROTE]->(:BOOK {book: "NW"})
+                     |CREATE (zadie)-[:WROTE]->(:BOOK {book: "Swing Time"})""".stripMargin)
+
+    // When
+    val result = graph.execute("CYPHER runtime=morsel  MATCH (a)-[r]->(b) RETURN b.book as book, count(r), count(distinct a)")
+
+    // Then
+    asScalaResult(result).toList should not be empty
+  }
+
   //we use a ridiculously small morsel size in order to trigger as many morsel overflows as possible
   override def databaseConfig(): Map[Setting[_], String] = Map(GraphDatabaseSettings.cypher_morsel_size -> "4")
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MorselRuntimeAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MorselRuntimeAcceptanceTest.scala
@@ -359,6 +359,22 @@ class MorselRuntimeAcceptanceTest extends ExecutionEngineFunSuite {
     asScalaResult(result).toList should not be empty
   }
 
+  test("foo") {
+    // Given
+    graph.execute( """
+                     |CREATE (zadie: AUTHOR {name: "Zadie Smith"})
+                     |CREATE (zadie)-[:WROTE]->(:BOOK {book: "White teeth", rating: 5})
+                     |CREATE (zadie)-[:WROTE]->(:BOOK {book: "The Autograph Man", rating: 3})
+                     |CREATE (zadie)-[:WROTE]->(:BOOK {book: "On Beauty", rating: 4})
+                     |CREATE (zadie)-[:WROTE]->(:BOOK {book: "NW"})
+                     |CREATE (zadie)-[:WROTE]->(:BOOK {book: "Swing Time", rating: 5})""".stripMargin)
+
+    // When
+    val result = graph.execute("CYPHER runtime=morsel  MATCH (b:BOOK) RETURN b.book as book, count(b.rating) ORDER BY book")
+
+    // Then
+    println(result.resultAsString())
+  }
   //we use a ridiculously small morsel size in order to trigger as many morsel overflows as possible
   override def databaseConfig(): Map[Setting[_], String] = Map(GraphDatabaseSettings.cypher_morsel_size -> "4")
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildVectorizedExecutionPlan.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildVectorizedExecutionPlan.scala
@@ -31,11 +31,6 @@ import org.neo4j.cypher.internal.compatibility.v3_5.runtime.helpers.InternalWrap
 import org.neo4j.cypher.internal.compatibility.v3_5.runtime.phases.CompilationState
 import org.neo4j.cypher.internal.compiler.v3_5.phases.LogicalPlanState
 import org.neo4j.cypher.internal.compiler.v3_5.planner.CantCompileQueryException
-import org.opencypher.v9_0.frontend.PlannerName
-import org.opencypher.v9_0.frontend.phases.CompilationPhaseTracer.CompilationPhase
-import org.opencypher.v9_0.frontend.phases._
-import org.opencypher.v9_0.ast.semantics.SemanticTable
-import org.neo4j.cypher.internal.planner.v3_5.spi.GraphStatistics
 import org.neo4j.cypher.internal.planner.v3_5.spi.PlanningAttributes.Cardinalities
 import org.neo4j.cypher.internal.runtime.compiled.EnterpriseRuntimeContext
 import org.neo4j.cypher.internal.runtime.interpreted.commands.convert.{CommunityExpressionConverter, ExpressionConverters}
@@ -46,11 +41,15 @@ import org.neo4j.cypher.internal.runtime.vectorized.dispatcher.{Dispatcher, Sing
 import org.neo4j.cypher.internal.runtime.vectorized.expressions.MorselExpressionConverters
 import org.neo4j.cypher.internal.runtime.vectorized.{Pipeline, PipelineBuilder}
 import org.neo4j.cypher.internal.runtime.{QueryStatistics, _}
-import org.opencypher.v9_0.util.{ExperimentalFeatureNotification, TaskCloser}
 import org.neo4j.cypher.internal.v3_5.logical.plans.LogicalPlan
 import org.neo4j.cypher.result.QueryResult.QueryResultVisitor
 import org.neo4j.graphdb._
 import org.neo4j.values.virtual.MapValue
+import org.opencypher.v9_0.ast.semantics.SemanticTable
+import org.opencypher.v9_0.frontend.PlannerName
+import org.opencypher.v9_0.frontend.phases.CompilationPhaseTracer.CompilationPhase
+import org.opencypher.v9_0.frontend.phases._
+import org.opencypher.v9_0.util.{ExperimentalFeatureNotification, TaskCloser}
 
 import scala.util.{Failure, Success}
 

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/Operator.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/Operator.scala
@@ -67,6 +67,7 @@ case class Lazy(pipeline: Pipeline) extends Dependency {
 
 case class Eager(pipeline: Pipeline) extends Dependency {
   override def foreach(f: Pipeline => Unit): Unit = f(pipeline)
+  lazy val eagerData = new java.util.concurrent.ConcurrentLinkedQueue[Morsel]()
 }
 
 case object NoDependencies extends Dependency {
@@ -77,6 +78,12 @@ case object NoDependencies extends Dependency {
 
 case class QueryState(params: MapValue, visitor: QueryResultVisitor[_])
 
+object PipeLineWithEagerDependency {
+  def unapply(arg: Pipeline): Option[java.util.Queue[Morsel]] = arg match {
+    case Pipeline(_,_,_, eager@Eager(_)) => Some(eager.eagerData)
+    case _ => None
+  }
+}
 
 case class Pipeline(start: Operator,
                     operators: IndexedSeq[MiddleOperator],

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/dispatcher/ParallelDispatcher.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/dispatcher/ParallelDispatcher.scala
@@ -28,10 +28,10 @@ import java.util.{concurrent, function}
 
 import org.neo4j.cypher.internal.runtime.QueryContext
 import org.neo4j.cypher.internal.runtime.vectorized._
-import org.opencypher.v9_0.util.{InternalException, TaskCloser}
 import org.neo4j.cypher.result.QueryResult.QueryResultVisitor
 import org.neo4j.util.concurrent.BinaryLatch
 import org.neo4j.values.virtual.MapValue
+import org.opencypher.v9_0.util.TaskCloser
 
 import scala.collection.JavaConverters._
 
@@ -78,15 +78,14 @@ class ParallelDispatcher(morselSize: Int, workers: Int, executor: Executor) exte
         val loopsLeft = query.endLoop(message.iterationState)
         val weJustClosedTheLastLoop = loopsLeft == 0
         if (weJustClosedTheLastLoop) {
-          query.eagerReceiver match {
-            case None =>
+
+          pipeline.parent match {
+            case Some(eagerConsumingPipeline@PipeLineWithEagerDependency(eagerData)) =>
+              val startEager = StartLoopWithEagerData(eagerData.asScala.toArray, incoming.iterationState)
+              executor.execute(createAction(query, startEager, eagerConsumingPipeline, queryContext, state))
+            case _ =>
               // We where the last pipeline! Cool! Let's signal the query that we are done here.
               query.releaseBlockedThreads()
-
-            case Some(eagerConsumingPipeline) =>
-              query.eagerReceiver = None
-              val startEager = StartLoopWithEagerData(query.eagerData.asScala.toArray, incoming.iterationState)
-              executor.execute(createAction(query, startEager, eagerConsumingPipeline, queryContext, state))
           }
 
         }
@@ -103,17 +102,10 @@ class ParallelDispatcher(morselSize: Int, workers: Int, executor: Executor) exte
     val continuation = pipeline.operate(message, data, queryContext, state)
 
     pipeline.parent match {
-      case Some(mother) if mother.dependency.isInstanceOf[Eager] && query.eagerReceiver.contains(mother) =>
-        query.eagerData.add(data)
+      case Some(PipeLineWithEagerDependency(eagerData)) =>
+        eagerData.add(data)
 
-      case Some(mother) if mother.dependency.isInstanceOf[Eager] && query.eagerReceiver.isEmpty =>
-        query.eagerReceiver = Some(mother)
-        query.eagerData.add(data)
-
-      case Some(mother) if mother.dependency.isInstanceOf[Eager] =>
-        throw new InternalException("This is not the same eager receiver as I want to use")
-
-      case Some(mother) if mother.dependency.isInstanceOf[Lazy] =>
+      case Some(mother@Pipeline(_,_,_, Lazy(_))) =>
         val nextStep = StartLoopWithSingleMorsel(data, message.iterationState)
         executor.execute(createAction(query, nextStep, mother, queryContext, state))
 
@@ -136,8 +128,6 @@ class ParallelDispatcher(morselSize: Int, workers: Int, executor: Executor) exte
     private val error = new AtomicReference[Throwable]()
     private val latch = new BinaryLatch
     private val name = Thread.currentThread().getName
-    var eagerReceiver: Option[Pipeline] = None
-    lazy val eagerData = new java.util.concurrent.ConcurrentLinkedQueue[Morsel]()
 
     def startLoop(iteration: Iteration): Unit = {
       loopCount.computeIfAbsent(iteration, createAtomicInteger).incrementAndGet()


### PR DESCRIPTION
Fixed the following two bugs
- In the reduce step of aggregation we could overflow the morsel
- When having multiple eager pipelines the dispatcher was combining data from both of them

~Builds on top of https://github.com/neo4j/neo4j/pull/11874~