### PR TITLE
Add folding analyzer

### DIFF
--- a/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/analyzer/providers/StandardFolding.java
+++ b/community/fulltext-index/src/main/java/org/neo4j/kernel/api/impl/fulltext/analyzer/providers/StandardFolding.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.fulltext.analyzer.providers;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.neo4j.graphdb.index.fulltext.AnalyzerProvider;
+import org.neo4j.helpers.Service;
+import org.neo4j.index.impl.lucene.explicit.StandardFoldingAnalyzer;
+
+@Service.Implementation( AnalyzerProvider.class )
+public class StandardFolding extends AnalyzerProvider
+{
+    public static final String STANDARD_FOLDING_ANALYZER_NAME = "standard-folding";
+
+    public StandardFolding()
+    {
+        super( STANDARD_FOLDING_ANALYZER_NAME );
+    }
+
+    @Override
+    public Analyzer createAnalyzer()
+    {
+        return new StandardFoldingAnalyzer();
+    }
+
+    @Override
+    public String description()
+    {
+        return "Analyzer that uses ASCIIFoldingFilter to remove accents (diacritics). Otherwise behaves as standard " +
+                "english analyzer.";
+    }
+}

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/StandardFoldingAnalyzer.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/StandardFoldingAnalyzer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index.impl.lucene.explicit;
+
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.core.LowerCaseFilter;
+import org.apache.lucene.analysis.core.StopAnalyzer;
+import org.apache.lucene.analysis.core.StopFilter;
+import org.apache.lucene.analysis.miscellaneous.ASCIIFoldingFilter;
+import org.apache.lucene.analysis.standard.StandardFilter;
+import org.apache.lucene.analysis.standard.StandardTokenizer;
+import org.apache.lucene.analysis.util.StopwordAnalyzerBase;
+
+/**
+ * Analyzer that uses ASCIIFoldingFilter to remove accents (diacritics).
+ * Otherwise behaves as standard english analyzer.
+ *
+ * Implementation inspired by org.apache.lucene.analysis.standard.StandardAnalyzer
+ */
+public final class StandardFoldingAnalyzer extends StopwordAnalyzerBase
+{
+
+    /** Default maximum allowed token length */
+    public static final int DEFAULT_MAX_TOKEN_LENGTH = 255;
+
+    public StandardFoldingAnalyzer()
+    {
+        super( StopAnalyzer.ENGLISH_STOP_WORDS_SET );
+    }
+
+    @Override
+    protected TokenStreamComponents createComponents( String fieldName )
+    {
+        StandardTokenizer src = new StandardTokenizer();
+        src.setMaxTokenLength( DEFAULT_MAX_TOKEN_LENGTH );
+        TokenStream tok = new StandardFilter( src );
+        tok = new LowerCaseFilter( tok );
+        tok = new StopFilter( tok, stopwords );
+        tok = new ASCIIFoldingFilter( tok );
+        return new TokenStreamComponents( src, tok );
+    }
+
+    @Override
+    public String toString()
+    {
+        return getClass().getSimpleName();
+    }
+}


### PR DESCRIPTION
In accented languages it is common that users expect keywords
without diacritics to match text with diacritics and vice versa.

For more background see https://graphaware.com/neo4j/2019/09/06/custom-fulltext-analyzer.html

Lucene implements ASCIIFoldingFilter and ICUFoldingFilter for this
task. The latter works better on various unicode characters.
The ASCIIFoldingFilter is already on Neo4j classpath, while
ICUFoldingFilter is in another package (analyzers-icu), hence the
choice.
