### PR TITLE
Remove opencsv dependency

### DIFF
--- a/community/bolt/LICENSES.txt
+++ b/community/bolt/LICENSES.txt
@@ -16,7 +16,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/bolt/NOTICE.txt
+++ b/community/bolt/NOTICE.txt
@@ -38,7 +38,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/community-it/algo-it/LICENSES.txt
+++ b/community/community-it/algo-it/LICENSES.txt
@@ -19,7 +19,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/community-it/algo-it/NOTICE.txt
+++ b/community/community-it/algo-it/NOTICE.txt
@@ -41,7 +41,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/community-it/bolt-it/LICENSES.txt
+++ b/community/community-it/bolt-it/LICENSES.txt
@@ -19,7 +19,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/community-it/bolt-it/NOTICE.txt
+++ b/community/community-it/bolt-it/NOTICE.txt
@@ -41,7 +41,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/community-it/community-it/LICENSES.txt
+++ b/community/community-it/community-it/LICENSES.txt
@@ -19,7 +19,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/community-it/community-it/NOTICE.txt
+++ b/community/community-it/community-it/NOTICE.txt
@@ -41,7 +41,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/community-it/consistency-it/LICENSES.txt
+++ b/community/community-it/consistency-it/LICENSES.txt
@@ -19,7 +19,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/community-it/consistency-it/NOTICE.txt
+++ b/community/community-it/consistency-it/NOTICE.txt
@@ -41,7 +41,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/community-it/cypher-it/LICENSES.txt
+++ b/community/community-it/cypher-it/LICENSES.txt
@@ -19,7 +19,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/community-it/cypher-it/NOTICE.txt
+++ b/community/community-it/cypher-it/NOTICE.txt
@@ -41,7 +41,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/community-it/dbms-it/LICENSES.txt
+++ b/community/community-it/dbms-it/LICENSES.txt
@@ -19,7 +19,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/community-it/dbms-it/NOTICE.txt
+++ b/community/community-it/dbms-it/NOTICE.txt
@@ -41,7 +41,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/community-it/import-it/LICENSES.txt
+++ b/community/community-it/import-it/LICENSES.txt
@@ -19,7 +19,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/community-it/import-it/NOTICE.txt
+++ b/community/community-it/import-it/NOTICE.txt
@@ -41,7 +41,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/community-it/index-it/LICENSES.txt
+++ b/community/community-it/index-it/LICENSES.txt
@@ -19,7 +19,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/community-it/index-it/NOTICE.txt
+++ b/community/community-it/index-it/NOTICE.txt
@@ -41,7 +41,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/community-it/it-test-support/LICENSES.txt
+++ b/community/community-it/it-test-support/LICENSES.txt
@@ -19,7 +19,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/community-it/it-test-support/NOTICE.txt
+++ b/community/community-it/it-test-support/NOTICE.txt
@@ -41,7 +41,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/community-it/kernel-it/LICENSES.txt
+++ b/community/community-it/kernel-it/LICENSES.txt
@@ -19,7 +19,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/community-it/kernel-it/NOTICE.txt
+++ b/community/community-it/kernel-it/NOTICE.txt
@@ -41,7 +41,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/cypher/cypher/LICENSES.txt
+++ b/community/cypher/cypher/LICENSES.txt
@@ -14,7 +14,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/cypher/cypher/NOTICE.txt
+++ b/community/cypher/cypher/NOTICE.txt
@@ -36,7 +36,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/cypher/cypher/pom.xml
+++ b/community/cypher/cypher/pom.xml
@@ -346,10 +346,6 @@
       <groupId>org.parboiled</groupId>
       <artifactId>parboiled-scala_2.11</artifactId>
     </dependency>
-    <dependency>
-      <groupId>net.sf.opencsv</groupId>
-      <artifactId>opencsv</artifactId>
-    </dependency>
 
     <!-- other -->
     <dependency>

