### PR TITLE
First part of Migration to JUnit 5

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/transport/TransportWriteThrottleTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/transport/TransportWriteThrottleTest.java
@@ -64,7 +64,7 @@ import static org.mockito.Mockito.when;
 public class TransportWriteThrottleTest
 {
     @Rule
-    public OtherThreadRule<Void> otherThread = new OtherThreadRule<>( 1, TimeUnit.MINUTES );
+    public OtherThreadRule<Void> otherThread = new OtherThreadRule<>();
 
     private ChannelHandlerContext context;
     private Channel channel;

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/ShutdownSequenceIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/ShutdownSequenceIT.java
@@ -92,7 +92,7 @@ public class ShutdownSequenceIT
     public RuleChain ruleChain = RuleChain.outerRule( SuppressOutput.suppressAll() ).around( fsRule ).around( server );
 
     @Rule
-    public OtherThreadRule<Void> otherThread = new OtherThreadRule<>( 1, MINUTES );
+    public OtherThreadRule<Void> otherThread = new OtherThreadRule<>();
 
     @Before
     public void setup() throws Exception

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/AuthenticationIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/AuthenticationIT.java
@@ -19,10 +19,12 @@
  */
 package org.neo4j.bolt.transport;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -36,6 +38,7 @@ import java.util.function.Consumer;
 
 import org.neo4j.bolt.AbstractBoltTransportsTest;
 import org.neo4j.bolt.messaging.ResponseMessage;
+import org.neo4j.bolt.packstream.Neo4jPack;
 import org.neo4j.bolt.runtime.DefaultBoltConnection;
 import org.neo4j.bolt.testing.client.TransportConnection;
 import org.neo4j.bolt.v3.messaging.response.FailureMessage;
@@ -47,7 +50,8 @@ import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.impl.util.ValueUtils;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.test.TestDatabaseManagementServiceBuilder;
-import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
+import org.neo4j.test.extension.EphemeralFileSystemExtension;
+import org.neo4j.test.extension.Inject;
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.virtual.MapValue;
 import org.neo4j.values.virtual.VirtualValues;
@@ -55,7 +59,7 @@ import org.neo4j.values.virtual.VirtualValues;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.neo4j.bolt.testing.MessageConditions.msgFailure;
 import static org.neo4j.bolt.testing.MessageConditions.msgIgnored;
 import static org.neo4j.bolt.testing.MessageConditions.msgSuccess;
@@ -66,22 +70,35 @@ import static org.neo4j.configuration.GraphDatabaseSettings.SYSTEM_DATABASE_NAME
 import static org.neo4j.internal.helpers.collection.MapUtil.map;
 import static org.neo4j.logging.AssertableLogProvider.Level.WARN;
 import static org.neo4j.logging.LogAssertions.assertThat;
-import static org.neo4j.test.conditions.Conditions.TRUE;
 import static org.neo4j.test.assertion.Assert.assertEventually;
+import static org.neo4j.test.conditions.Conditions.TRUE;
 
+@ExtendWith( {EphemeralFileSystemExtension.class, Neo4jWithSocketExtension.class} )
 public class AuthenticationIT extends AbstractBoltTransportsTest
 {
-    protected EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
     protected final AssertableLogProvider logProvider = new AssertableLogProvider();
-    protected Neo4jWithSocket server =
-            new Neo4jWithSocket( getClass(), getTestGraphDatabaseFactory(), fsRule, getSettingsFunction() );
 
-    @Rule
-    public RuleChain ruleChain = RuleChain.outerRule( fsRule ).around( server );
+    @Inject
+    private Neo4jWithSocket server;
 
     protected TestDatabaseManagementServiceBuilder getTestGraphDatabaseFactory()
     {
         return new TestDatabaseManagementServiceBuilder().setUserLogProvider( logProvider );
+    }
+
+    @BeforeEach
+    public void setup( TestInfo testInfo ) throws IOException
+    {
+        server.setGraphDatabaseFactory( getTestGraphDatabaseFactory() );
+        server.setConfigure( getSettingsFunction() );
+        server.init( testInfo );
+        address = server.lookupDefaultConnector();
+    }
+
+    @AfterEach
+    public void cleanup()
+    {
+        server.shutdownDatabase();
     }
 
     @Override
@@ -93,17 +110,13 @@ public class AuthenticationIT extends AbstractBoltTransportsTest
         };
     }
 
-    private HostnamePort address;
-
-    @Before
-    public void setup()
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldRespondWithCredentialsExpiredOnFirstUse(
+            Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
-        address = server.lookupDefaultConnector();
-    }
+        initParameters( connectionClass, neo4jPack, name );
 
-    @Test
-    public void shouldRespondWithCredentialsExpiredOnFirstUse() throws Throwable
-    {
         // When
         connection.connect( address )
                 .send( util.defaultAcceptedVersions() )
@@ -126,9 +139,13 @@ public class AuthenticationIT extends AbstractBoltTransportsTest
         assertThat( connection ).satisfies( util.eventuallyReceives( msgSuccess() ) );
     }
 
-    @Test
-    public void shouldFailIfWrongCredentials() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldFailIfWrongCredentials(
+            Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // When
         connection.connect( address )
                 .send( util.defaultAcceptedVersions() )
@@ -157,9 +174,13 @@ public class AuthenticationIT extends AbstractBoltTransportsTest
         }
     }
 
-    @Test
-    public void shouldFailIfWrongCredentialsFollowingSuccessfulLogin() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldFailIfWrongCredentialsFollowingSuccessfulLogin(
+            Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // When
         connection.connect( address )
                 .send( util.defaultAcceptedVersions() )
@@ -202,9 +223,13 @@ public class AuthenticationIT extends AbstractBoltTransportsTest
         assertThat( connection ).satisfies( eventuallyDisconnects() );
     }
 
-    @Test
-    public void shouldFailIfMalformedAuthTokenWrongType() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldFailIfMalformedAuthTokenWrongType(
+            Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // When
         connection.connect( address )
                 .send( util.defaultAcceptedVersions() )
@@ -219,9 +244,13 @@ public class AuthenticationIT extends AbstractBoltTransportsTest
         assertThat( connection ).satisfies( eventuallyDisconnects() );
     }
 
