### PR TITLE
Make the EOL of `PublicApi.txt` matches the OS one

### DIFF
--- a/annotations/src/main/java/org/neo4j/annotations/api/PublicApiAnnotationProcessor.java
+++ b/annotations/src/main/java/org/neo4j/annotations/api/PublicApiAnnotationProcessor.java
@@ -148,7 +148,7 @@ public class PublicApiAnnotationProcessor extends AbstractProcessor
             StringBuilder sb = new StringBuilder();
             for ( final String element : publicElements )
             {
-                sb.append( element ).append( '\n' );
+                sb.append( element ).append( System.lineSeparator() );
             }
             String newSignature = sb.toString();
 


### PR DESCRIPTION
On compiling the project in Windows, all `PublicApi.txt` are seen by `git` as changed, because their End Of Line is `\n`.

This PR ensures the OS-specific line separator is used.