--- a/community/neo4j-community/LICENSES.txt
+++ b/community/neo4j-community/LICENSES.txt
@@ -19,7 +19,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/neo4j-community/NOTICE.txt
+++ b/community/neo4j-community/NOTICE.txt
@@ -41,7 +41,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/neo4j-harness/LICENSES.txt
+++ b/community/neo4j-harness/LICENSES.txt
@@ -35,7 +35,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/neo4j-harness/NOTICE.txt
+++ b/community/neo4j-harness/NOTICE.txt
@@ -57,7 +57,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/neo4j/LICENSES.txt
+++ b/community/neo4j/LICENSES.txt
@@ -19,7 +19,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/neo4j/NOTICE.txt
+++ b/community/neo4j/NOTICE.txt
@@ -41,7 +41,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/server-plugin-test/LICENSES.txt
+++ b/community/server-plugin-test/LICENSES.txt
@@ -32,7 +32,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/server-plugin-test/NOTICE.txt
+++ b/community/server-plugin-test/NOTICE.txt
@@ -54,7 +54,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/server/LICENSES.txt
+++ b/community/server/LICENSES.txt
@@ -32,7 +32,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/community/server/NOTICE.txt
+++ b/community/server/NOTICE.txt
@@ -54,7 +54,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/backup/LICENSES.txt
+++ b/enterprise/backup/LICENSES.txt
@@ -30,7 +30,6 @@ Apache Software License, Version 2.0
   LZ4 and xxHash
   Netty
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/backup/NOTICE.txt
+++ b/enterprise/backup/NOTICE.txt
@@ -46,7 +46,6 @@ Apache Software License, Version 2.0
   LZ4 and xxHash
   Netty
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/cluster/LICENSES.txt
+++ b/enterprise/cluster/LICENSES.txt
@@ -20,7 +20,6 @@ Apache Software License, Version 2.0
   Lucene QueryParsers
   Netty
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/cluster/NOTICE.txt
+++ b/enterprise/cluster/NOTICE.txt
@@ -36,7 +36,6 @@ Apache Software License, Version 2.0
   Lucene QueryParsers
   Netty
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/com/LICENSES.txt
+++ b/enterprise/com/LICENSES.txt
@@ -17,7 +17,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Netty
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/com/NOTICE.txt
+++ b/enterprise/com/NOTICE.txt
@@ -33,7 +33,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Netty
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/cypher/acceptance-spec-suite/LICENSES.txt
+++ b/enterprise/cypher/acceptance-spec-suite/LICENSES.txt
@@ -20,7 +20,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/cypher/acceptance-spec-suite/NOTICE.txt
+++ b/enterprise/cypher/acceptance-spec-suite/NOTICE.txt
@@ -36,7 +36,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/cypher/compatibility-spec-suite/LICENSES.txt
+++ b/enterprise/cypher/compatibility-spec-suite/LICENSES.txt
@@ -20,7 +20,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/cypher/compatibility-spec-suite/NOTICE.txt
+++ b/enterprise/cypher/compatibility-spec-suite/NOTICE.txt
@@ -36,7 +36,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/cypher/compiled-expressions/LICENSES.txt
+++ b/enterprise/cypher/compiled-expressions/LICENSES.txt
@@ -14,7 +14,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/cypher/compiled-expressions/NOTICE.txt
+++ b/enterprise/cypher/compiled-expressions/NOTICE.txt
@@ -30,7 +30,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/cypher/cypher/LICENSES.txt
+++ b/enterprise/cypher/cypher/LICENSES.txt
@@ -20,7 +20,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/cypher/cypher/NOTICE.txt
+++ b/enterprise/cypher/cypher/NOTICE.txt
@@ -36,7 +36,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/cypher/cypher/pom.xml
+++ b/enterprise/cypher/cypher/pom.xml
@@ -227,10 +227,6 @@
       <groupId>org.parboiled</groupId>
       <artifactId>parboiled-scala_2.11</artifactId>
     </dependency>
