### PR TITLE
Mention Commons Clause with AGPLv3 in README note

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -12,7 +12,7 @@ Neo4j is available both as a standalone server, or an embeddable component. You 
 
 We encourage experimentation with Neo4j. You can build extensions to Neo4j, develop library or drivers atop the product, or make contributions directly to the product core. You'll need to sign a Contributor License Agreement in order for us to accept your patches.
 
-NOTE: This GitHub repository contains mixed GPL and AGPL code. Our Community edition (in the link:community/[community/] directory) is GPLv3. Our Enterprise edition (link:enterprise/[enterprise/]) is differently licensed under the AGPLv3.
+NOTE: This GitHub repository contains mixed GPL and AGPL code. Our Community edition (in the link:community/[community/] directory) is GPLv3. Our Enterprise edition (link:enterprise/[enterprise/]) is differently licensed under the AGPLv3 with the Commons Clause.
 
 == Dependencies ==
 


### PR DESCRIPTION
Tiny README patch to mention Commons Clause along with AGPLv3 the first time it comes up, in the note.  I copied the language from the Licensing section at the end of README which does mention Commons Clause.

I do _not_ mean to tell you what your license terms should be, or how to express them.  I was reading through README trying to figure out how the split between `community` and `enterprise` gets expressed in your terms, saw the Note, did a double take, and then scrolled down to the bottom.