### PR TITLE
Don't load property keys if label has no indexes

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/IndexTxStateUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/IndexTxStateUpdater.java
@@ -75,6 +75,14 @@ public class IndexTxStateUpdater
     {
         assert noSchemaChangedInTx();
 
+        // Check all indexes of the changed label
+        Iterator<? extends IndexDescriptor> indexes = storageReader.indexesGetForLabel( labelId );
+
+        if ( !indexes.hasNext() )
+        {
+            return;
+        }
+
         // Find properties of the changed node
         final MutableIntSet nodePropertyIds = new IntHashSet();
         node.properties( propertyCursor );
@@ -83,8 +91,6 @@ public class IndexTxStateUpdater
             nodePropertyIds.add( propertyCursor.propertyKey() );
         }
 
-        // Check all indexes of the changed label
-        Iterator<? extends IndexDescriptor> indexes = storageReader.indexesGetForLabel( labelId );
         while ( indexes.hasNext() )
         {
             IndexDescriptor index = indexes.next();


### PR DESCRIPTION
When many, many labels are being added to many nodes
and those labels don't have indexes, loading property keys
is unnecessary and can drastically slow down queries if
the property keys aren't already in the page cache.

In some cases this can turn a query that should take a few
minutes into one that takes an hour or so.