-    <dependency>
-      <groupId>net.sf.opencsv</groupId>
-      <artifactId>opencsv</artifactId>
-    </dependency>
 
     <!-- code generation testing -->
 

--- a/enterprise/cypher/morsel-runtime/LICENSES.txt
+++ b/enterprise/cypher/morsel-runtime/LICENSES.txt
@@ -19,7 +19,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/cypher/morsel-runtime/NOTICE.txt
+++ b/enterprise/cypher/morsel-runtime/NOTICE.txt
@@ -35,7 +35,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/cypher/physical-planning/LICENSES.txt
+++ b/enterprise/cypher/physical-planning/LICENSES.txt
@@ -14,7 +14,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/cypher/physical-planning/NOTICE.txt
+++ b/enterprise/cypher/physical-planning/NOTICE.txt
@@ -30,7 +30,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/cypher/physical-planning/pom.xml
+++ b/enterprise/cypher/physical-planning/pom.xml
@@ -175,10 +175,6 @@
       <groupId>org.parboiled</groupId>
       <artifactId>parboiled-scala_2.11</artifactId>
     </dependency>
-    <dependency>
-      <groupId>net.sf.opencsv</groupId>
-      <artifactId>opencsv</artifactId>
-    </dependency>
 
     <!-- code generation testing -->
 

--- a/enterprise/cypher/slotted-runtime/LICENSES.txt
+++ b/enterprise/cypher/slotted-runtime/LICENSES.txt
@@ -19,7 +19,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/cypher/slotted-runtime/NOTICE.txt
+++ b/enterprise/cypher/slotted-runtime/NOTICE.txt
@@ -35,7 +35,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/cypher/slotted-runtime/pom.xml
+++ b/enterprise/cypher/slotted-runtime/pom.xml
@@ -203,10 +203,6 @@
       <groupId>org.parboiled</groupId>
       <artifactId>parboiled-scala_2.11</artifactId>
     </dependency>
-    <dependency>
-      <groupId>net.sf.opencsv</groupId>
-      <artifactId>opencsv</artifactId>
-    </dependency>
 
     <!-- code generation testing -->
 

--- a/enterprise/neo4j-enterprise/LICENSES.txt
+++ b/enterprise/neo4j-enterprise/LICENSES.txt
@@ -35,7 +35,6 @@ Apache Software License, Version 2.0
   Metrics Core
   Netty
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/neo4j-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-enterprise/NOTICE.txt
@@ -51,7 +51,6 @@ Apache Software License, Version 2.0
   Metrics Core
   Netty
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/neo4j-harness-enterprise/LICENSES.txt
+++ b/enterprise/neo4j-harness-enterprise/LICENSES.txt
@@ -49,7 +49,6 @@ Apache Software License, Version 2.0
   Metrics Core
   Netty
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/neo4j-harness-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-harness-enterprise/NOTICE.txt
@@ -65,7 +65,6 @@ Apache Software License, Version 2.0
   Metrics Core
   Netty
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/server-enterprise/LICENSES.txt
+++ b/enterprise/server-enterprise/LICENSES.txt
@@ -49,7 +49,6 @@ Apache Software License, Version 2.0
   Metrics Core
   Netty
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/enterprise/server-enterprise/NOTICE.txt
+++ b/enterprise/server-enterprise/NOTICE.txt
@@ -65,7 +65,6 @@ Apache Software License, Version 2.0
   Metrics Core
   Netty
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/packaging/standalone/standalone-community/src/main/assemblies/community-unix-dist.xml
+++ b/packaging/standalone/standalone-community/src/main/assemblies/community-unix-dist.xml
@@ -111,7 +111,6 @@
         <include>org.scala-lang:*</include>
         <include>org.parboiled:*</include>
         <include>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</include>
-        <include>net.sf.opencsv:opencsv</include>
         <include>org.apache.commons:commons-lang3</include>
       </includes>
       <excludes>
