### PR TITLE
StoreCopy E_TOO_FAR_BEHIND response before async checkpoint

### DIFF
--- a/community/common/src/main/java/org/neo4j/scheduler/LockingExecutor.java
+++ b/community/common/src/main/java/org/neo4j/scheduler/LockingExecutor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.scheduler;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class LockingExecutor implements Executor
+{
+    private final JobScheduler jobScheduler;
+    private final JobScheduler.Group group;
+    private final AtomicBoolean latch = new AtomicBoolean( false );
+
+    public LockingExecutor( JobScheduler jobScheduler, JobScheduler.Group group )
+    {
+        this.jobScheduler = jobScheduler;
+        this.group = group;
+    }
+
+    @Override
+    public void execute( Runnable runnable )
+    {
+        if ( latch.compareAndSet( false, true ) )
+        {
+            jobScheduler.schedule( group, () ->
+            {
+                try
+                {
+                    runnable.run();
+                }
+                finally
+                {
+                    latch.set( false );
+                }
+            } );
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CheckPointerService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CheckPointerService.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j Enterprise Edition. The included source
+ * code can be redistributed and/or modified under the terms of the
+ * GNU AFFERO GENERAL PUBLIC LICENSE Version 3
+ * (http://www.fsf.org/licensing/licenses/agpl-3.0.html) with the
+ * Commons Clause, as found in the associated LICENSE.txt file.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * Neo4j object code can be licensed independently from the source
+ * under separate terms from the AGPL. Inquiries can be directed to:
+ * licensing@neo4j.com
+ *
+ * More information is also available at:
+ * https://neo4j.com/licensing/
+ */
+package org.neo4j.causalclustering.catchup;
+
+import java.io.IOException;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
+import org.neo4j.scheduler.JobScheduler;
+import org.neo4j.scheduler.LockingExecutor;
+
+public class CheckPointerService
+{
+    private final Supplier<CheckPointer> checkPointerSupplier;
+    private final Executor lockingCheckpointExecutor;
+
+    public CheckPointerService( Supplier<CheckPointer> checkPointerSupplier, JobScheduler jobScheduler, JobScheduler.Group group )
+    {
+        this.checkPointerSupplier = checkPointerSupplier;
+        this.lockingCheckpointExecutor = new LockingExecutor( jobScheduler, group );
+    }
+
+    public CheckPointer getCheckPointer()
+    {
+        return checkPointerSupplier.get();
+    }
+
+    public long lastCheckPointedTransactionId()
+    {
+        return checkPointerSupplier.get().lastCheckPointedTransactionId();
+    }
+
+    public void tryAsyncCheckpoint( Consumer<IOException> exceptionHandler )
+    {
+        lockingCheckpointExecutor.execute( () ->
+        {
+            try
+            {
+                getCheckPointer().tryCheckPoint( new SimpleTriggerInfo( "Store file copy" ) );
+            }
+            catch ( IOException e )
+            {
+                exceptionHandler.accept( e );
+            }
+        } );
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/DataSourceChecks.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/DataSourceChecks.java
@@ -22,14 +22,8 @@
  */
 package org.neo4j.causalclustering.catchup.storecopy;
 
-import java.io.IOException;
-import java.util.Optional;
-import java.util.concurrent.Future;
-
 import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.kernel.NeoStoreDataSource;
-import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
-import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 
 class DataSourceChecks
 {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/DataSourceChecks.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/DataSourceChecks.java
@@ -23,6 +23,8 @@
 package org.neo4j.causalclustering.catchup.storecopy;
 
 import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.Future;
 
 import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.kernel.NeoStoreDataSource;
@@ -33,31 +35,6 @@ class DataSourceChecks
 {
     private DataSourceChecks()
     {
-    }
-
-    static boolean isTransactionWithinReach( long requiredTxId, CheckPointer checkpointer )
-    {
-        if ( isWithinLastCheckPoint( requiredTxId, checkpointer ) )
-        {
-            return true;
-        }
-        else
-        {
-            try
-            {
-                checkpointer.tryCheckPoint( new SimpleTriggerInfo( "Store file copy" ) );
-                return isWithinLastCheckPoint( requiredTxId, checkpointer );
-            }
-            catch ( IOException e )
-            {
-                return false;
-            }
-        }
-    }
-
-    private static boolean isWithinLastCheckPoint( long atLeast, CheckPointer checkPointer )
-    {
-        return checkPointer.lastCheckPointedTransactionId() >= atLeast;
     }
 
     static boolean hasSameStoreId( StoreId storeId, NeoStoreDataSource dataSource )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
@@ -35,6 +35,7 @@ import org.neo4j.causalclustering.catchup.CatchupClientBuilder;
 import org.neo4j.causalclustering.catchup.CatchupProtocolServerInstaller;
 import org.neo4j.causalclustering.catchup.CatchupServerBuilder;
 import org.neo4j.causalclustering.catchup.CatchupServerHandler;
+import org.neo4j.causalclustering.catchup.CheckPointerService;
 import org.neo4j.causalclustering.catchup.CheckpointerSupplier;
 import org.neo4j.causalclustering.catchup.RegularCatchupServerHandler;
 import org.neo4j.causalclustering.catchup.storecopy.CommitStateHelper;
@@ -192,11 +193,13 @@ public class CoreServerModule
         ApplicationProtocolRepository catchupProtocolRepository = new ApplicationProtocolRepository( ApplicationProtocols.values(), supportedCatchupProtocols );
         ModifierProtocolRepository modifierProtocolRepository = new ModifierProtocolRepository( ModifierProtocols.values(), supportedModifierProtocols );
 
+        CheckPointerService checkPointerService =
+                new CheckPointerService( new CheckpointerSupplier( platformModule.dependencies ), jobScheduler, JobScheduler.Groups.checkPoint );
         CatchupServerHandler catchupServerHandler = new RegularCatchupServerHandler( platformModule.monitors,
                 logProvider, localDatabase::storeId, platformModule.dependencies.provideDependency( TransactionIdStore.class ),
                 platformModule.dependencies.provideDependency( LogicalTransactionStore.class ), localDatabase::dataSource, localDatabase::isAvailable,
                 fileSystem, platformModule.pageCache, platformModule.storeCopyCheckPointMutex, snapshotService,
-                new CheckpointerSupplier( platformModule.dependencies ) );
+                checkPointerService );
 
         CatchupProtocolServerInstaller.Factory catchupProtocolServerInstaller = new CatchupProtocolServerInstaller.Factory( serverPipelineBuilderFactory,
                 logProvider, catchupServerHandler );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
@@ -39,6 +39,7 @@ import org.neo4j.causalclustering.catchup.CatchUpClient;
 import org.neo4j.causalclustering.catchup.CatchUpResponseHandler;
 import org.neo4j.causalclustering.catchup.CatchupProtocolClientInstaller;
 import org.neo4j.causalclustering.catchup.CatchupServerBuilder;
+import org.neo4j.causalclustering.catchup.CheckPointerService;
 import org.neo4j.causalclustering.catchup.CheckpointerSupplier;
 import org.neo4j.causalclustering.catchup.RegularCatchupServerHandler;
 import org.neo4j.causalclustering.catchup.storecopy.CopiedStoreRecovery;
@@ -137,6 +138,7 @@ import org.neo4j.kernel.internal.DefaultKernelData;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.LifecycleStatus;
 import org.neo4j.logging.LogProvider;
+import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.storageengine.api.StorageEngine;
 import org.neo4j.time.Clocks;
 import org.neo4j.udc.UsageData;
@@ -315,10 +317,12 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
         life.add( new ReadReplicaStartupProcess( remoteStore, localDatabase, txPulling, upstreamDatabaseStrategySelector, retryStrategy, logProvider,
                 platformModule.logging.getUserLogProvider(), storeCopyProcess, topologyService ) );
 
-        RegularCatchupServerHandler catchupServerHandler = new RegularCatchupServerHandler( platformModule.monitors,
-                logProvider, localDatabase::storeId, platformModule.dependencies.provideDependency( TransactionIdStore.class ),
+        RegularCatchupServerHandler catchupServerHandler = new RegularCatchupServerHandler( platformModule.monitors, logProvider, localDatabase::storeId,
+                platformModule.dependencies.provideDependency( TransactionIdStore.class ),
                 platformModule.dependencies.provideDependency( LogicalTransactionStore.class ), localDatabase::dataSource, localDatabase::isAvailable,
-                fileSystem, platformModule.pageCache, platformModule.storeCopyCheckPointMutex, null, new CheckpointerSupplier( platformModule.dependencies ) );
+                fileSystem, platformModule.pageCache, platformModule.storeCopyCheckPointMutex, null,
+                new CheckPointerService( new CheckpointerSupplier( platformModule.dependencies ),
+                        platformModule.jobScheduler, JobScheduler.Groups.checkPoint ) );
 
         InstalledProtocolHandler installedProtocolHandler = new InstalledProtocolHandler(); // TODO: hook into a procedure
         Server catchupServer = new CatchupServerBuilder( catchupServerHandler )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyRequestHandlerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyRequestHandlerTest.java
@@ -23,17 +23,21 @@
 package org.neo4j.causalclustering.catchup.storecopy;
 
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Optional;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import org.neo4j.causalclustering.catchup.CatchupServerProtocol;
+import org.neo4j.causalclustering.catchup.CheckPointerService;
 import org.neo4j.causalclustering.catchup.ResponseMessageType;
 import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.causalclustering.messaging.StoreCopyRequest;
@@ -47,6 +51,7 @@ import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.TriggerInfo;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
+import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.storageengine.api.StoreFileMetadata;
 
 import static org.junit.Assert.assertEquals;
@@ -66,6 +71,9 @@ public class StoreCopyRequestHandlerTest
     private final PageCache pageCache = mock( PageCache.class );
     private EmbeddedChannel embeddedChannel;
     private CatchupServerProtocol catchupServerProtocol;
+    private JobScheduler jobScheduler = new FakeSingleThreadedJobScheduler();
+    private CheckPointerService checkPointerService =
+            new CheckPointerService( () -> checkPointer, jobScheduler, JobScheduler.Groups.checkPoint );
 
     @Before
     public void setup()
@@ -73,7 +81,7 @@ public class StoreCopyRequestHandlerTest
         catchupServerProtocol = new CatchupServerProtocol();
         catchupServerProtocol.expect( CatchupServerProtocol.State.GET_STORE_FILE );
         StoreCopyRequestHandler storeCopyRequestHandler =
-                new NiceStoreCopyRequestHandler( catchupServerProtocol, () -> neoStoreDataSource, () -> checkPointer, new StoreFileStreamingProtocol(),
+                new NiceStoreCopyRequestHandler( catchupServerProtocol, () -> neoStoreDataSource, checkPointerService, new StoreFileStreamingProtocol(),
                         pageCache, fileSystemAbstraction, NullLogProvider.getInstance() );
         when( neoStoreDataSource.getStoreId() ).thenReturn( new org.neo4j.kernel.impl.store.StoreId( 1, 2, 5, 3, 4 ) );
         embeddedChannel = new EmbeddedChannel( storeCopyRequestHandler );
@@ -125,10 +133,10 @@ public class StoreCopyRequestHandlerTest
     }
 
     @Test
-    public void shoulResetProtoclAndGiveErrorIfFilesThrowException()
+    public void shouldResetProtocolAndGiveErrorIfFilesThrowException()
     {
         EmbeddedChannel alternativeChannel = new EmbeddedChannel(
-                new EvilStoreCopyRequestHandler( catchupServerProtocol, () -> neoStoreDataSource, () -> checkPointer, new StoreFileStreamingProtocol(),
+                new EvilStoreCopyRequestHandler( catchupServerProtocol, () -> neoStoreDataSource, checkPointerService, new StoreFileStreamingProtocol(),
                         pageCache, fileSystemAbstraction, NullLogProvider.getInstance() ) );
         try
         {
@@ -137,7 +145,7 @@ public class StoreCopyRequestHandlerTest
         }
         catch ( IllegalStateException ignore )
         {
-
+            // do nothing
         }
         assertEquals( ResponseMessageType.STORE_COPY_FINISHED, alternativeChannel.readOutbound() );
         StoreCopyFinishedResponse expectedResponse = new StoreCopyFinishedResponse( StoreCopyFinishedResponse.Status.E_UNKNOWN );
@@ -153,23 +161,31 @@ public class StoreCopyRequestHandlerTest
         checkPointer._tryCheckPoint = Optional.empty();
 
         // when
-        embeddedChannel.writeInbound( new GetStoreFileRequest( STORE_ID_MATCHING, new File( "some-file" ), 123 ) );
+        try
+        {
+            embeddedChannel.writeInbound( new GetStoreFileRequest( STORE_ID_MATCHING, new File( "some-file" ), 123 ) );
+            fail();
+        }
+        catch ( RuntimeException e )
+        {
+            assertEquals( "FakeCheckPointer", e.getMessage() );
+        }
 
         // then should have received error message
         assertEquals( ResponseMessageType.STORE_COPY_FINISHED, embeddedChannel.readOutbound() );
 
-        // and should have failed on async TODO
-        Assert.assertEquals( 1, checkPointer.invocationCounter.get() );
+        // and should have failed on async
+        assertEquals( 1, checkPointer.invocationCounter.get() );
         assertEquals( 1, checkPointer.failCounter.get() );
     }
 
     private class NiceStoreCopyRequestHandler extends StoreCopyRequestHandler<StoreCopyRequest>
     {
         private NiceStoreCopyRequestHandler( CatchupServerProtocol protocol, Supplier<NeoStoreDataSource> dataSource,
-                Supplier<CheckPointer> checkpointerSupplier, StoreFileStreamingProtocol storeFileStreamingProtocol, PageCache pageCache,
+                CheckPointerService checkPointerService, StoreFileStreamingProtocol storeFileStreamingProtocol, PageCache pageCache,
                 FileSystemAbstraction fs, LogProvider logProvider )
         {
-            super( protocol, dataSource, checkpointerSupplier, storeFileStreamingProtocol, pageCache, fs, logProvider );
+            super( protocol, dataSource, checkPointerService, storeFileStreamingProtocol, pageCache, fs, logProvider );
         }
 
         @Override
@@ -182,10 +198,10 @@ public class StoreCopyRequestHandlerTest
     private class EvilStoreCopyRequestHandler extends StoreCopyRequestHandler<StoreCopyRequest>
     {
         private EvilStoreCopyRequestHandler( CatchupServerProtocol protocol, Supplier<NeoStoreDataSource> dataSource,
-                Supplier<CheckPointer> checkpointerSupplier, StoreFileStreamingProtocol storeFileStreamingProtocol, PageCache pageCache,
+                CheckPointerService checkPointerService, StoreFileStreamingProtocol storeFileStreamingProtocol, PageCache pageCache,
                 FileSystemAbstraction fs, LogProvider logProvider )
         {
-            super( protocol, dataSource, checkpointerSupplier, storeFileStreamingProtocol, pageCache, fs, logProvider );
+            super( protocol, dataSource, checkPointerService, storeFileStreamingProtocol, pageCache, fs, logProvider );
         }
 
         @Override
@@ -241,6 +257,82 @@ public class StoreCopyRequestHandlerTest
                 return;
             }
             failCounter.getAndIncrement();
+        }
+    }
+
+    class FakeSingleThreadedJobScheduler implements JobScheduler
+    {
+        @Override
+        public void setTopLevelGroupName( String name )
+        {
+            // do nothing
+        }
+
+        @Override
+        public Executor executor( Group group )
+        {
+            throw new RuntimeException( "Unimplemented" );
+        }
+
+        @Override
+        public ExecutorService workStealingExecutor( Group group, int parallelism )
+        {
+            throw new RuntimeException( "Unimplemented" );
+        }
+
+        @Override
+        public ThreadFactory threadFactory( Group group )
+        {
+            throw new RuntimeException( "Unimplemented" );
+        }
+
+        @Override
+        public JobHandle schedule( Group group, Runnable job )
+        {
+            job.run();
+            return mock( JobHandle.class );
+        }
+
+        @Override
+        public JobHandle schedule( Group group, Runnable runnable, long initialDelay, TimeUnit timeUnit )
+        {
+            throw new RuntimeException( "Unimplemented" );
+        }
+
+        @Override
+        public JobHandle scheduleRecurring( Group group, Runnable runnable, long period, TimeUnit timeUnit )
+        {
+            throw new RuntimeException( "Unimplemented" );
+        }
+
+        @Override
+        public JobHandle scheduleRecurring( Group group, Runnable runnable, long initialDelay, long period, TimeUnit timeUnit )
+        {
+            throw new RuntimeException( "Unimplemented" );
+        }
+
+        @Override
+        public void init() throws Throwable
+        {
+            // do nothing
+        }
+
+        @Override
+        public void start() throws Throwable
+        {
+            // do nothing
+        }
+
+        @Override
+        public void stop() throws Throwable
+        {
+            // do nothing
+        }
+
+        @Override
+        public void shutdown() throws Throwable
+        {
+            // do nothing
         }
     }
 }


### PR DESCRIPTION
Performing a store copy against a machine that is too far behind will cause a checkpoint to be performed before the erroneous response is sent.

This change sends the response first then asynchronously performs a checkpoint.