-    @Test
-    public void shouldFailIfMalformedAuthTokenMissingKey() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldFailIfMalformedAuthTokenMissingKey(
+            Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // When
         connection.connect( address )
                 .send( util.defaultAcceptedVersions() )
@@ -235,9 +264,13 @@ public class AuthenticationIT extends AbstractBoltTransportsTest
         assertThat( connection ).satisfies( eventuallyDisconnects() );
     }
 
-    @Test
-    public void shouldFailIfMalformedAuthTokenMissingScheme() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldFailIfMalformedAuthTokenMissingScheme(
+            Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // When
         connection.connect( address )
                 .send( util.defaultAcceptedVersions() )
@@ -251,9 +284,13 @@ public class AuthenticationIT extends AbstractBoltTransportsTest
         assertThat( connection ).satisfies( eventuallyDisconnects() );
     }
 
-    @Test
-    public void shouldFailIfMalformedAuthTokenUnknownScheme() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldFailIfMalformedAuthTokenUnknownScheme(
+            Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // When
         connection.connect( address )
                 .send( util.defaultAcceptedVersions() )
@@ -267,9 +304,13 @@ public class AuthenticationIT extends AbstractBoltTransportsTest
         assertThat( connection ).satisfies( eventuallyDisconnects() );
     }
 
-    @Test
-    public void shouldFailDifferentlyIfTooManyFailedAuthAttempts() throws Exception
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldFailDifferentlyIfTooManyFailedAuthAttempts(
+            Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // Given
         final long timeout = System.currentTimeMillis() + 60_000;
         FailureMessage failureMessage = null;
@@ -324,9 +365,13 @@ public class AuthenticationIT extends AbstractBoltTransportsTest
         assertThat( failureMessage.message() ).contains( "The client has provided incorrect authentication details too many times in a row." );
     }
 
-    @Test
-    public void shouldBeAbleToChangePasswordUsingSystemCommand() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldBeAbleToChangePasswordUsingSystemCommand(
+            Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // When
         connection.connect( address )
                 .send( util.defaultAcceptedVersions() )
@@ -363,9 +408,12 @@ public class AuthenticationIT extends AbstractBoltTransportsTest
         assertThat( connection ).satisfies( util.eventuallyReceives( msgSuccess() ) );
     }
 
-    @Test
-    public void shouldFailWhenReusingTheSamePassword() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldFailWhenReusingTheSamePassword( Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // When
         connection.connect( address )
                 .send( util.defaultAcceptedVersions() )
@@ -392,9 +440,12 @@ public class AuthenticationIT extends AbstractBoltTransportsTest
         assertThat( connection ).satisfies( util.eventuallyReceives( msgIgnored(), msgSuccess(), msgSuccess(), msgSuccess() ) );
     }
 
-    @Test
-    public void shouldFailWhenSubmittingEmptyPassword() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldFailWhenSubmittingEmptyPassword( Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // When
         connection.connect( address )
                 .send( util.defaultAcceptedVersions() )
@@ -421,9 +472,13 @@ public class AuthenticationIT extends AbstractBoltTransportsTest
         assertThat( connection ).satisfies( util.eventuallyReceives( msgIgnored(), msgSuccess(), msgSuccess(), msgSuccess() ) );
     }
 
