### PR TITLE
More index nested loop joins

### DIFF
--- a/community/cypher/cypher-logical-plans-3.5/src/main/scala/org/neo4j/cypher/internal/v3_5/logical/plans/NodeIndexSeek.scala
+++ b/community/cypher/cypher-logical-plans-3.5/src/main/scala/org/neo4j/cypher/internal/v3_5/logical/plans/NodeIndexSeek.scala
@@ -23,7 +23,7 @@ import org.opencypher.v9_0.util.attribution.IdGen
 import org.opencypher.v9_0.expressions.{Expression, LabelToken, PropertyKeyToken}
 
 /**
-  * For every node with the given label and property values, produces one row with that node.
+  * For every node with the given label and property values, produces rows with that node.
   */
 case class NodeIndexSeek(idName: String,
                          label: LabelToken,

--- a/community/cypher/cypher-planner-3.5/src/main/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/plans/Sargable.scala
+++ b/community/cypher/cypher-planner-3.5/src/main/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/plans/Sargable.scala
@@ -102,8 +102,7 @@ object AsStringRangeSeekable {
 
 object AsValueRangeSeekable {
   def unapply(v: Any): Option[InequalityRangeSeekable] = v match {
-    case inequalities@AndedPropertyInequalities(ident, prop, innerInequalities)
-      if innerInequalities.forall( _.rhs.dependencies.isEmpty ) =>
+    case inequalities@AndedPropertyInequalities(ident, prop, innerInequalities) =>
         Some(InequalityRangeSeekable(ident, prop.propertyKey, inequalities))
     case _ =>
       None

--- a/community/cypher/cypher-planner-3.5/src/main/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/steps/AbstractIndexSeekLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.5/src/main/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/steps/AbstractIndexSeekLeafPlanner.scala
@@ -107,14 +107,14 @@ abstract class AbstractIndexSeekLeafPlanner extends LeafPlanner with LeafPlanFro
   }
 
   private def createLogicalPlan(idName: String,
-                  hints: Seq[Hint],
-                  argumentIds: Set[String],
-                  labelPredicate: HasLabels,
-                  labelName: LabelName,
-                  labelId: LabelId,
-                  plannables: Seq[IndexPlannableExpression],
-                  context: LogicalPlanningContext,
-                  semanticTable: SemanticTable ): LogicalPlan = {
+                                hints: Seq[Hint],
+                                argumentIds: Set[String],
+                                labelPredicate: HasLabels,
+                                labelName: LabelName,
+                                labelId: LabelId,
+                                plannables: Seq[IndexPlannableExpression],
+                                context: LogicalPlanningContext,
+                                semanticTable: SemanticTable): LogicalPlan = {
     val hint = {
       val name = idName
       val propertyNames = plannables.map(_.propertyKeyName.name)
@@ -139,7 +139,6 @@ abstract class AbstractIndexSeekLeafPlanner extends LeafPlanner with LeafPlanFro
     if (plannables.length == 1)
       plannables.head.queryExpression
     else {
-      val expressions: Seq[Expression] = plannables.flatMap(_.queryExpression.expressions)
       CompositeQueryExpression(plannables.map(_.queryExpression))
     }
 
@@ -169,7 +168,8 @@ abstract class AbstractIndexSeekLeafPlanner extends LeafPlanner with LeafPlanFro
       IndexPlannableExpression(seekable.name, propertyKey, partialPredicate, queryExpression, hints, argumentIds, solvesPredicate = true)
 
     // n.prop <|<=|>|>= value
-    case predicate@AsValueRangeSeekable(seekable) =>
+    case predicate@AsValueRangeSeekable(seekable)
+      if predicate.asInstanceOf[AndedPropertyInequalities].inequalities.forall(x => (x.rhs.dependencies -- arguments).isEmpty) =>
       val queryExpression = seekable.asQueryExpression
       val keyName = seekable.propertyKeyName
       IndexPlannableExpression(seekable.name, keyName, predicate, queryExpression, hints, argumentIds, solvesPredicate = true)

--- a/community/cypher/cypher-planner-3.5/src/test/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/SelectionsTest.scala
+++ b/community/cypher/cypher-planner-3.5/src/test/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/SelectionsTest.scala
@@ -117,64 +117,6 @@ class SelectionsTest extends CypherFunSuite with LogicalPlanningTestSupport with
     result should equal(Selections(Set(Predicate(idNames("a"), covering))))
   }
 
-  test("should recognize value joins") {
-    // given WHERE x.id = z.id
-    val lhs = prop("x", "id")
-    val rhs = prop("z", "id")
-    val equalityComparison = Equals(lhs, rhs)(pos)
-    val selections = Selections.from(equalityComparison)
-
-    // when
-    val result = selections.valueJoins
-
-    // then
-    result should equal(Set(equalityComparison))
-  }
-
-  test("if one side is a literal, it's not a value join") {
-    // given WHERE x.id = 42
-    val selections = Selections.from(propEquality("x","id", 42))
-
-    // when
-    val result = selections.valueJoins
-
-    // then
-    result should be(empty)
-  }
-
-  test("if both lhs and rhs come from the same variable, it's not a value join") {
-    // given WHERE x.id1 = x.id2
-    val lhs = prop("x", "id1")
-    val rhs = prop("x", "id2")
-    val equalityComparison = Equals(lhs, rhs)(pos)
-    val selections = Selections.from(equalityComparison)
-
-    // when
-    val result = selections.valueJoins
-
-    // then
-    result should be(empty)
-  }
-
-  test("combination of predicates is not a problem") {
-    // given WHERE x.id1 = z.id AND x.id1 = x.id2 AND x.id2 = 42
-    val x_id1 = prop("x", "id1")
-    val x_id2 = prop("x", "id2")
-    val z_id = prop("z", "id")
-    val lit = literalInt(42)
-
-    val pred1 = Equals(x_id1, x_id2)(pos)
-    val pred2 = Equals(x_id1, z_id)(pos)
-    val pred3 = Equals(x_id2, lit)(pos)
-
-    val selections = Selections.from(Seq(pred1, pred2, pred3))
-
-    // when
-    val result = selections.valueJoins
-
-    // then
-    result should be(Set(pred2))
-  }
 
   private def idNames(names: String*) = names.toSet
 

--- a/community/cypher/cypher-planner-3.5/src/test/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/idp/CartesianProductsOrValueJoinsTest.scala
+++ b/community/cypher/cypher-planner-3.5/src/test/scala/org/neo4j/cypher/internal/compiler/v3_5/planner/logical/idp/CartesianProductsOrValueJoinsTest.scala
@@ -205,7 +205,6 @@ class CartesianProductsOrValueJoinsTest
     val qg1 = QueryGraph.empty.withPatternNodes(Set("n"))
     val qg2 = QueryGraph.empty.withPatternNodes(Set("x"))
 
-     
     // when
     val result = cartesianProductsOrValueJoins.predicatesDependendingOnBothSides(Seq(predicate1, predicate2), qg1, qg2)
 

--- a/community/cypher/ir-3.5/src/main/scala/org/neo4j/cypher/internal/ir/v3_5/QueryGraph.scala
+++ b/community/cypher/ir-3.5/src/main/scala/org/neo4j/cypher/internal/ir/v3_5/QueryGraph.scala
@@ -355,7 +355,7 @@ case class QueryGraph(// !!! If you change anything here, make sure to update th
   override def toString: String = {
     var added = false
     val builder = new StringBuilder("QueryGraph {")
-    val stringifier = ExpressionStringifier()
+    val stringifier = ExpressionStringifier(_.asCanonicalStringVal)
 
     def prettyPattern(p: PatternRelationship): String = {
       val lArrow = if (p.dir == SemanticDirection.INCOMING) "<" else ""

--- a/community/cypher/ir-3.5/src/main/scala/org/neo4j/cypher/internal/ir/v3_5/Selections.scala
+++ b/community/cypher/ir-3.5/src/main/scala/org/neo4j/cypher/internal/ir/v3_5/Selections.scala
@@ -98,15 +98,6 @@ case class Selections(predicates: Set[Predicate] = Set.empty) {
     Selections(keptPredicates ++ other.predicates)
   }
 
-  // Value joins are equality comparisons between two expressions. As long as they depend on different, non-overlapping
-  // sets of variables, they can be solved with a traditional hash join, similar to what a SQL database would
-  lazy val valueJoins: Set[Equals] = flatPredicates.collect {
-    case e@Equals(l, r)
-      if l.dependencies.nonEmpty &&
-         r.dependencies.nonEmpty &&
-         r.dependencies != l.dependencies => e
-  }.toSet
-
   def ++(expressions: Traversable[Expression]): Selections = Selections(predicates ++ expressions.flatMap(_.asPredicates))
 
   def nonEmpty: Boolean = !isEmpty

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
@@ -194,7 +194,7 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
     val r1 = relate(node1, node2)
 
     val query = "MATCH (a)-[r]-(b) RETURN a, r, b, count(a) ORDER BY a, r, b"
-    val result = executeWith(Configs.All - Configs.OldAndRule, query) // Neo4j version <= 3.1 cannot order by nodes
+    val result = executeWith(Configs.All - Configs.Before3_3AndRule, query) // Neo4j version <= 3.1 cannot order by nodes
     result.toList should equal(List(
       Map("a" -> node1, "r" -> r1, "b" -> node2, "count(a)" -> 1),
       Map("a" -> node2, "r" -> r1, "b" -> node1, "count(a)" -> 1)
@@ -207,7 +207,7 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
     val r1 = relate(node1, node2)
 
     val query = "MATCH (a)-[r]-(b) RETURN a, r, b, a.prop as s, count(a) ORDER BY a, r, b, s"
-    val result = executeWith(Configs.All - Configs.OldAndRule, query) // Neo4j version <= 3.1 cannot order by nodes
+    val result = executeWith(Configs.All - Configs.Before3_3AndRule, query) // Neo4j version <= 3.1 cannot order by nodes
     result.toList should equal(List(
       Map("a" -> node1, "r" -> r1, "b" -> node2, "s" -> "alice", "count(a)" -> 1),
       Map("a" -> node2, "r" -> r1, "b" -> node1, "s" -> "bob", "count(a)" -> 1)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeIndexAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeIndexAcceptanceTest.scala
@@ -69,7 +69,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperators("NodeIndexSeek")
-      }, Configs.OldAndRule))
+      }, Configs.Before3_3AndRule))
 
     // Then
     result.toComparableResult should equal(List(Map("n" -> n1)))
@@ -117,7 +117,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
         plan should useOperatorWithText("NodeIndexSeek", ":User(firstname,lastname)")
         plan should not(useOperatorWithText("NodeIndexSeek", ":User(firstname)"))
         plan should not(useOperatorWithText("NodeIndexSeek", ":User(lastname)"))
-      }, Configs.OldAndRule))
+      }, Configs.Before3_3AndRule))
 
     // Then
     result.toComparableResult should equal(List(Map("n" -> n1)))
