### PR TITLE
Add jmxremote.host to JMX configurations

### DIFF
--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
@@ -291,6 +291,7 @@ dbms.jvm.additional=-Dio.netty.tryReflectionSetAccessible=true
 # and have permissions set to 0600.
 # For details on setting these file permissions on Windows see:
 #     http://docs.oracle.com/javase/8/docs/technotes/guides/management/security-windows.html
+#dbms.jvm.additional=-Dcom.sun.management.jmxremote.host=$THE_NEO4J_SERVER_IP
 #dbms.jvm.additional=-Dcom.sun.management.jmxremote.port=3637
 #dbms.jvm.additional=-Dcom.sun.management.jmxremote.authenticate=true
 #dbms.jvm.additional=-Dcom.sun.management.jmxremote.ssl=false


### PR DESCRIPTION
With Java 11 we can bind JMX to a particular interface for security reasons.