### PR TITLE
ShortestPlan predicate planning error

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/CommunityPipeBuilder.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/CommunityPipeBuilder.scala
@@ -220,16 +220,22 @@ case class CommunityPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe
 
       case FindShortestPaths(_, shortestPathPattern, predicates, withFallBack, disallowSameNode) =>
         val legacyShortestPath = shortestPathPattern.expr.asLegacyPatterns(shortestPathPattern.name, expressionConverters).head
-
         val pathVariables = Set(legacyShortestPath.pathName, legacyShortestPath.relIterator.getOrElse(""))
+
+        def noDependency(expression: ASTExpression) =
+          (expression.dependencies.map(_.name) intersect pathVariables).isEmpty
+
         val (perStepPredicates, fullPathPredicates) = predicates.partition {
-          case p =>
-            (p.dependencies.map(_.name) intersect pathVariables).isEmpty
+          case p: IterablePredicateExpression =>
+            noDependency(
+              p.innerPredicate.getOrElse(throw new InternalException("This should have been handled in planning")))
+          case e => noDependency(e)
         }
         val commandPerStepPredicates = perStepPredicates.map(p => buildPredicate(p))
         val commandFullPathPredicates = fullPathPredicates.map(p => buildPredicate(p))
 
-        val commandExpression = ShortestPathExpression(legacyShortestPath, commandPerStepPredicates, commandFullPathPredicates, withFallBack, disallowSameNode)
+        val commandExpression = ShortestPathExpression(legacyShortestPath, commandPerStepPredicates,
+                                                       commandFullPathPredicates, withFallBack, disallowSameNode)
         ShortestPathPipe(source, commandExpression, withFallBack, disallowSameNode)(id = id)
 
       case UnwindCollection(_, variable, collection) =>

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -192,6 +192,7 @@ Feature "ShortestPathAcceptance": Scenario "Find no shortest path when a length 
 Feature "ShortestPathAcceptance": Scenario "Find no shortest path when the start node is null"
 Feature "ShortestPathAcceptance": Scenario "Find all shortest paths"
 Feature "ShortestPathAcceptance": Scenario "Find a combination of a shortest path and a pattern expression"
+Feature "ShortestPathAcceptance": Scenario "Find shortest path when there are shorter paths with same start and end node"
 Feature "SkipLimitAcceptance": Scenario "Combining LIMIT and aggregation"
 Feature "SkipLimitAcceptance": Scenario "Limit before sort"
 Feature "SkipLimitAcceptance": Scenario "Limit before top"

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/ShortestPathAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/ShortestPathAcceptance.feature
@@ -401,3 +401,22 @@ Feature: ShortestPathAcceptance
       | 1      |
     And no side effects
 
+
+  Scenario: Find shortest path when there are shorter paths with same start and end node
+    And having executed:
+      """
+      CREATE (s:START), (e:END)
+      CREATE(s)-[:R]->()-[:R]->(e),
+             (s)-[:R {p:42}]->()-[:R {p:42}]->()-[:R {p:42}]->(e)
+      """
+    When executing query:
+      """
+      MATCH p = allShortestPaths((start:START)-[*]->(end:END))
+      WHERE ALL(x in relationships(p) WHERE exists(x.p))
+      RETURN length(p) AS len
+      """
+    Then the result should be, in order:
+      | len |
+      |  3  |
+    And no side effects
+


### PR DESCRIPTION
In pipe-building when deciding if a predicate has a dependency on the
full path or not we were not using the internal expression but instead the
outer expression.

changelog: Fix error where the wrong result were returned for some
`allShortestPath`-queries.