### PR TITLE
Fix format string typo (%s instead of $s)

### DIFF
--- a/community/push-to-cloud/src/main/java/org/neo4j/pushtocloud/HttpCopier.java
+++ b/community/push-to-cloud/src/main/java/org/neo4j/pushtocloud/HttpCopier.java
@@ -628,7 +628,7 @@ public class HttpCopier implements PushToCloudCommand.Copier
         debugErrorResponse( true, connection );
         return new CommandFailed( "We encountered a problem while communicating to the Neo4j cloud system. \n" +
                 "You can re-try using the existing dump by running this command: \n" +
-                String.format( "neo4j-admin push-to-cloud --%s=%s --$s=%s", ARG_DUMP, dump.toFile().getAbsolutePath(), ARG_BOLT_URI, boltUri ) );
+                String.format( "neo4j-admin push-to-cloud --%s=%s --%s=%s", ARG_DUMP, dump.toFile().getAbsolutePath(), ARG_BOLT_URI, boltUri ) );
     }
 
     private CommandFailed updatePluginErrorResponse( HttpURLConnection connection ) throws IOException


### PR DESCRIPTION
* replaced $s in format string with %s to get it properly substituted with the passed in parameter
* fix is based on [LGTM finding](https://lgtm.com/projects/g/neo4j/neo4j/snapshot/316d6a2af7a44a155f6b0140cf26156349a09f6b/files/community/push-to-cloud/src/main/java/org/neo4j/pushtocloud/HttpCopier.java?sort=name&dir=ASC&mode=heatmap#x4451d85cbcbeee18:1)