### PR TITLE
Remove duplicate version in maven submodules

### DIFF
--- a/community/batch-insert/pom.xml
+++ b/community/batch-insert/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-batch-insert</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Legacy Batch Inserter</name>

--- a/community/codegen/pom.xml
+++ b/community/codegen/pom.xml
@@ -16,7 +16,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-codegen</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Code Generator</name>

--- a/community/collections/pom.xml
+++ b/community/collections/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-collections</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Collections</name>

--- a/community/command-line/pom.xml
+++ b/community/command-line/pom.xml
@@ -11,7 +11,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-command-line</artifactId>
     <name>Neo4j - Command Line</name>
-    <version>4.0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/community/common/pom.xml
+++ b/community/common/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-common</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Common</name>

--- a/community/community-it/algo-it/pom.xml
+++ b/community/community-it/algo-it/pom.xml
@@ -11,7 +11,6 @@
 
     <groupId>org.neo4j.community</groupId>
     <artifactId>algo-it</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <name>Neo4j - Community Graph Algorithms Integration Tests</name>
     <packaging>jar</packaging>

--- a/community/community-it/batch-insert-it/pom.xml
+++ b/community/community-it/batch-insert-it/pom.xml
@@ -10,7 +10,6 @@
 
     <groupId>org.neo4j.community</groupId>
     <artifactId>batch-insert-it</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <name>Neo4j - Legacy Batch Inserter Integration Tests</name>
     <packaging>jar</packaging>

--- a/community/community-it/bolt-it/pom.xml
+++ b/community/community-it/bolt-it/pom.xml
@@ -11,7 +11,6 @@
 
     <groupId>org.neo4j.community</groupId>
     <artifactId>bolt-it</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <name>Neo4j - Community Bolt Integration Tests</name>
     <packaging>jar</packaging>

--- a/community/community-it/community-it/pom.xml
+++ b/community/community-it/community-it/pom.xml
@@ -11,7 +11,6 @@
 
     <groupId>org.neo4j.community</groupId>
     <artifactId>community-it</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <name>Neo4j - Community Generic Integration Tests</name>
     <packaging>jar</packaging>

--- a/community/community-it/consistency-it/pom.xml
+++ b/community/community-it/consistency-it/pom.xml
@@ -11,7 +11,6 @@
 
     <groupId>org.neo4j.community</groupId>
     <artifactId>consistency-it</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <name>Neo4j - Community Consistency Checker Integration Tests</name>
     <packaging>jar</packaging>

--- a/community/community-it/cypher-it/pom.xml
+++ b/community/community-it/cypher-it/pom.xml
@@ -11,7 +11,6 @@
 
     <groupId>org.neo4j.community</groupId>
     <artifactId>cypher-it</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <name>Neo4j - Community Cypher Integration Tests</name>
     <packaging>jar</packaging>

--- a/community/community-it/dbms-it/pom.xml
+++ b/community/community-it/dbms-it/pom.xml
@@ -11,7 +11,6 @@
 
     <groupId>org.neo4j.community</groupId>
     <artifactId>dbms-it</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <name>Neo4j - Community DBMS Integration Tests</name>
     <packaging>jar</packaging>

--- a/community/community-it/import-it/pom.xml
+++ b/community/community-it/import-it/pom.xml
@@ -11,7 +11,6 @@
 
     <groupId>org.neo4j.community</groupId>
     <artifactId>import-it</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <name>Neo4j - Community Import Integration Tests</name>
     <packaging>jar</packaging>

--- a/community/community-it/index-it/pom.xml
+++ b/community/community-it/index-it/pom.xml
@@ -11,7 +11,6 @@
 
     <groupId>org.neo4j.community</groupId>
     <artifactId>index-it</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <name>Neo4j - Community Index Integration Tests</name>
     <packaging>jar</packaging>

--- a/community/community-it/it-test-support/pom.xml
+++ b/community/community-it/it-test-support/pom.xml
@@ -10,7 +10,6 @@
 
     <groupId>org.neo4j.community</groupId>
     <artifactId>it-test-support</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <name>Neo4j - Community Integration Test Support</name>
     <packaging>jar</packaging>

--- a/community/community-it/kernel-it/pom.xml
+++ b/community/community-it/kernel-it/pom.xml
@@ -10,7 +10,6 @@
 
     <groupId>org.neo4j.community</groupId>
     <artifactId>kernel-it</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <name>Neo4j - Community Kernel Integration Tests</name>
     <packaging>jar</packaging>