-    @Test
-    public void shouldNotBeAbleToReadWhenPasswordChangeRequired() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldNotBeAbleToReadWhenPasswordChangeRequired(
+            Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // When
         connection.connect( address )
                 .send( util.defaultAcceptedVersions() )

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/BoltChannelAutoReadLimiterIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/BoltChannelAutoReadLimiterIT.java
@@ -19,10 +19,11 @@
  */
 package org.neo4j.bolt.transport;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Map;
 import java.util.function.Consumer;
@@ -48,7 +49,8 @@ import org.neo4j.kernel.impl.util.ValueUtils;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.test.TestDatabaseManagementServiceBuilder;
-import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
+import org.neo4j.test.extension.EphemeralFileSystemExtension;
+import org.neo4j.test.extension.Inject;
 import org.neo4j.values.AnyValue;
 
 import static java.util.Collections.singletonMap;
@@ -57,18 +59,35 @@ import static org.neo4j.internal.kernel.api.procs.ProcedureSignature.procedureSi
 import static org.neo4j.logging.AssertableLogProvider.Level.WARN;
 import static org.neo4j.logging.LogAssertions.assertThat;
 
+@ExtendWith( {EphemeralFileSystemExtension.class, Neo4jWithSocketExtension.class} )
 public class BoltChannelAutoReadLimiterIT
 {
+    @Inject
+    private Neo4jWithSocket server;
+
     private AssertableLogProvider logProvider;
-    private EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
-    private Neo4jWithSocket server = new Neo4jWithSocket( getClass(), getTestGraphDatabaseFactory(), fsRule, getSettingsFunction() );
-
-    @Rule
-    public RuleChain ruleChain = RuleChain.outerRule( fsRule ).around( server );
-
     private HostnamePort address;
     private TransportConnection connection;
     private TransportTestUtil util;
+
+    @BeforeEach
+    public void setup( TestInfo testInfo ) throws Exception
+    {
+        server.setGraphDatabaseFactory( getTestGraphDatabaseFactory() );
+        server.setConfigure( getSettingsFunction() );
+        server.init( testInfo );
+        address = server.lookupDefaultConnector();
+        connection = new SocketConnection();
+        util = new TransportTestUtil();
+
+        installSleepProcedure( server.graphDatabaseService() );
+    }
+
+    @AfterEach
+    public void cleanup()
+    {
+        server.shutdownDatabase();
+    }
 
     protected TestDatabaseManagementServiceBuilder getTestGraphDatabaseFactory()
     {
@@ -85,16 +104,6 @@ public class BoltChannelAutoReadLimiterIT
     protected Consumer<Map<Setting<?>,Object>> getSettingsFunction()
     {
         return settings -> settings.put( GraphDatabaseSettings.auth_enabled, false );
-    }
-
-    @Before
-    public void setup() throws Exception
-    {
-        installSleepProcedure( server.graphDatabaseService() );
-
-        address = server.lookupDefaultConnector();
-        connection = new SocketConnection();
-        util = new TransportTestUtil();
     }
 
     @Test

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/ConnectionIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/ConnectionIT.java
@@ -19,66 +19,74 @@
  */
 package org.neo4j.bolt.transport;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
-import java.util.Collection;
+import java.util.stream.Stream;
 
+import org.neo4j.bolt.packstream.Neo4jPackV2;
+import org.neo4j.bolt.testing.TransportTestUtil;
 import org.neo4j.bolt.testing.client.SecureSocketConnection;
 import org.neo4j.bolt.testing.client.SecureWebSocketConnection;
 import org.neo4j.bolt.testing.client.SocketConnection;
 import org.neo4j.bolt.testing.client.TransportConnection;
 import org.neo4j.bolt.testing.client.WebSocketConnection;
 import org.neo4j.internal.helpers.HostnamePort;
+import org.neo4j.test.extension.EphemeralFileSystemExtension;
+import org.neo4j.test.extension.Inject;
 
-import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.bolt.transport.Neo4jWithSocket.withOptionalBoltEncryption;
 
-@RunWith( Parameterized.class )
+@ExtendWith( {EphemeralFileSystemExtension.class, Neo4jWithSocketExtension.class} )
 public class ConnectionIT
 {
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
+    @Inject
+    private Neo4jWithSocket server;
 
-    @Rule
-    public Neo4jWithSocket server = new Neo4jWithSocket( getClass(), withOptionalBoltEncryption() );
-
-    @Parameterized.Parameter
     public TransportConnection connection;
 
     private HostnamePort address;
 
-    @Parameterized.Parameters
-    public static Collection<TransportConnection> transports()
+    @BeforeEach
+    public void setup( TestInfo testInfo ) throws IOException
     {
-        return asList( new SecureSocketConnection(), new SocketConnection(), new SecureWebSocketConnection(),
-                new WebSocketConnection() );
-    }
-
-    @Before
-    public void setUp()
-    {
+        server.setConfigure( withOptionalBoltEncryption() );
+        server.init( testInfo );
         address = server.lookupDefaultConnector();
     }
 
-    @After
+    @AfterEach
     public void cleanup() throws IOException
     {
         if ( connection != null )
         {
             connection.disconnect();
         }
+        server.shutdownDatabase();
     }
 
-    @Test
-    public void shouldCloseConnectionOnInvalidHandshake() throws Exception
+    public static Stream<Arguments> transportFactory()
     {
+        return Stream.of( Arguments.of( new SecureSocketConnection() ),
+                Arguments.of( new SocketConnection() ),
+                Arguments.of( new SecureWebSocketConnection()),
+                Arguments.of( new WebSocketConnection() ) );
+    }
+
+    @ParameterizedTest( name = "{displayName} {index}" )
+    @MethodSource( "transportFactory" )
+    public void shouldCloseConnectionOnInvalidHandshake( TransportConnection connection ) throws Exception
+    {
+        this.connection = connection;
+
         // GIVEN
         connection.connect( address );
 
@@ -86,7 +94,6 @@ public class ConnectionIT
         connection.send( new byte[]{(byte) 0xDE, (byte) 0xAD, (byte) 0xB0, (byte) 0x17, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0} );
 
         // THEN
-        exception.expect( IOException.class );
-        connection.recv( 4 );
+        assertThrows( IOException.class, () -> connection.recv( 4 ) );
     }
 }

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/RejectTransportEncryptionIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/RejectTransportEncryptionIT.java
@@ -19,74 +19,72 @@
  */
 package org.neo4j.bolt.transport;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.neo4j.bolt.testing.TransportTestUtil;
 import org.neo4j.bolt.testing.client.SecureSocketConnection;
 import org.neo4j.bolt.testing.client.SecureWebSocketConnection;
 import org.neo4j.bolt.testing.client.TransportConnection;
 import org.neo4j.configuration.connectors.BoltConnector;
-import org.neo4j.function.Factory;
+import org.neo4j.test.extension.EphemeralFileSystemExtension;
+import org.neo4j.test.extension.Inject;
 
-import static java.util.Arrays.asList;
-import static org.apache.commons.lang3.JavaVersion.JAVA_9;
-import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtLeast;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.configuration.connectors.BoltConnector.EncryptionLevel.DISABLED;
 
-@RunWith( Parameterized.class )
+@ExtendWith( {EphemeralFileSystemExtension.class, Neo4jWithSocketExtension.class} )
 public class RejectTransportEncryptionIT
 {
-    @Rule
-    public Neo4jWithSocket server = new Neo4jWithSocket( getClass(),
-            settings ->
-            {
-                settings.put( BoltConnector.encryption_level, DISABLED );
-            } );
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
+    @Inject
+    private Neo4jWithSocket server;
 
-    @Parameterized.Parameter( 0 )
-    public Factory<TransportConnection> cf;
+    @BeforeEach
+    public void setup( TestInfo testInfo ) throws IOException
+    {
+        server.setConfigure( settings ->
+        {
+            settings.put( BoltConnector.encryption_level, DISABLED );
+        } );
+        server.init( testInfo );
+    }
 
-    @Parameterized.Parameter( 1 )
-    public Exception expected;
+    @AfterEach
+    public void cleanup()
+    {
+        server.shutdownDatabase();
+    }
 
     private TransportConnection client;
     private TransportTestUtil util;
 
-    @Parameterized.Parameters
-    public static Collection<Object[]> transports()
+    public static Stream<Arguments> transportFactory()
     {
-        return asList(
-                new Object[]{
-                        (Factory<TransportConnection>) SecureWebSocketConnection::new,
-                        new IOException( "Failed to connect to the server within 10 seconds" )
-                },
-                new Object[]{
-                        (Factory<TransportConnection>) SecureSocketConnection::new, new IOException(
-                        isJavaVersionAtLeast( JAVA_9 ) ? "Remote host terminated the handshake"
-                                                       : "Remote host closed connection during handshake" )
-
-                } );
+        return Stream.of(
+                Arguments.of( SecureWebSocketConnection.class,
+                        new IOException( "Failed to connect to the server within 10 seconds" ) ),
+                Arguments.of( SecureSocketConnection.class,
+                        new IOException( "Remote host terminated the handshake" )
+                ) );
     }
 
-    @Before
+    @BeforeEach
     public void setup()
     {
-        this.client = cf.newInstance();
         this.util = new TransportTestUtil();
     }
 
-    @After
+    @AfterEach
     public void teardown() throws Exception
     {
         if ( client != null )
@@ -95,11 +93,14 @@ public class RejectTransportEncryptionIT
         }
     }
 
-    @Test
-    public void shouldRejectConnectionAfterHandshake() throws Throwable
+    @ParameterizedTest( name = "{displayName} {index}" )
+    @MethodSource( "transportFactory" )
+    public void shouldRejectConnectionAfterHandshake( Class<? extends TransportConnection> c, Exception expected ) throws Exception
     {
-        exception.expect( expected.getClass() );
-        exception.expectMessage( expected.getMessage() );
-        client.connect( server.lookupDefaultConnector() ).send( util.defaultAcceptedVersions() );
+        this.client = c.getDeclaredConstructor().newInstance();
+
+        var exception = assertThrows( expected.getClass(), () -> client.connect( server.lookupDefaultConnector() ).send( util.defaultAcceptedVersions() ),
+                                      expected.getMessage() );
+        assertEquals( expected.getMessage(), exception.getMessage() );
     }
 }

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/TransportErrorIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/TransportErrorIT.java
@@ -19,36 +19,58 @@
  */
 package org.neo4j.bolt.transport;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.IOException;
 import java.util.Arrays;
 
 import org.neo4j.bolt.AbstractBoltTransportsTest;
 import org.neo4j.bolt.messaging.RecordingByteChannel;
 import org.neo4j.bolt.packstream.BufferedChannelOutput;
+import org.neo4j.bolt.packstream.Neo4jPack;
 import org.neo4j.bolt.packstream.PackStream;
+import org.neo4j.bolt.testing.client.TransportConnection;
 import org.neo4j.bolt.v4.messaging.RunMessage;
+import org.neo4j.test.extension.EphemeralFileSystemExtension;
+import org.neo4j.test.extension.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.neo4j.bolt.testing.MessageConditions.serialize;
 import static org.neo4j.bolt.testing.TransportTestUtil.eventuallyDisconnects;
 
+@ExtendWith( {EphemeralFileSystemExtension.class, Neo4jWithSocketExtension.class} )
 public class TransportErrorIT extends AbstractBoltTransportsTest
 {
-    @Rule
-    public Neo4jWithSocket server = new Neo4jWithSocket( getClass(), getSettingsFunction() );
+    @Inject
+    private Neo4jWithSocket server;
 
-    @Before
-    public void setup()
+    @BeforeEach
+    public void setup( TestInfo testInfo ) throws IOException
     {
+        server.setConfigure( getSettingsFunction() );
+        server.init( testInfo );
+
         address = server.lookupDefaultConnector();
     }
 
-    @Test
-    public void shouldHandleIncorrectFraming() throws Throwable
+    @AfterEach
+    public void cleanup()
     {
+        server.shutdownDatabase();
+    }
+
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldHandleIncorrectFraming( Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
+    {
+        initParameters( connectionClass, neo4jPack, name );
+
         // Given I have a message that gets truncated in the chunking, so part of it is missing
         byte[] truncated = serialize( util.getNeo4jPack(), new RunMessage( "UNWIND [1,2,3] AS a RETURN a, a * a AS a_squared" ) );
         truncated = Arrays.copyOf(truncated, truncated.length - 12);
@@ -63,9 +85,13 @@ public class TransportErrorIT extends AbstractBoltTransportsTest
         assertThat( connection ).satisfies( eventuallyDisconnects() );
     }
 
-    @Test
-    public void shouldHandleMessagesWithIncorrectFields() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldHandleMessagesWithIncorrectFields(
+            Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // Given I send a message with the wrong types in its fields
         final RecordingByteChannel rawData = new RecordingByteChannel();
         final PackStream.Packer packer = new PackStream.Packer( new BufferedChannelOutput( rawData ) );
@@ -87,9 +113,12 @@ public class TransportErrorIT extends AbstractBoltTransportsTest
         assertThat( connection ).satisfies( eventuallyDisconnects() );
     }
 
-    @Test
-    public void shouldHandleUnknownMessages() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldHandleUnknownMessages( Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // Given I send a message with an invalid type
         final RecordingByteChannel rawData = new RecordingByteChannel();
         final PackStream.Packer packer = new PackStream.Packer( new BufferedChannelOutput( rawData ) );
@@ -110,9 +139,12 @@ public class TransportErrorIT extends AbstractBoltTransportsTest
         assertThat( connection ).satisfies( eventuallyDisconnects() );
     }
 
-    @Test
-    public void shouldHandleUnknownMarkerBytes() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldHandleUnknownMarkerBytes( Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // Given I send a message with an invalid type
         final RecordingByteChannel rawData = new RecordingByteChannel();
         final BufferedChannelOutput out = new BufferedChannelOutput( rawData );

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/TransportSessionIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/TransportSessionIT.java
@@ -20,19 +20,28 @@
 package org.neo4j.bolt.transport;
 
 import org.assertj.core.api.Condition;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.IOException;
 import java.util.HashMap;
 
 import org.neo4j.bolt.AbstractBoltTransportsTest;
+import org.neo4j.bolt.packstream.Neo4jPack;
 import org.neo4j.bolt.testing.TestNotification;
+import org.neo4j.bolt.testing.client.TransportConnection;
 import org.neo4j.graphdb.InputPosition;
 import org.neo4j.graphdb.SeverityLevel;
 import org.neo4j.internal.helpers.HostnamePort;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.impl.util.ValueUtils;
+import org.neo4j.test.extension.EphemeralFileSystemExtension;
+import org.neo4j.test.extension.Inject;
 import org.neo4j.values.AnyValue;
 
 import static java.util.Arrays.asList;
@@ -48,22 +57,32 @@ import static org.neo4j.bolt.testing.TransportTestUtil.eventuallyReceives;
 import static org.neo4j.values.storable.Values.longValue;
 import static org.neo4j.values.storable.Values.stringValue;
 
+@ExtendWith( {EphemeralFileSystemExtension.class, Neo4jWithSocketExtension.class} )
 public class TransportSessionIT extends AbstractBoltTransportsTest
 {
-    @Rule
-    public Neo4jWithSocket server = new Neo4jWithSocket( getClass(), getSettingsFunction() );
+    @Inject
+    private Neo4jWithSocket server;
 
-    private HostnamePort address;
-
-    @Before
-    public void setup()
+    @BeforeEach
+    public void setup( TestInfo testInfo ) throws IOException
     {
+        server.setConfigure( getSettingsFunction() );
+        server.init( testInfo );
         address = server.lookupDefaultConnector();
     }
 
-    @Test
-    public void shouldNegotiateProtocolVersion() throws Throwable
+    @AfterEach
+    public void cleanup()
     {
+        server.shutdownDatabase();
+    }
+
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldNegotiateProtocolVersion( Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
+    {
+        initParameters( connectionClass, neo4jPack, name );
+
         // When
         connection.connect( address )
                 .send( util.defaultAcceptedVersions() );
@@ -72,9 +91,12 @@ public class TransportSessionIT extends AbstractBoltTransportsTest
         assertThat( connection ).satisfies( util.eventuallyReceivesSelectedProtocolVersion() );
     }
 
-    @Test
-    public void shouldReturnNilOnNoApplicableVersion() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldReturnNilOnNoApplicableVersion( Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // When
         connection.connect( address )
                 .send( util.acceptedVersions( 1337, 0, 0, 0 ) );
@@ -83,9 +105,12 @@ public class TransportSessionIT extends AbstractBoltTransportsTest
         assertThat( connection ).satisfies( eventuallyReceives( new byte[]{0, 0, 0, 0} ) );
     }
 
-    @Test
-    public void shouldRunSimpleStatement() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldRunSimpleStatement( Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // When
         connection.connect( address )
                 .send( util.defaultAcceptedVersions() )
@@ -105,9 +130,12 @@ public class TransportSessionIT extends AbstractBoltTransportsTest
                         .containsKey( "t_last" ).containsEntry( "type", "r" ) ) ) );
     }
 
-    @Test
-    public void shouldRespondWithMetadataToDiscardAll() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldRespondWithMetadataToDiscardAll( Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // When
         connection.connect( address )
                 .send( util.defaultAcceptedVersions() )
@@ -124,9 +152,12 @@ public class TransportSessionIT extends AbstractBoltTransportsTest
                         .containsKey("t_last" ).containsEntry( "type", "r" ) ) ) );
     }
 
-    @Test
-    public void shouldBeAbleToRunQueryAfterAckFailure() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldBeAbleToRunQueryAfterAckFailure( Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // Given
         connection.connect( address )
                 .send( util.defaultAcceptedVersions() )
@@ -152,9 +183,12 @@ public class TransportSessionIT extends AbstractBoltTransportsTest
                 msgSuccess() ) );
     }
 
