### PR TITLE
[Almost] all slotted expressions now compiled

### DIFF
--- a/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/internal/runtime/EntityProducer.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/internal/runtime/EntityProducer.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.neo4j.cypher.internal.runtime;
 
 import org.neo4j.values.virtual.NodeValue;

--- a/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/internal/runtime/EntityProducer.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/internal/runtime/EntityProducer.java
@@ -1,0 +1,11 @@
+package org.neo4j.cypher.internal.runtime;
+
+import org.neo4j.values.virtual.NodeValue;
+import org.neo4j.values.virtual.RelationshipValue;
+
+public interface EntityProducer
+{
+    NodeValue nodeById( long id );
+
+    RelationshipValue relationshipById( long id );
+}

--- a/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherDbAccess.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherDbAccess.java
@@ -243,6 +243,39 @@ public final class CypherDbAccess
         return nodeHasProperty( tx, node, property );
     }
 
+    public static BooleanValue relationshipHasProperty( Transaction tx, long node, int property )
+    {
+        CursorFactory cursors = tx.cursors();
+        try ( RelationshipScanCursor relationships = cursors.allocateRelationshipScanCursor();
+              PropertyCursor properties = cursors.allocatePropertyCursor() )
+        {
+            tx.dataRead().singleRelationship( node, relationships );
+            if ( !relationships.next() )
+            {
+                return Values.FALSE;
+            }
+            relationships.properties( properties );
+            while ( properties.next() )
+            {
+                if ( properties.propertyKey() == property )
+                {
+                    return Values.TRUE;
+                }
+            }
+            return Values.FALSE;
+        }
+    }
+
+    public static BooleanValue relationshipHasProperty( Transaction tx, long node, String key )
+    {
+        int property = tx.tokenRead().propertyKey( key );
+        if ( property == NO_TOKEN )
+        {
+            return Values.FALSE;
+        }
+        return relationshipHasProperty( tx, node, property );
+    }
+
     private static Value property( PropertyCursor properties, int property )
     {
         while ( properties.next() )

--- a/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherDbAccess.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherDbAccess.java
@@ -233,6 +233,16 @@ public final class CypherDbAccess
         }
     }
 
+    public static BooleanValue nodeHasProperty( Transaction tx, long node, String key )
+    {
+        int property = tx.tokenRead().propertyKey( key );
+        if ( property == NO_TOKEN )
+        {
+            return Values.FALSE;
+        }
+        return nodeHasProperty( tx, node, property );
+    }
+
     private static Value property( PropertyCursor properties, int property )
     {
         while ( properties.next() )

--- a/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherDbAccess.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherDbAccess.java
@@ -27,6 +27,7 @@ import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.RelationshipScanCursor;
 import org.neo4j.internal.kernel.api.Transaction;
 import org.neo4j.internal.kernel.api.helpers.Nodes;
+import org.neo4j.values.storable.BooleanValue;
 import org.neo4j.values.storable.IntegralValue;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
@@ -92,7 +93,8 @@ public final class CypherDbAccess
             if ( tx.dataRead().relationshipDeletedInTransaction( relationship ) )
             {
                 throw new EntityNotFoundException(
-                        String.format( "Relationship with id %d has been deleted in this transaction", relationship ), null );
+                        String.format( "Relationship with id %d has been deleted in this transaction", relationship ),
+                        null );
             }
             return NO_VALUE;
         }
@@ -109,7 +111,7 @@ public final class CypherDbAccess
         return relationshipProperty( tx, node, property );
     }
 
-    public static IntegralValue getOutgoingDegree(Transaction tx, long node )
+    public static IntegralValue getOutgoingDegree( Transaction tx, long node )
     {
         CursorFactory cursors = tx.cursors();
         try ( NodeCursor cursor = cursors.allocateNodeCursor() )
@@ -123,7 +125,7 @@ public final class CypherDbAccess
         }
     }
 
-    public static IntegralValue getOutgoingDegree(Transaction tx, long node, String relationshipType )
+    public static IntegralValue getOutgoingDegree( Transaction tx, long node, String relationshipType )
     {
         int relationship = tx.tokenRead().relationshipType( relationshipType );
         if ( relationship == NO_TOKEN )
@@ -142,7 +144,7 @@ public final class CypherDbAccess
         }
     }
 
-    public static IntegralValue getIncomingDegree(Transaction tx, long node )
+    public static IntegralValue getIncomingDegree( Transaction tx, long node )
     {
         CursorFactory cursors = tx.cursors();
         try ( NodeCursor cursor = cursors.allocateNodeCursor() )
@@ -156,7 +158,7 @@ public final class CypherDbAccess
         }
     }
 
-    public static IntegralValue getIncomingDegree(Transaction tx, long node, String relationshipType )
+    public static IntegralValue getIncomingDegree( Transaction tx, long node, String relationshipType )
     {
         int relationship = tx.tokenRead().relationshipType( relationshipType );
         if ( relationship == NO_TOKEN )
@@ -171,11 +173,11 @@ public final class CypherDbAccess
             {
                 return Values.ZERO_INT;
             }
-            return Values.intValue( Nodes.countIncoming( cursor, cursors, relationship ));
+            return Values.intValue( Nodes.countIncoming( cursor, cursors, relationship ) );
         }
     }
 
-    public static IntegralValue getTotalDegree(Transaction tx, long node )
+    public static IntegralValue getTotalDegree( Transaction tx, long node )
     {
         CursorFactory cursors = tx.cursors();
         try ( NodeCursor cursor = cursors.allocateNodeCursor() )
@@ -189,7 +191,7 @@ public final class CypherDbAccess
         }
     }
 
-    public static IntegralValue getTotalDegree(Transaction tx, long node, String relationshipType )
+    public static IntegralValue getTotalDegree( Transaction tx, long node, String relationshipType )
     {
         int relationship = tx.tokenRead().relationshipType( relationshipType );
         if ( relationship == NO_TOKEN )
@@ -205,6 +207,29 @@ public final class CypherDbAccess
                 return Values.ZERO_INT;
             }
             return Values.intValue( Nodes.countAll( cursor, cursors, relationship ) );
+        }
+    }
+
+    public static BooleanValue nodeHasProperty( Transaction tx, long node, int property )
+    {
+        CursorFactory cursors = tx.cursors();
+        try ( NodeCursor nodes = cursors.allocateNodeCursor();
+              PropertyCursor properties = cursors.allocatePropertyCursor() )
+        {
+            tx.dataRead().singleNode( node, nodes );
+            if ( !nodes.next() )
+            {
+                return Values.FALSE;
+            }
+            nodes.properties( properties );
+            while ( properties.next() )
+            {
+                if ( properties.propertyKey() == property )
+                {
+                    return Values.TRUE;
+                }
+            }
+            return Values.FALSE;
         }
     }
 

--- a/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherDbAccess.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherDbAccess.java
@@ -26,7 +26,10 @@ import org.neo4j.internal.kernel.api.NodeCursor;
 import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.RelationshipScanCursor;
 import org.neo4j.internal.kernel.api.Transaction;
+import org.neo4j.internal.kernel.api.helpers.Nodes;
+import org.neo4j.values.storable.IntegralValue;
 import org.neo4j.values.storable.Value;
+import org.neo4j.values.storable.Values;
 
 import static org.neo4j.internal.kernel.api.TokenRead.NO_TOKEN;
 import static org.neo4j.values.storable.Values.NO_VALUE;
@@ -104,6 +107,105 @@ public final class CypherDbAccess
         }
 
         return relationshipProperty( tx, node, property );
