### PR TITLE
3.5: Pin urls to 3.5 documentation

### DIFF
--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
@@ -113,7 +113,7 @@ public class ImportCommand implements AdminCommand
                     "  INTEGER: arbitrary integer values for identifying nodes,\n" +
                     "  ACTUAL: (advanced) actual node ids.\n" +
                     "For more information on id handling, please see the Neo4j Manual: " +
-                    "https://neo4j.com/docs/operations-manual/current/tools/import/" ) )
+                    "https://neo4j.com/docs/operations-manual/3.5/tools/import/" ) )
             .withArgument( new OptionalNamedArg( "input-encoding", "character-set", "UTF-8",
                     "Character set that input data is encoded in." ) )
             .withArgument( new OptionalBooleanArg( "ignore-extra-columns", false,

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
@@ -287,7 +287,7 @@ class ImportCommandTest
                             "        INTEGER: arbitrary integer values for identifying nodes,%n" +
                             "        ACTUAL: (advanced) actual node ids.%n" +
                             "      For more information on id handling, please see the Neo4j Manual:%n" +
-                            "      https://neo4j.com/docs/operations-manual/current/tools/import/%n" +
+                            "      https://neo4j.com/docs/operations-manual/3.5/tools/import/%n" +
                             "      [default:STRING]%n" +
                             "  --input-encoding=<character-set>%n" +
                             "      Character set that input data is encoded in. [default:UTF-8]%n" +

--- a/community/kernel/src/main/java/org/neo4j/kernel/DeadlockDetectedException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/DeadlockDetectedException.java
@@ -41,7 +41,7 @@ public class DeadlockDetectedException extends TransientTransactionFailureExcept
                 "between these transactions. This exception was thrown instead of ending up in that deadlock.\n" +
                 "\n" +
                 "See the deadlock section in the Neo4j Java developer reference for how to avoid this: " +
-                "https://neo4j.com/docs/java-reference/current/#transactions-deadlocks\n" +
+                "https://neo4j.com/docs/java-reference/3.5/#transactions-deadlocks\n" +
                 "\n" +
                 "Details: '" + message + "'.", cause );
     }

--- a/community/udc/readme.md
+++ b/community/udc/readme.md
@@ -5,4 +5,4 @@ The Usage Data Collector (UDC) is a kernel extension which collects
 statistics about a Neo4j Server.
 
 For details, please see:
-https://neo4j.com/docs/operations-manual/current/configuration/usage-data-collector/
+https://neo4j.com/docs/operations-manual/3.5/configuration/usage-data-collector/

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/README.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/README.txt
@@ -24,7 +24,7 @@ Here in the installation directory, you'll find:
 Make it go
 ----------
 
-For full instructions, see https://neo4j.com/docs/operations-manual/current/installation/
+For full instructions, see https://neo4j.com/docs/operations-manual/3.5/installation/
 
 To get started with Neo4j, let's start the server and take a
 look at the web interface ...
@@ -43,7 +43,7 @@ Learn more
 ----------
 
 * Neo4j Home: https://neo4j.com/
-* Getting Started: https://neo4j.com/docs/developer-manual/current/introduction/
+* Getting Started: https://neo4j.com/docs/developer-manual/3.5/introduction/
 * Neo4j Documentation: https://neo4j.com/docs/
 
 License(s)

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/UPGRADE.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/UPGRADE.txt
@@ -1,1 +1,1 @@
-For upgrade instructions, please see https://neo4j.com/docs/operations-manual/current/upgrade/.
+For upgrade instructions, please see https://neo4j.com/docs/operations-manual/3.5/upgrade/.

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
@@ -2,7 +2,7 @@
 # Neo4j configuration
 #
 # For more details and a complete list of settings, please see
-# https://neo4j.com/docs/operations-manual/current/reference/configuration-settings/
+# https://neo4j.com/docs/operations-manual/3.5/reference/configuration-settings/
 #*****************************************************************
 
 # The name of the database to mount

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/plugins/README.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/plugins/README.txt
@@ -2,7 +2,7 @@ Neo4j Extensions
 ================
 
 Neo4j can be extended by writing custom code which can be invoked directly from Cypher,
-as described in the developer manual at https://neo4j.com/docs/developer-manual/current/extending-neo4j/
+as described in the developer manual at https://neo4j.com/docs/developer-manual/3.5/extending-neo4j/
 
 These extensions are user defined procedures, user defined functions or security plugins. They are written in Java
 and compiled into jar files. They can be deployed to the database by dropping a JAR file into the $NEO4J_HOME/plugins
@@ -18,7 +18,7 @@ or user defined functions:
 * dbms.security.procedures.whitelist
 
 These are described in more detail in the documentation at
-https://neo4j.com/docs/operations-manual/current/security/securing-extensions/
+https://neo4j.com/docs/operations-manual/3.5/security/securing-extensions/
 
 Sandboxing
 ----------


### PR DESCRIPTION
Error messages from Neo4J 3.5 shouldn't point to the current operations manual as that's the operations manual for 4.0...