### PR TITLE
Introducing transient discovery state and multi-cluster unbinding

### DIFF
--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupCommandCcIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupCommandCcIT.java
@@ -143,7 +143,7 @@ public class OnlineBackupCommandCcIT
         Cluster cluster = startCluster( recordFormat );
 
         // and the database has indexes
-        ClusterHelper.createIndexes( cluster.getMemberWithAnyRole( Role.LEADER ).database() );
+        ClusterHelper.createIndexes( cluster.getCoreMemberWithAnyRole( Role.LEADER ).database() );
 
         // and the database is being populated
         AtomicBoolean populateDatabaseFlag = new AtomicBoolean( true );
@@ -232,7 +232,7 @@ public class OnlineBackupCommandCcIT
     {
         // given
         Cluster cluster = startCluster( recordFormat );
-        ClusterHelper.createIndexes( cluster.getMemberWithAnyRole( Role.LEADER ).database() );
+        ClusterHelper.createIndexes( cluster.getCoreMemberWithAnyRole( Role.LEADER ).database() );
         String customAddress = CausalClusteringTestHelpers.backupAddress( clusterLeader( cluster ).database() );
 
         // and
@@ -357,7 +357,7 @@ public class OnlineBackupCommandCcIT
 
     private static CoreClusterMember clusterLeader( Cluster cluster )
     {
-        return cluster.getMemberWithRole( Role.LEADER );
+        return cluster.getCoreMemberWithRole( Role.LEADER );
     }
 
     public static DbRepresentation getBackupDbRepresentation( String name, File backupDir )

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/BackupCoreIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/BackupCoreIT.java
@@ -105,7 +105,7 @@ public class BackupCoreIT
 
     static String backupAddress( Cluster cluster )
     {
-        return cluster.getMemberWithRole( Role.LEADER ).settingValue( "causal_clustering.transaction_listen_address" );
+        return cluster.getCoreMemberWithRole( Role.LEADER ).settingValue( "causal_clustering.transaction_listen_address" );
     }
 
     static String[] backupArguments( String from, File backupsDir, String name )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
@@ -44,6 +44,7 @@ import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.helpers.ListenSocketAddress;
 import org.neo4j.logging.LogProvider;
 
+import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.neo4j.causalclustering.protocol.Protocol.ModifierProtocols.Implementations.GZIP;
 import static org.neo4j.causalclustering.protocol.Protocol.ModifierProtocols.Implementations.LZ4;
 import static org.neo4j.causalclustering.protocol.Protocol.ModifierProtocols.Implementations.LZ4_HIGH_COMPRESSION;
@@ -98,6 +99,12 @@ public class CausalClusteringSettings implements LoadableConfig
             "neo4j-admin unbind." )
     public static final Setting<String> database =
             setting( "causal_clustering.database", STRING, "default" );
+
+    //TODO: Description
+    @Description( "Time after which a ClusterId for which there are no active members may be overridden by a new value. Due to the potential " +
+            "for clock skew between machines in a cluster, the minimum value for this ttl is 30 seconds." )
+    public static final Setting<Duration>  clusterId_ttl = buildSetting( "causal_clustering.clusterId_ttl", DURATION, "30s" )
+            .constraint( min( Duration.of( 30, SECONDS ) ) ).build();
 
     @Description( "Enable pre-voting extension to the Raft protocol (this is breaking and must match between the core cluster members)" )
     public static final Setting<Boolean> enable_pre_voting =

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderInfo.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderInfo.java
@@ -28,7 +28,6 @@ import org.neo4j.causalclustering.identity.MemberId;
 
 public class LeaderInfo implements Serializable
 {
-
     private static final long serialVersionUID = 7983780359510842910L;
 
     public static final LeaderInfo INITIAL = new LeaderInfo( null, -1 );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/ClusteringModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/ClusteringModule.java
@@ -23,6 +23,7 @@
 package org.neo4j.causalclustering.core.state;
 
 import java.io.File;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -87,9 +88,10 @@ public class ClusteringModule
 
         String dbName = config.get( CausalClusteringSettings.database );
         int minimumCoreHosts = config.get( CausalClusteringSettings.minimum_core_cluster_size_at_formation );
+        Duration clusterIdTtl = config.get( CausalClusteringSettings.clusterId_ttl );
 
         clusterBinder = new ClusterBinder( clusterIdStorage, dbNameStorage, topologyService, Clocks.systemClock(), () -> sleep( 100 ), 300_000,
-                coreBootstrapper, dbName, minimumCoreHosts, logProvider );
+                coreBootstrapper, dbName, minimumCoreHosts, logProvider, clusterIdTtl );
     }
 
     private static TopologyServiceRetryStrategy resolveStrategy( Config config, LogProvider logProvider )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopology.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopology.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
-import org.neo4j.causalclustering.identity.ClusterId;
+import org.neo4j.causalclustering.discovery.data.RefCounted;
 import org.neo4j.causalclustering.identity.MemberId;
 
 import static java.lang.String.format;