--- a/community/community-it/pom.xml
+++ b/community/community-it/pom.xml
@@ -10,7 +10,6 @@
     </parent>
 
     <artifactId>community-integration-tests</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Neo4j - Community Integration Tests</name>

--- a/community/community-it/record-storage-engine-it/pom.xml
+++ b/community/community-it/record-storage-engine-it/pom.xml
@@ -10,7 +10,6 @@
 
     <groupId>org.neo4j.community</groupId>
     <artifactId>record-storage-engine-it</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <name>Neo4j - Record Storage Engine Integration Tests</name>
     <packaging>jar</packaging>

--- a/community/concurrent/pom.xml
+++ b/community/concurrent/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-concurrent</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Concurrent</name>

--- a/community/configuration/pom.xml
+++ b/community/configuration/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-configuration</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Configuration</name>

--- a/community/consistency-check/pom.xml
+++ b/community/consistency-check/pom.xml
@@ -8,7 +8,6 @@
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>neo4j-consistency-check</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <name>Neo4j - Consistency Checker</name>
     <description>Tool for checking consistency of a Neo4j data store.</description>

--- a/community/csv/pom.xml
+++ b/community/csv/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-csv</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - CSV reading and parsing</name>

--- a/community/cypher/acceptance-spec-suite/pom.xml
+++ b/community/cypher/acceptance-spec-suite/pom.xml
@@ -13,7 +13,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-cypher-acceptance-spec-suite</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.3-SNAPSHOT</version>
     <name>Neo4j - Cypher Acceptance</name>
     <description>Neo4j - Cypher Acceptance Specification Suite</description>
     <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/community/cypher/compatibility-spec-suite/pom.xml
+++ b/community/cypher/compatibility-spec-suite/pom.xml
@@ -13,7 +13,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-cypher-compatibility-spec-suite</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.3-SNAPSHOT</version>
     <name>Neo4j - Cypher Compatibility Specification Suite</name>
     <description>Neo4j query language compatibility suite</description>
     <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/community/cypher/cypher-logical-plans/pom.xml
+++ b/community/cypher/cypher-logical-plans/pom.xml
@@ -11,7 +11,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-cypher-logical-plans</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.3-SNAPSHOT</version>
     <name>Neo4j - Cypher Logical Plans</name>
 
     <description>Cypher logical plans</description>

--- a/community/cypher/cypher-planner/pom.xml
+++ b/community/cypher/cypher-planner/pom.xml
@@ -11,7 +11,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-cypher-planner</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.3-SNAPSHOT</version>
     <name>Neo4j - Cypher Planner</name>
     <description>Planner for Cypher</description>
     <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/community/cypher/cypher/pom.xml
+++ b/community/cypher/cypher/pom.xml
@@ -11,7 +11,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-cypher</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.3-SNAPSHOT</version>
     <name>Neo4j - Cypher</name>
     <description>Neo4j query language</description>
     <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/community/cypher/expression-evaluator/pom.xml
+++ b/community/cypher/expression-evaluator/pom.xml
@@ -11,7 +11,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-cypher-expression-evaluator</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.3-SNAPSHOT</version>
     <name>Neo4j - Cypher Expression Evaluator</name>
 
     <description>Cypher Expression Evaluator</description>

--- a/community/cypher/front-end/ast/pom.xml
+++ b/community/cypher/front-end/ast/pom.xml
@@ -11,7 +11,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-ast-4.0</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.3-SNAPSHOT</version>
     <name>openCypher AST for the Cypher Query Language</name>
 
     <description>Abstract Syntax Tree and semantic analysis for the Cypher query language</description>

--- a/community/cypher/front-end/expressions/pom.xml
+++ b/community/cypher/front-end/expressions/pom.xml
@@ -11,7 +11,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-expressions-4.0</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.3-SNAPSHOT</version>
     <name>openCypher Expressions</name>
 
     <description>Cypher expressions</description>

--- a/community/cypher/front-end/frontend/pom.xml
+++ b/community/cypher/front-end/frontend/pom.xml
@@ -11,7 +11,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-front-end-4.0</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.3-SNAPSHOT</version>
     <name>openCypher Front End</name>
 
     <description>

--- a/community/cypher/front-end/parser/pom.xml
+++ b/community/cypher/front-end/parser/pom.xml
@@ -11,7 +11,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-parser-4.0</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.3-SNAPSHOT</version>
     <name>openCypher Parser</name>
 
     <description>Cypher parser</description>