@@ -189,7 +189,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperators("NodeIndexSeek")
-      }, Configs.OldAndRule))
+      }, Configs.Before3_3AndRule))
     result.toComparableResult should equal(List(Map("n" -> n)))
   }
 
@@ -202,7 +202,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperatorWithText("NodeIndexSeek", ":Person(firstname,lastname)")
-      }, Configs.OldAndRule))
+      }, Configs.Before3_3AndRule))
   }
 
   test("should use composite index correctly given two IN predicates") {
@@ -225,7 +225,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperatorWithText("NodeIndexSeek", ":Foo(bar,baz)")
-      }, Configs.OldAndRule))
+      }, Configs.Before3_3AndRule))
 
     // Then
     result.toComparableResult should equal((0 to 99).map(i => Map("x" -> i)).toList)
@@ -249,7 +249,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperatorWithText("NodeIndexSeek", ":Foo(bar,baz)")
-      }, Configs.OldAndRule))
+      }, Configs.Before3_3AndRule))
 
     // Then
     result.toComparableResult should equal((0 to 9).map(i => Map("x" -> i)).toList)
@@ -273,7 +273,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperatorWithText("NodeIndexSeek", ":Foo(bar,baz)")
-      }, Configs.OldAndRule))
+      }, Configs.Before3_3AndRule))
 
     // Then
     result.toComparableResult should equal(List(Map("x" -> 1), Map("x" -> 3), Map("x" -> 5), Map("x" -> 7), Map("x" -> 9)))
