### PR TITLE
Consider length field when computing maximum frame length

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/pipeline/ChunkDecoder.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/pipeline/ChunkDecoder.java
@@ -23,7 +23,7 @@ import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 
 public class ChunkDecoder extends LengthFieldBasedFrameDecoder
 {
-    private static final int MAX_FRAME_LENGTH = 0xFFFF;
+    private static final int MAX_CHUNK_LENGTH = 0xFFFF;
     private static final int LENGTH_FIELD_OFFSET = 0;
     private static final int LENGTH_FIELD_SIZE = 2;
     private static final int LENGTH_ADJUSTMENT = 0;
@@ -31,6 +31,6 @@ public class ChunkDecoder extends LengthFieldBasedFrameDecoder
 
     public ChunkDecoder()
     {
-        super( MAX_FRAME_LENGTH, LENGTH_FIELD_OFFSET, LENGTH_FIELD_SIZE, LENGTH_ADJUSTMENT, INITIAL_BYTES_TO_STRIP );
+        super( MAX_CHUNK_LENGTH + LENGTH_FIELD_SIZE, LENGTH_FIELD_OFFSET, LENGTH_FIELD_SIZE, LENGTH_ADJUSTMENT, INITIAL_BYTES_TO_STRIP );
     }
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/transport/pipeline/ChunkDecoderTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/transport/pipeline/ChunkDecoderTest.java
@@ -120,4 +120,20 @@ public class ChunkDecoderTest
         // it should have no size header and empty body
         assertByteBufEquals( wrappedBuffer( new byte[0] ), channel.readInbound() );
     }
+
+    @Test
+    public void shouldDecodeMaxSizeChunk()
+    {
+        byte[] message = new byte[0xFFFF];
+
+        ByteBuf input = buffer();
+        input.writeShort( message.length );
+        input.writeBytes( message );
+
+        assertTrue( channel.writeInbound( input ) );
+        assertTrue( channel.finish() );
+
+        assertEquals( 1, channel.inboundMessages().size() );
+        assertByteBufEquals( wrappedBuffer( message ), channel.readInbound() );
+    }
 }


### PR DESCRIPTION
Previously `ChunkDecoder` was configured to have a maximum `0xFFFF (65535)` frame length, which did not include the 2-byte length field. However, chunks of length `0xFFFF` are valid and when such a chunk is sent to the server, `ChunkDecoder` fails with `TooLongFrameException`.

This PR makes maximum frame length to include 2 byte length field so that the server can process incoming data without failing.

Reported by [#307](https://github.com/neo4j/neo4j-dotnet-driver/issues/307).