--- a/community/cypher/front-end/pom.xml
+++ b/community/cypher/front-end/pom.xml
@@ -11,7 +11,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>neo4j-front-end-parent-4.0</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>openCypher Front End Parent</name>
     <description>Project that builds the openCypher front end modules</description>

--- a/community/cypher/front-end/rewriting/pom.xml
+++ b/community/cypher/front-end/rewriting/pom.xml
@@ -11,7 +11,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-rewriting-4.0</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.3-SNAPSHOT</version>
     <name>openCypher Rewriting</name>
 
     <description>Tree rewriting support, and AST rewriters for the Cypher query language</description>

--- a/community/cypher/front-end/util/pom.xml
+++ b/community/cypher/front-end/util/pom.xml
@@ -11,7 +11,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-util-4.0</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.3-SNAPSHOT</version>
     <name>openCypher Utils</name>
 
     <description>Cypher utilities</description>

--- a/community/cypher/interpreted-runtime/pom.xml
+++ b/community/cypher/interpreted-runtime/pom.xml
@@ -11,7 +11,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-cypher-interpreted-runtime</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.3-SNAPSHOT</version>
     <name>Neo4j - Cypher Interpreted Runtime</name>
 
     <description>The traditional cypher interpreted runtime</description>

--- a/community/cypher/ir/pom.xml
+++ b/community/cypher/ir/pom.xml
@@ -11,7 +11,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-cypher-ir</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.3-SNAPSHOT</version>
     <name>Neo4j - Cypher Intermediate Representation</name>
 
     <description>The intermediate representations, such as the query graph</description>

--- a/community/cypher/logical-query-builder/pom.xml
+++ b/community/cypher/logical-query-builder/pom.xml
@@ -13,7 +13,6 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>neo4j-cypher-logical-query-builder</artifactId>
   <packaging>jar</packaging>
-  <version>4.0.3-SNAPSHOT</version>
   <name>Neo4j - Cypher logical query builder</name>
   <description>Neo4j - Cypher logical query builder</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/community/cypher/planner-spi/pom.xml
+++ b/community/cypher/planner-spi/pom.xml
@@ -11,7 +11,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-cypher-planner-spi</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.3-SNAPSHOT</version>
     <name>Neo4j - Cypher Planner SPI</name>
 
     <description>Cypher planner SPI</description>

--- a/community/cypher/pom.xml
+++ b/community/cypher/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>cypher-parent</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Neo4j - Community Cypher Build</name>
     <description>Project that builds the Neo4j Cypher modules as part of the Community distribution.</description>

--- a/community/cypher/runtime-spec-suite/pom.xml
+++ b/community/cypher/runtime-spec-suite/pom.xml
@@ -13,7 +13,6 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>neo4j-cypher-runtime-spec-suite</artifactId>
   <packaging>jar</packaging>
-  <version>4.0.3-SNAPSHOT</version>
   <name>Neo4j - Cypher Runtime Acceptance</name>
   <description>Neo4j - Cypher Runtime Specification Suite</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/community/cypher/runtime-util/pom.xml
+++ b/community/cypher/runtime-util/pom.xml
@@ -11,7 +11,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-cypher-runtime-util</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.3-SNAPSHOT</version>
     <name>Neo4j - Cypher Runtime Utilities</name>
 
     <description>Cypher runtime utilities</description>

--- a/community/cypher/spec-suite-tools/pom.xml
+++ b/community/cypher/spec-suite-tools/pom.xml
@@ -13,7 +13,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-cypher-spec-suite-tools</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.3-SNAPSHOT</version>
     <name>Neo4j - Cypher Specification Suite Tools</name>
     <description>Neo4j query language test suite tools</description>
     <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/community/data-collector/pom.xml
+++ b/community/data-collector/pom.xml
@@ -16,7 +16,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-data-collector</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Data Collector</name>

--- a/community/dbms/pom.xml
+++ b/community/dbms/pom.xml
@@ -10,7 +10,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-dbms</artifactId>
     <name>Neo4j - Database Management System</name>
-    <version>4.0.3-SNAPSHOT</version>
 
     <properties>
         <license-text.header>headers/GPL-3-header.txt</license-text.header>

--- a/community/diagnostics/pom.xml
+++ b/community/diagnostics/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-diagnostics</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Diagnostics</name>

