### PR TITLE
Log full message on protocol error in Bolt

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/DefaultBoltProtocolPipelineInstaller.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/DefaultBoltProtocolPipelineInstaller.java
@@ -66,7 +66,7 @@ public class DefaultBoltProtocolPipelineInstaller implements BoltProtocolPipelin
 
         pipeline.addLast( new ChunkDecoder() );
         pipeline.addLast( new MessageAccumulator() );
-        pipeline.addLast( new MessageDecoder( neo4jPack, messageHandler ) );
+        pipeline.addLast( new MessageDecoder( neo4jPack, messageHandler, logging ) );
         pipeline.addLast( new HouseKeeper( connection, logging ) );
     }
 

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltRequestMessage.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltRequestMessage.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.bolt.v1.messaging;
 
-import static java.lang.String.format;
-
 /**
  * Enumeration representing all defined Bolt request messages.
  * Also contains the signature byte with which the message is
@@ -35,7 +33,7 @@ public enum BoltRequestMessage
     DISCARD_ALL( 0x2F ),
     PULL_ALL( 0x3F );
 
-    private static BoltRequestMessage[] valuesBySignature = new BoltRequestMessage[0x40];
+    private static final BoltRequestMessage[] valuesBySignature = new BoltRequestMessage[0x40];
     static
     {
         for ( BoltRequestMessage value : values() )
@@ -47,18 +45,16 @@ public enum BoltRequestMessage
     /**
      * Obtain a request message by signature.
      *
-     * @param signature the signature byte to look up
-     * @return the appropriate message instance
-     * @throws IllegalArgumentException if no such message exists
+     * @param signature the signature byte to look up.
+     * @return the appropriate message instance or {@code null} if no message with the given signature exists.
      */
     public static BoltRequestMessage withSignature( int signature )
     {
-        BoltRequestMessage message = valuesBySignature[signature];
-        if ( message == null )
+        if ( signature < 0 || signature > valuesBySignature.length - 1 )
         {
-            throw new IllegalArgumentException( format( "No message with signature %d", signature ) );
+            return null;
         }
-        return message;
+        return valuesBySignature[signature];
     }
 
     private final byte signature;

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageReader.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageReader.java
@@ -51,43 +51,41 @@ public class BoltRequestMessageReader
         try
         {
             unpacker.unpackStructHeader();
-            final int signature = (int) unpacker.unpackStructSignature();
+            int signature = unpacker.unpackStructSignature();
             BoltRequestMessage message = BoltRequestMessage.withSignature( signature );
-            try
-            {
-                switch ( message )
-                {
-                case INIT:
-                    String clientName = unpacker.unpackString();
-                    Map<String,Object> authToken = readAuthToken( unpacker );
-                    handler.onInit( clientName, authToken );
-                    break;
-                case ACK_FAILURE:
-                    handler.onAckFailure();
-                    break;
-                case RESET:
-                    handler.onReset();
-                    break;
-                case RUN:
-                    String statement = unpacker.unpackString();
-                    MapValue params = unpacker.unpackMap();
-                    handler.onRun( statement, params );
-                    break;
-                case DISCARD_ALL:
-                    handler.onDiscardAll();
-                    break;
-                case PULL_ALL:
-                    handler.onPullAll();
-                    break;
-                default:
-                    throw new BoltIOException( Status.Request.InvalidFormat,
-                            String.format( "Message 0x%s is not supported.", Integer.toHexString( signature ) ) );
-                }
-            }
-            catch ( IllegalArgumentException e )
+            if ( message == null )
             {
                 throw new BoltIOException( Status.Request.InvalidFormat,
                         String.format( "Message 0x%s is not a valid message signature.", Integer.toHexString( signature ) ) );
+            }
+
+            switch ( message )
+            {
+            case INIT:
+                String clientName = unpacker.unpackString();
+                Map<String,Object> authToken = readAuthToken( unpacker );
+                handler.onInit( clientName, authToken );
+                break;
+            case ACK_FAILURE:
+                handler.onAckFailure();
+                break;
+            case RESET:
+                handler.onReset();
+                break;
+            case RUN:
+                String statement = unpacker.unpackString();
+                MapValue params = unpacker.unpackMap();
+                handler.onRun( statement, params );
+                break;
+            case DISCARD_ALL:
+                handler.onDiscardAll();
+                break;
+            case PULL_ALL:
+                handler.onPullAll();
+                break;
+            default:
+                throw new BoltIOException( Status.Request.InvalidFormat,
+                        String.format( "Message 0x%s is not supported.", Integer.toHexString( signature ) ) );
             }
         }
         catch ( PackStream.PackStreamException e )

