### PR TITLE
Fixes for several LGTM alerts

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/runtime/Neo4jError.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/runtime/Neo4jError.java
@@ -152,13 +152,13 @@ public class Neo4jError
     {
         for ( Throwable cause = any; cause != null; cause = cause.getCause() )
         {
-            if ( cause instanceof Status.HasStatus )
-            {
-                return new Neo4jError( ((Status.HasStatus) cause).status(), any.getMessage(), any, isFatal );
-            }
             if ( cause instanceof DatabaseShutdownException )
             {
                 return new Neo4jError( Status.General.DatabaseUnavailable, cause, isFatal );
+            }
+            if ( cause instanceof Status.HasStatus )
+            {
+                return new Neo4jError( ((Status.HasStatus) cause).status(), any.getMessage(), any, isFatal );
             }
             if ( cause instanceof OutOfMemoryError )
             {

--- a/community/cypher/cypher-planner-3.5/src/main/java/org/neo4j/cypher/internal/compiler/v3_5/common/CypherOrderability.java
+++ b/community/cypher/cypher-planner-3.5/src/main/java/org/neo4j/cypher/internal/compiler/v3_5/common/CypherOrderability.java
@@ -121,7 +121,7 @@ public class CypherOrderability
         }
         else if ( rhs instanceof AnyValue )
         {
-            AnyValue lhsValue = (lhs instanceof AnyValue) ? (AnyValue) lhs : ValueUtils.of( lhs );
+            AnyValue lhsValue = ValueUtils.of( lhs );
             return AnyValues.COMPARATOR.compare( lhsValue, (AnyValue) rhs );
         }
         // Compare the types

--- a/community/dbms/src/main/java/org/neo4j/dbms/archive/Loader.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/archive/Loader.java
@@ -99,6 +99,12 @@ public class Loader
     private void loadEntry( Path destination, ArchiveInputStream stream, ArchiveEntry entry ) throws IOException
     {
         Path file = destination.resolve( entry.getName() );
+
+        if ( !file.normalize().startsWith( destination ) )
+        {
+            throw new IOException( "Zip entry outside destination path." );
+        }
+
         if ( entry.isDirectory() )
         {
             Files.createDirectories( file );

--- a/community/jmx/src/main/java/org/neo4j/jmx/impl/ThrottlingBeanSnapshotProxy.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/impl/ThrottlingBeanSnapshotProxy.java
@@ -96,7 +96,7 @@ class ThrottlingBeanSnapshotProxy implements InvocationHandler
         {
             return target;
         }
-        checkArgument( iface.isInterface(), "%s is not an interface" );
+        checkArgument( iface.isInterface(), "%s is not an interface", iface );
         requirePositive( updateInterval );
         final ThrottlingBeanSnapshotProxy proxy = new ThrottlingBeanSnapshotProxy( iface, target, updateInterval, clock );
         return iface.cast( newProxyInstance( iface.getClassLoader(), new Class[] {iface}, proxy ) );


### PR DESCRIPTION
Hi. I'm an [LGTM](https://lgtm.com/) developer, and had some time to fix a few alerts flagged in Neo4J by our analyses. Three are for things categorized as "error", one is for a possible security issue when loading from zip files.

There should be one commit per file, and the commit messages have links back to the original alerts to make it easy for you to check what each thing is about.

Let me know if this is helpful or not, what I can do better, or if there are any specific (types of) alerts you're interested in which I can look at in the future.