--- a/community/fulltext-index/pom.xml
+++ b/community/fulltext-index/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>neo4j-fulltext-index</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <name>Neo4j - Fulltext index</name>
     <description>Fulltext index for neo4j</description>

--- a/community/graph-algo/pom.xml
+++ b/community/graph-algo/pom.xml
@@ -20,7 +20,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-graph-algo</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Graph Algorithms</name>

--- a/community/graphdb-api/pom.xml
+++ b/community/graphdb-api/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-graphdb-api</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Graph Database API</name>

--- a/community/id-generator/pom.xml
+++ b/community/id-generator/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-id-generator</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - ID Generator</name>

--- a/community/import-tool/pom.xml
+++ b/community/import-tool/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-import-tool</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Import Command Line Tool</name>

--- a/community/import-util/pom.xml
+++ b/community/import-util/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-import-util</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Common</name>

--- a/community/io/pom.xml
+++ b/community/io/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-io</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - IO</name>

--- a/community/kernel-api/pom.xml
+++ b/community/kernel-api/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-kernel-api</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Kernel API</name>

--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -10,7 +10,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-kernel</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <name>Neo4j - Graph Database Kernel</name>
     <description>

--- a/community/label-index/pom.xml
+++ b/community/label-index/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-label-index</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Label index</name>

--- a/community/layout/pom.xml
+++ b/community/layout/pom.xml
@@ -9,7 +9,6 @@
         <relativePath>../..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <version>4.0.3-SNAPSHOT</version>
     <artifactId>neo4j-layout</artifactId>
 
     <properties>

--- a/community/lock/pom.xml
+++ b/community/lock/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-lock</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Locking</name>

--- a/community/logging/pom.xml
+++ b/community/logging/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-logging</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Logging</name>

--- a/community/lucene-index/pom.xml
+++ b/community/lucene-index/pom.xml
@@ -8,7 +8,6 @@
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>neo4j-lucene-index</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <name>Neo4j - Lucene Index</name>
     <description>

--- a/community/monitoring/pom.xml
+++ b/community/monitoring/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-monitoring</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Monitoring</name>

--- a/community/native/pom.xml
+++ b/community/native/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-native</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Native</name>

--- a/community/neo4j-community/pom.xml
+++ b/community/neo4j-community/pom.xml
@@ -10,7 +10,6 @@
     </parent>
 
     <artifactId>neo4j-community</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <name>Neo4j - Community (Bill of Materials)</name>
     <packaging>pom</packaging>

--- a/community/neo4j-exceptions/pom.xml
+++ b/community/neo4j-exceptions/pom.xml
@@ -12,7 +12,6 @@
 
     <artifactId>neo4j-exceptions</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.3-SNAPSHOT</version>
     <name>Neo4j - Exceptions</name>
 
     <description>Neo4j exceptions</description>

--- a/community/neo4j-slf4j/pom.xml
+++ b/community/neo4j-slf4j/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-slf4j</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - SLF4J Neo4j Binding</name>

--- a/community/neo4j/pom.xml
+++ b/community/neo4j/pom.xml
@@ -10,7 +10,6 @@
     </parent>
 
     <artifactId>neo4j</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <name>Neo4j - Community</name>
     <packaging>jar</packaging>

--- a/community/pom.xml
+++ b/community/pom.xml
@@ -11,7 +11,6 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.neo4j.build</groupId>
   <artifactId>community-build</artifactId>
-  <version>4.0.3-SNAPSHOT</version>
 
   <name>Neo4j - Community Build</name>
   <packaging>pom</packaging>

--- a/community/procedure-api/pom.xml
+++ b/community/procedure-api/pom.xml
@@ -16,7 +16,6 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>neo4j-procedure-api</artifactId>
-  <version>4.0.3-SNAPSHOT</version>
 
   <packaging>jar</packaging>
   <name>Neo4j - Procedure API</name>

--- a/community/procedure-compiler/pom.xml
+++ b/community/procedure-compiler/pom.xml
@@ -14,7 +14,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>procedure-compiler-parent</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Neo4j - Procedure Compiler Parent POM</name>

--- a/community/procedure/pom.xml
+++ b/community/procedure/pom.xml
@@ -16,7 +16,6 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>neo4j-procedure</artifactId>
-  <version>4.0.3-SNAPSHOT</version>
 
   <packaging>jar</packaging>
   <name>Neo4j - Community Procedures</name>

