### PR TITLE
Avoid spending heap memory on printing OOME stack traces in scheduled threads.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/scheduler/CentralJobScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/scheduler/CentralJobScheduler.java
@@ -66,6 +66,31 @@ public class CentralJobScheduler extends LifecycleAdapter implements JobSchedule
             field.setAccessible( true );
             field.set( this, name );
         }
+
+        @Override
+        public void uncaughtException( Thread t, Throwable e )
+        {
+            // Some JVMs cope poorly when the uncaught exception handler itself throws an exception,
+            // which is a likely scenario when we don't have enough heap memory to even print a stack trace.
+            if ( e instanceof OutOfMemoryError )
+            {
+                synchronized ( System.err )
+                {
+                    try
+                    {
+                        System.err.print( "OutOfMemoryError: " );
+                        System.err.println( e.getMessage() );
+                    }
+                    catch ( Throwable ignore )
+                    {
+                    }
+                }
+            }
+            else
+            {
+                super.uncaughtException( t, e );
+            }
+        }
     }
 
     public CentralJobScheduler()


### PR DESCRIPTION
It turns out that some JVMs crashes when an exception is thrown from the uncaught exception handler,
and this can happen when we have run out of heap memory so the printing of the OOME stack trace itself throws an OOME.
We will now instead just print the message of the OOME which should be allocated already.