### PR TITLE
Store copy catchup avoids self

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupAddressProvider.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupAddressProvider.java
@@ -26,9 +26,7 @@ import org.neo4j.causalclustering.core.consensus.LeaderLocator;
 import org.neo4j.causalclustering.core.consensus.NoLeaderFoundException;
 import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.MemberId;
-import org.neo4j.causalclustering.upstream.UpstreamDatabaseSelectionException;
 import org.neo4j.causalclustering.upstream.UpstreamDatabaseStrategySelector;
-import org.neo4j.function.ThrowingSupplier;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 
 /**
@@ -137,32 +135,6 @@ public interface CatchupAddressProvider
         public AdvertisedSocketAddress secondary() throws CatchupAddressResolutionException
         {
             return secondaryUpstreamStrategyAddressSupplier.get();
-        }
-    }
-
-    class UpstreamStrategyAddressSupplier implements ThrowingSupplier<AdvertisedSocketAddress,CatchupAddressResolutionException>
-    {
-        private final UpstreamDatabaseStrategySelector strategySelector;
-        private final TopologyService topologyService;
-
-        private UpstreamStrategyAddressSupplier( UpstreamDatabaseStrategySelector strategySelector, TopologyService topologyService )
-        {
-            this.strategySelector = strategySelector;
-            this.topologyService = topologyService;
-        }
-
-        @Override
-        public AdvertisedSocketAddress get() throws CatchupAddressResolutionException
-        {
-            try
-            {
-                MemberId upstreamMember = strategySelector.bestUpstreamDatabase();
-                return topologyService.findCatchupAddress( upstreamMember ).orElseThrow( () -> new CatchupAddressResolutionException( upstreamMember ) );
-            }
-            catch ( UpstreamDatabaseSelectionException e )
-            {
-                throw new CatchupAddressResolutionException( e );
-            }
         }
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/UpstreamStrategyAddressSupplier.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/UpstreamStrategyAddressSupplier.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j Enterprise Edition. The included source
+ * code can be redistributed and/or modified under the terms of the
+ * GNU AFFERO GENERAL PUBLIC LICENSE Version 3
+ * (http://www.fsf.org/licensing/licenses/agpl-3.0.html) with the
+ * Commons Clause, as found in the associated LICENSE.txt file.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * Neo4j object code can be licensed independently from the source
+ * under separate terms from the AGPL. Inquiries can be directed to:
+ * licensing@neo4j.com
+ *
+ * More information is also available at:
+ * https://neo4j.com/licensing/
+ */
+package org.neo4j.causalclustering.catchup;
+
+import org.neo4j.causalclustering.discovery.TopologyService;
+import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.causalclustering.upstream.UpstreamDatabaseSelectionException;
+import org.neo4j.causalclustering.upstream.UpstreamDatabaseStrategySelector;
+import org.neo4j.function.ThrowingSupplier;
+import org.neo4j.helpers.AdvertisedSocketAddress;
+
+public class UpstreamStrategyAddressSupplier implements ThrowingSupplier<AdvertisedSocketAddress,CatchupAddressResolutionException>
+{
+    private final UpstreamDatabaseStrategySelector strategySelector;
+    private final TopologyService topologyService;
+
+    UpstreamStrategyAddressSupplier( UpstreamDatabaseStrategySelector strategySelector, TopologyService topologyService )
+    {
+        this.strategySelector = strategySelector;
+        this.topologyService = topologyService;
+    }
+
+    @Override
+    public AdvertisedSocketAddress get() throws CatchupAddressResolutionException
+    {
+        try
+        {
+            MemberId upstreamMember = strategySelector.bestUpstreamDatabase();
+            return topologyService.findCatchupAddress( upstreamMember ).orElseThrow( () -> new CatchupAddressResolutionException( upstreamMember ) );
+        }
+        catch ( UpstreamDatabaseSelectionException e )
+        {
+            throw new CatchupAddressResolutionException( e );
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ReadReplicaTopology.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ReadReplicaTopology.java
@@ -59,15 +59,6 @@ public class ReadReplicaTopology implements Topology<ReadReplicaInfo>
         return String.format( "{readReplicas=%s}", readReplicaMembers );
     }
 
-    public Optional<MemberId> randomReadReplicaMemberId()
-    {
-        if ( readReplicaMembers.isEmpty() )
-        {
-            return Optional.empty();
-        }
-        return readReplicaMembers.keySet().stream().skip( ThreadLocalRandom.current().nextInt( readReplicaMembers.size() ) ).findFirst();
-    }
-
     @Override
     public ReadReplicaTopology filterTopologyByDb( String dbName )
     {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/strategies/LeaderOnlyStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/upstream/strategies/LeaderOnlyStrategy.java
@@ -23,6 +23,7 @@
 package org.neo4j.causalclustering.upstream.strategies;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.neo4j.causalclustering.discovery.RoleInfo;
@@ -54,7 +55,7 @@ public class LeaderOnlyStrategy extends UpstreamDatabaseSelectionStrategy
         for ( Map.Entry<MemberId,RoleInfo> entry : memberRoles.entrySet() )
         {
             RoleInfo role = entry.getValue();
-            if ( role == RoleInfo.LEADER )
+            if ( role == RoleInfo.LEADER && !Objects.equals( myself, entry.getKey() ) )
             {
                 return Optional.of( entry.getKey() );
             }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/UpstreamStrategyAddressSupplierTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/UpstreamStrategyAddressSupplierTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j Enterprise Edition. The included source
+ * code can be redistributed and/or modified under the terms of the
+ * GNU AFFERO GENERAL PUBLIC LICENSE Version 3
+ * (http://www.fsf.org/licensing/licenses/agpl-3.0.html) with the
+ * Commons Clause, as found in the associated LICENSE.txt file.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * Neo4j object code can be licensed independently from the source
+ * under separate terms from the AGPL. Inquiries can be directed to:
+ * licensing@neo4j.com
+ *
+ * More information is also available at:
+ * https://neo4j.com/licensing/
+ */
+package org.neo4j.causalclustering.catchup;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.neo4j.causalclustering.discovery.TopologyService;
+import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.causalclustering.upstream.UpstreamDatabaseSelectionException;
+import org.neo4j.causalclustering.upstream.UpstreamDatabaseSelectionStrategy;
+import org.neo4j.causalclustering.upstream.UpstreamDatabaseStrategySelector;
+import org.neo4j.helpers.AdvertisedSocketAddress;
+import org.neo4j.logging.NullLogProvider;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UpstreamStrategyAddressSupplierTest
+{
+    private MemberId defaultMember = new MemberId( UUID.randomUUID() );
+    private MemberId firstMember = new MemberId( UUID.randomUUID() );
+    private MemberId secondMember = new MemberId( UUID.randomUUID() );
+    private AdvertisedSocketAddress defaultAddress = new AdvertisedSocketAddress( "Default", 123 );
+    private AdvertisedSocketAddress firstAddress = new AdvertisedSocketAddress( "First", 456 );
+    private AdvertisedSocketAddress secondAddress = new AdvertisedSocketAddress( "Second", 789 );
+    private TopologyService topologyService = mock( TopologyService.class );
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Before
+    public void setup()
+    {
+        when( topologyService.findCatchupAddress( eq( defaultMember ) ) ).thenReturn( Optional.of( defaultAddress ) );
+        when( topologyService.findCatchupAddress( eq( firstMember ) ) ).thenReturn( Optional.of( firstAddress ) );
+        when( topologyService.findCatchupAddress( eq( secondMember ) ) ).thenReturn( Optional.of( secondAddress ) );
+    }
+
+    @Test
+    public void selectionPrioritiesAreKept() throws CatchupAddressResolutionException
+    {
+        // given various strategies with different priorities
+        UpstreamDatabaseStrategySelector upstreamDatabaseStrategySelector =
+                new UpstreamDatabaseStrategySelector( new CountedSelectionStrategy( defaultMember, 5 ),
+                        Arrays.asList( new CountedSelectionStrategy( firstMember, 1 ), new CountedSelectionStrategy( secondMember, 1 ) ),
+                        NullLogProvider.getInstance() );
+
+        // and
+        UpstreamStrategyAddressSupplier upstreamStrategyAddressSupplier =
+                new UpstreamStrategyAddressSupplier( upstreamDatabaseStrategySelector, topologyService );
+
+        // when
+        AdvertisedSocketAddress firstResult = upstreamStrategyAddressSupplier.get();
+        AdvertisedSocketAddress secondResult = upstreamStrategyAddressSupplier.get();
+        AdvertisedSocketAddress thirdResult = upstreamStrategyAddressSupplier.get();
+
+        // then
+        assertEquals( firstAddress, firstResult );
+        assertEquals( secondAddress, secondResult );
+        assertEquals( defaultAddress, thirdResult );
+    }
+
+    @Test
+    public void exceptionWhenStrategiesFail() throws CatchupAddressResolutionException
+    {
+        // given a guaranteed fail strategy
+        UpstreamDatabaseStrategySelector upstreamDatabaseStrategySelector =
+                new UpstreamDatabaseStrategySelector( new CountedSelectionStrategy( defaultMember, 0 ) );
+
+        // and
+        UpstreamStrategyAddressSupplier upstreamStrategyAddressSupplier =
+                new UpstreamStrategyAddressSupplier( upstreamDatabaseStrategySelector, topologyService );
+
+        // then
+        expectedException.expect( CatchupAddressResolutionException.class );
+
+        // when
+        upstreamStrategyAddressSupplier.get();
+    }
+
+    private class CountedSelectionStrategy extends UpstreamDatabaseSelectionStrategy
+    {
+        MemberId upstreamDatabase;
+        private int numberOfIterations;
+
+        CountedSelectionStrategy( MemberId upstreamDatabase, int numberOfIterations )
+        {
+            super( CountedSelectionStrategy.class.getName() );
+            this.upstreamDatabase = upstreamDatabase;
+            this.numberOfIterations = numberOfIterations;
+        }
+
+        @Override
+        public Optional<MemberId> upstreamDatabase() throws UpstreamDatabaseSelectionException
+        {
+            MemberId consumed = upstreamDatabase;
+            numberOfIterations--;
+            if ( numberOfIterations < 0 )
+            {
+                upstreamDatabase = null;
+            }
+            return Optional.ofNullable( consumed );
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return super.hashCode() + (upstreamDatabase.hashCode() * 17) + (31 * numberOfIterations);
+        }
+
+        @Override
+        public boolean equals( Object o )
+        {
+            if ( o == null || !(o instanceof CountedSelectionStrategy) )
+            {
+                return false;
+            }
+            CountedSelectionStrategy other = (CountedSelectionStrategy) o;
+            return this.upstreamDatabase.equals( other.upstreamDatabase ) && this.numberOfIterations == other.numberOfIterations;
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/UpstreamDatabaseStrategySelectorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/UpstreamDatabaseStrategySelectorTest.java
@@ -41,8 +41,7 @@ import org.neo4j.logging.NullLogProvider;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.collection.Iterables.iterable;
 
@@ -104,7 +103,7 @@ public class UpstreamDatabaseStrategySelectorTest
         when( topologyService.localCoreServers() ).thenReturn(
                 new CoreTopology( new ClusterId( UUID.randomUUID() ), false, mapOf( memberId, mock( CoreServerInfo.class ) ) ) );
 
-        ConnectToRandomCoreServerStrategy shouldNotUse = new ConnectToRandomCoreServerStrategy();
+        ConnectToRandomCoreServerStrategy shouldNotUse = mock( ConnectToRandomCoreServerStrategy.class );
 
         UpstreamDatabaseSelectionStrategy mockStrategy = mock( UpstreamDatabaseSelectionStrategy.class );
         when( mockStrategy.upstreamDatabase() ).thenReturn( Optional.of( new MemberId( UUID.randomUUID() ) ) );
@@ -116,7 +115,7 @@ public class UpstreamDatabaseStrategySelectorTest
         selector.bestUpstreamDatabase();
 
         // then
-        verify( mockStrategy, times( 2 ) ).upstreamDatabase();
+        verifyZeroInteractions( shouldNotUse );
     }
 
     @Service.Implementation( UpstreamDatabaseSelectionStrategy.class )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/strategies/ConnectRandomlyToServerGroupStrategyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/strategies/ConnectRandomlyToServerGroupStrategyTest.java
@@ -26,16 +26,20 @@ import org.junit.Test;
 
 import java.util.Collections;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 
 import static co.unruly.matchers.OptionalMatchers.contains;
 import static org.hamcrest.Matchers.isIn;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.neo4j.causalclustering.upstream.strategies.UserDefinedConfigurationStrategyTest.memberIDs;
 
 public class ConnectRandomlyToServerGroupStrategyTest
@@ -60,5 +64,27 @@ public class ConnectRandomlyToServerGroupStrategyTest
 
         // then
         assertThat( result, contains( isIn( targetGroupMemberIds ) ) );
+    }
+
+    @Test
+    public void doesNotConnectToSelf()
+    {
+        // given
+        ConnectRandomlyToServerGroupStrategy connectRandomlyToServerGroupStrategy = new ConnectRandomlyToServerGroupStrategy();
+        MemberId myself = new MemberId( new UUID( 1234, 5678 ) );
+
+        // and
+        LogProvider logProvider = NullLogProvider.getInstance();
+        Config config = Config.defaults();
+        config.augment( CausalClusteringSettings.connect_randomly_to_server_group_strategy, "firstGroup" );
+        TopologyService topologyService = new TopologyServiceThatPrioritisesItself( myself, "firstGroup" );
+        connectRandomlyToServerGroupStrategy.inject( topologyService, config, logProvider, myself );
+
+        // when
+        Optional<MemberId> found = connectRandomlyToServerGroupStrategy.upstreamDatabase();
+
+        // then
+        assertTrue( found.isPresent() );
+        assertNotEquals( myself, found.get() );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/strategies/LeaderOnlyStrategyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/strategies/LeaderOnlyStrategyTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j Enterprise Edition. The included source
+ * code can be redistributed and/or modified under the terms of the
+ * GNU AFFERO GENERAL PUBLIC LICENSE Version 3
+ * (http://www.fsf.org/licensing/licenses/agpl-3.0.html) with the
+ * Commons Clause, as found in the associated LICENSE.txt file.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * Neo4j object code can be licensed independently from the source
+ * under separate terms from the AGPL. Inquiries can be directed to:
+ * licensing@neo4j.com
+ *
+ * More information is also available at:
+ * https://neo4j.com/licensing/
+ */
+package org.neo4j.causalclustering.upstream.strategies;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.neo4j.causalclustering.discovery.RoleInfo;
+import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.causalclustering.upstream.UpstreamDatabaseSelectionException;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.logging.NullLogProvider;
+
+
+public class LeaderOnlyStrategyTest
+{
+    @Test
+    public void ignoresSelf() throws UpstreamDatabaseSelectionException
+    {
+        // given
+        MemberId myself = new MemberId( new UUID( 1234, 5678 ) );
+        String groupName = "groupName";
+
+        // and
+        LeaderOnlyStrategy leaderOnlyStrategy = new LeaderOnlyStrategy();
+        TopologyServiceThatPrioritisesItself topologyServiceNoRetriesStrategy = new TopologyServiceThatPrioritisesItself( myself, groupName )
+        {
+            @Override
+            public Map<MemberId,RoleInfo> allCoreRoles()
+            {
+                Map<MemberId,RoleInfo> roles = new HashMap<>();
+                roles.put( myself, RoleInfo.LEADER );
+                roles.put( coreNotSelf, RoleInfo.LEADER );
+                return roles;
+            }
+        };
+        leaderOnlyStrategy.inject( topologyServiceNoRetriesStrategy, Config.defaults(), NullLogProvider.getInstance(), myself );
+
+        // when
+        Optional<MemberId> resolved = leaderOnlyStrategy.upstreamDatabase();
+
+        // then
+        Assert.assertTrue( resolved.isPresent() );
+        Assert.assertNotEquals( myself, resolved.get() );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/strategies/TopologyServiceThatPrioritisesItself.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/strategies/TopologyServiceThatPrioritisesItself.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j Enterprise Edition. The included source
+ * code can be redistributed and/or modified under the terms of the
+ * GNU AFFERO GENERAL PUBLIC LICENSE Version 3
+ * (http://www.fsf.org/licensing/licenses/agpl-3.0.html) with the
+ * Commons Clause, as found in the associated LICENSE.txt file.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * Neo4j object code can be licensed independently from the source
+ * under separate terms from the AGPL. Inquiries can be directed to:
+ * licensing@neo4j.com
+ *
+ * More information is also available at:
+ * https://neo4j.com/licensing/
+ */
+package org.neo4j.causalclustering.upstream.strategies;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.neo4j.causalclustering.discovery.ClientConnectorAddresses;
+import org.neo4j.causalclustering.discovery.CoreServerInfo;
+import org.neo4j.causalclustering.discovery.CoreTopology;
+import org.neo4j.causalclustering.discovery.ReadReplicaInfo;
+import org.neo4j.causalclustering.discovery.ReadReplicaTopology;
+import org.neo4j.causalclustering.discovery.RoleInfo;
+import org.neo4j.causalclustering.discovery.TopologyService;
+import org.neo4j.causalclustering.identity.ClusterId;
+import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.helpers.AdvertisedSocketAddress;
+
+class TopologyServiceThatPrioritisesItself implements TopologyService
+{
+    private final MemberId myself;
+    private final String matchingGroupName;
+
+    MemberId coreNotSelf = new MemberId( new UUID( 321, 654 ) );
+    MemberId readReplicaNotSelf = new MemberId( new UUID( 432, 543 ) );
+
+    TopologyServiceThatPrioritisesItself( MemberId myself, String matchingGroupName )
+    {
+        this.myself = myself;
+        this.matchingGroupName = matchingGroupName;
+    }
+
+    @Override
+    public String localDBName()
+    {
+        throw new RuntimeException( "Unimplemented" );
+    }
+
+    @Override
+    public CoreTopology allCoreServers()
+    {
+        boolean canBeBootstrapped = true;
+        Map<MemberId,CoreServerInfo> coreMembers = new HashMap<>();
+        coreMembers.put( myself, coreServerInfo() );
+        coreMembers.put( coreNotSelf, coreServerInfo() );
+        return new CoreTopology( new ClusterId( new UUID( 99, 88 ) ), canBeBootstrapped, coreMembers );
+    }
+
+    @Override
+    public CoreTopology localCoreServers()
+    {
+        return allCoreServers();
+    }
+
+    @Override
+    public ReadReplicaTopology allReadReplicas()
+    {
+        Map<MemberId,ReadReplicaInfo> readReplicaMembers = new HashMap<>();
+        readReplicaMembers.put( myself, readReplicaInfo( matchingGroupName ) );
+        readReplicaMembers.put( readReplicaNotSelf, readReplicaInfo( matchingGroupName ) );
+        return new ReadReplicaTopology( readReplicaMembers );
+    }
+
+    @Override
+    public ReadReplicaTopology localReadReplicas()
+    {
+        return allReadReplicas();
+    }
+
+    @Override
+    public Optional<AdvertisedSocketAddress> findCatchupAddress( MemberId upstream )
+    {
+        throw new RuntimeException( "Unimplemented" );
+    }
+
+    @Override
+    public Map<MemberId,RoleInfo> allCoreRoles()
+    {
+        throw new RuntimeException( "Unimplemented" );
+    }
+
+    @Override
+    public void init() throws Throwable
+    {
+    }
+
+    @Override
+    public void start() throws Throwable
+    {
+    }
+
+    @Override
+    public void stop() throws Throwable
+    {
+    }
+
+    @Override
+    public void shutdown() throws Throwable
+    {
+    }
+
+    private static CoreServerInfo coreServerInfo( String... groupNames )
+    {
+        AdvertisedSocketAddress anyRaftAddress = new AdvertisedSocketAddress( "hostname", 1234 );
+        AdvertisedSocketAddress anyCatchupServer = new AdvertisedSocketAddress( "hostname", 5678 );
+        ClientConnectorAddresses clientConnectorAddress = new ClientConnectorAddresses( Collections.emptyList() );
+        Set<String> groups = new HashSet<>( Arrays.asList( groupNames ) );
+        return new CoreServerInfo( anyRaftAddress, anyCatchupServer, clientConnectorAddress, groups, "dbName" );
+    }
+
+    private static ReadReplicaInfo readReplicaInfo( String... groupNames )
+    {
+        ClientConnectorAddresses clientConnectorAddresses = new ClientConnectorAddresses( Collections.emptyList() );
+        AdvertisedSocketAddress catchupServerAddress = new AdvertisedSocketAddress( "hostname", 2468 );
+        Set<String> groups = new HashSet<>( Arrays.asList( groupNames ) );
+        ReadReplicaInfo readReplicaInfo = new ReadReplicaInfo( clientConnectorAddresses, catchupServerAddress, groups, "dbName" );
+        return readReplicaInfo;
+    }
+}


### PR DESCRIPTION
There were some cases where store catchup would pick itself as a target to catch up from (even though it would retry if that were the case)

This change should prevent cores and RR from picking themselves as targets to catch up from.