### PR TITLE
Close old CleanupJobs on restart of GroupingRecoveryCleanupWorkCollector

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GroupingRecoveryCleanupWorkCollector.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GroupingRecoveryCleanupWorkCollector.java
@@ -48,7 +48,11 @@ public class GroupingRecoveryCleanupWorkCollector implements RecoveryCleanupWork
     @Override
     public void init() throws Throwable
     {
-        jobs.clear();
+        CleanupJob job;
+        while ( (job = jobs.poll()) != null )
+        {
+            job.close();
+        }
     }
 
     @Override


### PR DESCRIPTION
Those jobs hold the cleaner lock in GBPTree and closing the jobs will release the lock.
If we don't release the lock we can block checkpoint (and thus also shutdown) forever.