-    @Test
-    public void shouldRunProcedure() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldRunProcedure( Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // Given
         connection.connect( address )
                 .send( util.defaultAcceptedVersions() )
@@ -181,9 +215,12 @@ public class TransportSessionIT extends AbstractBoltTransportsTest
         ) );
     }
 
-    @Test
-    public void shouldHandleDeletedNodes() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldHandleDeletedNodes( Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // When
         connection.connect( address )
                 .send( util.defaultAcceptedVersions() )
@@ -211,9 +248,12 @@ public class TransportSessionIT extends AbstractBoltTransportsTest
         assertThat( connection ).satisfies( util.eventuallyReceives( msgSuccess() ) );
     }
 
-    @Test
-    public void shouldHandleDeletedRelationships() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldHandleDeletedRelationships( Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // When
         connection.connect( address )
                 .send( util.defaultAcceptedVersions() )
@@ -242,9 +282,12 @@ public class TransportSessionIT extends AbstractBoltTransportsTest
         assertThat( connection ).satisfies( util.eventuallyReceives( msgSuccess() ) );
     }
 
-    @Test
-    public void shouldNotLeakStatsToNextStatement() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldNotLeakStatsToNextStatement( Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // Given
         connection.connect( address )
                 .send( util.defaultAcceptedVersions() )
@@ -267,9 +310,12 @@ public class TransportSessionIT extends AbstractBoltTransportsTest
                         .containsKey( "t_last" ).containsEntry( "type", "r" ) ) ) );
     }
 
