### PR TITLE
Remove unused dependency

### DIFF
--- a/community/collections/pom.xml
+++ b/community/collections/pom.xml
@@ -73,11 +73,6 @@ the relevant Commercial Agreement.
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.neo4j</groupId>
-            <artifactId>neo4j-unsafe</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections</artifactId>
         </dependency>


### PR DESCRIPTION
Hello. I noticed that dependency `neo4j-unsafe` in `neo4j-collections` is not used. Hence, it can be safely removed to make the `pom` clearer :) 