+    }
+
+    public static IntegralValue getOutgoingDegree(Transaction tx, long node )
+    {
+        CursorFactory cursors = tx.cursors();
+        try ( NodeCursor cursor = cursors.allocateNodeCursor() )
+        {
+            tx.dataRead().singleNode( node, cursor );
+            if ( !cursor.next() )
+            {
+                return Values.ZERO_INT;
+            }
+            return Values.intValue( Nodes.countOutgoing( cursor, cursors ) );
+        }
+    }
+
+    public static IntegralValue getOutgoingDegree(Transaction tx, long node, String relationshipType )
+    {
+        int relationship = tx.tokenRead().relationshipType( relationshipType );
+        if ( relationship == NO_TOKEN )
+        {
+            return Values.ZERO_INT;
+        }
+        CursorFactory cursors = tx.cursors();
+        try ( NodeCursor cursor = cursors.allocateNodeCursor() )
+        {
+            tx.dataRead().singleNode( node, cursor );
+            if ( !cursor.next() )
+            {
+                return Values.ZERO_INT;
+            }
+            return Values.intValue( Nodes.countOutgoing( cursor, cursors, relationship ) );
+        }
+    }
+
+    public static IntegralValue getIncomingDegree(Transaction tx, long node )
+    {
+        CursorFactory cursors = tx.cursors();
+        try ( NodeCursor cursor = cursors.allocateNodeCursor() )
+        {
+            tx.dataRead().singleNode( node, cursor );
+            if ( !cursor.next() )
+            {
+                return Values.ZERO_INT;
+            }
+            return Values.intValue( Nodes.countIncoming( cursor, cursors ) );
+        }
+    }
+
+    public static IntegralValue getIncomingDegree(Transaction tx, long node, String relationshipType )
+    {
+        int relationship = tx.tokenRead().relationshipType( relationshipType );
+        if ( relationship == NO_TOKEN )
+        {
+            return Values.ZERO_INT;
+        }
+        CursorFactory cursors = tx.cursors();
+        try ( NodeCursor cursor = cursors.allocateNodeCursor() )
+        {
+            tx.dataRead().singleNode( node, cursor );
+            if ( !cursor.next() )
+            {
+                return Values.ZERO_INT;
+            }
+            return Values.intValue( Nodes.countIncoming( cursor, cursors, relationship ));
+        }
+    }
+
+    public static IntegralValue getTotalDegree(Transaction tx, long node )
+    {
+        CursorFactory cursors = tx.cursors();
+        try ( NodeCursor cursor = cursors.allocateNodeCursor() )
+        {
+            tx.dataRead().singleNode( node, cursor );
+            if ( !cursor.next() )
+            {
+                return Values.ZERO_INT;
+            }
+            return Values.intValue( Nodes.countAll( cursor, cursors ) );
+        }
+    }
+
+    public static IntegralValue getTotalDegree(Transaction tx, long node, String relationshipType )
+    {
+        int relationship = tx.tokenRead().relationshipType( relationshipType );
+        if ( relationship == NO_TOKEN )
+        {
+            return Values.ZERO_INT;
+        }
+        CursorFactory cursors = tx.cursors();
+        try ( NodeCursor cursor = cursors.allocateNodeCursor() )
+        {
+            tx.dataRead().singleNode( node, cursor );
+            if ( !cursor.next() )
+            {
+                return Values.ZERO_INT;
+            }
+            return Values.intValue( Nodes.countAll( cursor, cursors, relationship ) );
+        }
     }
 
     private static Value property( PropertyCursor properties, int property )

--- a/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherDbAccess.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherDbAccess.java
@@ -95,6 +95,17 @@ public final class CypherDbAccess
         }
     }
 
+    public static Value relationshipProperty( Transaction tx, long node, String key )
+    {
+        int property = tx.tokenRead().propertyKey( key );
+        if ( property == NO_TOKEN )
+        {
+            return NO_VALUE;
+        }
+
+        return relationshipProperty( tx, node, property );
+    }
+
     private static Value property( PropertyCursor properties, int property )
     {
         while ( properties.next() )

--- a/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherDbAccess.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherDbAccess.java
@@ -27,7 +27,9 @@ import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.RelationshipScanCursor;
 import org.neo4j.internal.kernel.api.Transaction;
 import org.neo4j.values.storable.Value;
-import org.neo4j.values.storable.Values;
+
+import static org.neo4j.internal.kernel.api.TokenRead.NO_TOKEN;
+import static org.neo4j.values.storable.Values.NO_VALUE;
 
 /**
  * This class contains static helper methods for expressions interacting with the database
@@ -40,7 +42,6 @@ public final class CypherDbAccess
         throw new UnsupportedOperationException( "Do not instantiate" );
     }
 
-    //data access
     public static Value nodeProperty( Transaction tx, long node, int property )
     {
         CursorFactory cursors = tx.cursors();
@@ -58,8 +59,19 @@ public final class CypherDbAccess
                 throw new EntityNotFoundException(
                         String.format( "Node with id %d has been deleted in this transaction", node ), null );
             }
-            return Values.NO_VALUE;
+            return NO_VALUE;
         }
+    }
+
+    public static Value nodeProperty( Transaction tx, long node, String key )
+    {
+        int property = tx.tokenRead().propertyKey( key );
+        if ( property == NO_TOKEN )
+        {
+            return NO_VALUE;
+        }
+
+        return nodeProperty( tx, node, property );
     }
 
     public static Value relationshipProperty( Transaction tx, long relationship, int property )
@@ -79,7 +91,7 @@ public final class CypherDbAccess
                 throw new EntityNotFoundException(
                         String.format( "Relationship with id %d has been deleted in this transaction", relationship ), null );
             }
-            return Values.NO_VALUE;
+            return NO_VALUE;
         }
     }
 
@@ -92,6 +104,6 @@ public final class CypherDbAccess
                 return properties.propertyValue();
             }
         }
-        return Values.NO_VALUE;
+        return NO_VALUE;
     }
 }

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryContext.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryContext.scala
@@ -50,7 +50,7 @@ import scala.collection.Iterator
  * The driver for this was clarifying who is responsible for ensuring query isolation. By exposing a query concept in
  * the core layer, we can move that responsibility outside of the scope of cypher.
  */
-trait QueryContext extends TokenContext {
+trait QueryContext extends TokenContext with EntityProducer {
 
   // See QueryContextAdaptation if you need a dummy that overrides all methods as ??? for writing a test
 
@@ -207,6 +207,9 @@ trait QueryContext extends TokenContext {
 
   def assertSchemaWritesAllowed(): Unit
 
+  override def nodeById(id: Long): NodeValue = nodeOps.getById(id)
+
+  override def relationshipById(id: Long): RelationshipValue = relationshipOps.getById(id)
 }
 
 trait Operations[T] {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompiledExpressionTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompiledExpressionTest.scala
@@ -182,6 +182,26 @@ class CompiledExpressionTest extends ExecutionEngineFunSuite with AstConstructio
     }
   }
 
+  test("NodePropertyExists") {
+    // Given
+    val node = createNode("prop" -> 42)
+    createNode("otherProp" -> 42)
+
+    val offset = 42
+    val ctx = mock[ExecutionContext]
+    when(ctx.getLongAt(offset)).thenReturn(node.getId)
+    graph.inTx {
+      compile(NodePropertyExists(offset, propertyToken("prop"), "prop")(null)).evaluate(ctx, transaction, EMPTY_MAP) should
+        equal(Values.TRUE)
+      compile(NodePropertyExists(offset, propertyToken("otherProp"), "otherProp")(null)).evaluate(ctx, transaction, EMPTY_MAP) should
+        equal(Values.FALSE)
+      //this property probably doesn't exists in the db
+      compile(NodePropertyExists(offset, 1234567, "otherProp")(null)).evaluate(ctx, transaction, EMPTY_MAP) should
+        equal(Values.FALSE)
+    }
+
+  }
+
   private def compile(e: Expression) =
     CodeGeneration.compile(IntermediateCodeGeneration.compile(e).getOrElse(fail()))
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompiledExpressionTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompiledExpressionTest.scala
@@ -199,7 +199,25 @@ class CompiledExpressionTest extends ExecutionEngineFunSuite with AstConstructio
       compile(NodePropertyExists(offset, 1234567, "otherProp")(null)).evaluate(ctx, transaction, EMPTY_MAP) should
         equal(Values.FALSE)
     }
+  }
 