@@ -38,11 +38,11 @@ public class CoreTopology implements Topology<CoreServerInfo>
 {
     static final CoreTopology EMPTY = new CoreTopology( null, false, emptyMap() );
 
-    private final ClusterId clusterId;
+    private final RefCounted<TransientClusterId> clusterId;
     private final boolean canBeBootstrapped;
     private final Map<MemberId,CoreServerInfo> coreMembers;
 
-    public CoreTopology( ClusterId clusterId, boolean canBeBootstrapped, Map<MemberId,CoreServerInfo> coreMembers )
+    public CoreTopology( RefCounted<TransientClusterId> clusterId, boolean canBeBootstrapped, Map<MemberId,CoreServerInfo> coreMembers )
     {
         this.clusterId = clusterId;
         this.canBeBootstrapped = canBeBootstrapped;
@@ -55,7 +55,7 @@ public class CoreTopology implements Topology<CoreServerInfo>
         return coreMembers;
     }
 
-    public ClusterId clusterId()
+    public RefCounted<TransientClusterId> clusterId()
     {
         return clusterId;
     }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyService.java
@@ -37,12 +37,18 @@ public interface CoreTopologyService extends TopologyService
     void removeLocalCoreTopologyListener( Listener listener );
 
     /**
-     * Publishes the cluster ID so that other members might discover it.
-     * Should only succeed to publish if one missing or already the same (CAS logic).
+     * Publishes a transient cluster Id so that other members might discover it.
+     * Should only succeed to publish a cluster Id under the following circumstances:
      *
-     * @param clusterId The cluster ID to publish.
+     *  - if a cluster Id does not already exist for the given dbName.
+     *  - a cluster Id does exist for the given dbName, but it has been inactive for a
+     *      period longer than the configured timeout.
+     *  - a cluster Id does exist for the given dbName, but it is equal to the clusterId
+     *      being set.
      *
-     * @return True if the cluster ID was successfully CAS:ed, otherwise false.
+     * @param clusterId The cluster Id to publish.
+     * @param dbName The database name for the cluster Id.
+     * @return True if the cluster Id was successfully updated, otherwise false.
      */
     boolean setClusterId( ClusterId clusterId, String dbName ) throws InterruptedException;
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/Topology.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/Topology.java
@@ -60,5 +60,10 @@ public interface Topology<T extends DiscoveryServerInfo>
                 .collect( Collectors.toMap( Map.Entry::getKey, Map.Entry::getValue ) );
     }
 
