### PR TITLE
Explicitly catching BoltConnectionFatality and exposing causing clie…

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/DefaultBoltConnection.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/DefaultBoltConnection.java
@@ -22,6 +22,7 @@ package org.neo4j.bolt.runtime;
 import io.netty.channel.Channel;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.List;
@@ -220,12 +221,19 @@ public class DefaultBoltConnection implements BoltConnection
         catch ( BoltProtocolBreachFatality ex )
         {
             shouldClose.set( true );
-            log.error( String.format( "Protocol breach detected in bolt session '%s'.", id() ), ex );
+            log.error(String.format("Protocol breach detected in bolt session '%s'.", id()), ex);
         }
         catch ( InterruptedException ex )
         {
             shouldClose.set( true );
-            log.info( "Bolt session '%s' is interrupted probably due to server shutdown.", id() );
+            log.info("Bolt session '%s' is interrupted probably due to server shutdown.", id());
+        }
+        catch ( BoltConnectionFatality ex )
+        {
+            shouldClose.set( true );
+            InetSocketAddress remoteSocketAddress = (InetSocketAddress) remoteAddress();
+            String remoteIPAddress = remoteSocketAddress.getAddress().getHostAddress();
+            userLog.error( String.format( "The bolt connection has been fatally misused. Client IP: '%s'.", remoteIPAddress), ex );
         }
         catch ( Throwable t )
         {


### PR DESCRIPTION
…nt IP so that counter measuers on a network level can be taken.

This allows using tools like fail2ban which would read the debug.log, pickup the client IP address which is trying to authenticate too often and then ban it (using a iptables REJECT rule on OS level).