--- a/community/random-values/pom.xml
+++ b/community/random-values/pom.xml
@@ -16,7 +16,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-random-values</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Random Value</name>

--- a/community/record-storage-engine/pom.xml
+++ b/community/record-storage-engine/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-record-storage-engine</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Record storage engine</name>

--- a/community/resource/pom.xml
+++ b/community/resource/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-resource</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Resource interface</name>

--- a/community/schema/pom.xml
+++ b/community/schema/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-schema</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Schema</name>

--- a/community/security/pom.xml
+++ b/community/security/pom.xml
@@ -16,7 +16,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-security</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Security</name>

--- a/community/server-api/pom.xml
+++ b/community/server-api/pom.xml
@@ -10,7 +10,6 @@
     </parent>
 
     <artifactId>server-api</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Server API</name>

--- a/community/server/pom.xml
+++ b/community/server/pom.xml
@@ -11,7 +11,6 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.neo4j.app</groupId>
     <artifactId>neo4j-server</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
     <name>Neo4j - Server</name>
     <description>Standalone Neo4j server application.</description>
     <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/community/spatial-index/pom.xml
+++ b/community/spatial-index/pom.xml
@@ -16,7 +16,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-spatial-index</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Native Spatial Index</name>

--- a/community/ssl/pom.xml
+++ b/community/ssl/pom.xml
@@ -16,7 +16,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-ssl</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - SSL</name>

--- a/community/storage-engine-api/pom.xml
+++ b/community/storage-engine-api/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-storage-engine-api</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Storage Engine API</name>

--- a/community/testing/import-utils/pom.xml
+++ b/community/testing/import-utils/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>import-test-utils</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/community/testing/io-utils/pom.xml
+++ b/community/testing/io-utils/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>io-test-utils</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/community/testing/kernel-api-utils/pom.xml
+++ b/community/testing/kernel-api-utils/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>kernel-api-test-utils</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/community/testing/layout-test-utils/pom.xml
+++ b/community/testing/layout-test-utils/pom.xml
@@ -10,7 +10,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>layout-test-utils</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <license-text.header>headers/GPL-3-header.txt</license-text.header>

--- a/community/testing/log-utils/pom.xml
+++ b/community/testing/log-utils/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>log-test-utils</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/community/testing/pom.xml
+++ b/community/testing/pom.xml
@@ -31,7 +31,6 @@
 
     <name>Neo4j - Testing Utils Parent</name>
     <artifactId>testing-parent</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/community/testing/storage-engine-utils/pom.xml
+++ b/community/testing/storage-engine-utils/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>storage-engine-test-utils</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/community/testing/test-utils/pom.xml
+++ b/community/testing/test-utils/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>test-utils</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/community/testing/wal-utils/pom.xml
+++ b/community/testing/wal-utils/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>wal-test-utils</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/community/token-api/pom.xml
+++ b/community/token-api/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-token-api</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Token API</name>

--- a/community/unsafe/pom.xml
+++ b/community/unsafe/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-unsafe</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Unsafe Access</name>

--- a/community/values/pom.xml
+++ b/community/values/pom.xml
@@ -16,7 +16,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-values</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Value</name>

--- a/community/wal/pom.xml
+++ b/community/wal/pom.xml
@@ -17,7 +17,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-wal</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Write-Ahead Log</name>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -12,7 +12,6 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.neo4j.build</groupId>
     <artifactId>packaging-build</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
 
     <name>Neo4j - Packaging Build</name>
     <packaging>pom</packaging>

--- a/packaging/standalone/pom.xml
+++ b/packaging/standalone/pom.xml
@@ -16,8 +16,6 @@
 
     <name>Neo4j - Server Assembler</name>
 
-    <version>4.0.3-SNAPSHOT</version>
-
     <description>This project assembles the Neo4j stand-alone distribution,
         pulling together all the deliverable artifacts and packaging them
         into a downloadable installer.

--- a/packaging/standalone/standalone-community/pom.xml
+++ b/packaging/standalone/standalone-community/pom.xml
@@ -13,7 +13,6 @@
     <packaging>pom</packaging>
 
     <name>Neo4j - Community Server Assembler</name>
-    <version>4.0.3-SNAPSHOT</version>
 
     <description>This project assembles the Neo4j Community stand-alone distribution,
         pulling together all the deliverable artifacts and packaging them


### PR DESCRIPTION
In all maven submodules, the `<version>` is redundant in POM, as it matches the parent version.