+  test("NodePropertyExistsLate") {
+    // Given
+    val node = createNode("prop" -> 42)
+    createNode("otherProp" -> 42)
+
+    val offset = 42
+    val ctx = mock[ExecutionContext]
+    when(ctx.getLongAt(offset)).thenReturn(node.getId)
+    graph.inTx {
+      compile(NodePropertyExistsLate(offset, "prop", "prop")(null)).evaluate(ctx, transaction, EMPTY_MAP) should
+        equal(Values.TRUE)
+      compile(NodePropertyExistsLate(offset, "otherProp", "otherProp")(null))
+        .evaluate(ctx, transaction, EMPTY_MAP) should
+        equal(Values.FALSE)
+      compile(NodePropertyExistsLate(offset, "NOT_THERE_AT_ALL", "otherProp")(null)).evaluate(ctx, transaction, EMPTY_MAP) should
+        equal(Values.FALSE)
+    }
   }
 
   private def compile(e: Expression) =

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MutatingIntegrationTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MutatingIntegrationTest.scala
@@ -267,7 +267,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
     executeWith(Configs.UpdateConf, """match (n) optional match (n)-[r]-() delete n,r""")
 
     graph.inTx {
-      graph.getAllNodes.asScala shouldBe empty
+      graph.getAllNodes().asScala shouldBe empty
     }
   }
 

--- a/enterprise/cypher/compiled-expressions/src/main/java/org/neo4j/cypher/internal/runtime/compiled/expressions/CompiledExpression.java
+++ b/enterprise/cypher/compiled-expressions/src/main/java/org/neo4j/cypher/internal/runtime/compiled/expressions/CompiledExpression.java
@@ -22,6 +22,7 @@
  */
 package org.neo4j.cypher.internal.runtime.compiled.expressions;
 
+import org.neo4j.cypher.internal.runtime.EntityProducer;
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext;
 import org.neo4j.internal.kernel.api.Transaction;
 import org.neo4j.values.AnyValue;
@@ -37,8 +38,10 @@ public interface CompiledExpression
      *
      * @param context the current context.
      * @param tx the current transaction
+     * @param producer used for creating nodes and relationships
      * @param params the parameters of the query
      * @return an evaluated result from the compiled expression and given input.
      */
-    AnyValue evaluate( ExecutionContext context, Transaction tx, MapValue params );
+    AnyValue evaluate( ExecutionContext context, Transaction tx,
+            EntityProducer producer, MapValue params );
 }

--- a/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/CodeGeneration.scala
+++ b/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/CodeGeneration.scala
@@ -97,9 +97,10 @@ object CodeGeneration {
     case TRUE => getStatic(staticField(VALUES, classOf[BooleanValue], "TRUE"))
     //Values.FALSE
     case FALSE => getStatic(staticField(VALUES, classOf[BooleanValue], "FALSE"))
-      //new ArrayValue[]{p1, p2,...}
+    //new ArrayValue[]{p1, p2,...}
     case ArrayLiteral(values) => newArray(typeReference(classOf[AnyValue]),
                                           values.map(v => compileExpression(v, block)):_*)
+
   }
 
 

--- a/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/CodeGeneration.scala
+++ b/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/CodeGeneration.scala
@@ -32,6 +32,7 @@ import org.neo4j.codegen.Parameter.param
 import org.neo4j.codegen.TypeReference.typeReference
 import org.neo4j.codegen._
 import org.neo4j.codegen.bytecode.ByteCode.BYTECODE
+import org.neo4j.cypher.internal.runtime.EntityProducer
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.internal.kernel.api.Transaction
 import org.neo4j.values.AnyValue
