### PR TITLE
Use new static helpers in interpreted runtime

### DIFF
--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Add.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Add.scala
@@ -19,38 +19,13 @@
  */
 package org.neo4j.cypher.internal.runtime.interpreted.commands.expressions
 
+import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.QueryState
-import org.neo4j.cypher.internal.runtime.interpreted.{ExecutionContext, IsList}
-import org.opencypher.v9_0.util.CypherTypeException
-import org.opencypher.v9_0.util.symbols._
+import org.neo4j.cypher.operations.CypherMath
 import org.neo4j.values._
-import org.neo4j.values.storable.{UTF8StringValue, _}
-import org.neo4j.values.utils.UTF8Utils
-import org.neo4j.values.virtual.VirtualValues
 
 case class Add(a: Expression, b: Expression) extends Expression {
-  def apply(ctx: ExecutionContext, state: QueryState): AnyValue = {
-    val aVal = a(ctx, state)
-    val bVal = b(ctx, state)
-
-    (aVal, bVal) match {
-      case (x, y) if x == Values.NO_VALUE || y == Values.NO_VALUE => Values.NO_VALUE
-      case (x: NumberValue, y: NumberValue) => x.plus(y)
-      case (x: UTF8StringValue, y: UTF8StringValue) => UTF8Utils.add(x, y)
-      case (x: TextValue, y: TextValue) => Values.stringValue(x.stringValue() + y.stringValue())
-      case (IsList(x), IsList(y)) => VirtualValues.concat(x, y)
-      case (IsList(x), y)         => x.append(y)
-      case (x, IsList(y))         => y.prepend(x)
-      case (x: TextValue, y: IntegralValue) => Values.stringValue(x.stringValue() + y.longValue())
-      case (x: IntegralValue, y: TextValue) => Values.stringValue(x.longValue() + y.stringValue())
-      case (x: TextValue, y: FloatValue) => Values.stringValue(x.stringValue() + y.doubleValue())
-      case (x: FloatValue, y: TextValue) => Values.stringValue(x.doubleValue() + y.stringValue())
-      case (x: TemporalValue[_,_], y: DurationValue) => x.plus(y)
-      case (x: DurationValue, y: TemporalValue[_,_]) => y.plus(x)
-      case (x: DurationValue, y: DurationValue) => x.add(y)
-      case _                      => throw new CypherTypeException("Don't know how to add `" + aVal.toString + "` and `" + bVal.toString + "`")
-    }
-  }
+  def apply(ctx: ExecutionContext, state: QueryState): AnyValue = CypherMath.add(a(ctx, state), b(ctx, state))
 
   def rewrite(f: (Expression) => Expression) = f(Add(a.rewrite(f), b.rewrite(f)))
 

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/MathFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/MathFunction.scala
@@ -19,13 +19,14 @@
  */
 package org.neo4j.cypher.internal.runtime.interpreted.commands.expressions
 
-import org.opencypher.v9_0.util.{CypherTypeException, InvalidArgumentException}
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.QueryState
-import org.opencypher.v9_0.util.symbols._
+import org.neo4j.cypher.operations.CypherFunctions
 import org.neo4j.values._
 import org.neo4j.values.storable._
 import org.neo4j.values.virtual.VirtualValues
+import org.opencypher.v9_0.util.symbols._
+import org.opencypher.v9_0.util.{CypherTypeException, InvalidArgumentException}
 
 abstract class MathFunction(arg: Expression) extends Expression with NumericHelper {
 
@@ -69,36 +70,32 @@ trait NumericHelper {
 
 case class AbsFunction(argument: Expression) extends MathFunction(argument) {
 
-  override def apply(ctx: ExecutionContext, state: QueryState): AnyValue = {
-    val value = argument(ctx, state)
-    if (Values.NO_VALUE == value) Values.NO_VALUE
-    else value match {
-      case f: IntegralValue => Values.longValue(Math.abs(f.longValue()))
-      case d: NumberValue =>  Values.doubleValue(Math.abs(d.doubleValue()))
-      case x => throw new CypherTypeException("Expected a numeric value for " + toString + ", but got: " + x.toString)
-    }
-  }
+  override def apply(ctx: ExecutionContext, state: QueryState): AnyValue =
+    CypherFunctions.abs(argument(ctx, state))
 
   override def rewrite(f: (Expression) => Expression) = f(AbsFunction(argument.rewrite(f)))
 }
 
-case class AcosFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class AcosFunction(argument: Expression) extends MathFunction(argument) {
 
-  override def apply(value: Double): Double = Math.acos(value)
+  override def apply(ctx: ExecutionContext,
+                     state: QueryState): AnyValue = CypherFunctions.acos(argument(ctx, state))
 
   override def rewrite(f: (Expression) => Expression) = f(AcosFunction(argument.rewrite(f)))
 }
 
-case class AsinFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class AsinFunction(argument: Expression) extends MathFunction(argument) {
 
-  override def apply(value: Double): Double = Math.asin(value)
+  override def apply(ctx: ExecutionContext,
+                     state: QueryState): AnyValue = CypherFunctions.asin(argument(ctx, state))
 
   override def rewrite(f: (Expression) => Expression) = f(AsinFunction(argument.rewrite(f)))
 }
 
-case class AtanFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class AtanFunction(argument: Expression) extends MathFunction(argument) {
 
-  override def apply(value: Double): Double = Math.atan(value)
+  override def apply(ctx: ExecutionContext,
+                     state: QueryState): AnyValue = CypherFunctions.atan(argument(ctx, state))
 
   override def rewrite(f: (Expression) => Expression) = f(AtanFunction(argument.rewrite(f)))
 }
@@ -121,23 +118,26 @@ case class Atan2Function(y: Expression, x: Expression) extends Expression with N
   override def symbolTableDependencies = x.symbolTableDependencies ++ y.symbolTableDependencies
 }
 
-case class CeilFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class CeilFunction(argument: Expression) extends MathFunction(argument) {
 
-  override def apply(value: Double) = math.ceil(value)
+  override def apply(ctx: ExecutionContext,
+                     state: QueryState): AnyValue = CypherFunctions.ceil(argument(ctx, state))
 
   override def rewrite(f: (Expression) => Expression) = f(CeilFunction(argument.rewrite(f)))
 }
 
-case class CosFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class CosFunction(argument: Expression) extends MathFunction(argument) {
 
-  override def apply(value: Double): Double = math.cos(value)
+  override def apply(ctx: ExecutionContext,
+                     state: QueryState): AnyValue = CypherFunctions.cos(argument(ctx, state))
 
   override def rewrite(f: (Expression) => Expression) = f(CosFunction(argument.rewrite(f)))
 }
 
-case class CotFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class CotFunction(argument: Expression)extends MathFunction(argument) {
 
-  override def apply(value: Double): Double = 1.0 / math.tan(value)
+  override def apply(ctx: ExecutionContext,
+                     state: QueryState): AnyValue = CypherFunctions.cot(argument(ctx, state))
 
   override def rewrite(f: (Expression) => Expression) = f(CotFunction(argument.rewrite(f)))
 }
@@ -167,9 +167,10 @@ case class ExpFunction(argument: Expression) extends NullSafeMathFunction(argume
   override def rewrite(f: (Expression) => Expression) = f(ExpFunction(argument.rewrite(f)))
 }
 
-case class FloorFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class FloorFunction(argument: Expression) extends MathFunction(argument) {
 
-  override def apply(value: Double) = math.floor(value)
+  override def apply(ctx: ExecutionContext,
+                     state: QueryState): AnyValue = CypherFunctions.floor(argument(ctx, state))
 
   override def rewrite(f: (Expression) => Expression) = f(FloorFunction(argument.rewrite(f)))
 }
@@ -206,30 +207,33 @@ case class RadiansFunction(argument: Expression) extends NullSafeMathFunction(ar
   override def rewrite(f: (Expression) => Expression) = f(RadiansFunction(argument.rewrite(f)))
 }
 
-case class SinFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class SinFunction(argument: Expression) extends MathFunction(argument) {
 
-  override def apply(value: Double) = math.sin(value)
+  override def apply(ctx: ExecutionContext,
+                     state: QueryState): AnyValue = CypherFunctions.sin(argument(ctx, state))
 
   override def rewrite(f: (Expression) => Expression) = f(SinFunction(argument.rewrite(f)))
 }
 
-case class HaversinFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class HaversinFunction(argument: Expression) extends MathFunction(argument) {
 
-  override def apply(value: Double) = (1.0d - math.cos(value)) / 2
+  override def apply(ctx: ExecutionContext,
+                     state: QueryState): AnyValue = CypherFunctions.haversin(argument(ctx, state))
 
   override def rewrite(f: (Expression) => Expression) = f(HaversinFunction(argument.rewrite(f)))
 }
 
-case class TanFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class TanFunction(argument: Expression) extends MathFunction(argument) {
 
-  override def apply(value: Double) = math.tan(value)
+  override def apply(ctx: ExecutionContext,
+                     state: QueryState): AnyValue = CypherFunctions.tan(argument(ctx, state))
 
   override def rewrite(f: (Expression) => Expression) = f(TanFunction(argument.rewrite(f)))
 }
 
 case class RandFunction() extends Expression {
 
-  override def apply(ctx: ExecutionContext, state: QueryState): AnyValue = Values.doubleValue(math.random)
+  override def apply(ctx: ExecutionContext, state: QueryState): AnyValue = CypherFunctions.rand()
 
   override def arguments = Seq()
 
@@ -274,9 +278,10 @@ case class SignFunction(argument: Expression) extends MathFunction(argument) {
   override def rewrite(f: (Expression) => Expression) = f(SignFunction(argument.rewrite(f)))
 }
 
-case class RoundFunction(expression: Expression) extends NullSafeMathFunction(expression) {
+case class RoundFunction(expression: Expression) extends MathFunction(expression) {
 
-  override def apply(value: Double) = math.round(value)
+  override def apply(ctx: ExecutionContext,
+                     state: QueryState): AnyValue = CypherFunctions.round(expression(ctx, state))
 
   override def rewrite(f: (Expression) => Expression) = f(RoundFunction(expression.rewrite(f)))
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Multiply.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Multiply.scala
@@ -21,21 +21,14 @@ package org.neo4j.cypher.internal.runtime.interpreted.commands.expressions
 
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.QueryState
+import org.neo4j.cypher.operations.CypherMath
 import org.neo4j.values.AnyValue
-import org.neo4j.values.storable.{DurationValue, NumberValue}
+import org.neo4j.values.storable.NumberValue
 
 case class Multiply(a: Expression, b: Expression) extends Arithmetics(a, b) {
 
-  override def apply(ctx: ExecutionContext, state: QueryState): AnyValue = {
-    val aVal = a(ctx, state)
-    val bVal = b(ctx, state)
-
-    (aVal, bVal) match {
-      case (x: DurationValue, y: NumberValue) => x.mul(y)
-      case (x: NumberValue, y: DurationValue) => y.mul(x)
-      case _ => applyWithValues(aVal, bVal)
-    }
-  }
+  override def apply(ctx: ExecutionContext, state: QueryState): AnyValue =
+    CypherMath.multiply(a(ctx, state), b(ctx, state))
 
   def calc(a: NumberValue, b: NumberValue): AnyValue = a.times(b)
 

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Subtract.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Subtract.scala
@@ -21,24 +21,14 @@ package org.neo4j.cypher.internal.runtime.interpreted.commands.expressions
 
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.QueryState
-import org.opencypher.v9_0.util.CypherTypeException
+import org.neo4j.cypher.operations.CypherMath
 import org.neo4j.values.AnyValue
-import org.neo4j.values.storable.{DurationValue, NumberValue, TemporalValue}
+import org.neo4j.values.storable.NumberValue
 
 case class Subtract(a: Expression, b: Expression) extends Arithmetics(a, b) {
 
-  override def apply(ctx: ExecutionContext, state: QueryState): AnyValue = {
-    val aVal = a(ctx, state)
-    val bVal = b(ctx, state)
-
-    (aVal, bVal) match {
-      case (x: TemporalValue[_,_], y: DurationValue) => x.minus(y)
-      case (x: DurationValue, y: DurationValue) => x.sub(y)
-      case (x: TemporalValue[_,_], y: TemporalValue[_,_]) => throw new CypherTypeException("You cannot subtract a temporal instant from another. " +
-        "To obtain the duration, use 'duration.between(temporal1, temporal2)' instead.")
-      case _ => applyWithValues(aVal, bVal)
-    }
-  }
+  override def apply(ctx: ExecutionContext, state: QueryState): AnyValue =
+    CypherMath.subtract(a(ctx, state), b(ctx, state))
 
   def calc(a: NumberValue, b: NumberValue) = a.minus(b)
 

--- a/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherBoolean.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherBoolean.java
@@ -2,33 +2,25 @@
  * Copyright (c) 2002-2018 "Neo4j,"
  * Neo4j Sweden AB [http://neo4j.com]
  *
- * This file is part of Neo4j Enterprise Edition. The included source
- * code can be redistributed and/or modified under the terms of the
- * GNU AFFERO GENERAL PUBLIC LICENSE Version 3
- * (http://www.fsf.org/licensing/licenses/agpl-3.0.html) with the
- * Commons Clause, as found in the associated LICENSE.txt file.
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * GNU General Public License for more details.
  *
- * Neo4j object code can be licensed independently from the source
- * under separate terms from the AGPL. Inquiries can be directed to:
- * licensing@neo4j.com
- *
- * More information is also available at:
- * https://neo4j.com/licensing/
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.runtime.compiled.expressions;
+package org.neo4j.cypher.operations;
 
 import org.opencypher.v9_0.util.CypherTypeException;
 
-import org.neo4j.internal.kernel.api.CursorFactory;
-import org.neo4j.internal.kernel.api.NodeCursor;
-import org.neo4j.internal.kernel.api.PropertyCursor;
-import org.neo4j.internal.kernel.api.RelationshipScanCursor;
-import org.neo4j.internal.kernel.api.Transaction;
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.SequenceValue;
 import org.neo4j.values.ValueMapper;
@@ -40,21 +32,16 @@ import org.neo4j.values.storable.LocalDateTimeValue;
 import org.neo4j.values.storable.LocalTimeValue;
 import org.neo4j.values.storable.NumberValue;
 import org.neo4j.values.storable.PointValue;
-import org.neo4j.values.storable.TemporalValue;
 import org.neo4j.values.storable.TextValue;
 import org.neo4j.values.storable.TimeValue;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
-import org.neo4j.values.virtual.ListValue;
 import org.neo4j.values.virtual.MapValue;
 import org.neo4j.values.virtual.PathValue;
 import org.neo4j.values.virtual.VirtualNodeValue;
 import org.neo4j.values.virtual.VirtualRelationshipValue;
-import org.neo4j.values.virtual.VirtualValues;
 
 import static org.neo4j.values.storable.Values.NO_VALUE;
-import static org.neo4j.values.storable.Values.booleanValue;
-import static org.neo4j.values.storable.Values.stringValue;
 
 /**
  * This class contains static helper boolean methods used by the compiled expressions

--- a/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherDbAccess.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherDbAccess.java
@@ -2,27 +2,23 @@
  * Copyright (c) 2002-2018 "Neo4j,"
  * Neo4j Sweden AB [http://neo4j.com]
  *
- * This file is part of Neo4j Enterprise Edition. The included source
- * code can be redistributed and/or modified under the terms of the
- * GNU AFFERO GENERAL PUBLIC LICENSE Version 3
- * (http://www.fsf.org/licensing/licenses/agpl-3.0.html) with the
- * Commons Clause, as found in the associated LICENSE.txt file.
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * GNU General Public License for more details.
  *
- * Neo4j object code can be licensed independently from the source
- * under separate terms from the AGPL. Inquiries can be directed to:
- * licensing@neo4j.com
- *
- * More information is also available at:
- * https://neo4j.com/licensing/
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.runtime.compiled.expressions;
+package org.neo4j.cypher.operations;
 
-import org.opencypher.v9_0.util.CypherTypeException;
 import org.opencypher.v9_0.util.EntityNotFoundException;
 
 import org.neo4j.internal.kernel.api.CursorFactory;
@@ -30,19 +26,8 @@ import org.neo4j.internal.kernel.api.NodeCursor;
 import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.RelationshipScanCursor;
 import org.neo4j.internal.kernel.api.Transaction;
-import org.neo4j.values.AnyValue;
-import org.neo4j.values.storable.DurationValue;
-import org.neo4j.values.storable.NumberValue;
-import org.neo4j.values.storable.PointValue;
-import org.neo4j.values.storable.TemporalValue;
-import org.neo4j.values.storable.TextValue;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
-import org.neo4j.values.virtual.ListValue;
-import org.neo4j.values.virtual.VirtualValues;
-
-import static org.neo4j.values.storable.Values.NO_VALUE;
-import static org.neo4j.values.storable.Values.stringValue;
 
 /**
  * This class contains static helper methods for expressions interacting with the database

--- a/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherFunctions.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherFunctions.java
@@ -2,25 +2,22 @@
  * Copyright (c) 2002-2018 "Neo4j,"
  * Neo4j Sweden AB [http://neo4j.com]
  *
- * This file is part of Neo4j Enterprise Edition. The included source
- * code can be redistributed and/or modified under the terms of the
- * GNU AFFERO GENERAL PUBLIC LICENSE Version 3
- * (http://www.fsf.org/licensing/licenses/agpl-3.0.html) with the
- * Commons Clause, as found in the associated LICENSE.txt file.
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * GNU General Public License for more details.
  *
- * Neo4j object code can be licensed independently from the source
- * under separate terms from the AGPL. Inquiries can be directed to:
- * licensing@neo4j.com
- *
- * More information is also available at:
- * https://neo4j.com/licensing/
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.runtime.compiled.expressions;
+package org.neo4j.cypher.operations;
 
 import org.opencypher.v9_0.util.CypherTypeException;
 

--- a/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherMath.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherMath.java
@@ -2,25 +2,22 @@
  * Copyright (c) 2002-2018 "Neo4j,"
  * Neo4j Sweden AB [http://neo4j.com]
  *
- * This file is part of Neo4j Enterprise Edition. The included source
- * code can be redistributed and/or modified under the terms of the
- * GNU AFFERO GENERAL PUBLIC LICENSE Version 3
- * (http://www.fsf.org/licensing/licenses/agpl-3.0.html) with the
- * Commons Clause, as found in the associated LICENSE.txt file.
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * GNU General Public License for more details.
  *
- * Neo4j object code can be licensed independently from the source
- * under separate terms from the AGPL. Inquiries can be directed to:
- * licensing@neo4j.com
- *
- * More information is also available at:
- * https://neo4j.com/licensing/
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.runtime.compiled.expressions;
+package org.neo4j.cypher.operations;
 
 import org.opencypher.v9_0.util.CypherTypeException;
 

--- a/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateCodeGeneration.scala
+++ b/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateCodeGeneration.scala
@@ -24,6 +24,7 @@ package org.neo4j.cypher.internal.runtime.compiled.expressions
 
 import org.neo4j.cypher.internal.compatibility.v3_5.runtime.ast.{NodeProperty, RelationshipProperty}
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
+import org.neo4j.cypher.operations.{CypherBoolean, CypherDbAccess, CypherFunctions, CypherMath}
 import org.neo4j.internal.kernel.api.Transaction
 import org.neo4j.values.AnyValue
 import org.neo4j.values.storable.Values.{doubleValue, longValue}


### PR DESCRIPTION
We recently introduced static helpers used by compiled expressions, we should also use these from the interpreted runtime in order to minimize code duplication.

- move helpers to `runtime-util`
- port functions and math operations