-    @Test
-    public void shouldSendNotifications() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldSendNotifications( Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // When
         connection.connect( address )
                 .send( util.defaultAcceptedVersions() )
@@ -302,9 +348,12 @@ public class TransportSessionIT extends AbstractBoltTransportsTest
         return bytes;
     }
 
-    @Test
-    public void shouldFailNicelyOnNullKeysInMap() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldFailNicelyOnNullKeysInMap( Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         //Given
         HashMap<String,Object> params = new HashMap<>();
         HashMap<String,Object> inner = new HashMap<>();
@@ -337,9 +386,13 @@ public class TransportSessionIT extends AbstractBoltTransportsTest
                 msgSuccess() ) );
     }
 
-    @Test
-    public void shouldFailNicelyWhenDroppingUnknownIndex() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldFailNicelyWhenDroppingUnknownIndex(
+            Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // When
         connection.connect( address )
                 .send( util.defaultAcceptedVersions() )

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/TransportUnauthenticatedConnectionTimeoutErrorIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/TransportUnauthenticatedConnectionTimeoutErrorIT.java
@@ -19,10 +19,14 @@
  */
 package org.neo4j.bolt.transport;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.HashMap;
@@ -30,10 +34,15 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import org.neo4j.bolt.AbstractBoltTransportsTest;
+import org.neo4j.bolt.packstream.Neo4jPack;
+import org.neo4j.bolt.testing.client.TransportConnection;
 import org.neo4j.configuration.connectors.BoltConnector;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.io.ByteUnit;
 import org.neo4j.io.memory.ByteBuffers;
+import org.neo4j.test.extension.EphemeralFileSystemExtension;
+import org.neo4j.test.extension.Inject;
+import org.neo4j.test.extension.OtherThreadExtension;
 import org.neo4j.test.rule.OtherThreadRule;
 
 import static java.nio.ByteOrder.BIG_ENDIAN;
@@ -43,18 +52,27 @@ import static org.neo4j.bolt.testing.MessageConditions.msgSuccess;
 import static org.neo4j.bolt.testing.TransportTestUtil.eventuallyDisconnects;
 import static org.neo4j.configuration.connectors.BoltConnector.EncryptionLevel.OPTIONAL;
 
+@ExtendWith( {EphemeralFileSystemExtension.class, Neo4jWithSocketExtension.class, OtherThreadExtension.class} )
 public class TransportUnauthenticatedConnectionTimeoutErrorIT extends AbstractBoltTransportsTest
 {
-    @Rule
-    public Neo4jWithSocket server = new Neo4jWithSocket( getClass(), getSettingsFunction() );
+    @Inject
+    private Neo4jWithSocket server;
 
-    @Rule
-    public OtherThreadRule<Void> otherThread = new OtherThreadRule<>( 1, MINUTES );
+    @Inject
+    private OtherThreadRule otherThread;
 
-    @Before
-    public void setup()
+    @BeforeEach
+    public void setup( TestInfo testInfo ) throws IOException
     {
+        server.setConfigure( getSettingsFunction() );
+        server.init( testInfo );
         address = server.lookupDefaultConnector();
+    }
+
+    @AfterEach
+    public void cleanup()
+    {
+        server.shutdownDatabase();
     }
 
     protected Consumer<Map<Setting<?>,Object>> getSettingsFunction()
@@ -66,9 +84,12 @@ public class TransportUnauthenticatedConnectionTimeoutErrorIT extends AbstractBo
         };
     }
 