@@ -293,7 +293,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperatorWithText("NodeIndexSeek", ":L(foo,bar,baz")
-      }, Configs.OldAndRule))
+      }, Configs.Before3_3AndRule))
     result.toComparableResult should equal(Seq(Map("count(n)" -> 1)))
   }
 
@@ -311,7 +311,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperatorWithText("NodeIndexSeek", ":L(foo,bar,baz)")
-      }, Configs.OldAndRule))
+      }, Configs.Before3_3AndRule))
     result.toComparableResult should equal(Seq(Map("count(n)" -> 1)))
   }
 
@@ -365,7 +365,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
               planComparisonStrategy = ComparePlansWithAssertion((plan) => {
                 //THEN
                 plan should useOperatorWithText("NodeIndexSeek", ":User(name,surname,age,active)")
-              }, Configs.OldAndRule))
+              }, Configs.Before3_3AndRule))
           else
             executeWith(testConfig, query,
               planComparisonStrategy = ComparePlansWithAssertion((plan) => {
@@ -404,7 +404,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperatorWithText("NodeIndexSeek", ":X(p1,p2)")
-      }, Configs.OldAndRule), params = Map("id" -> a.getId))
+      }, Configs.Before3_3AndRule), params = Map("id" -> a.getId))
 
     result.toComparableResult should equal(Seq(Map("b" -> b)))
   }
@@ -418,10 +418,10 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
     // When
     val query = "MATCH (n:User) WHERE n.name = 'Joe' AND n.city = point({x: 1.2, y: 5.6}) RETURN n"
 
-    val resultNoIndex = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    val resultNoIndex = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query)
 
     graph.createIndex("User", "name", "city")
-    val resultIndex = executeWith(Configs.Interpreted - Configs.OldAndRule, query,
+    val resultIndex = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query,
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperators("NodeIndexSeek")
@@ -447,10 +447,10 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
         |RETURN n
       """.stripMargin
 
-    val resultNoIndex = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    val resultNoIndex = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query)
 
     graph.createIndex("Label", "date", "time")
-    val resultIndex = executeWith(Configs.Interpreted - Configs.OldAndRule, query,
+    val resultIndex = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query,
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperators("NodeIndexSeek")
@@ -475,10 +475,10 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
         |RETURN n
       """.stripMargin
 
-    val resultNoIndex = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    val resultNoIndex = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query)
 
     graph.createIndex("Runner", "name", "result")