@@ -132,7 +131,6 @@
         <exclude>org.scala-lang:*</exclude>
         <exclude>org.parboiled:*</exclude>
         <exclude>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</exclude>
-        <exclude>net.sf.opencsv:opencsv</exclude>
         <exclude>org.apache.commons:commons-lang3</exclude>
         <exclude>org.ow2.asm:*</exclude>
       </excludes>

--- a/packaging/standalone/standalone-community/src/main/assemblies/community-windows-dist.xml
+++ b/packaging/standalone/standalone-community/src/main/assemblies/community-windows-dist.xml
@@ -102,7 +102,6 @@
         <include>org.scala-lang:*</include>
         <include>org.parboiled:*</include>
         <include>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</include>
-        <include>net.sf.opencsv:opencsv</include>
         <include>org.apache.commons:commons-lang3</include>
       </includes>
       <excludes>
@@ -121,7 +120,6 @@
         <exclude>org.scala-lang:*</exclude>
         <exclude>org.parboiled:*</exclude>
         <exclude>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</exclude>
-        <exclude>net.sf.opencsv:opencsv</exclude>
         <exclude>org.apache.commons:commons-lang3</exclude>
         <exclude>org.ow2.asm:*</exclude>
       </excludes>

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/LICENSES.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/LICENSES.txt
@@ -36,7 +36,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
@@ -58,7 +58,6 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/pom.xml
+++ b/pom.xml
@@ -1287,11 +1287,6 @@
         <version>1.2.17</version>
       </dependency>
       <dependency>
-        <groupId>net.sf.opencsv</groupId>
-        <artifactId>opencsv</artifactId>
-        <version>2.3</version>
-      </dependency>
-      <dependency>
         <groupId>com.sun.jersey</groupId>
         <artifactId>jersey-client</artifactId>
         <version>${jersey.version}</version>

--- a/tools/LICENSES.txt
+++ b/tools/LICENSES.txt
@@ -24,7 +24,6 @@ Apache Software License, Version 2.0
   Lucene QueryParsers
   Netty
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End

--- a/tools/NOTICE.txt
+++ b/tools/NOTICE.txt
@@ -40,7 +40,6 @@ Apache Software License, Version 2.0
   Lucene QueryParsers
   Netty
   Netty/All-in-One
-  opencsv
   openCypher AST for the Cypher Query Language
   openCypher Expressions
   openCypher Front End


### PR DESCRIPTION
In issue https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/652, I [noted](https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/652#issuecomment-344015791) that APOC uses an outdated version of opencsv (2.3 from 2011), which comes transitively from the `org.neo4j:neo4j-cypher` package. It is important to note that while APOC actively uses opencsv, the codebase of Neo4j does not use it at all. In fact, opencsv [was](https://github.com/neo4j/neo4j/pull/3338/files#diff-db86b497e6d883e62b2ab9488807f421R114) [removed](https://github.com/neo4j/neo4j/pull/3338/files#diff-3afecc1349064e30f9a14a43bf9a9632L389) from Neo4j's Cypher module, but it was later added back as part of commit https://github.com/neo4j/neo4j/commit/2b6bb8b60dcf3576f2bd87e45531932243ce497a (maybe the author, @thobe knows why). However, currenty opencsv is not necessary for compilation and maybe its dependency can be removed from the build.

I created this PR as an experiment to see if it can be removed.

The `mvn package -DskipTests` Maven build runs without issues. I didn't manage to get a clean run with all tests as `ThreadSafeDataWriterTest` crashed on my laptop.

Of course, this change might have effects that ripple through the ecosystem -- for one, it will break the current APOC build, which does not have an explicit opencsv dependency. (Then we can add a [new opencsv lib](https://mvnrepository.com/artifact/com.opencsv/opencsv), which partially fixes the issue we've started with, https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/652).

Let me know what you think.

cc @jexp 