--- a/community/bolt/src/test/java/org/neo4j/bolt/transport/pipeline/MessageDecoderTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/transport/pipeline/MessageDecoderTest.java
@@ -25,6 +25,7 @@ import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -46,18 +47,28 @@ import org.neo4j.bolt.v1.runtime.Neo4jError;
 import org.neo4j.bolt.v2.messaging.Neo4jPackV2;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.util.ValueUtils;
+import org.neo4j.logging.Log;
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.virtual.MapValue;
 import org.neo4j.values.virtual.PathValue;
 import org.neo4j.values.virtual.VirtualValues;
 
+import static io.netty.buffer.ByteBufUtil.hexDump;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 import static org.neo4j.bolt.v1.messaging.BoltRequestMessage.INIT;
 import static org.neo4j.bolt.v1.messaging.BoltRequestMessage.RUN;
 import static org.neo4j.bolt.v1.messaging.example.Edges.ALICE_KNOWS_BOB;
@@ -71,6 +82,7 @@ import static org.neo4j.bolt.v1.messaging.message.ResetMessage.reset;
 import static org.neo4j.bolt.v1.messaging.message.RunMessage.run;
 import static org.neo4j.bolt.v1.messaging.util.MessageMatchers.serialize;
 import static org.neo4j.values.storable.Values.durationValue;
+import static org.neo4j.values.virtual.VirtualValues.EMPTY_MAP;
 
 @RunWith( Parameterized.class )
 public class MessageDecoderTest