-    @Test
-    public void shouldFinishHelloMessage() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldFinishHelloMessage( Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // When
         connection.connect( address )
                 .send( util.defaultAcceptedVersions() )
@@ -82,9 +103,12 @@ public class TransportUnauthenticatedConnectionTimeoutErrorIT extends AbstractBo
         assertThat( connection ).satisfies( eventuallyDisconnects() );
     }
 
-    @Test
-    public void shouldTimeoutTooSlowConnection() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldTimeoutTooSlowConnection( Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // Given
         var handshakeBytes = util.defaultAcceptedVersions();
 
@@ -107,9 +131,13 @@ public class TransportUnauthenticatedConnectionTimeoutErrorIT extends AbstractBo
         assertThat( connection ).satisfies( eventuallyDisconnects() );
     }
 
-    @Test
-    public void shouldTimeoutToHandshakeForHalfHandshake() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldTimeoutToHandshakeForHalfHandshake(
+            Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // Given half written bolt handshake message
         ByteBuffer bb = ByteBuffers.allocate( Integer.BYTES, BIG_ENDIAN );
         bb.putInt( 0x6060B017 );
@@ -120,9 +148,13 @@ public class TransportUnauthenticatedConnectionTimeoutErrorIT extends AbstractBo
         assertThat( connection ).satisfies( eventuallyDisconnects() );
     }
 
-    @Test
-    public void shouldTimeoutToAuthForHalfHelloMessage() throws Throwable
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldTimeoutToAuthForHalfHelloMessage(
+            Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // Given half written hello message
         var helloMessage = util.defaultAuth();
         var buffer = ByteBuffer.wrap( helloMessage, 0, helloMessage.length / 2 );
@@ -139,9 +171,14 @@ public class TransportUnauthenticatedConnectionTimeoutErrorIT extends AbstractBo
         assertThat( connection ).satisfies( eventuallyDisconnects() );
     }
 
