### PR TITLE
StoreCopy E_TOO_FAR_BEHIND response before async checkpoint

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/DataSourceChecks.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/DataSourceChecks.java
@@ -23,6 +23,8 @@
 package org.neo4j.causalclustering.catchup.storecopy;
 
 import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.Future;
 
 import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.kernel.NeoStoreDataSource;
@@ -33,31 +35,6 @@ class DataSourceChecks
 {
     private DataSourceChecks()
     {
-    }
-
-    static boolean isTransactionWithinReach( long requiredTxId, CheckPointer checkpointer )
-    {
-        if ( isWithinLastCheckPoint( requiredTxId, checkpointer ) )
-        {
-            return true;
-        }
-        else
-        {
-            try
-            {
-                checkpointer.tryCheckPoint( new SimpleTriggerInfo( "Store file copy" ) );
-                return isWithinLastCheckPoint( requiredTxId, checkpointer );
-            }
-            catch ( IOException e )
-            {
-                return false;
-            }
-        }
-    }
-
-    private static boolean isWithinLastCheckPoint( long atLeast, CheckPointer checkPointer )
-    {
-        return checkPointer.lastCheckPointedTransactionId() >= atLeast;
     }
 
     static boolean hasSameStoreId( StoreId storeId, NeoStoreDataSource dataSource )


### PR DESCRIPTION
Performing a store copy against a machine that is too far behind will cause a checkpoint to be performed before the erroneous response is sent.

This change sends the response first then asynchronously performs a checkpoint.