### PR TITLE
Don't load property keys if label has no indexes when adding a label

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/IndexTxStateUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/IndexTxStateUpdater.java
@@ -74,6 +74,14 @@ public class IndexTxStateUpdater
     {
         assert noSchemaChangedInTx();
 
+        // Check all indexes of the changed label
+        Iterator<SchemaIndexDescriptor> indexes = storeReadLayer.indexesGetForLabel( labelId );
+
+        if ( !indexes.hasNext() )
+        {
+            return;
+        }
+
         // Find properties of the changed node
         PrimitiveIntSet nodePropertyIds = Primitive.intSet();
         node.properties( propertyCursor );
@@ -82,8 +90,6 @@ public class IndexTxStateUpdater
             nodePropertyIds.add( propertyCursor.propertyKey() );
         }
 
-        // Check all indexes of the changed label
-        Iterator<SchemaIndexDescriptor> indexes = storeReadLayer.indexesGetForLabel( labelId );
         while ( indexes.hasNext() )
         {
             SchemaIndexDescriptor index = indexes.next();


### PR DESCRIPTION
When many, many labels are being added to many nodes
and those labels don't have indexes, loading property keys
is unnecessary and can drastically slow down queries if
the property keys aren't already in the page cache.

In some cases this can turn a query that should take a few
minutes into one that takes an hour or so.