-    @Test
-    public void shouldCloseConnectionDueToTooBigHelloMessage() throws Throwable
+
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldCloseConnectionDueToTooBigHelloMessage(
+            Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         // When
         Map<String,Object> authMeta = new HashMap<>();
         for ( int i = 0; i < 100; i++ )

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/UnsupportedStructTypesV1V2IT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/UnsupportedStructTypesV1V2IT.java
@@ -19,18 +19,25 @@
  */
 package org.neo4j.bolt.transport;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 
 import org.neo4j.bolt.AbstractBoltTransportsTest;
 import org.neo4j.bolt.packstream.Neo4jPack;
 import org.neo4j.bolt.packstream.PackedOutputArray;
+import org.neo4j.bolt.testing.client.TransportConnection;
 import org.neo4j.bolt.v4.messaging.RunMessage;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.impl.util.ValueUtils;
+import org.neo4j.test.extension.EphemeralFileSystemExtension;
+import org.neo4j.test.extension.Inject;
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.virtual.PathValue;
 
@@ -43,22 +50,34 @@ import static org.neo4j.bolt.testing.MessageConditions.msgSuccess;
 import static org.neo4j.bolt.testing.TransportTestUtil.eventuallyDisconnects;
 import static org.neo4j.kernel.api.exceptions.Status.Statement.TypeError;
 
+@ExtendWith( {EphemeralFileSystemExtension.class, Neo4jWithSocketExtension.class} )
 public class UnsupportedStructTypesV1V2IT extends AbstractBoltTransportsTest
 {
     public static final byte DEFAULT_SIGNATURE = RunMessage.SIGNATURE;
 
-    @Rule
-    public Neo4jWithSocket server = new Neo4jWithSocket( getClass(), getSettingsFunction() );
+    @Inject
+    private Neo4jWithSocket server;
 
-    @Before
-    public void setup()
+    @BeforeEach
+    public void setup( TestInfo testInfo ) throws IOException
     {
+        server.setConfigure( getSettingsFunction() );
+        server.init( testInfo );
         address = server.lookupDefaultConnector();
     }
 
-    @Test
-    public void shouldFailWhenNullKeyIsSent() throws Exception
+    @AfterEach
+    public void cleanup()
     {
+        server.shutdownDatabase();
+    }
+
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldFailWhenNullKeyIsSent( Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
+    {
+        initParameters( connectionClass, neo4jPack, name );
+
         connection.connect( address ).send( util.defaultAcceptedVersions() );
         assertThat( connection ).satisfies( util.eventuallyReceivesSelectedProtocolVersion() );
         connection.send( util.defaultAuth() );
@@ -71,9 +90,12 @@ public class UnsupportedStructTypesV1V2IT extends AbstractBoltTransportsTest
         assertThat( connection ).satisfies( eventuallyDisconnects() );
     }
 
-    @Test
-    public void shouldFailWhenDuplicateKey() throws Exception
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldFailWhenDuplicateKey( Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         connection.connect( address ).send( util.defaultAcceptedVersions() );
         assertThat( connection ).satisfies( util.eventuallyReceivesSelectedProtocolVersion() );
         connection.send( util.defaultAuth() );
@@ -85,21 +107,32 @@ public class UnsupportedStructTypesV1V2IT extends AbstractBoltTransportsTest
         assertThat( connection ).satisfies( eventuallyDisconnects() );
     }
 
-    @Test
-    public void shouldFailWhenNodeIsSentWithRun() throws Exception
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldFailWhenNodeIsSentWithRun(
+            Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         testFailureWithV1Value( ALICE, "Node" );
     }
 
-    @Test
-    public void shouldFailWhenRelationshipIsSentWithRun() throws Exception
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldFailWhenRelationshipIsSentWithRun(
+            Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         testFailureWithV1Value( ALICE_KNOWS_BOB, "Relationship" );
     }
 
-    @Test
-    public void shouldFailWhenPathIsSentWithRun() throws Exception
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldFailWhenPathIsSentWithRun( Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         for ( PathValue path : ALL_PATHS )
         {
             try
@@ -113,9 +146,13 @@ public class UnsupportedStructTypesV1V2IT extends AbstractBoltTransportsTest
         }
     }
 
-    @Test
-    public void shouldTerminateConnectionWhenUnknownMessageIsSent() throws Exception
+    @ParameterizedTest( name = "{displayName} {2}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldTerminateConnectionWhenUnknownMessageIsSent(
+            Class<? extends TransportConnection> connectionClass, Neo4jPack neo4jPack, String name ) throws Exception
     {
+        initParameters( connectionClass, neo4jPack, name );
+
         connection.connect( address ).send( util.defaultAcceptedVersions() );
         assertThat( connection ).satisfies( util.eventuallyReceivesSelectedProtocolVersion() );
         connection.send( util.defaultAuth() );

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/UnsupportedStructTypesV2IT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/UnsupportedStructTypesV2IT.java
@@ -19,17 +19,17 @@
  */
 package org.neo4j.bolt.transport;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.stream.Stream;
 
 import org.neo4j.bolt.messaging.StructType;
 import org.neo4j.bolt.packstream.Neo4jPack;
@@ -45,54 +45,63 @@ import org.neo4j.bolt.v4.messaging.RunMessage;
 import org.neo4j.function.ThrowingConsumer;
 import org.neo4j.internal.helpers.HostnamePort;
 import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.test.extension.EphemeralFileSystemExtension;
+import org.neo4j.test.extension.Inject;
 import org.neo4j.values.storable.CoordinateReferenceSystem;
 import org.neo4j.values.storable.Values;
 
-import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.neo4j.bolt.testing.MessageConditions.msgFailure;
 import static org.neo4j.bolt.testing.MessageConditions.msgSuccess;
 import static org.neo4j.bolt.testing.TransportTestUtil.eventuallyDisconnects;
+import static org.neo4j.bolt.transport.Neo4jWithSocket.withOptionalBoltEncryption;
 
-@RunWith( Parameterized.class )
+@ExtendWith( {EphemeralFileSystemExtension.class, Neo4jWithSocketExtension.class} )
 public class UnsupportedStructTypesV2IT
 {
-    @Rule
-    public Neo4jWithSocket server = new Neo4jWithSocket( getClass(), Neo4jWithSocket.withOptionalBoltEncryption() );
-
-    @Parameter
-    public Class<? extends TransportConnection> connectionClass;
+    @Inject
+    private Neo4jWithSocket server;
 
     private HostnamePort address;
     private TransportConnection connection;
     private TransportTestUtil util;
 
-    @Parameters( name = "{0}" )
-    public static List<Class<? extends TransportConnection>> transports()
+    @BeforeEach
+    public void setup( TestInfo testInfo ) throws IOException
     {
-        return asList( SocketConnection.class, WebSocketConnection.class, SecureSocketConnection.class, SecureWebSocketConnection.class );
-    }
-
-    @Before
-    public void setup() throws Exception
-    {
+        server.setConfigure( withOptionalBoltEncryption() );
+        server.init( testInfo );
         address = server.lookupDefaultConnector();
-        connection = connectionClass.getDeclaredConstructor().newInstance();
         util = new TransportTestUtil( new Neo4jPackV2() );
     }
 
-    @After
+    @AfterEach
     public void cleanup() throws Exception
     {
         if ( connection != null )
         {
             connection.disconnect();
         }
+        server.shutdownDatabase();
     }
 
-    @Test
-    public void shouldFailWhenPoint2DIsSentWithInvalidCrsId() throws Exception
+    public static Stream<Arguments> classProvider()
     {
+        return Stream.of( Arguments.of( SocketConnection.class ), Arguments.of( WebSocketConnection.class ),
+                Arguments.of( SecureSocketConnection.class ), Arguments.of( SecureWebSocketConnection.class ) );
+    }
+
+    private void initConnection( Class<? extends TransportConnection> connectionClass ) throws Exception
+    {
+        connection = connectionClass.getDeclaredConstructor().newInstance();
+    }
+
+    @ParameterizedTest( name = "{displayName} {0}" )
+    @MethodSource( "classProvider" )
+    public void shouldFailWhenPoint2DIsSentWithInvalidCrsId( Class<? extends TransportConnection> connectionClass ) throws Exception
+    {
+        initConnection( connectionClass );
+
         testFailureWithUnpackableValue( packer ->
         {
             packer.packStructHeader( 3, StructType.POINT_2D.signature() );
@@ -102,9 +111,12 @@ public class UnsupportedStructTypesV2IT
         }, "Unable to construct Point value: `Unknown coordinate reference system code: 5`" );
     }
 
-    @Test
-    public void shouldFailWhenPoint3DIsSentWithInvalidCrsId() throws Exception
+    @ParameterizedTest( name = "{displayName} {0}" )
+    @MethodSource( "classProvider" )
+    public void shouldFailWhenPoint3DIsSentWithInvalidCrsId( Class<? extends TransportConnection> connectionClass ) throws Exception
     {
+        initConnection( connectionClass );
+
         testFailureWithUnpackableValue( packer ->
         {
             packer.packStructHeader( 4, StructType.POINT_3D.signature() );
@@ -115,9 +127,12 @@ public class UnsupportedStructTypesV2IT
         }, "Unable to construct Point value: `Unknown coordinate reference system code: 1200`" );
     }
 
-    @Test
-    public void shouldFailWhenPoint2DDimensionsDoNotMatch() throws Exception
+    @ParameterizedTest( name = "{displayName} {0}" )
+    @MethodSource( "classProvider" )
+    public void shouldFailWhenPoint2DDimensionsDoNotMatch( Class<? extends TransportConnection> connectionClass ) throws Exception
     {
+        initConnection( connectionClass );
+
         testDisconnectWithUnpackableValue( packer ->
         {
             packer.packStructHeader( 3, StructType.POINT_3D.signature() );
@@ -127,9 +142,12 @@ public class UnsupportedStructTypesV2IT
         }, "Unable to construct Point value: `Cannot create point, CRS cartesian-3d expects 3 dimensions, but got coordinates [3.15, 4.012]`" );
     }
 
-    @Test
-    public void shouldFailWhenPoint3DDimensionsDoNotMatch() throws Exception
+    @ParameterizedTest( name = "{displayName} {0}" )
+    @MethodSource( "classProvider" )
+    public void shouldFailWhenPoint3DDimensionsDoNotMatch( Class<? extends TransportConnection> connectionClass ) throws Exception
     {
+        initConnection( connectionClass );
+
         testFailureWithUnpackableValue( packer ->
         {
             packer.packStructHeader( 4, StructType.POINT_3D.signature() );
@@ -140,9 +158,12 @@ public class UnsupportedStructTypesV2IT
         }, "Unable to construct Point value: `Cannot create point, CRS cartesian expects 2 dimensions, but got coordinates [3.15, 4.012, 5.905]`" );
     }
 
-    @Test
-    public void shouldFailWhenZonedDateTimeZoneIdIsNotKnown() throws Exception
+    @ParameterizedTest( name = "{displayName} {0}" )
+    @MethodSource( "classProvider" )
+    public void shouldFailWhenZonedDateTimeZoneIdIsNotKnown( Class<? extends TransportConnection> connectionClass ) throws Exception
     {
+        initConnection( connectionClass );
+
         testFailureWithUnpackableValue( packer ->
         {
             packer.packStructHeader( 3, StructType.DATE_TIME_WITH_ZONE_NAME.signature() );

--- a/community/community-it/it-test-support/src/main/java/org/neo4j/bolt/transport/Neo4jWithSocketExtension.java
+++ b/community/community-it/it-test-support/src/main/java/org/neo4j/bolt/transport/Neo4jWithSocketExtension.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.transport;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.test.TestDatabaseManagementServiceBuilder;
+import org.neo4j.test.extension.FileSystemExtension;
+import org.neo4j.test.extension.StatefulFieldExtension;
+
+import static org.neo4j.test.extension.FileSystemExtension.FILE_SYSTEM;
+import static org.neo4j.test.extension.FileSystemExtension.FILE_SYSTEM_NAMESPACE;
+
+public class Neo4jWithSocketExtension extends StatefulFieldExtension<Neo4jWithSocket>
+{
+    private static final String FIELD_KEY = "neo4jWithSocket";
+    private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create( "org", "neo4j", FIELD_KEY );
+
+    @Override
+    protected String getFieldKey()
+    {
+        return FIELD_KEY;
+    }
+
+    @Override
+    protected Class<Neo4jWithSocket> getFieldType()
+    {
+        return Neo4jWithSocket.class;
+    }
+
+    @Override
+    protected Neo4jWithSocket createField( ExtensionContext context )
+    {
+        var fs = getFileSystem( context );
+        return new Neo4jWithSocket( context.getRequiredTestClass(), new TestDatabaseManagementServiceBuilder(), () -> fs, settings -> {} );
+    }
+
+    public FileSystemAbstraction getFileSystem( ExtensionContext context )
+    {
+        var fs = context.getStore( FILE_SYSTEM_NAMESPACE ).get( FILE_SYSTEM, FileSystemAbstraction.class );
+        if ( fs == null )
+        {
+            var fsClassName = FileSystemExtension.class.getSimpleName();
+            var neo4JClassName = getClass().getSimpleName();
+            throw new IllegalStateException( fsClassName + " not in scope, make sure to add it before " + neo4JClassName );
+        }
+        return fs;
+    }
+
+    @Override
+    protected ExtensionContext.Namespace getNameSpace()
+    {
+        return NAMESPACE;
+    }
+}

--- a/community/testing/test-utils/src/main/java/org/neo4j/test/extension/OtherThreadExtension.java
+++ b/community/testing/test-utils/src/main/java/org/neo4j/test/extension/OtherThreadExtension.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test.extension;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+
+import org.neo4j.test.rule.OtherThreadRule;
+
+public class OtherThreadExtension extends StatefulFieldExtension<OtherThreadRule> implements BeforeEachCallback, AfterEachCallback
+{
+    private static final String OTHER_THREAD = "otherThread";
+    private static final Namespace OTHER_THREAD_NAMESPACE = Namespace.create( "org", "neo4j", OTHER_THREAD );
+
+    @Override
+    protected String getFieldKey()
+    {
+        return OTHER_THREAD;
+    }
+
+    @Override
+    protected Class<OtherThreadRule> getFieldType()
+    {
+        return OtherThreadRule.class;
+    }
+
+    @Override
+    protected OtherThreadRule createField( ExtensionContext extensionContext )
+    {
+        return new OtherThreadRule();
+    }
+
+    @Override
+    protected Namespace getNameSpace()
+    {
+        return OTHER_THREAD_NAMESPACE;
+    }
+
+    @Override
+    public void beforeEach( ExtensionContext context )
+    {
+        var otherThread = getStoredValue( context );
+        otherThread.beforeEach( context );
+    }
+
+    @Override
+    public void afterEach( ExtensionContext context )
+    {
+        var otherThread = getStoredValue( context );
+        otherThread.afterEach( context );
+    }
+}


### PR DESCRIPTION
As there are many tests cases with are still with JUnit 4, this PR tries to make a first step in migrating them to JUnit 5, it would be followed by other PRs (or I can continue adding, but it would be difficult to review).

Gradually, we would have `Rules` for both v4 and v5, till we remove all usages of v4.

So, for example, we now have `Neo4jWithSocket2` with v5, and the original one is left for v4 tests.

Also, just before deleting the old `Rules` (e.g. `FileSystemRule`), we would rename the new one to something like `FileSystemExtension`, but for now prefix `Rule2` helps to hint about a migrated rule.