### PR TITLE
Avoid duplicate path tracking during dijkstra

### DIFF
--- a/community/community-it/algo-it/src/test/java/org/neo4j/graphalgo/shortestpath/DijkstraMultiplePathsTest.java
+++ b/community/community-it/algo-it/src/test/java/org/neo4j/graphalgo/shortestpath/DijkstraMultiplePathsTest.java
@@ -368,9 +368,7 @@ public class DijkstraMultiplePathsTest extends Neo4jAlgoTestCase
 
     /**
      * Should generate three paths. The three paths must have the prefix: a, b, and c. The three paths must have the sufix: f and g.
-     * <p>
      * All the edges have cost 0.
-     * <p>
      */
     @Test
     public void test9()

--- a/community/community-it/algo-it/src/test/java/org/neo4j/graphalgo/shortestpath/DijkstraMultiplePathsTest.java
+++ b/community/community-it/algo-it/src/test/java/org/neo4j/graphalgo/shortestpath/DijkstraMultiplePathsTest.java
@@ -365,4 +365,59 @@ public class DijkstraMultiplePathsTest extends Neo4jAlgoTestCase
         assertTrue( pathBD2 );
         assertTrue( pathB2D2 );
     }
+
+    /**
+     * Should generate three paths. The three paths must have the prefix: a, b, and c. The three paths must have the sufix: f and g.
+     * <p>
+     * All the edges have cost 0.
+     * <p>
+     */
+    @Test
+    public void test9()
+    {
+        graph.makeEdge( "a", "b", "cost", (double) 0 );
+        graph.makeEdge( "b", "c", "cost", (double) 0 );
+        graph.makeEdge( "c", "d", "cost", (double) 0 );
+        graph.makeEdge( "d", "e", "cost", (double) 0 );
+        graph.makeEdge( "e", "f", "cost", (double) 0 );
+        graph.makeEdge( "f", "g", "cost", (double) 0 );
+
+        graph.makeEdge( "d", "j", "cost", (double) 0 );
+        graph.makeEdge( "j", "k", "cost", (double) 0 );
+        graph.makeEdge( "k", "f", "cost", (double) 0 );
+
+        graph.makeEdge( "c", "h", "cost", (double) 0 );
+        graph.makeEdge( "h", "i", "cost", (double) 0 );
+        graph.makeEdge( "i", "e", "cost", (double) 0 );
+
+        Dijkstra<Double> dijkstra =
+                new Dijkstra<>( 0.0, graph.getNode( "a" ), graph.getNode( "g" ), ( relationship, direction ) -> .0,
+                                new DoubleAdder(), Double::compareTo, Direction.OUTGOING, MyRelTypes.R1 );
+
+        List<List<Node>> paths = dijkstra.getPathsAsNodes();
+
+        assertEquals( paths.size(), 3 );
+        String[] commonPrefix = {"a", "b", "c"};
+        String[] commonSuffix = {"f", "g"};
+        for ( List<Node> path : paths )
+        {
+            /**
+             * Check if the prefixes are all correct.
+             */
+            for ( int j = 0; j < commonPrefix.length; j++ )
+            {
+                assertEquals( path.get( j ), graph.getNode( commonPrefix[j] ) );
+            }
+
+            int pathSize = path.size();
+
+            /**
+             * Check if the suffixes are all correct.
+             */
+            for ( int j = 0; j < commonSuffix.length; j++ )
+            {
+                assertEquals( path.get( pathSize - j - 1 ), graph.getNode( commonSuffix[commonSuffix.length - j - 1] ) );
+            }
+        }
+    }
 }

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/Dijkstra.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/Dijkstra.java
@@ -333,6 +333,10 @@ public class Dijkstra<CostType> implements
                             ++numberOfTraversedRelationShips;
                             // Target node
                             Node target = relationship.getOtherNode( currentNode );
+                            if ( otherDistances.containsKey( target ) )
+                            {
+                                continue;
+                            }
                             // Find out if an eventual path would go in the opposite
                             // direction of the edge
                             boolean backwardsEdge = relationship.getEndNode().equals( currentNode ) ^ backwards;
@@ -558,9 +562,8 @@ public class Dijkstra<CostType> implements
         {
             return Collections.emptyList();
         }
-        // Currently we use a set to avoid duplicate paths
-        // TODO: can this be done smarter?
-        Set<List<PropertyContainer>> paths = new HashSet<>();
+
+        List<List<PropertyContainer>> paths = new LinkedList<>();
         for ( Node middleNode : foundPathsMiddleNodes )
         {
             List<List<PropertyContainer>> paths1 = Util.constructAllPathsToNode(
@@ -581,7 +584,8 @@ public class Dijkstra<CostType> implements
                 }
             }
         }
-        return new LinkedList<>( paths );
+
+        return paths;
     }
 
     /**
@@ -599,9 +603,8 @@ public class Dijkstra<CostType> implements
         {
             return null;
         }
-        // Currently we use a set to avoid duplicate paths
-        // TODO: can this be done smarter?
-        Set<List<Node>> paths = new HashSet<>();
+
+        List<List<Node>> paths = new LinkedList<>();
         for ( Node middleNode : foundPathsMiddleNodes )
         {
             List<List<Node>> paths1 = Util.constructAllPathsToNodeAsNodes(
@@ -622,7 +625,8 @@ public class Dijkstra<CostType> implements
                 }
             }
         }
-        return new LinkedList<>( paths );
+
+        return paths;
     }
 
     /**
@@ -640,9 +644,8 @@ public class Dijkstra<CostType> implements
         {
             return null;
         }
-        // Currently we use a set to avoid duplicate paths
-        // TODO: can this be done smarter?
-        Set<List<Relationship>> paths = new HashSet<>();
+
+        List<List<Relationship>> paths = new LinkedList<>();
         for ( Node middleNode : foundPathsMiddleNodes )
         {
             List<List<Relationship>> paths1 = Util.constructAllPathsToNodeAsRelationships(
@@ -663,7 +666,8 @@ public class Dijkstra<CostType> implements
                 }
             }
         }
-        return new LinkedList<>( paths );
+
+        return paths;
     }
 
     /**


### PR DESCRIPTION
It is not needed to use a Set to eliminate duplicated paths. The only reason why the code was computing duplicated paths is that the Dijkstra's algorithm implementation was finding the entire path in the normal direction and backwards. This issue is solved by this pull request. 
Solution: 
If a DijkstraIterator D1 has already computed the final distance to a node V, then the other DijkstraIterator D2 must not put V in his queue, because if D2 puts V in his queue, D2 will end up computing the entire path again.

My change to the code does not change the overall time or space complexity of the Dijkstra's algorithm itself, but my pull request improves the time complexity of the computation of the paths found by the Dijkstra's algorithm since the use of a Set is not needed anymore.