-    val resultIndex = executeWith(Configs.Interpreted - Configs.OldAndRule, query,
+    val resultIndex = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query,
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperators("NodeIndexSeek")

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeNodeKeyConstraintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeNodeKeyConstraintAcceptanceTest.scala
@@ -146,7 +146,7 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
     // Then
     val query = "CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS NODE KEY"
     val errorMessage = "Both Node(%d) and Node(%d) have the label `User` and properties `firstname` = 'Joe', `lastname` = 'Soap'".format(a, c)
-    failWithError(Configs.AbsolutelyAll - Configs.OldAndRule, query, List(errorMessage))
+    failWithError(Configs.AbsolutelyAll - Configs.Before3_3AndRule, query, List(errorMessage))
   }
 
   test("trying to add duplicate node when node key constraint exists") {
@@ -176,7 +176,7 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
     val b = createLabeledNode(Map("name" -> "A", "surname" -> "B"), "Person").getId
 
     failWithError(
-      Configs.AbsolutelyAll - Configs.OldAndRule,
+      Configs.AbsolutelyAll - Configs.Before3_3AndRule,
       "CREATE CONSTRAINT ON (person:Person) ASSERT (person.name, person.surname) IS NODE KEY",
       List(("Unable to create CONSTRAINT ON ( person:Person ) ASSERT (person.name, person.surname) IS NODE KEY:%s" +
         "Both Node(%d) and Node(%d) have the label `Person` and properties `name` = 'A', `surname` = 'B'").format(String.format("%n"), a, b))
@@ -188,7 +188,7 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
     val b = createLabeledNode(Map("name" -> "A"), "Person").getId
 
     failWithError(
-      Configs.AbsolutelyAll - Configs.OldAndRule,
+      Configs.AbsolutelyAll - Configs.Before3_3AndRule,
       "CREATE CONSTRAINT ON (person:Person) ASSERT (person.name) IS NODE KEY",
       List(("Unable to create CONSTRAINT ON ( person:Person ) ASSERT person.name IS NODE KEY:%s" +
         "Both Node(%d) and Node(%d) have the label `Person` and property `name` = 'A'").format(String.format("%n"), a, b))
@@ -197,7 +197,7 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
 
   test("drop a non existent node key constraint") {
     failWithError(
-      Configs.AbsolutelyAll - Configs.OldAndRule,
+      Configs.AbsolutelyAll - Configs.Before3_3AndRule,
       "DROP CONSTRAINT ON (person:Person) ASSERT (person.name) IS NODE KEY",
       List("No such constraint")
     )
@@ -219,7 +219,7 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
     graph.execute("CREATE INDEX ON :Person(firstname, lastname)".fixNewLines)
 
     // then
-    failWithError(Configs.AbsolutelyAll - Configs.OldAndRule,
+    failWithError(Configs.AbsolutelyAll - Configs.Before3_3AndRule,
       "CREATE CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS NODE KEY",
       List("There already exists an index for label 'Person' on properties 'firstname' and 'lastname'. " +
                   "A constraint cannot be created until the index has been dropped."))
@@ -231,7 +231,7 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
 
     // then
     failWithError(
-      Configs.AbsolutelyAll - Configs.OldAndRule,
+      Configs.AbsolutelyAll - Configs.Before3_3AndRule,
       "CREATE INDEX ON :Person(firstname, lastname)",
       List("Label 'Person' and properties 'firstname' and 'lastname' have a unique constraint defined on them, " +
                   "so an index is already created that matches this."))

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
@@ -628,6 +628,8 @@ object CypherComparisonSupport {
     /**
       * Handy configs for things not supported in older versions
       */
+    def Before3_3AndRule: TestConfiguration = Cost2_3 + Cost3_1 + AllRulePlanners
+
     def OldAndRule: TestConfiguration = BackwardsCompatibility + AllRulePlanners
 
     /**

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
@@ -626,9 +626,9 @@ object CypherComparisonSupport {
     def Procs: TestConfiguration = TestScenario(Versions.Default, Planners.Default, Runtimes.ProcedureOrSchema)
 
     /**
-      * Handy configs for things only supported from 3.3 (not rule) and for checking plans
+      * Handy configs for things not supported in older versions
       */
-    def OldAndRule: TestConfiguration = Cost2_3 + Cost3_1 + AllRulePlanners
+    def OldAndRule: TestConfiguration = BackwardsCompatibility + AllRulePlanners
 
     /**
       * Configs which support CREATE, DELETE, SET, REMOVE, MERGE etc.

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/HintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/HintAcceptanceTest.scala
@@ -51,7 +51,7 @@ class HintAcceptanceTest
       planComparisonStrategy = ComparePlansWithAssertion((p) => {
       p should useOperators("NodeLeftOuterHashJoin")
       p should not(useOperators("NodeHashJoin"))
-    }, expectPlansToFail = Configs.OldAndRule))
+    }, expectPlansToFail = Configs.Before3_3AndRule))
   }
 
   test("should not plan multiple joins for one hint - right outer join") {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/IndexingTestSupport.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/IndexingTestSupport.scala
@@ -65,7 +65,7 @@ trait IndexingTestSupport extends ExecutionEngineFunSuite with CypherComparisonS
 
   protected def assertSeekMatchFor(value: Value, nodes: Node*): Unit = {
     val query = s"MATCH (n:$LABEL) WHERE n.$PROPERTY = $$param RETURN n"
-    testRead(query, Map("param" -> value.asObject()), "NodeIndexSeek", nodes, config = Configs.All - Configs.OldAndRule)
+    testRead(query, Map("param" -> value.asObject()), "NodeIndexSeek", nodes, config = Configs.All - Configs.Before3_3AndRule)
   }
 
   protected def assertScanMatch(nodes: Node*): Unit = {
@@ -93,7 +93,7 @@ trait IndexingTestSupport extends ExecutionEngineFunSuite with CypherComparisonS
   }
 
   private def testRead(query: String, params: Map[String, AnyRef], wantedOperator: String, expected: Seq[Node],
-                       config: TestConfiguration = Configs.Interpreted - Configs.OldAndRule): Unit = {
+                       config: TestConfiguration = Configs.Interpreted - Configs.Before3_3AndRule): Unit = {
     if (cypherComparisonSupport) {
       val result =
         executeWith(

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -37,7 +37,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     createNode("id" -> 0)
     for (i <- 1 to 1000) createNode("id" -> i)
     val result = executeWith(
-      Configs.Interpreted - Configs.OldAndRule,
+      Configs.Interpreted - Configs.Before3_3AndRule,
       "MATCH (n) WHERE id(n) IN {ids} RETURN n.id",
       params = Map("ids" -> List(-2, -3, 0, -4)))
     result.executionPlanDescription() should useOperators("NodeByIdSeek")

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MiscAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MiscAcceptanceTest.scala
@@ -49,7 +49,7 @@ class MiscAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSu
         |ORDER BY y
       """.stripMargin
 
-    val result = executeWith(Configs.All, query, expectedDifferentResults = Configs.OldAndRule)
+    val result = executeWith(Configs.All, query, expectedDifferentResults = Configs.Before3_3AndRule)
     result.toList should equal(List(Map("y" -> 1, "y3" -> 3), Map("y" -> 1, "y3" -> 4), Map("y" -> 2, "y3" -> 3), Map("y" -> 2, "y3" -> 4)))
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekAcceptanceTest.scala
@@ -79,7 +79,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherCom
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         plan should useOperatorTimes("NodeIndexSeek", 2)
         plan should useOperators("Union")
-    }, expectPlansToFail = Configs.OldAndRule))
+    }, expectPlansToFail = Configs.Before3_3AndRule))
 
     result.columnAs("c").toSet should be(Set(nodes(1), nodes(11)))
   }
@@ -99,7 +99,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherCom
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         plan should useOperatorTimes("NodeIndexScan", 2)
         plan should useOperators("Union")
-      }, expectPlansToFail = Configs.OldAndRule))
+      }, expectPlansToFail = Configs.Before3_3AndRule))
 
     result.columnAs("c").toSet should be(Set(nodes(1), nodes(11)))
   }
@@ -119,7 +119,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherCom
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         plan should useOperatorTimes("NodeIndexSeekByRange", 2)
         plan should useOperators("Union")
-      }, expectPlansToFail = Configs.OldAndRule))
+      }, expectPlansToFail = Configs.Before3_3AndRule))
 
     result.columnAs("c").toSet should be(Set(nodes(1), nodes(11)))
   }
@@ -139,7 +139,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherCom
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         plan should useOperatorTimes("NodeIndexScan", 2)
         plan should useOperators("Union")
-      }, expectPlansToFail = Configs.OldAndRule))
+      }, expectPlansToFail = Configs.Before3_3AndRule))
 
     result.columnAs("c").toSet should be(Set(nodes(1), nodes(11)))
   }
@@ -157,7 +157,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherCom
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         plan should useOperatorTimes("NodeIndexScan", 2)
         plan should useOperators("Union")
-      }, expectPlansToFail = Configs.OldAndRule))
+      }, expectPlansToFail = Configs.Before3_3AndRule))
 
     result.columnAs("c").toSet should be(Set(nodes(1), nodes(11)))
   }
@@ -309,7 +309,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherCom
     // When
     val result = executeWith(Configs.All,
       "MATCH (root:Company) WHERE root.uuid IN {uuids} RETURN DISTINCT root",
-      planComparisonStrategy = ComparePlansWithAssertion(_ should useOperatorTimes("NodeIndexSeek", 1), expectPlansToFail = Configs.OldAndRule),
+      planComparisonStrategy = ComparePlansWithAssertion(_ should useOperatorTimes("NodeIndexSeek", 1), expectPlansToFail = Configs.Before3_3AndRule),
       params = Map("uuids" -> Array("a", "b", "c")))
 
     //Then
@@ -327,7 +327,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherCom
     // When
     val result = executeWith(Configs.All,
       "MATCH (root:Company) WHERE root.uuid IN {uuids} RETURN DISTINCT root",
-      planComparisonStrategy = ComparePlansWithAssertion(_ should useOperatorTimes("NodeIndexSeek", 1), expectPlansToFail = Configs.OldAndRule),
+      planComparisonStrategy = ComparePlansWithAssertion(_ should useOperatorTimes("NodeIndexSeek", 1), expectPlansToFail = Configs.Before3_3AndRule),
       params = Map("uuids" -> Array(1, 2, 3)))
 
     //Then

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekByRangeAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekByRangeAcceptanceTest.scala
@@ -1051,7 +1051,7 @@ class NodeIndexSeekByRangeAcceptanceTest extends ExecutionEngineFunSuite with Cy
 
     val query = "MATCH (n:Label) WHERE n.prop >= {param} RETURN n.prop AS prop"
 
-    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query,
+    val result = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query,
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperators(IndexSeekByRange.name)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NullListAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NullListAcceptanceTest.scala
@@ -28,7 +28,7 @@ import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
 class NullListAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
 
   // Changed behaviour to comply with opencypher in 3.3
-  val nullInListConfigOld = Configs.OldAndRule
+  val nullInListConfigOld = Configs.Before3_3AndRule
 
   // Comparison between lists and non-lists
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
@@ -433,7 +433,7 @@ class PatternComprehensionAcceptanceTest extends ExecutionEngineFunSuite with Cy
         | return c
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    val result = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query)
     result.toList should equal(List.empty)
   }
 
@@ -450,7 +450,7 @@ class PatternComprehensionAcceptanceTest extends ExecutionEngineFunSuite with Cy
         | return c
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    val result = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query)
     result.toList should equal(List(Map("c" -> node2), Map("c" -> node3)))
   }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialDistanceAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialDistanceAcceptanceTest.scala
@@ -29,7 +29,7 @@ import org.neo4j.values.storable.{CoordinateReferenceSystem, Values}
 class SpatialDistanceAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
 
   val pointConfig = Configs.Interpreted - Configs.Version2_3
-  val distanceConfig = Configs.Interpreted - Configs.OldAndRule
+  val distanceConfig = Configs.Interpreted - Configs.Before3_3AndRule
 
   test("distance function should work on co-located points") {
     val result = executeWith(pointConfig, "WITH point({latitude: 12.78, longitude: 56.7}) as point RETURN distance(point,point) as dist",
@@ -123,7 +123,7 @@ class SpatialDistanceAcceptanceTest extends ExecutionEngineFunSuite with CypherC
   }
 
   test("distance function should not fail if provided with points from different CRS") {
-    val localConfig = pointConfig - Configs.OldAndRule
+    val localConfig = pointConfig - Configs.Before3_3AndRule
       val res = executeWith(localConfig,
         """WITH point({x: 2.3, y: 4.5, crs: 'cartesian'}) as p1, point({longitude: 1.1, latitude: 5.4, crs: 'WGS-84'}) as p2
         |RETURN distance(p1,p2) as dist""".stripMargin)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialFunctionsAcceptanceTest.scala
@@ -30,7 +30,7 @@ import org.neo4j.values.storable.{CoordinateReferenceSystem, Values}
 class SpatialFunctionsAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
 
   val pointConfig = Configs.Interpreted - Configs.Version2_3
-  val equalityConfig = Configs.Interpreted - Configs.OldAndRule
+  val equalityConfig = Configs.Interpreted - Configs.Before3_3AndRule
   val latestPointConfig = Configs.Interpreted - Configs.BackwardsCompatibility - Configs.AllRulePlanners
 
   test("toString on points") {
@@ -596,12 +596,12 @@ class SpatialFunctionsAcceptanceTest extends ExecutionEngineFunSuite with Cypher
     graph.execute("CREATE (:P {p : point({x: 1, y: 2})})")
 
     // when
-    val result = executeWith(Configs.All - Configs.OldAndRule, "MATCH (n:P) WITH n.p AS p RETURN p.x, p.y, p.crs, p.srid")
+    val result = executeWith(Configs.All - Configs.Before3_3AndRule, "MATCH (n:P) WITH n.p AS p RETURN p.x, p.y, p.crs, p.srid")
 
     // then
     result.toList should be(List(Map("p.x" -> 1.0, "p.y" -> 2.0, "p.crs" -> "cartesian", "p.srid" -> 7203)))
-    failWithError(Configs.All - Configs.OldAndRule + Configs.Procs, "MATCH (n:P) WITH n.p AS p RETURN p.latitude", Seq("Field: latitude is not available"))
-    failWithError(Configs.All - Configs.OldAndRule + Configs.Procs, "MATCH (n:P) WITH n.p AS p RETURN p.z", Seq("Field: z is not available"))
+    failWithError(Configs.All - Configs.Before3_3AndRule + Configs.Procs, "MATCH (n:P) WITH n.p AS p RETURN p.latitude", Seq("Field: latitude is not available"))
+    failWithError(Configs.All - Configs.Before3_3AndRule + Configs.Procs, "MATCH (n:P) WITH n.p AS p RETURN p.z", Seq("Field: z is not available"))
   }
 
   test("accessors on 3D cartesian points") {
@@ -609,11 +609,11 @@ class SpatialFunctionsAcceptanceTest extends ExecutionEngineFunSuite with Cypher
     graph.execute("CREATE (:P {p : point({x: 1, y: 2, z:3})})")
 
     // when
-    val result = executeWith(Configs.All - Configs.OldAndRule, "MATCH (n:P) WITH n.p AS p RETURN p.x, p.y, p.z, p.crs, p.srid")
+    val result = executeWith(Configs.All - Configs.Before3_3AndRule, "MATCH (n:P) WITH n.p AS p RETURN p.x, p.y, p.z, p.crs, p.srid")
 
     // then
     result.toList should be(List(Map("p.x" -> 1.0, "p.y" -> 2.0, "p.z" -> 3.0, "p.crs" -> "cartesian-3d", "p.srid" -> 9157)))
-    failWithError(Configs.All - Configs.OldAndRule + Configs.Procs, "MATCH (n:P) WITH n.p AS p RETURN p.latitude", Seq("Field: latitude is not available"))
+    failWithError(Configs.All - Configs.Before3_3AndRule + Configs.Procs, "MATCH (n:P) WITH n.p AS p RETURN p.latitude", Seq("Field: latitude is not available"))
   }
 
   test("accessors on 2D geographic points") {
@@ -621,12 +621,12 @@ class SpatialFunctionsAcceptanceTest extends ExecutionEngineFunSuite with Cypher
     graph.execute("CREATE (:P {p : point({longitude: 1, latitude: 2})})")
 
     // when
-    val result = executeWith(Configs.All - Configs.OldAndRule,  "MATCH (n:P) WITH n.p AS p RETURN p.longitude, p.latitude, p.crs, p.x, p.y, p.srid")
+    val result = executeWith(Configs.All - Configs.Before3_3AndRule,  "MATCH (n:P) WITH n.p AS p RETURN p.longitude, p.latitude, p.crs, p.x, p.y, p.srid")
 
     // then
     result.toList should be(List(Map("p.longitude" -> 1.0, "p.latitude" -> 2.0, "p.crs" -> "wgs-84", "p.x" -> 1.0, "p.y" -> 2.0, "p.srid" -> 4326)))
-    failWithError(Configs.All - Configs.OldAndRule + Configs.Procs, "MATCH (n:P) WITH n.p AS p RETURN p.height", Seq("Field: height is not available"))
-    failWithError(Configs.All - Configs.OldAndRule + Configs.Procs, "MATCH (n:P) WITH n.p AS p RETURN p.z", Seq("Field: z is not available"))
+    failWithError(Configs.All - Configs.Before3_3AndRule + Configs.Procs, "MATCH (n:P) WITH n.p AS p RETURN p.height", Seq("Field: height is not available"))
+    failWithError(Configs.All - Configs.Before3_3AndRule + Configs.Procs, "MATCH (n:P) WITH n.p AS p RETURN p.z", Seq("Field: z is not available"))
   }
 
   test("accessors on 3D geographic points") {
@@ -634,7 +634,7 @@ class SpatialFunctionsAcceptanceTest extends ExecutionEngineFunSuite with Cypher
     graph.execute("CREATE (:P {p : point({longitude: 1, latitude: 2, height:3})})")
 
     // when
-    val result = executeWith(Configs.All - Configs.OldAndRule,
+    val result = executeWith(Configs.All - Configs.Before3_3AndRule,
                              "MATCH (n:P) WITH n.p AS p RETURN p.longitude, p.latitude, p.height, p.crs, p.x, p.y, p.z, p.srid")
 
     // then

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialIndexResultsAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SpatialIndexResultsAcceptanceTest.scala
@@ -31,7 +31,7 @@ import scala.collection.immutable.{Map => ImmutableMap}
 
 class SpatialIndexResultsAcceptanceTest extends IndexingTestSupport {
 
-  private val equalityConfig = Configs.Interpreted - Configs.OldAndRule
+  private val equalityConfig = Configs.Interpreted - Configs.Before3_3AndRule
   private val indexConfig = Configs.Interpreted - Configs.BackwardsCompatibility - Configs.AllRulePlanners
 
   override def cypherComparisonSupport = true
@@ -81,7 +81,7 @@ class SpatialIndexResultsAcceptanceTest extends IndexingTestSupport {
     graph.execute("MATCH (p:Place) SET p.location = point({latitude: 56.7, longitude: 12.78, crs: 'WGS-84'}) RETURN p.location as point")
 
     // When
-    val localConfig = Configs.All - Configs.OldAndRule
+    val localConfig = Configs.All - Configs.Before3_3AndRule
     val result = executeWith(localConfig,
                              "MATCH (p:Place) WHERE p.location = $param RETURN p.location as point",
                              planComparisonStrategy = ComparePlansWithAssertion({ plan =>
@@ -104,7 +104,7 @@ class SpatialIndexResultsAcceptanceTest extends IndexingTestSupport {
     graph.execute("MATCH (p:Place) SET p.location = [point({latitude: 56.7, longitude: 12.78, crs: 'WGS-84'})] RETURN p.location as point")
 
     // When
-    val localConfig = Configs.All - Configs.OldAndRule
+    val localConfig = Configs.All - Configs.Before3_3AndRule
     val result = executeWith(localConfig,
                              "MATCH (p:Place) WHERE p.location = $param RETURN p.location as point",
                              planComparisonStrategy = ComparePlansWithAssertion({ plan =>
@@ -131,7 +131,7 @@ class SpatialIndexResultsAcceptanceTest extends IndexingTestSupport {
         |RETURN p.location as point""".stripMargin)
 
     // When
-    val localConfig = Configs.All - Configs.OldAndRule
+    val localConfig = Configs.All - Configs.Before3_3AndRule
     val result = executeWith(localConfig,
                              "MATCH (p:Place) WHERE p.location = $param RETURN p.location as point",
                              planComparisonStrategy = ComparePlansWithAssertion({ plan =>
@@ -164,7 +164,7 @@ class SpatialIndexResultsAcceptanceTest extends IndexingTestSupport {
         |RETURN p.location as point""".stripMargin)
 
     // When
-    val localConfig = Configs.All - Configs.OldAndRule
+    val localConfig = Configs.All - Configs.Before3_3AndRule
     val result = executeWith(localConfig,
                              "MATCH (p:Place) WHERE p.location = $param RETURN p.location as point",
                              planComparisonStrategy = ComparePlansWithAssertion({ plan =>

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TemporalAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TemporalAcceptanceTest.scala
@@ -32,7 +32,7 @@ import org.neo4j.values.storable.{DateValue, DurationValue}
 
 class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with CypherComparisonSupport {
 
-  private val failConf1 = Configs.Interpreted + Configs.Procs - Configs.OldAndRule
+  private val failConf1 = Configs.Interpreted + Configs.Procs - Configs.Before3_3AndRule
   private val failConf2 = Configs.Interpreted + Configs.Procs - Configs.Version2_3
 
   // Getting current value of a temporal
@@ -72,7 +72,7 @@ class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistic
     val dateValue = DateValue.date(2018, 5, 5).asObject()
     createNode(Map("prop" -> dateValue))
 
-    val config = Configs.All - Configs.OldAndRule
+    val config = Configs.All - Configs.Before3_3AndRule
     val query = "MATCH (n) WHERE n.prop = $param RETURN n.prop as prop"
     val result = executeWith(config, query, params = Map("param" -> dateValue))
 
@@ -87,7 +87,7 @@ class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistic
 
     createNode(Map("prop" -> javaDateArray))
 
-    val config = Configs.All - Configs.OldAndRule
+    val config = Configs.All - Configs.Before3_3AndRule
     val query = "MATCH (n) WHERE n.prop = $param RETURN n.prop as prop"
     val result = executeWith(config, query, params = Map("param" -> javaDateArray))
 
@@ -106,7 +106,7 @@ class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistic
     val dateArray = new Array[LocalDate](javaDateList.size)
     createNode(Map("prop" -> javaDateList.toArray(dateArray)))
 
-    val config = Configs.All - Configs.OldAndRule
+    val config = Configs.All - Configs.Before3_3AndRule
     val query = "MATCH (n) WHERE n.prop = $param RETURN n.prop as prop"
     val result = executeWith(config, query, params = Map("param" -> javaDateList))
 
@@ -124,7 +124,7 @@ class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistic
 
     graph.execute("CREATE ($param)", Map[String,Object]("param" -> dateMap).asJava)
 
-    val config = Configs.All - Configs.OldAndRule
+    val config = Configs.All - Configs.Before3_3AndRule
     val query = "MATCH (n) WHERE n.a = $param.a RETURN n.a as a, n.b as b"
     val result = executeWith(config, query, params = Map("param" -> dateMap))
 
@@ -141,7 +141,7 @@ class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistic
 
     graph.execute("CREATE ($param)", Map[String,Object]("param" -> dateMap).asJava)
 
-    val config = Configs.All - Configs.OldAndRule
+    val config = Configs.All - Configs.Before3_3AndRule
     val query = "MATCH (n) RETURN $param, n.a as a, n.b as b"
     val result = executeWith(config, query, params = Map("param" -> dateMap))
 
@@ -157,7 +157,7 @@ class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistic
         |RETURN o.timeSpan as timeSpan""".stripMargin)
 
     // When
-    val localConfig = Configs.All - Configs.OldAndRule
+    val localConfig = Configs.All - Configs.Before3_3AndRule
     val result = executeWith(localConfig,
                              "MATCH (o:Occasion) WHERE o.timeSpan = $param RETURN o.timeSpan as timeSpan",
                              planComparisonStrategy = ComparePlansWithAssertion({ plan =>
@@ -183,7 +183,7 @@ class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistic
         |RETURN o.timeSpan as timeSpan""".stripMargin)
 
     // When
-    val localConfig = Configs.All - Configs.OldAndRule
+    val localConfig = Configs.All - Configs.Before3_3AndRule
     val result = executeWith(localConfig,
                              "MATCH (o:Occasion) WHERE o.timeSpan = $param RETURN o.timeSpan as timeSpan",
                              planComparisonStrategy = ComparePlansWithAssertion({ plan =>
@@ -209,7 +209,7 @@ class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistic
         |RETURN o.timeSpan as timeSpan""".stripMargin)
 
     // When
-    val localConfig = Configs.All - Configs.OldAndRule
+    val localConfig = Configs.All - Configs.Before3_3AndRule
     val result = executeWith(localConfig,
                              "MATCH (o:Occasion) WHERE o.timeSpan = $param RETURN o.timeSpan as timeSpan",
                              planComparisonStrategy = ComparePlansWithAssertion({ plan =>
@@ -236,7 +236,7 @@ class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistic
         |RETURN o.timeSpan as timeSpan""".stripMargin)
 
     // When
-    val localConfig = Configs.All - Configs.OldAndRule
+    val localConfig = Configs.All - Configs.Before3_3AndRule
     val result = executeWith(localConfig,
                              "MATCH (o:Occasion) WHERE o.timeSpan = $param RETURN o.timeSpan as timeSpan",
                              planComparisonStrategy = ComparePlansWithAssertion({ plan =>
@@ -268,7 +268,7 @@ class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistic
     createLabeledNode(Map("date1" -> dateValue1, "date2" -> dateValue2), "Date")
 
     // When
-    val config = Configs.All - Configs.OldAndRule + Configs.Cost2_3
+    val config = Configs.All - Configs.Before3_3AndRule + Configs.Cost2_3
     val query = "MATCH (n:Date) WITH [n.date1, n.date2] as dateList MATCH (m:Occasion) WHERE m.timeSpan = dateList RETURN m.timeSpan as timeSpan"
     val result = executeWith(config, query)
 
@@ -285,7 +285,7 @@ class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistic
     val duration = DurationValue.duration(11, 12, 13, 14).asObject()
     createNode(Map("prop" -> duration))
 
-    val config = Configs.All - Configs.OldAndRule
+    val config = Configs.All - Configs.Before3_3AndRule
     val query = "MATCH (n) WHERE n.prop = $param RETURN n.prop as prop"
     val result = executeWith(config, query, params = Map("param" -> duration))
 
@@ -819,7 +819,7 @@ class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistic
         | RETURN time({hour: 12, minute: 34, second: 56, timezone:'Europe/Stockholm'}) = currentCorrectTime as comparison
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    val result = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query)
     result.toList should equal(List(Map("comparison" -> true)))
   }
 
@@ -830,7 +830,7 @@ class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistic
         | RETURN toString(time({time:dt})) as t1, toString(time.truncate('second', dt)) as t2
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    val result = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query)
     result.toList should equal(List(Map("t1" -> "12:31:14+02:00", "t2" -> "12:31:14+02:00")))
   }
 
@@ -844,7 +844,7 @@ class TemporalAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistic
         |        time.truncate('second', ld, {timezone: 'Europe/Stockholm'}) = currentCorrectTime as comp2
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    val result = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query)
     result.toList should equal(List(Map("comp1" -> true, "comp2" -> true)))
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TemporalIndexAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TemporalIndexAcceptanceTest.scala
@@ -88,10 +88,10 @@ class TemporalIndexAcceptanceTest extends IndexingTestSupport {
         |RETURN n
       """.stripMargin
 
-    val resultNoIndex = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    val resultNoIndex = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query)
 
     graph.createIndex("Runner", "results")
-    val resultIndex = executeWith(Configs.Interpreted - Configs.OldAndRule, query,
+    val resultIndex = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query,
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperators("NodeIndexSeek")
@@ -148,7 +148,7 @@ class TemporalIndexAcceptanceTest extends IndexingTestSupport {
         | RETURN n
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query,
+    val result = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query,
       planComparisonStrategy = ComparePlansWithAssertion(_ should useOperators("NodeIndexSeekByRange")))
 
     result.toList should equal(List(Map("n" -> node2)))

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TimeZoneAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TimeZoneAcceptanceTest.scala
@@ -51,55 +51,55 @@ abstract class TimeZoneAcceptanceTest(timezone: String) extends ExecutionEngineF
 
   test("should get timezone for current datetime") {
     val query = s"RETURN datetime().timezone as tz"
-    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    val result = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query)
     result.toList should equal(List(Map("tz" -> timezone)))
   }
 
   test("should get timezone for parse time") {
     val query = s"RETURN time('12:00').timezone as tz"
-    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    val result = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query)
     result.toList should equal(List(Map("tz" -> ZonedDateTime.now(ZoneId.of(timezone)).getOffset.toString)))
   }
 
   test("should get timezone for parse datetime") {
     val query = s"RETURN datetime('2018-01-01T12:00').timezone as tz"
-    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    val result = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query)
     result.toList should equal(List(Map("tz" -> timezone)))
   }
 
   test("should get timezone for select time") {
     val query = s"RETURN time(localtime()).timezone as tz"
-    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    val result = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query)
     result.toList should equal(List(Map("tz" -> ZonedDateTime.now(ZoneId.of(timezone)).getOffset.toString)))
   }
 
   test("should get timezone for select datetime") {
     val query = s"RETURN datetime({date: date(), time: localtime()}).timezone as tz"
-    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    val result = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query)
     result.toList should equal(List(Map("tz" -> timezone)))
   }
 
   test("should get timezone for build time") {
     val query = s"RETURN time({hour: 12}).timezone as tz"
-    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    val result = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query)
     result.toList should equal(List(Map("tz" -> ZonedDateTime.now(ZoneId.of(timezone)).getOffset.toString)))
   }
 
   test("should get timezone for build datetime") {
     val query = s"RETURN datetime({year: 2018}).timezone as tz"
-    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    val result = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query)
     result.toList should equal(List(Map("tz" -> timezone)))
   }
 
   test("should get timezone for truncate time") {
     val query = s"RETURN time.truncate('minute', localtime()).timezone as tz"
-    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    val result = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query)
     result.toList should equal(List(Map("tz" -> ZonedDateTime.now(ZoneId.of(timezone)).getOffset.toString)))
   }
 
   test("should get timezone for truncate datetime") {
     val query = s"RETURN datetime.truncate('minute', localdatetime()).timezone as tz"
-    val result = executeWith(Configs.Interpreted - Configs.OldAndRule, query)
+    val result = executeWith(Configs.Interpreted - Configs.Before3_3AndRule, query)
     result.toList should equal(List(Map("tz" -> timezone)))
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/VarLengthExpandQueryPlanAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/VarLengthExpandQueryPlanAcceptanceTest.scala
@@ -57,7 +57,7 @@ class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite wit
     executeWith(expectedToSucceed, query, planComparisonStrategy =
       ComparePlansWithAssertion( plan => {
         plan should useOperators("VarLengthExpand(Pruning)")
-      }, expectPlansToFail = Configs.OldAndRule))
+      }, expectPlansToFail = Configs.Before3_3AndRule))
   }
 
   test("Plan pruning var expand on distinct var-length match with projection and aggregation") {
@@ -65,7 +65,7 @@ class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite wit
     executeWith(expectedToSucceed, query, planComparisonStrategy =
       ComparePlansWithAssertion( plan => {
         plan should useOperators("VarLengthExpand(Pruning)")
-      }, expectPlansToFail = Configs.OldAndRule))
+      }, expectPlansToFail = Configs.Before3_3AndRule))
   }
 
   test("query with distinct aggregation") {
@@ -73,7 +73,7 @@ class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite wit
     executeWith(expectedToSucceed, query, planComparisonStrategy =
       ComparePlansWithAssertion( plan => {
         plan should useOperators("VarLengthExpand(Pruning)")
-      }, expectPlansToFail = Configs.OldAndRule))
+      }, expectPlansToFail = Configs.Before3_3AndRule))
   }
 
   test("Simple query that filters between expand and distinct") {
@@ -81,7 +81,7 @@ class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite wit
     executeWith(expectedToSucceed, query, planComparisonStrategy =
       ComparePlansWithAssertion( plan => {
         plan should useOperators("VarLengthExpand(Pruning)")
-      }, expectPlansToFail = Configs.OldAndRule))
+      }, expectPlansToFail = Configs.Before3_3AndRule))
   }
 
   test("Query that aggregates before making the result DISTINCT") {
@@ -97,7 +97,7 @@ class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite wit
     executeWith(expectedToSucceed, query, planComparisonStrategy =
       ComparePlansWithAssertion( plan => {
         plan should useOperators("VarLengthExpand(Pruning)")
-      }, expectPlansToFail = Configs.OldAndRule))
+      }, expectPlansToFail = Configs.Before3_3AndRule))
   }
 
   test("var expand followed by normal expand") {
@@ -105,7 +105,7 @@ class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite wit
     executeWith(expectedToSucceed, query, planComparisonStrategy =
       ComparePlansWithAssertion( plan => {
         plan should useOperators("VarLengthExpand(Pruning)")
-      }, expectPlansToFail = Configs.OldAndRule))
+      }, expectPlansToFail = Configs.Before3_3AndRule))
   }
 
   test("optional match can be solved with PruningVarExpand") {
@@ -113,7 +113,7 @@ class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite wit
     executeWith(expectedToSucceed, query, planComparisonStrategy =
       ComparePlansWithAssertion( plan => {
         plan should useOperators("VarLengthExpand(Pruning)")
-      }, expectPlansToFail = Configs.OldAndRule))
+      }, expectPlansToFail = Configs.Before3_3AndRule))
   }
 
   test("should not rewrite when doing non-distinct aggregation") {
@@ -129,7 +129,7 @@ class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite wit
     executeWith(expectedToSucceed, query, planComparisonStrategy =
       ComparePlansWithAssertion( plan => {
         plan should useOperators("VarLengthExpand(Pruning)")
-      }, expectPlansToFail = Configs.OldAndRule))
+      }, expectPlansToFail = Configs.Before3_3AndRule))
   }
 
   test("Do not plan pruning var expand for length=1") {


### PR DESCRIPTION
Makes the Cypher planner better at planning index operations on the RHS of Apply.

Before this change, the planner would only consider these options for equality comparisons. Now it considers any comparison that can be solved by an index.