@@ -102,7 +114,7 @@ public class MessageDecoderTest
     public void shouldDispatchInit() throws Exception
     {
         BoltRequestMessageHandler handler = mock( BoltRequestMessageHandler.class );
-        channel = new EmbeddedChannel( new MessageDecoder( packerUnderTest, handler ) );
+        channel = new EmbeddedChannel( newDecoder( handler ) );
 
         String userAgent = "Test/User Agent 1.0";
         Map<String, Object> authToken = MapUtil.map( "scheme", "basic", "principal", "user", "credentials", "password" );
@@ -118,7 +130,7 @@ public class MessageDecoderTest
     public void shouldDispatchAckFailure() throws Exception
     {
         BoltRequestMessageHandler handler = mock( BoltRequestMessageHandler.class );
-        channel = new EmbeddedChannel( new MessageDecoder( packerUnderTest, handler ) );
+        channel = new EmbeddedChannel( newDecoder( handler ) );
 
         channel.writeInbound( Unpooled.wrappedBuffer( serialize( packerUnderTest, ackFailure() ) ) );
         channel.finishAndReleaseAll();
@@ -131,7 +143,7 @@ public class MessageDecoderTest
     public void shouldDispatchReset() throws Exception
     {
         BoltRequestMessageHandler handler = mock( BoltRequestMessageHandler.class );
-        channel = new EmbeddedChannel( new MessageDecoder( packerUnderTest, handler ) );
+        channel = new EmbeddedChannel( newDecoder( handler ) );
 
         channel.writeInbound( Unpooled.wrappedBuffer( serialize( packerUnderTest, reset() ) ) );
         channel.finishAndReleaseAll();
@@ -144,7 +156,7 @@ public class MessageDecoderTest
     public void shouldDispatchRun() throws Exception
     {
         BoltRequestMessageHandler handler = mock( BoltRequestMessageHandler.class );
-        channel = new EmbeddedChannel( new MessageDecoder( packerUnderTest, handler ) );
+        channel = new EmbeddedChannel( newDecoder( handler ) );
 
         String statement = "RETURN 1";
         MapValue parameters = ValueUtils.asMapValue( MapUtil.map( "param1", 1, "param2", "2", "param3", true, "param4", 5.0 ) );
@@ -160,7 +172,7 @@ public class MessageDecoderTest
     public void shouldDispatchDiscardAll() throws Exception
     {
         BoltRequestMessageHandler handler = mock( BoltRequestMessageHandler.class );
-        channel = new EmbeddedChannel( new MessageDecoder( packerUnderTest, handler ) );
+        channel = new EmbeddedChannel( newDecoder( handler ) );
 
         channel.writeInbound( Unpooled.wrappedBuffer( serialize( packerUnderTest, discardAll() ) ) );
         channel.finishAndReleaseAll();
@@ -173,7 +185,7 @@ public class MessageDecoderTest
     public void shouldDispatchPullAll() throws Exception
     {
         BoltRequestMessageHandler handler = mock( BoltRequestMessageHandler.class );
-        channel = new EmbeddedChannel( new MessageDecoder( packerUnderTest, handler ) );
+        channel = new EmbeddedChannel( newDecoder( handler ) );
 
         channel.writeInbound( Unpooled.wrappedBuffer( serialize( packerUnderTest, pullAll() ) ) );
         channel.finishAndReleaseAll();
@@ -186,7 +198,7 @@ public class MessageDecoderTest
     public void shouldCallExternalErrorOnInitWithNullKeys() throws Exception
     {
         BoltRequestMessageHandler handler = mock( BoltRequestMessageHandler.class );
-        channel = new EmbeddedChannel( new MessageDecoder( packerUnderTest, handler ) );
+        channel = new EmbeddedChannel( newDecoder( handler ) );
 
         String userAgent = "Test/User Agent 1.0";
         Map<String,Object> authToken = MapUtil.map( "scheme", "basic", null, "user", "credentials", "password" );
@@ -203,7 +215,7 @@ public class MessageDecoderTest
     public void shouldCallExternalErrorOnInitWithDuplicateKeys() throws Exception
     {
         BoltRequestMessageHandler handler = mock( BoltRequestMessageHandler.class );
-        channel = new EmbeddedChannel( new MessageDecoder( packerUnderTest, handler ) );
+        channel = new EmbeddedChannel( newDecoder( handler ) );
 
         // Generate INIT message with duplicate keys
         PackedOutputArray out = new PackedOutputArray();
@@ -330,6 +342,60 @@ public class MessageDecoderTest
         }
     }
 
+    @Test
+    public void shouldLogContentOfTheMessageOnIOError() throws Exception
+    {
+        BoltRequestMessageHandler handler = mock( BoltRequestMessageHandler.class );
+
+        LogService logService = mock( LogService.class );
+        Log log = mock( Log.class );
+        when( logService.getInternalLog( MessageDecoder.class ) ).thenReturn( log );
+
+        channel = new EmbeddedChannel( new MessageDecoder( packerUnderTest, handler, logService ) );
+
+        byte invalidMessageSignature = Byte.MAX_VALUE;
+        byte[] messageBytes = packMessageWithSignature( invalidMessageSignature );
+
+        try
+        {
+            channel.writeInbound( Unpooled.wrappedBuffer( messageBytes ) );
+            fail( "Exception expected" );
+        }
+        catch ( Exception ignore )
+        {
+        }
+
+        assertMessageHexDumpLogged( log, messageBytes );
+    }
+
+    @Test
+    public void shouldLogContentOfTheMessageOnError() throws Exception
+    {
+        BoltRequestMessageHandler handler = mock( BoltRequestMessageHandler.class );
+        RuntimeException error = new RuntimeException( "Hello!" );
+        doThrow( error ).when( handler ).onRun( any(), any() );
+
+        LogService logService = mock( LogService.class );
+        Log log = mock( Log.class );
+        when( logService.getInternalLog( MessageDecoder.class ) ).thenReturn( log );
+
+        channel = new EmbeddedChannel( new MessageDecoder( packerUnderTest, handler, logService ) );
+
+        byte[] messageBytes = packMessageWithSignature( RUN.signature() );
+
+        try
+        {
+            channel.writeInbound( Unpooled.wrappedBuffer( messageBytes ) );
+            fail( "Exception expected" );
+        }
+        catch ( RuntimeException e )
+        {
+            assertEquals( error, e );
+        }
+
+        assertMessageHexDumpLogged( log, messageBytes );
+    }
+
     private void testUnpackableStructParametersWithKnownType( AnyValue parameterValue, String expectedMessage ) throws IOException
     {
         testUnpackableStructParametersWithKnownType( packerUnderTest, parameterValue, expectedMessage );
@@ -342,7 +408,7 @@ public class MessageDecoderTest
         MapValue parameters = VirtualValues.map( Collections.singletonMap( "x", parameterValue ) );
 
         BoltRequestMessageHandler handler = mock( BoltRequestMessageHandler.class );
-        channel = new EmbeddedChannel( new MessageDecoder( packerUnderTest, handler ) );
+        channel = new EmbeddedChannel( newDecoder( handler ) );
 
         channel.writeInbound( Unpooled.wrappedBuffer( serialize( packerForSerialization, run( statement, parameters ) ) ) );
         channel.finishAndReleaseAll();
@@ -354,9 +420,31 @@ public class MessageDecoderTest
     private void unpack( byte[] input ) throws IOException
     {
         BoltRequestMessageHandler handler = mock( BoltRequestMessageHandler.class );
-        channel = new EmbeddedChannel( new MessageDecoder( packerUnderTest, handler ) );
+        channel = new EmbeddedChannel( newDecoder( handler ) );
 
         channel.writeInbound( Unpooled.wrappedBuffer( input ) );
         channel.finishAndReleaseAll();
+    }
+
+    private byte[] packMessageWithSignature( byte signature ) throws IOException
+    {
+        PackedOutputArray out = new PackedOutputArray();
+        Neo4jPack.Packer packer = packerUnderTest.newPacker( out );
+        packer.packStructHeader( 2, signature );
+        packer.pack( "RETURN 'Hello World!'" );
+        packer.pack( EMPTY_MAP );
+        return out.bytes();
+    }
+
+    private MessageDecoder newDecoder( BoltRequestMessageHandler handler )
+    {
+        return new MessageDecoder( packerUnderTest, handler, NullLogService.getInstance() );
+    }
+
+    private static void assertMessageHexDumpLogged( Log logMock, byte[] messageBytes )
+    {
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass( String.class );
+        verify( logMock ).error( captor.capture() );
+        assertThat( captor.getValue(), containsString( hexDump( messageBytes ) ) );
     }
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageTest.java
@@ -41,6 +41,8 @@ import org.neo4j.values.virtual.VirtualValues;
 import static java.lang.System.lineSeparator;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.neo4j.bolt.v1.messaging.message.AckFailureMessage.ackFailure;
 import static org.neo4j.bolt.v1.messaging.message.DiscardAllMessage.discardAll;
 import static org.neo4j.bolt.v1.messaging.message.InitMessage.init;
@@ -113,6 +115,30 @@ public class BoltRequestMessageTest
         assertThat( serialized( rel ),
                 equalTo( "B1 71 91 B5 52 0C 01 02 85 4B 4E 4F 57 53 A2 84" + lineSeparator() +
                          "6E 61 6D 65 83 42 6F 62 83 61 67 65 0E" ) );
+    }
+
+    @Test
+    public void shouldReturnMessageWithValidSignature()
+    {
+        for ( BoltRequestMessage message : BoltRequestMessage.values() )
+        {
+            assertEquals( message, BoltRequestMessage.withSignature( message.signature() ) );
+        }
+    }
+
+    @Test
+    public void shouldReturnNullWithInvalidSignature()
+    {
+        assertNull( BoltRequestMessage.withSignature( -1 ) );
+        assertNull( BoltRequestMessage.withSignature( -42 ) );
+        assertNull( BoltRequestMessage.withSignature( Integer.MIN_VALUE ) );
+
+        assertNull( BoltRequestMessage.withSignature( 42 ) );
+        assertNull( BoltRequestMessage.withSignature( Integer.MAX_VALUE ) );
+
+        BoltRequestMessage[] messages = BoltRequestMessage.values();
+        assertNull( BoltRequestMessage.withSignature( messages[0].signature() - 1 ) );
+        assertNull( BoltRequestMessage.withSignature( messages[messages.length - 1].signature() + 1 ) );
     }
 
     private String serialized( AnyValue object ) throws IOException


### PR DESCRIPTION
This PR makes `MessageDecoder` log full content of the message buffer if it fails to decode a message from this buffer. Hex dump of the buffer is logged to the internal log. Network connection is then closed because of the error.

Also improved `BoltRequestMessage` enum to better handle illegal message signatures and not use exceptions for flow control.