+    default boolean isEmpty()
+    {
+        return this.members().isEmpty();
+    }
+
     Topology<T> filterTopologyByDb( String dbName );
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TransientClusterId.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TransientClusterId.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.discovery;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.neo4j.causalclustering.core.state.storage.SafeChannelMarshal;
+import org.neo4j.causalclustering.discovery.data.Transient;
+import org.neo4j.causalclustering.identity.ClusterId;
+import org.neo4j.causalclustering.messaging.EndOfStreamException;
+import org.neo4j.storageengine.api.ReadableChannel;
+import org.neo4j.storageengine.api.WritableChannel;
+
+public class TransientClusterId implements Transient, Serializable
+{
+
+    private static final long serialVersionUID = 24070572631L;
+
+    private final ClusterId clusterId;
+    private final Instant lastActive;
+
+    public TransientClusterId( ClusterId clusterId, Instant lastActive )
+    {
+        this.clusterId = clusterId;
+        this.lastActive = lastActive;
+    }
+
+    public Instant lastActive()
+    {
+        return lastActive;
+    }
+
+    public ClusterId clusterId()
+    {
+        return clusterId;
+    }
+
+    public UUID uuid()
+    {
+        return clusterId.uuid();
+    }
+
+    public boolean isActiveDuringLast( Duration timeout )
+    {
+        return isActiveDuringLast( timeout, Instant.now() );
+    }
+
+    @Override
+    public boolean isActiveDuringLast( Duration timeout, Instant now )
+    {
+        Duration elapsed = Duration.between( now, lastActive );
+        return elapsed.compareTo( timeout ) <= 0;
+    }
+
+    public TransientClusterId touchAt( Instant time )
+    {
+        if ( time.isAfter( lastActive ) )
+        {
+            return new TransientClusterId( clusterId, time );
+        }
+        else
+        {
+            return this;
+        }
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        TransientClusterId that = (TransientClusterId) o;
+        return Objects.equals( clusterId, that.clusterId );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( clusterId );
+    }
+
+    public static class Marshal extends SafeChannelMarshal<TransientClusterId>
+    {
+        public static Marshal INSTANCE = new Marshal();
+        private static ClusterId.Marshal clusterIdMarshal = ClusterId.Marshal.INSTANCE;
+
+        @Override
+        protected TransientClusterId unmarshal0( ReadableChannel channel ) throws IOException, EndOfStreamException
+        {
+            ClusterId clusterId = clusterIdMarshal.unmarshal( channel );
+            long lastActiveEpochSecond = channel.getLong();
+            Instant lastActive = Instant.ofEpochSecond( lastActiveEpochSecond );
+            return new TransientClusterId( clusterId, lastActive );
+        }
+
+        @Override
+        public void marshal( TransientClusterId transientClusterId, WritableChannel channel ) throws IOException
+        {
+            clusterIdMarshal.marshal( transientClusterId.clusterId, channel );
+            channel.putLong( transientClusterId.lastActive.getEpochSecond() );
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/data/RefCounted.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/data/RefCounted.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.discovery.data;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.neo4j.causalclustering.identity.MemberId;
+
+public final class RefCounted<T>
+{
+    private final T value;
+    private final Set<MemberId> references;
+
+    public RefCounted( T value )
+    {
+        this( value, Collections.emptySet() );
+    }
+
+    public RefCounted( T value, MemberId holder )
+    {
+        this( value, Collections.singleton( holder ) );
+    }
+
+    public RefCounted( T value, Set<MemberId> references )
+    {
+        this.value = value;
+        this.references = references;
+    }
+
+    public T value()
+    {
+        return value;
+    }
+
+    public <V> RefCounted<V> map( Function<T, V> mapper )
+    {
+        return new RefCounted<>( mapper.apply( value ), references );
+    }
+
+    public Set<MemberId> references()
+    {
+        return references;
+    }
+
+    public boolean safeToRemove()
+    {
+        return references.isEmpty();
+    }
+
+    public RefCounted<T> hold( MemberId instance )
+    {
+        HashSet<MemberId> newRefs = new HashSet<>( references );
+        newRefs.add( instance );
+        return new RefCounted<>( value, newRefs );
+    }
+
+    public RefCounted<T> release( MemberId instance )
+    {
+        HashSet<MemberId> newRefs = new HashSet<>( references );
+        newRefs.remove( instance );
+        return new RefCounted<>( value, newRefs );
+    }
+
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/data/RefCountedTransientClusterIdMarshal.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/data/RefCountedTransientClusterIdMarshal.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.discovery.data;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.neo4j.causalclustering.core.state.storage.SafeChannelMarshal;
+import org.neo4j.causalclustering.discovery.TransientClusterId;
+import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.causalclustering.messaging.EndOfStreamException;
+import org.neo4j.storageengine.api.ReadableChannel;
+import org.neo4j.storageengine.api.WritableChannel;
+
+public class RefCountedTransientClusterIdMarshal extends SafeChannelMarshal<RefCounted<TransientClusterId>>
+{
+
+    public static final RefCountedTransientClusterIdMarshal INSTANCE = new RefCountedTransientClusterIdMarshal();
+    private static final TransientClusterId.Marshal clusterIdMarshal = TransientClusterId.Marshal.INSTANCE;
+    private static final MemberId.Marshal memberIdMarshal = MemberId.Marshal.INSTANCE;
+
+    @Override
+    protected RefCounted<TransientClusterId> unmarshal0( ReadableChannel channel ) throws IOException, EndOfStreamException
+    {
+        TransientClusterId clusterId = clusterIdMarshal.unmarshal( channel );
+        int numReferences = channel.getInt();
+        Set<MemberId> references = new HashSet<>();
+        for ( int i = 0; i < numReferences; i++ )
+        {
+            references.add( memberIdMarshal.unmarshal( channel ) );
+        }
+        return new RefCounted<>( clusterId, references );
+    }
+
+    @Override
+    public void marshal( RefCounted<TransientClusterId> ref, WritableChannel channel ) throws IOException
+    {
+        clusterIdMarshal.marshal( ref.value(), channel );
+        channel.putInt( ref.references().size() );
+        for( MemberId m : ref.references() )
+        {
+            memberIdMarshal.marshal( m, channel );
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/data/Transient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/data/Transient.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.discovery.data;
+
+import java.time.Duration;
+import java.time.Instant;
+
+public interface Transient
+{
+    Instant lastActive();
+    Transient touchAt( Instant time );
+    boolean isActiveDuringLast( Duration timeout );
+    boolean isActiveDuringLast( Duration timeout, Instant now );
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/ClusterId.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/ClusterId.java
@@ -23,20 +23,30 @@
 package org.neo4j.causalclustering.identity;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Objects;
 import java.util.UUID;
 
 import org.neo4j.causalclustering.core.state.storage.SafeChannelMarshal;
+import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.storageengine.api.ReadableChannel;
 import org.neo4j.storageengine.api.WritableChannel;
 
-public class ClusterId
+public class ClusterId implements Serializable
 {
+
+    private static final long serialVersionUID = 890705346211L;
+
     private final UUID uuid;
 
     public ClusterId( UUID uuid )
     {
         this.uuid = uuid;
+    }
+
+    public UUID uuid()
+    {
+        return uuid;
     }
 
     @Override
@@ -58,11 +68,6 @@ public class ClusterId
     public int hashCode()
     {
         return Objects.hash( uuid );
-    }
-
-    public UUID uuid()
-    {
-        return uuid;
     }
 
     @Override

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/MemberId.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/MemberId.java
@@ -89,6 +89,7 @@ public class MemberId implements Serializable
      */
     public static class Marshal extends SafeStateMarshal<MemberId>
     {
+        public static final Marshal INSTANCE = new Marshal();
         private static final Charset UTF8 = Charset.forName("UTF-8");
 
         @Override

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ClusterMember.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ClusterMember.java
@@ -45,6 +45,8 @@ public interface ClusterMember<T extends GraphDatabaseAPI>
 
     Config config();
 
+    String dbName();
+
     /**
      * {@link Cluster} will use this {@link ThreadGroup} for the threads that start, and shut down, this cluster member.
      * This way, the group will be transitively inherited by all the threads that are in turn started by the member

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreClusterMember.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreClusterMember.java
@@ -252,6 +252,7 @@ public class CoreClusterMember implements ClusterMember<CoreGraphDatabase>
         return serverId;
     }
 
+    @Override
     public String dbName()
     {
         return dbName;

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ReadReplica.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ReadReplica.java
@@ -61,6 +61,7 @@ public class ReadReplica implements ClusterMember<ReadReplicaGraphDatabase>
     protected ReadReplicaGraphDatabase database;
     protected Monitors monitors;
     private final ThreadGroup threadGroup;
+    private final String dbName;
 
     public ReadReplica( File parentDir, int serverId, int boltPort, int httpPort, int txPort, int backupPort,
                         DiscoveryServiceFactory discoveryServiceFactory,
@@ -105,6 +106,8 @@ public class ReadReplica implements ClusterMember<ReadReplicaGraphDatabase>
         config.put( GraphDatabaseSettings.logs_directory.name(), new File( neo4jHome, "logs" ).getAbsolutePath() );
         config.put( GraphDatabaseSettings.logical_logs_location.name(), "replica-tx-logs-" + serverId );
         memberConfig = Config.defaults( config );
+
+        this.dbName = memberConfig.get( CausalClusteringSettings.database );
 
         this.discoveryServiceFactory = discoveryServiceFactory;
         storeDir = new File( new File( new File( neo4jHome, "data" ), "databases" ), "graph.db" );
@@ -205,6 +208,12 @@ public class ReadReplica implements ClusterMember<ReadReplicaGraphDatabase>
     public String directURI()
     {
         return String.format( "bolt://%s", boltAdvertisedSocketAddress );
+    }
+
+    @Override
+    public String dbName()
+    {
+        return dbName;
     }
 
     @Override

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/procedure/GetServersProcedureV1RoutingTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/procedure/GetServersProcedureV1RoutingTest.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -39,6 +40,8 @@ import org.neo4j.causalclustering.discovery.CoreServerInfo;
 import org.neo4j.causalclustering.discovery.CoreTopology;
 import org.neo4j.causalclustering.discovery.CoreTopologyService;
 import org.neo4j.causalclustering.discovery.ReadReplicaTopology;
+import org.neo4j.causalclustering.discovery.TransientClusterId;
+import org.neo4j.causalclustering.discovery.data.RefCounted;
 import org.neo4j.causalclustering.identity.ClusterId;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.internal.kernel.api.exceptions.ProcedureException;
@@ -66,7 +69,8 @@ public class GetServersProcedureV1RoutingTest
     @Parameter
     public int serverClass;
 
-    private ClusterId clusterId = new ClusterId( UUID.randomUUID() );
+    private TransientClusterId clusterId = new TransientClusterId( new ClusterId( UUID.randomUUID() ), Instant.now() );
+    private RefCounted<TransientClusterId> clusterIdRef = new RefCounted<>( clusterId );
     private Config config = Config.defaults();
 
     @Test
@@ -83,7 +87,7 @@ public class GetServersProcedureV1RoutingTest
         coreMembers.put( member( 1 ), addressesForCore( 1 ) );
         coreMembers.put( member( 2 ), addressesForCore( 2 ) );
 
-        final CoreTopology clusterTopology = new CoreTopology( clusterId, false, coreMembers );
+        final CoreTopology clusterTopology = new CoreTopology( clusterIdRef, false, coreMembers );
         when( coreTopologyService.localCoreServers() ).thenReturn( clusterTopology );
         when( coreTopologyService.localReadReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/procedure/GetServersProcedureV1Test.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/routing/load_balancing/procedure/GetServersProcedureV1Test.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -43,6 +44,8 @@ import org.neo4j.causalclustering.discovery.CoreServerInfo;
 import org.neo4j.causalclustering.discovery.CoreTopology;
 import org.neo4j.causalclustering.discovery.CoreTopologyService;
 import org.neo4j.causalclustering.discovery.ReadReplicaTopology;
+import org.neo4j.causalclustering.discovery.TransientClusterId;
+import org.neo4j.causalclustering.discovery.data.RefCounted;
 import org.neo4j.causalclustering.identity.ClusterId;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.routing.Role;
@@ -76,7 +79,8 @@ import static org.neo4j.logging.NullLogProvider.getInstance;
 @RunWith( Parameterized.class )
 public class GetServersProcedureV1Test
 {
-    private final ClusterId clusterId = new ClusterId( UUID.randomUUID() );
+    private final TransientClusterId clusterId = new TransientClusterId( new ClusterId( UUID.randomUUID() ), Instant.now() );
+    private final RefCounted<TransientClusterId> clusterIdRef = new RefCounted<>( clusterId );
 
     @Parameterized.Parameter( 0 )
     public String description;
@@ -104,7 +108,7 @@ public class GetServersProcedureV1Test
 
         LeaderLocator leaderLocator = mock( LeaderLocator.class );
 
-        final CoreTopology clusterTopology = new CoreTopology( clusterId, false, new HashMap<>() );
+        final CoreTopology clusterTopology = new CoreTopology( clusterIdRef, false, new HashMap<>() );
         when( coreTopologyService.localCoreServers() ).thenReturn( clusterTopology );
         when( coreTopologyService.localReadReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
 
@@ -149,7 +153,7 @@ public class GetServersProcedureV1Test
         Map<MemberId,CoreServerInfo> coreMembers = new HashMap<>();
         coreMembers.put( member( 0 ), addressesForCore( 0 ) );
 
-        final CoreTopology clusterTopology = new CoreTopology( clusterId, false, coreMembers );
+        final CoreTopology clusterTopology = new CoreTopology( clusterIdRef, false, coreMembers );
         when( coreTopologyService.localCoreServers() ).thenReturn( clusterTopology );
         when( coreTopologyService.localReadReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
 
@@ -181,7 +185,7 @@ public class GetServersProcedureV1Test
         coreMembers.put( member( 1 ), addressesForCore( 1 ) );
         coreMembers.put( member( 2 ), addressesForCore( 2 ) );
 
-        final CoreTopology clusterTopology = new CoreTopology( clusterId, false, coreMembers );
+        final CoreTopology clusterTopology = new CoreTopology( clusterIdRef, false, coreMembers );
         when( coreTopologyService.localCoreServers() ).thenReturn( clusterTopology );
         when( coreTopologyService.localReadReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
 
@@ -215,7 +219,7 @@ public class GetServersProcedureV1Test
         Map<MemberId,CoreServerInfo> coreMembers = new HashMap<>();
         coreMembers.put( member( 0 ), addressesForCore( 0 ) );
 
-        final CoreTopology clusterTopology = new CoreTopology( clusterId, false, coreMembers );
+        final CoreTopology clusterTopology = new CoreTopology( clusterIdRef, false, coreMembers );
         when( coreTopologyService.localCoreServers() ).thenReturn( clusterTopology );
         when( coreTopologyService.localReadReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
 
@@ -244,7 +248,7 @@ public class GetServersProcedureV1Test
         MemberId theLeader = member( 0 );
         coreMembers.put( theLeader, addressesForCore( 0 ) );
 
-        when( topologyService.localCoreServers() ).thenReturn( new CoreTopology( clusterId, false, coreMembers ) );
+        when( topologyService.localCoreServers() ).thenReturn( new CoreTopology( clusterIdRef, false, coreMembers ) );
         when( topologyService.localReadReplicas() ).thenReturn( new ReadReplicaTopology( readReplicaInfoMap( 1 ) ) );
 
         LeaderLocator leaderLocator = mock( LeaderLocator.class );
@@ -279,7 +283,7 @@ public class GetServersProcedureV1Test
         MemberId theLeader = member( 0 );
         coreMembers.put( theLeader, addressesForCore( 0 ) );
 
-        when( topologyService.localCoreServers() ).thenReturn( new CoreTopology( clusterId, false, coreMembers ) );
+        when( topologyService.localCoreServers() ).thenReturn( new CoreTopology( clusterIdRef, false, coreMembers ) );
         when( topologyService.localReadReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
 
         LeaderLocator leaderLocator = mock( LeaderLocator.class );
@@ -309,7 +313,7 @@ public class GetServersProcedureV1Test
         Map<MemberId,CoreServerInfo> coreMembers = new HashMap<>();
         coreMembers.put( member( 0 ), addressesForCore( 0 ) );
 
-        when( topologyService.localCoreServers() ).thenReturn( new CoreTopology( clusterId, false, coreMembers ) );
+        when( topologyService.localCoreServers() ).thenReturn( new CoreTopology( clusterIdRef, false, coreMembers ) );
         when( topologyService.localReadReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
 
         LeaderLocator leaderLocator = mock( LeaderLocator.class );
@@ -338,7 +342,7 @@ public class GetServersProcedureV1Test
         Map<MemberId,CoreServerInfo> coreMembers = new HashMap<>();
         coreMembers.put( member( 0 ), addressesForCore( 0 ) );
 
-        when( topologyService.localCoreServers() ).thenReturn( new CoreTopology( clusterId, false, coreMembers ) );
+        when( topologyService.localCoreServers() ).thenReturn( new CoreTopology( clusterIdRef, false, coreMembers ) );
         when( topologyService.localReadReplicas() ).thenReturn( new ReadReplicaTopology( emptyMap() ) );
 
         LeaderLocator leaderLocator = mock( LeaderLocator.class );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterFormationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterFormationIT.java
@@ -123,7 +123,7 @@ public class ClusterFormationIT
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         executorService.submit( () ->
         {
-            CoreGraphDatabase leader = cluster.getMemberWithRole( Role.LEADER ).database();
+            CoreGraphDatabase leader = cluster.getCoreMemberWithRole( Role.LEADER ).database();
             try ( Transaction tx = leader.beginTx() )
             {
                 leader.createNode();

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterOverviewIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterOverviewIT.java
@@ -236,8 +236,8 @@ public class ClusterOverviewIT
         }
 
         // when
-        cluster.removeReadReplicaWithMemberId( 0 );
-        cluster.removeReadReplicaWithMemberId( 1 );
+        cluster.removeReadReplicaWithServerId( 0 );
+        cluster.removeReadReplicaWithServerId( 1 );
 
         for ( int coreServerId = 0; coreServerId < coreMembers; coreServerId++ )
         {
@@ -281,8 +281,8 @@ public class ClusterOverviewIT
         clusterRule.withNumberOfReadReplicas( 2 );
 
         Cluster cluster = clusterRule.startCluster();
-        List<CoreClusterMember> followers = cluster.getAllMembersWithRole( Role.FOLLOWER );
-        CoreClusterMember leader = cluster.getMemberWithRole( Role.LEADER );
+        List<CoreClusterMember> followers = cluster.getAllCoreMembersWithRole( Role.FOLLOWER );
+        CoreClusterMember leader = cluster.getCoreMemberWithRole( Role.LEADER );
         followers.forEach( CoreClusterMember::shutdown );
 
         assertEventualOverview( cluster, containsRole( LEADER, 0 ), leader.serverId() );
@@ -300,7 +300,7 @@ public class ClusterOverviewIT
 
         List<MemberInfo> preElectionOverview = clusterOverview( leader.database() );
 
-        CoreClusterMember follower = cluster.getMemberWithRole( Role.FOLLOWER );
+        CoreClusterMember follower = cluster.getCoreMemberWithRole( Role.FOLLOWER );
         follower.raft().triggerElection( Clock.systemUTC() );
 
         assertEventualOverview( cluster, allOf(

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ConsensusGroupSettingsIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ConsensusGroupSettingsIT.java
@@ -64,7 +64,7 @@ public class ConsensusGroupSettingsIT
         // when
         for ( int i = 0; i < numberOfCoreSeversToRemove; i++ )
         {
-            cluster.removeCoreMember( cluster.getMemberWithRole( Role.LEADER ) );
+            cluster.removeCoreMember( cluster.getCoreMemberWithRole( Role.LEADER ) );
             cluster.awaitLeader( 30, SECONDS );
         }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreReplicationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreReplicationIT.java
@@ -97,7 +97,7 @@ public class CoreReplicationIT
         // given
         cluster.awaitLeader();
 
-        CoreGraphDatabase follower = cluster.getMemberWithRole( Role.FOLLOWER ).database();
+        CoreGraphDatabase follower = cluster.getCoreMemberWithRole( Role.FOLLOWER ).database();
 
         // when
         try ( Transaction tx = follower.beginTx() )
@@ -159,7 +159,7 @@ public class CoreReplicationIT
         // given
         cluster.awaitLeader();
 
-        CoreGraphDatabase follower = cluster.getMemberWithRole( Role.FOLLOWER ).database();
+        CoreGraphDatabase follower = cluster.getCoreMemberWithRole( Role.FOLLOWER ).database();
 
         // when
         try ( Transaction tx = follower.beginTx() )
@@ -188,7 +188,7 @@ public class CoreReplicationIT
         awaitForDataToBeApplied( leader );
         dataMatchesEventually( leader, cluster.coreMembers() );
 
-        CoreGraphDatabase follower = cluster.getMemberWithRole( Role.FOLLOWER ).database();
+        CoreGraphDatabase follower = cluster.getCoreMemberWithRole( Role.FOLLOWER ).database();
 
         // when
         try ( Transaction tx = follower.beginTx() )
@@ -337,8 +337,8 @@ public class CoreReplicationIT
                     db.createNode();
                     tx.success();
 
-                    cluster.removeCoreMember( cluster.getMemberWithAnyRole( Role.FOLLOWER, Role.CANDIDATE ) );
-                    cluster.removeCoreMember( cluster.getMemberWithAnyRole( Role.FOLLOWER, Role.CANDIDATE ) );
+                    cluster.removeCoreMember( cluster.getCoreMemberWithAnyRole( Role.FOLLOWER, Role.CANDIDATE ) );
+                    cluster.removeCoreMember( cluster.getCoreMemberWithAnyRole( Role.FOLLOWER, Role.CANDIDATE ) );
                     latch.countDown();
                 } );
                 fail( "Should have thrown" );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/MultiClusterRoutingIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/MultiClusterRoutingIT.java
@@ -136,7 +136,7 @@ public class MultiClusterRoutingIT
     public void superCallShouldReturnAllRouters()
     {
         List<CoreGraphDatabase> dbs = dbNames.stream()
-                .map( n -> cluster.getMemberWithAnyRole( n, Role.FOLLOWER, Role.LEADER ).database() ).collect( Collectors.toList() );
+                .map( n -> cluster.getCoreMemberWithAnyRole( n, Role.FOLLOWER, Role.LEADER ).database() ).collect( Collectors.toList() );
 
         Stream<Optional<MultiClusterRoutingResult>> optResults = dbs.stream()
                 .map( db -> callProcedure( db, GET_ROUTERS_FOR_ALL_DATABASES, Collections.emptyMap() ) );
@@ -156,7 +156,7 @@ public class MultiClusterRoutingIT
     public void subCallShouldReturnLocalRouters()
     {
         String dbName = getFirstDbName( dbNames );
-        Stream<CoreGraphDatabase> members = dbNames.stream().map( n -> cluster.getMemberWithAnyRole( n, Role.FOLLOWER, Role.LEADER ).database() );
+        Stream<CoreGraphDatabase> members = dbNames.stream().map( n -> cluster.getCoreMemberWithAnyRole( n, Role.FOLLOWER, Role.LEADER ).database() );
 
         Map<String,Object> params = new HashMap<>();
         params.put( DATABASE.parameterName(), dbName );
@@ -179,12 +179,12 @@ public class MultiClusterRoutingIT
     public void procedureCallsShouldReflectMembershipChanges() throws Exception
     {
         String dbName = getFirstDbName( dbNames );
-        CoreClusterMember follower = cluster.getMemberWithAnyRole( dbName, Role.FOLLOWER );
+        CoreClusterMember follower = cluster.getCoreMemberWithAnyRole( dbName, Role.FOLLOWER );
         int followerId = follower.serverId();
 
         cluster.removeCoreMemberWithServerId( followerId );
 
-        CoreGraphDatabase db = cluster.getMemberWithAnyRole( dbName, Role.FOLLOWER, Role.LEADER ).database();
+        CoreGraphDatabase db = cluster.getCoreMemberWithAnyRole( dbName, Role.FOLLOWER, Role.LEADER ).database();
 
         Function<CoreGraphDatabase, Set<Endpoint>> getResult = database ->
         {

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaReplicationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaReplicationIT.java
@@ -293,7 +293,7 @@ public class ReadReplicaReplicationIT
         cluster.coreTx( createSomeData );
 
         awaitEx( () -> readReplicasUpToDateAsTheLeader( cluster.awaitLeader(), cluster.readReplicas() ), 1, TimeUnit.MINUTES );
-        cluster.removeReadReplicaWithMemberId( readReplicaId );
+        cluster.removeReadReplicaWithServerId( readReplicaId );
 
         // let's spend some time by adding more data
         cluster.coreTx( createSomeData );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaToReadReplicaCatchupIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaToReadReplicaCatchupIT.java
@@ -138,7 +138,7 @@ public class ReadReplicaToReadReplicaCatchupIT
         firstReadReplica.shutdown();
         upstreamFactory.reset();
 
-        cluster.removeReadReplicaWithMemberId( firstReadReplicaLocalMemberId );
+        cluster.removeReadReplicaWithServerId( firstReadReplicaLocalMemberId );
 
         // when
         // More transactions into core

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/UpstreamDatabaseStrategySelectorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/UpstreamDatabaseStrategySelectorTest.java
@@ -24,6 +24,7 @@ package org.neo4j.causalclustering.upstream;
 
 import org.junit.Test;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -32,6 +33,8 @@ import java.util.UUID;
 import org.neo4j.causalclustering.discovery.CoreServerInfo;
 import org.neo4j.causalclustering.discovery.CoreTopology;
 import org.neo4j.causalclustering.discovery.TopologyService;
+import org.neo4j.causalclustering.discovery.TransientClusterId;
+import org.neo4j.causalclustering.discovery.data.RefCounted;
 import org.neo4j.causalclustering.identity.ClusterId;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.upstream.strategies.ConnectToRandomCoreServerStrategy;
@@ -49,6 +52,8 @@ import static org.neo4j.helpers.collection.Iterables.iterable;
 public class UpstreamDatabaseStrategySelectorTest
 {
     private MemberId dummyMemberId = new MemberId( UUID.randomUUID() );
+    private TransientClusterId clusterId = new TransientClusterId( new ClusterId( UUID.randomUUID() ), Instant.now() );
+    private RefCounted<TransientClusterId> clusterIdRef = new RefCounted<>(clusterId);
 
     @Test
     public void shouldReturnTheMemberIdFromFirstSucessfulStrategy() throws Exception
@@ -81,7 +86,7 @@ public class UpstreamDatabaseStrategySelectorTest
         TopologyService topologyService = mock( TopologyService.class );
         MemberId memberId = new MemberId( UUID.randomUUID() );
         when( topologyService.localCoreServers() ).thenReturn(
-                new CoreTopology( new ClusterId( UUID.randomUUID() ), false, mapOf( memberId, mock( CoreServerInfo.class ) ) ) );
+                new CoreTopology( clusterIdRef, false, mapOf( memberId, mock( CoreServerInfo.class ) ) ) );
 
         ConnectToRandomCoreServerStrategy defaultStrategy = new ConnectToRandomCoreServerStrategy();
         defaultStrategy.inject( topologyService, Config.defaults(), NullLogProvider.getInstance(), null );
@@ -102,7 +107,7 @@ public class UpstreamDatabaseStrategySelectorTest
         TopologyService topologyService = mock( TopologyService.class );
         MemberId memberId = new MemberId( UUID.randomUUID() );
         when( topologyService.localCoreServers() ).thenReturn(
-                new CoreTopology( new ClusterId( UUID.randomUUID() ), false, mapOf( memberId, mock( CoreServerInfo.class ) ) ) );
+                new CoreTopology( clusterIdRef, false, mapOf( memberId, mock( CoreServerInfo.class ) ) ) );
 
         ConnectToRandomCoreServerStrategy shouldNotUse = new ConnectToRandomCoreServerStrategy();
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/strategies/ConnectToRandomCoreServerStrategyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/upstream/strategies/ConnectToRandomCoreServerStrategyTest.java
@@ -24,6 +24,7 @@ package org.neo4j.causalclustering.upstream.strategies;
 
 import org.junit.Test;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -33,6 +34,8 @@ import org.neo4j.causalclustering.discovery.ClientConnectorAddresses;
 import org.neo4j.causalclustering.discovery.CoreServerInfo;
 import org.neo4j.causalclustering.discovery.CoreTopology;
 import org.neo4j.causalclustering.discovery.TopologyService;
+import org.neo4j.causalclustering.discovery.TransientClusterId;
+import org.neo4j.causalclustering.discovery.data.RefCounted;
 import org.neo4j.causalclustering.identity.ClusterId;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
@@ -76,7 +79,8 @@ public class ConnectToRandomCoreServerStrategyTest
     {
         assert memberIds.length > 0;
 
-        ClusterId clusterId = new ClusterId( UUID.randomUUID() );
+        TransientClusterId clusterId = new TransientClusterId( new ClusterId( UUID.randomUUID() ), Instant.now() );
+        RefCounted<TransientClusterId> clusterIdRef = new RefCounted<TransientClusterId>( clusterId );
         Map<MemberId,CoreServerInfo> coreMembers = new HashMap<>();
 
         int offset = 0;
@@ -91,6 +95,6 @@ public class ConnectToRandomCoreServerStrategyTest
             offset++;
         }
 
-        return new CoreTopology( clusterId, false, coreMembers );
+        return new CoreTopology( clusterIdRef, false, coreMembers );
     }
 }

--- a/integrationtests/src/test/java/org/neo4j/causalclustering/scenarios/BoltCausalClusteringIT.java
+++ b/integrationtests/src/test/java/org/neo4j/causalclustering/scenarios/BoltCausalClusteringIT.java
@@ -116,7 +116,7 @@ public class BoltCausalClusteringIT
         } );
 
         // when
-        int count = executeWriteAndReadThroughBolt( cluster.getMemberWithRole( Role.FOLLOWER ) );
+        int count = executeWriteAndReadThroughBolt( cluster.getCoreMemberWithRole( Role.FOLLOWER ) );
 
         // then
         assertEquals( 1, count );

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/CatchupNewReadReplica.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/CatchupNewReadReplica.java
@@ -83,7 +83,7 @@ class CatchupNewReadReplica extends Workload
         {
             try
             {
-                cluster.removeReadReplicaWithMemberId( newMemberId );
+                cluster.removeReadReplicaWithServerId( newMemberId );
                 if ( ex == null && deleteStore )
                 {
                     fs.deleteRecursively( readReplica.storeDir() );


### PR DESCRIPTION
Method for cleaning up cluster-ids in shared discovery state when all members which hold that id have gone away. In theory this is robust to both members shutting down in a well behaved manner (using `RefCounted<>`), and members which disappear suddenly (using `Transient` and a configured ttl).

The discovery service now tracks the `MemberIds` which "reference" a particular cluster id. When all members `release` a particular cluster Id, it is considered safe to remove, and may be overridden by a new joining member with a **different cluster id  for the same database name**. 

The same is true if no members holding a given cluster id have been "seen" for a given time.  This second method of clean up relies upon the periodic `refreshTopology()` operation in `HazelcastCoreTopologyService` and therefore does not presently work in the context of shared or akka discovery. Some minimal concept of a heartbeat may have to be introduced (or hooked into) in those services in order to replicate this functionality.

There is significant work still to do, including:

* More tests, both Unit and IT (really relying upon a single IT at the moment)
* Heartbeat in SharedDiscovery
* Reasoning about potential failure cases.

... but having the PR gives a central point for discussion and also more tests. 