@@ -53,6 +54,7 @@ object CodeGeneration {
   private val COMPUTE_METHOD = method(classOf[AnyValue], "evaluate",
                                       param(classOf[ExecutionContext], "context"),
                                       param(classOf[Transaction], "tx"),
+                                      param(classOf[EntityProducer], "producer"),
                                       param(classOf[MapValue], "params"))
 
   private def className(): String = "Expression" + System.nanoTime()

--- a/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/CodeGeneration.scala
+++ b/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/CodeGeneration.scala
@@ -101,6 +101,14 @@ object CodeGeneration {
     case ArrayLiteral(values) => newArray(typeReference(classOf[AnyValue]),
                                           values.map(v => compileExpression(v, block)):_*)
 
+    //condition ? onTrue : onFalse
+    case Ternary(condition, onTrue, onFalse) =>
+      Expression.ternary(compileExpression(condition, block),
+                         compileExpression(onTrue, block),
+                         compileExpression(onFalse, block))
+    //lhs == rhs
+    case Eq(lhs, rhs) =>
+      Expression.equal(compileExpression(lhs, block), compileExpression(rhs, block))
   }
 
 

--- a/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateCodeGeneration.scala
+++ b/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateCodeGeneration.scala
@@ -176,6 +176,14 @@ object IntermediateCodeGeneration {
       Some(invokeStatic(method[CypherDbAccess, Value, Transaction, Long, String]("relationshipProperty"),
                         load("tx"), getLongAt(offset), constant(key)))
 
+    case RelationshipPropertyExists(offset, token, _) =>
+      Some(invokeStatic(method[CypherDbAccess, BooleanValue, Transaction, Long, Int]("relationshipHasProperty"),
+                        load("tx"), getLongAt(offset), constant(token)))
+
+    case RelationshipPropertyExistsLate(offset, key, _) =>
+      Some(invokeStatic(method[CypherDbAccess, BooleanValue, Transaction, Long, String]("relationshipHasProperty"),
+                        load("tx"), getLongAt(offset), constant(key)))
+
     case GetDegreePrimitive(offset, typ, dir) =>
       val methodName = dir match {
         case SemanticDirection.OUTGOING => "getOutgoingDegree"

--- a/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateCodeGeneration.scala
+++ b/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateCodeGeneration.scala
@@ -23,12 +23,13 @@
 package org.neo4j.cypher.internal.runtime.compiled.expressions
 
 import org.neo4j.cypher.internal.compatibility.v3_5.runtime.ast._
+import org.neo4j.cypher.internal.runtime.EntityProducer
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.operations.{CypherBoolean, CypherDbAccess, CypherFunctions, CypherMath}
 import org.neo4j.internal.kernel.api.Transaction
 import org.neo4j.values.AnyValue
 import org.neo4j.values.storable._
-import org.neo4j.values.virtual.MapValue
+import org.neo4j.values.virtual.{MapValue, NodeValue, RelationshipValue}
 import org.opencypher.v9_0.expressions
 import org.opencypher.v9_0.expressions._
 
@@ -178,6 +179,12 @@ object IntermediateCodeGeneration {
     case RelationshipPropertyExistsLate(offset, key, _) =>
       Some(invokeStatic(method[CypherDbAccess, BooleanValue, Transaction, Long, String]("relationshipHasProperty"),
                         load("tx"), getLongAt(offset), constant(key)))
+    case NodeFromSlot(offset, _) =>
+      Some(invoke(load("producer"), method[EntityProducer, NodeValue, Long]("nodeById"),
+                  getLongAt(offset)))
+    case RelationshipFromSlot(offset, _) =>
+      Some(invoke(load("producer"), method[EntityProducer, RelationshipValue, Long]("relationshipById"),
+                  getLongAt(offset)))
 
     case GetDegreePrimitive(offset, typ, dir) =>
       val methodName = dir match {

--- a/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateCodeGeneration.scala
+++ b/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateCodeGeneration.scala
@@ -223,6 +223,9 @@ object IntermediateCodeGeneration {
     case NullCheckProperty(offset, inner) =>
       compile(inner).map(ternary(equal(getRefAt(offset), noValue), noValue, _))
 
+    case IsPrimitiveNull(offset) =>
+      Some(ternary(equal(getLongAt(offset), constant(-1L)), truthy, falsy))
+
     case _ => None
   }
 

--- a/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateCodeGeneration.scala
+++ b/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateCodeGeneration.scala
@@ -27,8 +27,7 @@ import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.operations.{CypherBoolean, CypherDbAccess, CypherFunctions, CypherMath}
 import org.neo4j.internal.kernel.api.Transaction
 import org.neo4j.values.AnyValue
-import org.neo4j.values.storable.Values.{doubleValue, longValue}
-import org.neo4j.values.storable.{DoubleValue, LongValue, Value, Values}
+import org.neo4j.values.storable._
 import org.neo4j.values.virtual.MapValue
 import org.opencypher.v9_0.expressions
 import org.opencypher.v9_0.expressions._
@@ -100,9 +99,9 @@ object IntermediateCodeGeneration {
       }
 
     //literals
-    case d: DoubleLiteral => Some(float(doubleValue(d.value)))
-    case i: IntegerLiteral => Some(integer(longValue(i.value)))
-    case s: expressions.StringLiteral => Some(string(Values.stringValue(s.value)))
+    case d: DoubleLiteral => Some(invokeStatic(method[Values, DoubleValue, Double]("doubleValue"), constantJavaValue(d.value)))
+    case i: IntegerLiteral => Some(invokeStatic(method[Values, LongValue, Long]("longValue"), constantJavaValue(i.value)))
+    case s: expressions.StringLiteral => Some(invokeStatic(method[Values, TextValue, String]("stringValue"), constantJavaValue(s.value)))
     case _: Null => Some(noValue)
     case _: True => Some(truthy)
     case _: False => Some(falsy)

--- a/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateCodeGeneration.scala
+++ b/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateCodeGeneration.scala
@@ -184,6 +184,15 @@ object IntermediateCodeGeneration {
         invokeStatic(method[Values, LongValue, Long]("longValue"),
                      invoke(load("context"), method[ExecutionContext, Long, Int]("getLongAt"),
                             constant(offset))))
+
+    case PrimitiveEquals(lhs, rhs) =>
+      for {l <- compile(lhs)
+           r <- compile(rhs)
+      } yield
+        invokeStatic(method[Values, BooleanValue, Boolean]("booleanValue"),
+          invoke(l, method[AnyValue, Boolean, AnyRef]("equals"), r)
+        )
+
     case _ => None
   }
 

--- a/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateCodeGeneration.scala
+++ b/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateCodeGeneration.scala
@@ -22,7 +22,7 @@
  */
 package org.neo4j.cypher.internal.runtime.compiled.expressions
 
-import org.neo4j.cypher.internal.compatibility.v3_5.runtime.ast.{NodeProperty, RelationshipProperty}
+import org.neo4j.cypher.internal.compatibility.v3_5.runtime.ast.{NodeProperty, ReferenceFromSlot, RelationshipProperty}
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.operations.{CypherBoolean, CypherDbAccess, CypherFunctions, CypherMath}
 import org.neo4j.internal.kernel.api.Transaction
@@ -164,6 +164,10 @@ object IntermediateCodeGeneration {
                         invoke(load("context"), method[ExecutionContext, Long, Int]("getLongAt"),
                                constantJavaValue(offset)), constantJavaValue(token)))
 
+      //slotted operations
+    case ReferenceFromSlot(offset, _) =>
+      Some(invoke(load("context"), method[ExecutionContext, AnyValue, Int]("getRefAt"),
+                                                     constantJavaValue(offset)))
     case _ => None
   }
 

--- a/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateCodeGeneration.scala
+++ b/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateCodeGeneration.scala
@@ -218,10 +218,10 @@ object IntermediateCodeGeneration {
       compile(inner).map(ternary(equal(getLongAt(offset), constant(-1L)), noValue, _))
 
     case NullCheckVariable(offset, inner) =>
-      compile(inner).map(ternary(equal(getRefAt(offset), noValue), noValue, _))
+      compile(inner).map(ternary(equal(getLongAt(offset), constant(-1L)), noValue, _))
 
     case NullCheckProperty(offset, inner) =>
-      compile(inner).map(ternary(equal(getRefAt(offset), noValue), noValue, _))
+      compile(inner).map(ternary(equal(getLongAt(offset), constant(-1L)), noValue, _))
 
     case IsPrimitiveNull(offset) =>
       Some(ternary(equal(getLongAt(offset), constant(-1L)), truthy, falsy))

--- a/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateCodeGeneration.scala
+++ b/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateCodeGeneration.scala
@@ -164,6 +164,10 @@ object IntermediateCodeGeneration {
       Some(invokeStatic(method[CypherDbAccess, BooleanValue, Transaction, Long, Int]("nodeHasProperty"),
                         load("tx"), getLongAt(offset), constant(token)))
 
+    case NodePropertyExistsLate(offset, key, _) =>
+      Some(invokeStatic(method[CypherDbAccess, BooleanValue, Transaction, Long, String]("nodeHasProperty"),
+                        load("tx"), getLongAt(offset), constant(key)))
+
     case RelationshipProperty(offset, token, _) =>
       Some(invokeStatic(method[CypherDbAccess, Value, Transaction, Long, Int]("relationshipProperty"),
                         load("tx"), getLongAt(offset), constant(token)))

--- a/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateCodeGeneration.scala
+++ b/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateCodeGeneration.scala
@@ -22,13 +22,13 @@
  */
 package org.neo4j.cypher.internal.runtime.compiled.expressions
 
-import org.neo4j.cypher.internal.compatibility.v3_5.runtime.ast.{NodeProperty, ReferenceFromSlot, RelationshipProperty}
+import org.neo4j.cypher.internal.compatibility.v3_5.runtime.ast.{IdFromSlot, NodeProperty, ReferenceFromSlot, RelationshipProperty}
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.operations.{CypherBoolean, CypherDbAccess, CypherFunctions, CypherMath}
 import org.neo4j.internal.kernel.api.Transaction
 import org.neo4j.values.AnyValue
 import org.neo4j.values.storable.Values.{doubleValue, longValue}
-import org.neo4j.values.storable.{DoubleValue, Value, Values}
+import org.neo4j.values.storable.{DoubleValue, LongValue, Value, Values}
 import org.neo4j.values.virtual.MapValue
 import org.opencypher.v9_0.expressions
 import org.opencypher.v9_0.expressions._
@@ -168,6 +168,11 @@ object IntermediateCodeGeneration {
     case ReferenceFromSlot(offset, _) =>
       Some(invoke(load("context"), method[ExecutionContext, AnyValue, Int]("getRefAt"),
                                                      constantJavaValue(offset)))
+    case IdFromSlot(offset) =>
+      Some(
+        invokeStatic(method[Values, LongValue, Long]("longValue"),
+                     invoke(load("context"), method[ExecutionContext, Long, Int]("getLongAt"),
+                            constantJavaValue(offset))))
     case _ => None
   }
 

--- a/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateCodeGeneration.scala
+++ b/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateCodeGeneration.scala
@@ -169,6 +169,12 @@ object IntermediateCodeGeneration {
                         invoke(load("context"), method[ExecutionContext, Long, Int]("getLongAt"),
                                constant(offset)), constant(token)))
 
+    case RelationshipPropertyLate(offset, key, _) =>
+      Some(invokeStatic(method[CypherDbAccess, Value, Transaction, Long, String]("relationshipProperty"),
+                        load("tx"),
+                        invoke(load("context"), method[ExecutionContext, Long, Int]("getLongAt"),
+                               constant(offset)), constant(key)))
+
       //slotted operations
     case ReferenceFromSlot(offset, _) =>
       Some(invoke(load("context"), method[ExecutionContext, AnyValue, Int]("getRefAt"),

--- a/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateRepresentation.scala
+++ b/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateRepresentation.scala
@@ -158,7 +158,7 @@ object IntermediateRepresentation {
 
   def falsy: IntermediateRepresentation = FALSE
 
-  def constantJavaValue(value: Any): IntermediateRepresentation = Constant(value)
+  def constant(value: Any): IntermediateRepresentation = Constant(value)
 
   def arrayOf(values: IntermediateRepresentation*): IntermediateRepresentation = ArrayLiteral(values.toArray)
 }

--- a/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateRepresentation.scala
+++ b/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateRepresentation.scala
@@ -110,6 +110,23 @@ case object FALSE extends IntermediateRepresentation
 case class ArrayLiteral(values: Array[IntermediateRepresentation]) extends IntermediateRepresentation
 
 /**
+  * Defines ternary expression, i.e. `condition ? onTrue : onFalse`
+  * @param condition the condition to test
+  * @param onTrue will be evaluted if condition is true
+  * @param onFalse will be evaluated if condition is false
+  */
+case class Ternary(condition: IntermediateRepresentation,
+                   onTrue: IntermediateRepresentation,
+                   onFalse: IntermediateRepresentation) extends IntermediateRepresentation
+
+/**
+  * Defines equality of identity, i.e. `lhs == rhs`
+  * @param lhs the left-hand side to check
+  * @param rhs the right-hand side to check
+  */
+case class Eq(lhs: IntermediateRepresentation, rhs: IntermediateRepresentation) extends IntermediateRepresentation
+
+/**
   * Defines a method
   *
   * @param owner  the owner of the method
@@ -161,4 +178,11 @@ object IntermediateRepresentation {
   def constant(value: Any): IntermediateRepresentation = Constant(value)
 
   def arrayOf(values: IntermediateRepresentation*): IntermediateRepresentation = ArrayLiteral(values.toArray)
+
+  def ternary(condition: IntermediateRepresentation,
+              onTrue: IntermediateRepresentation,
+              onFalse: IntermediateRepresentation): IntermediateRepresentation = Ternary(condition, onTrue, onFalse)
+
+  def equal(lhs: IntermediateRepresentation, rhs: IntermediateRepresentation): IntermediateRepresentation =
+    Eq(lhs, rhs)
 }

--- a/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateRepresentation.scala
+++ b/enterprise/cypher/compiled-expressions/src/main/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/IntermediateRepresentation.scala
@@ -105,7 +105,7 @@ case object FALSE extends IntermediateRepresentation
 
 /**
   * Loads an array literal of the given inputs
-  * @param values
+  * @param values the values of the array
   */
 case class ArrayLiteral(values: Array[IntermediateRepresentation]) extends IntermediateRepresentation
 
@@ -151,12 +151,6 @@ object IntermediateRepresentation {
     Invoke(owner, method, params)
 
   def load(variable: String): IntermediateRepresentation = Load(variable)
-
-  def integer(value: IntegralValue): IntermediateRepresentation = Integer(value)
-
-  def float(value: FloatingPointValue): IntermediateRepresentation = Float(value)
-
-  def string(value: TextValue): IntermediateRepresentation = StringLiteral(value)
 
   def noValue: IntermediateRepresentation = NULL
 

--- a/enterprise/cypher/compiled-expressions/src/test/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/CodeGenerationTest.scala
+++ b/enterprise/cypher/compiled-expressions/src/test/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/CodeGenerationTest.scala
@@ -468,6 +468,16 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
       equal(stringValue("hello"))
   }
 
+  test("IsPrimitiveNull") {
+    val nullOffset = 1337
+    val offset = 42
+    when(ctx.getLongAt(nullOffset)).thenReturn(-1L)
+    when(ctx.getLongAt(offset)).thenReturn(77L)
+
+    compile(IsPrimitiveNull(nullOffset)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.TRUE)
+    compile(IsPrimitiveNull(offset)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.FALSE)
+  }
+
   private def compile(e: Expression) =
     CodeGeneration.compile(IntermediateCodeGeneration.compile(e).getOrElse(fail()))
 

--- a/enterprise/cypher/compiled-expressions/src/test/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/CodeGenerationTest.scala
+++ b/enterprise/cypher/compiled-expressions/src/test/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/CodeGenerationTest.scala
@@ -26,9 +26,8 @@ import java.lang.Math.PI
 import java.time.Duration
 import java.util.concurrent.ThreadLocalRandom
 
-import org.mockito.Mockito
 import org.mockito.Mockito.when
-import org.neo4j.cypher.internal.compatibility.v3_5.runtime.ast.{IdFromSlot, ReferenceFromSlot}
+import org.neo4j.cypher.internal.compatibility.v3_5.runtime.ast.{IdFromSlot, PrimitiveEquals, ReferenceFromSlot}
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.internal.kernel.api.Transaction
 import org.neo4j.values.storable.LocalTimeValue.localTime
@@ -434,6 +433,15 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
 
     // Then
     compiled.evaluate(ctx, tx, EMPTY_MAP) should equal(longValue(42))
+  }
+
+  test("PrimitiveEquals") {
+    val compiled = compile(PrimitiveEquals(parameter("a"), parameter("b")))
+
+    compiled.evaluate(ctx, tx, map(Array("a", "b"), Array(longValue(42), longValue(42)))) should
+      equal(Values.TRUE)
+    compiled.evaluate(ctx, tx, map(Array("a", "b"), Array(longValue(42), longValue(1337)))) should
+      equal(Values.FALSE)
   }
 
   private def compile(e: Expression) =

--- a/enterprise/cypher/compiled-expressions/src/test/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/CodeGenerationTest.scala
+++ b/enterprise/cypher/compiled-expressions/src/test/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/CodeGenerationTest.scala
@@ -27,7 +27,7 @@ import java.time.Duration
 import java.util.concurrent.ThreadLocalRandom
 
 import org.mockito.Mockito.when
-import org.neo4j.cypher.internal.compatibility.v3_5.runtime.ast.{IdFromSlot, NullCheck, PrimitiveEquals, ReferenceFromSlot}
+import org.neo4j.cypher.internal.compatibility.v3_5.runtime.ast._
 import org.neo4j.cypher.internal.runtime.EntityProducer
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.internal.kernel.api.Transaction
@@ -454,6 +454,18 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
 
     compile(NullCheck(nullOffset, literalFloat(PI))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
     compile(NullCheck(offset, literalFloat(PI))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.PI)
+  }
+
+  test("NullCheckVariable") {
+    val nullOffset = 1337
+    val offset = 42
+    when(ctx.getRefAt(nullOffset)).thenReturn(NO_VALUE)
+    when(ctx.getRefAt(offset)).thenReturn(stringValue("hello"))
+
+    compile(NullCheckVariable(nullOffset, ReferenceFromSlot(offset, "a"))).evaluate(ctx, tx, producer, EMPTY_MAP) should
+      equal(Values.NO_VALUE)
+    compile(NullCheckVariable(offset, ReferenceFromSlot(offset, "a"))).evaluate(ctx, tx, producer, EMPTY_MAP) should
+      equal(stringValue("hello"))
   }
 
   private def compile(e: Expression) =

--- a/enterprise/cypher/compiled-expressions/src/test/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/CodeGenerationTest.scala
+++ b/enterprise/cypher/compiled-expressions/src/test/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/CodeGenerationTest.scala
@@ -28,7 +28,7 @@ import java.util.concurrent.ThreadLocalRandom
 
 import org.mockito.Mockito
 import org.mockito.Mockito.when
-import org.neo4j.cypher.internal.compatibility.v3_5.runtime.ast.ReferenceFromSlot
+import org.neo4j.cypher.internal.compatibility.v3_5.runtime.ast.{IdFromSlot, ReferenceFromSlot}
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.internal.kernel.api.Transaction
 import org.neo4j.values.storable.LocalTimeValue.localTime
@@ -421,6 +421,19 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
 
     // Then
     compiled.evaluate(ctx, tx, EMPTY_MAP) should equal(stringValue("hello"))
+  }
+
+  test("IdFromSlot") {
+    // Given
+    val offset = 1337
+    val expression = IdFromSlot(offset)
+    when(ctx.getLongAt(offset)).thenReturn(42L)
+
+    // When
+    val compiled = compile(expression)
+
+    // Then
+    compiled.evaluate(ctx, tx, EMPTY_MAP) should equal(longValue(42))
   }
 
   private def compile(e: Expression) =

--- a/enterprise/cypher/compiled-expressions/src/test/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/CodeGenerationTest.scala
+++ b/enterprise/cypher/compiled-expressions/src/test/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/CodeGenerationTest.scala
@@ -27,7 +27,7 @@ import java.time.Duration
 import java.util.concurrent.ThreadLocalRandom
 
 import org.mockito.Mockito.when
-import org.neo4j.cypher.internal.compatibility.v3_5.runtime.ast.{IdFromSlot, PrimitiveEquals, ReferenceFromSlot}
+import org.neo4j.cypher.internal.compatibility.v3_5.runtime.ast.{IdFromSlot, NullCheck, PrimitiveEquals, ReferenceFromSlot}
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.internal.kernel.api.Transaction
 import org.neo4j.values.storable.LocalTimeValue.localTime
@@ -442,6 +442,16 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
       equal(Values.TRUE)
     compiled.evaluate(ctx, tx, map(Array("a", "b"), Array(longValue(42), longValue(1337)))) should
       equal(Values.FALSE)
+  }
+
+  test("NullCheck") {
+    val nullOffset = 1337
+    val offset = 42
+    when(ctx.getLongAt(nullOffset)).thenReturn(-1L)
+    when(ctx.getLongAt(offset)).thenReturn(42L)
+
+    compile(NullCheck(nullOffset, literalFloat(PI))).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(NullCheck(offset, literalFloat(PI))).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.PI)
   }
 
   private def compile(e: Expression) =

--- a/enterprise/cypher/compiled-expressions/src/test/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/CodeGenerationTest.scala
+++ b/enterprise/cypher/compiled-expressions/src/test/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/CodeGenerationTest.scala
@@ -459,6 +459,8 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
   test("NullCheckVariable") {
     val nullOffset = 1337
     val offset = 42
+    when(ctx.getLongAt(nullOffset)).thenReturn(-1L)
+    when(ctx.getLongAt(offset)).thenReturn(42L)
     when(ctx.getRefAt(nullOffset)).thenReturn(NO_VALUE)
     when(ctx.getRefAt(offset)).thenReturn(stringValue("hello"))
 

--- a/enterprise/cypher/compiled-expressions/src/test/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/CodeGenerationTest.scala
+++ b/enterprise/cypher/compiled-expressions/src/test/scala/org/neo4j/cypher/internal/runtime/compiled/expressions/CodeGenerationTest.scala
@@ -28,6 +28,7 @@ import java.util.concurrent.ThreadLocalRandom
 
 import org.mockito.Mockito.when
 import org.neo4j.cypher.internal.compatibility.v3_5.runtime.ast.{IdFromSlot, NullCheck, PrimitiveEquals, ReferenceFromSlot}
+import org.neo4j.cypher.internal.runtime.EntityProducer
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.internal.kernel.api.Transaction
 import org.neo4j.values.storable.LocalTimeValue.localTime
@@ -43,11 +44,12 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
 
   private val tx = mock[Transaction]
   private val ctx = mock[ExecutionContext]
+  private val producer = mock[EntityProducer]
   private val random = ThreadLocalRandom.current()
 
   test("round function") {
-    compile(function("round", literalFloat(PI))).evaluate(ctx, tx, EMPTY_MAP) should equal(doubleValue(3.0))
-    compile(function("round", noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(NO_VALUE)
+    compile(function("round", literalFloat(PI))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(doubleValue(3.0))
+    compile(function("round", noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(NO_VALUE)
   }
 
   test("rand function") {
@@ -58,76 +60,76 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
     val compiled = compile(expression)
 
     // Then
-    val value = compiled.evaluate(ctx, tx, EMPTY_MAP).asInstanceOf[DoubleValue].doubleValue()
+    val value = compiled.evaluate(ctx, tx, producer, EMPTY_MAP).asInstanceOf[DoubleValue].doubleValue()
     value should (be >= 0.0 and be <1.0)
   }
 
   test("sin function") {
     val arg = random.nextDouble()
-    compile(function("sin", literalFloat(arg))).evaluate(ctx, tx, EMPTY_MAP) should equal(doubleValue(Math.sin(arg)))
-    compile(function("sin", noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(NO_VALUE)
+    compile(function("sin", literalFloat(arg))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(doubleValue(Math.sin(arg)))
+    compile(function("sin", noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(NO_VALUE)
   }
 
   test("asin function") {
     val arg = random.nextDouble()
-    compile(function("asin", literalFloat(arg))).evaluate(ctx, tx, EMPTY_MAP) should equal(doubleValue(Math.asin(arg)))
-    compile(function("asin", noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(NO_VALUE)
+    compile(function("asin", literalFloat(arg))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(doubleValue(Math.asin(arg)))
+    compile(function("asin", noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(NO_VALUE)
   }
 
   test("haversin function") {
     val arg = random.nextDouble()
-    compile(function("haversin", literalFloat(arg))).evaluate(ctx, tx, EMPTY_MAP) should equal(doubleValue((1.0 - Math.cos(arg)) / 2))
-    compile(function("haversin", noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(NO_VALUE)
+    compile(function("haversin", literalFloat(arg))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(doubleValue((1.0 - Math.cos(arg)) / 2))
+    compile(function("haversin", noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(NO_VALUE)
   }
 
   test("acos function") {
     val arg = random.nextDouble()
-    compile(function("acos", literalFloat(arg))).evaluate(ctx, tx, EMPTY_MAP) should equal(doubleValue(Math.acos(arg)))
-    compile(function("acos", noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(NO_VALUE)
+    compile(function("acos", literalFloat(arg))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(doubleValue(Math.acos(arg)))
+    compile(function("acos", noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(NO_VALUE)
   }
 
   test("cos function") {
     val arg = random.nextDouble()
-    compile(function("cos", literalFloat(arg))).evaluate(ctx, tx, EMPTY_MAP) should equal(doubleValue(Math.cos(arg)))
-    compile(function("cos", noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(NO_VALUE)
+    compile(function("cos", literalFloat(arg))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(doubleValue(Math.cos(arg)))
+    compile(function("cos", noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(NO_VALUE)
   }
 
   test("cot function") {
     val arg = random.nextDouble()
-    compile(function("cot", literalFloat(arg))).evaluate(ctx, tx, EMPTY_MAP) should equal(doubleValue(1 / Math.tan(arg)))
-    compile(function("cot", noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(NO_VALUE)
+    compile(function("cot", literalFloat(arg))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(doubleValue(1 / Math.tan(arg)))
+    compile(function("cot", noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(NO_VALUE)
   }
 
   test("atan function") {
     val arg = random.nextDouble()
-    compile(function("atan", literalFloat(arg))).evaluate(ctx, tx, EMPTY_MAP) should equal(doubleValue(Math.atan(arg)))
-    compile(function("atan", noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(NO_VALUE)
+    compile(function("atan", literalFloat(arg))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(doubleValue(Math.atan(arg)))
+    compile(function("atan", noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(NO_VALUE)
   }
 
   test("tan function") {
     val arg = random.nextDouble()
-    compile(function("tan", literalFloat(arg))).evaluate(ctx, tx, EMPTY_MAP) should equal(doubleValue(Math.tan(arg)))
-    compile(function("tan", noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(NO_VALUE)
+    compile(function("tan", literalFloat(arg))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(doubleValue(Math.tan(arg)))
+    compile(function("tan", noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(NO_VALUE)
   }
 
   test("ceil function") {
     val arg = random.nextDouble()
-    compile(function("ceil", literalFloat(arg))).evaluate(ctx, tx, EMPTY_MAP) should equal(doubleValue(Math.ceil(arg)))
-    compile(function("ceil", noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(NO_VALUE)
+    compile(function("ceil", literalFloat(arg))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(doubleValue(Math.ceil(arg)))
+    compile(function("ceil", noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(NO_VALUE)
   }
 
   test("floor function") {
     val arg = random.nextDouble()
-    compile(function("floor", literalFloat(arg))).evaluate(ctx, tx, EMPTY_MAP) should equal(doubleValue(Math.floor(arg)))
-    compile(function("floor", noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(NO_VALUE)
+    compile(function("floor", literalFloat(arg))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(doubleValue(Math.floor(arg)))
+    compile(function("floor", noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(NO_VALUE)
   }
 
   test("abs function") {
-    compile(function("abs", literalFloat(3.2))).evaluate(ctx, tx, EMPTY_MAP) should equal(doubleValue(3.2))
-    compile(function("abs", literalFloat(-3.2))).evaluate(ctx, tx, EMPTY_MAP) should equal(doubleValue(3.2))
-    compile(function("abs", literalInt(3))).evaluate(ctx, tx, EMPTY_MAP) should equal(longValue(3))
-    compile(function("abs", literalInt(-3))).evaluate(ctx, tx, EMPTY_MAP) should equal(longValue(3))
-    compile(function("abs", noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(function("abs", literalFloat(3.2))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(doubleValue(3.2))
+    compile(function("abs", literalFloat(-3.2))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(doubleValue(3.2))
+    compile(function("abs", literalInt(3))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(longValue(3))
+    compile(function("abs", literalInt(-3))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(longValue(3))
+    compile(function("abs", noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
   }
 
   test("add numbers") {
@@ -138,24 +140,24 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
     val compiled = compile(expression)
 
     // Then
-    compiled.evaluate(ctx, tx, EMPTY_MAP) should equal(longValue(52))
+    compiled.evaluate(ctx, tx, producer, EMPTY_MAP) should equal(longValue(52))
   }
 
   test("add temporals") {
     val compiled = compile(add(parameter("a"), parameter("b")))
 
     // temporal + duration
-    compiled.evaluate(ctx, tx, map(Array("a", "b"), Array(temporalValue(localTime(0)),
+    compiled.evaluate(ctx, tx, producer, map(Array("a", "b"), Array(temporalValue(localTime(0)),
                                    durationValue(Duration.ofHours(10))))) should
       equal(localTime(10, 0, 0, 0))
 
     // duration + temporal
-    compiled.evaluate(ctx, tx, map(Array("a", "b"), Array(durationValue(Duration.ofHours(10)),
+    compiled.evaluate(ctx, tx, producer, map(Array("a", "b"), Array(durationValue(Duration.ofHours(10)),
                                          temporalValue(localTime(0))))) should
       equal(localTime(10, 0, 0, 0))
 
     //duration + duration
-    compiled.evaluate(ctx, tx, map(Array("a", "b"), Array(durationValue(Duration.ofHours(10)),
+    compiled.evaluate(ctx, tx, producer, map(Array("a", "b"), Array(durationValue(Duration.ofHours(10)),
                                                           durationValue(Duration.ofHours(10))))) should
       equal(durationValue(Duration.ofHours(20)))
   }
@@ -168,8 +170,8 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
     val compiled = compile(expression)
 
     // Then
-    compiled.evaluate(ctx, tx, map(Array("a", "b"), Array(longValue(42), NO_VALUE))) should equal(NO_VALUE)
-    compiled.evaluate(ctx, tx, map(Array("a", "b"), Array(NO_VALUE, longValue(42)))) should equal(NO_VALUE)
+    compiled.evaluate(ctx, tx, producer, map(Array("a", "b"), Array(longValue(42), NO_VALUE))) should equal(NO_VALUE)
+    compiled.evaluate(ctx, tx, producer, map(Array("a", "b"), Array(NO_VALUE, longValue(42)))) should equal(NO_VALUE)
   }
 
   test("add strings") {
@@ -177,16 +179,16 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
     val compiled = compile(add(parameter("a"), parameter("b")))
 
     // string1 + string2
-    compiled.evaluate(ctx, tx,
+    compiled.evaluate(ctx, tx, producer,
                       map(Array("a", "b"), Array(stringValue("hello "), stringValue("world")))) should
       equal(stringValue("hello world"))
     //string + other
-    compiled.evaluate(ctx, tx,
+    compiled.evaluate(ctx, tx, producer,
                       map(Array("a", "b"),
                           Array(stringValue("hello "), longValue(1337)))) should
       equal(stringValue("hello 1337"))
     //other + string
-    compiled.evaluate(ctx, tx,
+    compiled.evaluate(ctx, tx, producer,
                       map(Array("a", "b"),
                           Array(longValue(1337), stringValue(" hello")))) should
       equal(stringValue("1337 hello"))
@@ -201,7 +203,7 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
     val compiled = compile(expression)
 
     // Then
-    compiled.evaluate(ctx, tx, map(Array("a", "b"),
+    compiled.evaluate(ctx, tx, producer, map(Array("a", "b"),
                                    Array(longArray(Array(42, 43)),
                                         longArray(Array(44, 45))))) should
       equal(list(longValue(42), longValue(43), longValue(44), longValue(45)))
@@ -212,18 +214,18 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
     val compiled = compile(add(parameter("a"), parameter("b")))
 
     // [a1,a2 ..] + [b1,b2 ..]
-    compiled.evaluate(ctx, tx, map(Array("a", "b"),
+    compiled.evaluate(ctx, tx, producer, map(Array("a", "b"),
                                    Array(list(longValue(42), longValue(43)),
                                          list(longValue(44), longValue(45))))) should
       equal(list(longValue(42), longValue(43), longValue(44), longValue(45)))
 
     // [a1,a2 ..] + b
-    compiled.evaluate(ctx, tx, map(Array("a", "b"),
+    compiled.evaluate(ctx, tx, producer, map(Array("a", "b"),
                                    Array(list(longValue(42), longValue(43)), longValue(44)))) should
       equal(list(longValue(42), longValue(43), longValue(44)))
 
     // a + [b1,b2 ..]
-    compiled.evaluate(ctx, tx, map(Array("a", "b"),
+    compiled.evaluate(ctx, tx, producer, map(Array("a", "b"),
                                    Array(longValue(43),
                                          list(longValue(44), longValue(45))))) should
       equal(list(longValue(43), longValue(44), longValue(45)))
@@ -237,7 +239,7 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
     val compiled = compile(expression)
 
     // Then
-    compiled.evaluate(ctx, tx, EMPTY_MAP) should equal(longValue(32))
+    compiled.evaluate(ctx, tx, producer, EMPTY_MAP) should equal(longValue(32))
   }
 
   test("subtract with NO_VALUE") {
@@ -248,20 +250,20 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
     val compiled = compile(expression)
 
     // Then
-    compiled.evaluate(ctx, tx, map(Array("a", "b"), Array(longValue(42), NO_VALUE))) should equal(NO_VALUE)
-    compiled.evaluate(ctx, tx, map(Array("a", "b"), Array(NO_VALUE, longValue(42)))) should equal(NO_VALUE)
+    compiled.evaluate(ctx, tx, producer, map(Array("a", "b"), Array(longValue(42), NO_VALUE))) should equal(NO_VALUE)
+    compiled.evaluate(ctx, tx, producer, map(Array("a", "b"), Array(NO_VALUE, longValue(42)))) should equal(NO_VALUE)
   }
 
   test("subtract temporals") {
     val compiled = compile(subtract(parameter("a"), parameter("b")))
 
     // temporal - duration
-    compiled.evaluate(ctx, tx, map(Array("a", "b"), Array(temporalValue(localTime(20, 0, 0, 0)),
+    compiled.evaluate(ctx, tx, producer, map(Array("a", "b"), Array(temporalValue(localTime(20, 0, 0, 0)),
                                                           durationValue(Duration.ofHours(10))))) should
       equal(localTime(10, 0, 0, 0))
 
     //duration - duration
-    compiled.evaluate(ctx, tx, map(Array("a", "b"), Array(durationValue(Duration.ofHours(10)),
+    compiled.evaluate(ctx, tx, producer, map(Array("a", "b"), Array(durationValue(Duration.ofHours(10)),
                                                           durationValue(Duration.ofHours(10))))) should
       equal(durationValue(Duration.ofHours(0)))
   }
@@ -274,7 +276,7 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
     val compiled = compile(expression)
 
     // Then
-    compiled.evaluate(ctx, tx, EMPTY_MAP) should equal(longValue(420))
+    compiled.evaluate(ctx, tx, producer, EMPTY_MAP) should equal(longValue(420))
   }
 
   test("multiply with NO_VALUE") {
@@ -285,8 +287,8 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
     val compiled = compile(expression)
 
     // Then
-    compiled.evaluate(ctx, tx, map(Array("a", "b"), Array(longValue(42), NO_VALUE))) should equal(NO_VALUE)
-    compiled.evaluate(ctx, tx, map(Array("a", "b"), Array(NO_VALUE, longValue(42)))) should equal(NO_VALUE)
+    compiled.evaluate(ctx, tx, producer, map(Array("a", "b"), Array(longValue(42), NO_VALUE))) should equal(NO_VALUE)
+    compiled.evaluate(ctx, tx, producer, map(Array("a", "b"), Array(NO_VALUE, longValue(42)))) should equal(NO_VALUE)
   }
 
   test("extract parameter") {
@@ -297,8 +299,8 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
     val compiled = compile(expression)
 
     // Then
-    compiled.evaluate(ctx, tx, EMPTY_MAP) should equal(NO_VALUE)
-    compiled.evaluate(ctx, tx, map(Array("prop"), Array(stringValue("foo")))) should equal(stringValue("foo"))
+    compiled.evaluate(ctx, tx, producer, EMPTY_MAP) should equal(NO_VALUE)
+    compiled.evaluate(ctx, tx, producer, map(Array("prop"), Array(stringValue("foo")))) should equal(stringValue("foo"))
   }
 
   test("NULL") {
@@ -309,7 +311,7 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
     val compiled = compile(expression)
 
     // Then
-    compiled.evaluate(ctx, tx, EMPTY_MAP) should equal(NO_VALUE)
+    compiled.evaluate(ctx, tx, producer, EMPTY_MAP) should equal(NO_VALUE)
   }
 
   test("TRUE") {
@@ -320,7 +322,7 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
     val compiled = compile(expression)
 
     // Then
-    compiled.evaluate(ctx, tx, EMPTY_MAP) should equal(Values.TRUE)
+    compiled.evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.TRUE)
   }
 
   test("FALSE") {
@@ -331,82 +333,82 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
     val compiled = compile(expression)
 
     // Then
-    compiled.evaluate(ctx, tx, EMPTY_MAP) should equal(Values.FALSE)
+    compiled.evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.FALSE)
   }
 
   test("OR") {
-    compile(or(t, t)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.TRUE)
-    compile(or(f, t)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.TRUE)
-    compile(or(t, f)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.TRUE)
-    compile(or(f, f)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.FALSE)
+    compile(or(t, t)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.TRUE)
+    compile(or(f, t)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.TRUE)
+    compile(or(t, f)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.TRUE)
+    compile(or(f, f)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.FALSE)
 
-    compile(or(noValue, noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
-    compile(or(noValue, t)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.TRUE)
-    compile(or(t, noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.TRUE)
-    compile(or(noValue, f)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
-    compile(or(f, noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(or(noValue, noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(or(noValue, t)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.TRUE)
+    compile(or(t, noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.TRUE)
+    compile(or(noValue, f)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(or(f, noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
   }
 
   test("XOR") {
-    compile(xor(t, t)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.FALSE)
-    compile(xor(f, t)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.TRUE)
-    compile(xor(t, f)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.TRUE)
-    compile(xor(f, f)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.FALSE)
+    compile(xor(t, t)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.FALSE)
+    compile(xor(f, t)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.TRUE)
+    compile(xor(t, f)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.TRUE)
+    compile(xor(f, f)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.FALSE)
 
-    compile(xor(noValue, noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
-    compile(xor(noValue, t)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
-    compile(xor(t, noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
-    compile(xor(noValue, f)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
-    compile(xor(f, noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(xor(noValue, noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(xor(noValue, t)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(xor(t, noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(xor(noValue, f)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(xor(f, noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
   }
 
   test("ORS") {
-    compile(ors(f, f, f, f, f, f, t, f)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.TRUE)
-    compile(ors(f, f, f, f, f, f, f, f)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.FALSE)
-    compile(ors(f, f, f, f, noValue, f, f, f)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
-    compile(ors(f, f, f, t, noValue, t, f, f)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.TRUE)
+    compile(ors(f, f, f, f, f, f, t, f)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.TRUE)
+    compile(ors(f, f, f, f, f, f, f, f)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.FALSE)
+    compile(ors(f, f, f, f, noValue, f, f, f)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(ors(f, f, f, t, noValue, t, f, f)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.TRUE)
   }
 
   test("AND") {
-    compile(and(t, t)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.TRUE)
-    compile(and(f, t)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.FALSE)
-    compile(and(t, f)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.FALSE)
-    compile(and(f, f)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.FALSE)
+    compile(and(t, t)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.TRUE)
+    compile(and(f, t)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.FALSE)
+    compile(and(t, f)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.FALSE)
+    compile(and(f, f)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.FALSE)
 
-    compile(and(noValue, noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
-    compile(and(noValue, t)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
-    compile(and(t, noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
-    compile(and(noValue, f)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.FALSE)
-    compile(and(f, noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.FALSE)
+    compile(and(noValue, noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(and(noValue, t)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(and(t, noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(and(noValue, f)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.FALSE)
+    compile(and(f, noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.FALSE)
   }
 
   test("ANDS") {
-    compile(ands(t, t, t, t, t)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.TRUE)
-    compile(ands(t, t, t, t, t, f)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.FALSE)
-    compile(ands(t, t, t, t, noValue, t)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
-    compile(ands(t, t, t, f, noValue, f)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.FALSE)
+    compile(ands(t, t, t, t, t)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.TRUE)
+    compile(ands(t, t, t, t, t, f)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.FALSE)
+    compile(ands(t, t, t, t, noValue, t)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(ands(t, t, t, f, noValue, f)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.FALSE)
   }
 
   test("NOT") {
-    compile(not(f)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.TRUE)
-    compile(not(t)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.FALSE)
-    compile(not(noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(not(f)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.TRUE)
+    compile(not(t)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.FALSE)
+    compile(not(noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
   }
 
   test("EQUALS") {
-    compile(equals(literalInt(42), literalInt(42))).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.TRUE)
-    compile(equals(literalInt(42), literalInt(43))).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.FALSE)
-    compile(equals(noValue, literalInt(43))).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
-    compile(equals(literalInt(42), noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
-    compile(equals(noValue, noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(equals(literalInt(42), literalInt(42))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.TRUE)
+    compile(equals(literalInt(42), literalInt(43))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.FALSE)
+    compile(equals(noValue, literalInt(43))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(equals(literalInt(42), noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(equals(noValue, noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
   }
 
   test("NOT EQUALS") {
-    compile(notEquals(literalInt(42), literalInt(42))).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.FALSE)
-    compile(notEquals(literalInt(42), literalInt(43))).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.TRUE)
-    compile(notEquals(noValue, literalInt(43))).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
-    compile(notEquals(literalInt(42), noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
-    compile(notEquals(noValue, noValue)).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(notEquals(literalInt(42), literalInt(42))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.FALSE)
+    compile(notEquals(literalInt(42), literalInt(43))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.TRUE)
+    compile(notEquals(noValue, literalInt(43))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(notEquals(literalInt(42), noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(notEquals(noValue, noValue)).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
   }
 
   test("ReferenceFromSlot") {
@@ -419,7 +421,7 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
     val compiled = compile(expression)
 
     // Then
-    compiled.evaluate(ctx, tx, EMPTY_MAP) should equal(stringValue("hello"))
+    compiled.evaluate(ctx, tx, producer, EMPTY_MAP) should equal(stringValue("hello"))
   }
 
   test("IdFromSlot") {
@@ -432,15 +434,15 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
     val compiled = compile(expression)
 
     // Then
-    compiled.evaluate(ctx, tx, EMPTY_MAP) should equal(longValue(42))
+    compiled.evaluate(ctx, tx, producer, EMPTY_MAP) should equal(longValue(42))
   }
 
   test("PrimitiveEquals") {
     val compiled = compile(PrimitiveEquals(parameter("a"), parameter("b")))
 
-    compiled.evaluate(ctx, tx, map(Array("a", "b"), Array(longValue(42), longValue(42)))) should
+    compiled.evaluate(ctx, tx, producer, map(Array("a", "b"), Array(longValue(42), longValue(42)))) should
       equal(Values.TRUE)
-    compiled.evaluate(ctx, tx, map(Array("a", "b"), Array(longValue(42), longValue(1337)))) should
+    compiled.evaluate(ctx, tx, producer, map(Array("a", "b"), Array(longValue(42), longValue(1337)))) should
       equal(Values.FALSE)
   }
 
@@ -450,8 +452,8 @@ class CodeGenerationTest extends CypherFunSuite with AstConstructionTestSupport 
     when(ctx.getLongAt(nullOffset)).thenReturn(-1L)
     when(ctx.getLongAt(offset)).thenReturn(42L)
 
-    compile(NullCheck(nullOffset, literalFloat(PI))).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.NO_VALUE)
-    compile(NullCheck(offset, literalFloat(PI))).evaluate(ctx, tx, EMPTY_MAP) should equal(Values.PI)
+    compile(NullCheck(nullOffset, literalFloat(PI))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.NO_VALUE)
+    compile(NullCheck(offset, literalFloat(PI))).evaluate(ctx, tx, producer, EMPTY_MAP) should equal(Values.PI)
   }
 
   private def compile(e: Expression) =

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/CompiledExpressionConverter.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/CompiledExpressionConverter.scala
@@ -62,7 +62,7 @@ case class CompileWrappingExpression(ce: CompiledExpression, legacy: Expression)
   override def arguments: Seq[Expression] = legacy.arguments
 
   override def apply(ctx: ExecutionContext, state: QueryState): AnyValue =
-    ce.evaluate(ctx, state.query.transactionalContext.transaction, state.params)
+    ce.evaluate(ctx, state.query.transactionalContext.transaction, state.query, state.params)
 
   override def symbolTableDependencies: Set[String] = legacy.symbolTableDependencies
 


### PR DESCRIPTION
Ported all expressions that are handled in `SlottedExpressionConverter` except `PathExpression` so that we now handle them also in `CompiledExpressionConverter`. Why not `PathExpression`? It is slightly trickier and I got tired - stay tuned.