### PR TITLE
Add .checkstyle to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ out
 .shell_history
 .mailmap
 .java-version
+.checkstyle
 Thumbs.db
 /cypher-shell.zip
 packaging/standalone/src/main/distribution/cypher-shell


### PR DESCRIPTION
Since `maven-checkstyle-plugin` seems to generate this file in many places, it is better to ignore it.