### PR TITLE
Remove redundant .toString() from string concatenation

### DIFF
--- a/annotations/src/main/java/org/neo4j/annotations/api/PublicApiAnnotationProcessor.java
+++ b/annotations/src/main/java/org/neo4j/annotations/api/PublicApiAnnotationProcessor.java
@@ -244,7 +244,7 @@ public class PublicApiAnnotationProcessor extends AbstractProcessor
         Path parent = path.getParent();
         if ( !parent.getFileName().toString().equals( name ) )
         {
-            throw new IllegalStateException( path.toAbsolutePath().toString() + " parent is not " + name );
+            throw new IllegalStateException( path.toAbsolutePath() + " parent is not " + name );
         }
         return parent;
     }
@@ -293,17 +293,17 @@ public class PublicApiAnnotationProcessor extends AbstractProcessor
                 case ENUM:
                 case INTERFACE:
                 case CLASS:
-                    pushScope( "." + element.getSimpleName().toString() );
+                    pushScope( "." + element.getSimpleName() );
                     processType( (TypeElement) element );
                     break;
                 case ENUM_CONSTANT:
                 case FIELD:
-                    pushScope( "#" + element.toString() );
+                    pushScope( "#" + element );
                     processField( (VariableElement) element );
                     break;
                 case CONSTRUCTOR:
                 case METHOD:
-                    pushScope( "::" + element.toString() );
+                    pushScope( "::" + element );
                     processMethod( (ExecutableElement) element );
                     break;
                 default:
@@ -422,7 +422,7 @@ public class PublicApiAnnotationProcessor extends AbstractProcessor
         {
             return typeParameter.toString();
         }
-        return typeParameter.toString() + " extends " + String.join( " & ", bounds );
+        return typeParameter + " extends " + String.join( " & ", bounds );
     }
 
     private void addFieldName( StringBuilder sb, VariableElement variableElement )
@@ -524,7 +524,7 @@ public class PublicApiAnnotationProcessor extends AbstractProcessor
         if ( kind == TypeKind.TYPEVAR )
         {
             TypeVariable typeVariable = (TypeVariable) type;
-            return "#" + typeVariable.toString();
+            return "#" + typeVariable;
         }
         if ( kind == TypeKind.DECLARED )
         {

--- a/annotations/src/main/java/org/neo4j/annotations/service/ServiceAnnotationProcessor.java
+++ b/annotations/src/main/java/org/neo4j/annotations/service/ServiceAnnotationProcessor.java
@@ -164,7 +164,7 @@ public class ServiceAnnotationProcessor extends AbstractProcessor
     {
         for ( final TypeElement service : serviceProviders.keySet() )
         {
-            final String path = "META-INF/services/" + elementUtils.getBinaryName( service ).toString();
+            final String path = "META-INF/services/" + elementUtils.getBinaryName( service );
             info( "Generating service config file: " + path );
 
             final SortedSet<String> oldProviders = loadIfExists( path );

--- a/community/bolt/src/test/java/org/neo4j/bolt/testing/BoltConditions.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/testing/BoltConditions.java
@@ -73,7 +73,7 @@ public class BoltConditions
     public static Condition<RecordedBoltResponse> succeededWithMetadata( final String key, final AnyValue value )
     {
         return new Condition<>( response -> response.message() == SUCCESS && response.hasMetadata( key ) && response.metadata( key ).equals( value ),
-                "SUCCESS " + format( " with metadata %s = %s", key, value.toString() ) );
+                "SUCCESS " + format( " with metadata %s = %s", key, value ) );
     }
 
     public static Condition<RecordedBoltResponse> containsNoRecord()
@@ -106,7 +106,7 @@ public class BoltConditions
     {
         return new Condition<>( response -> response.message() == SUCCESS && response.hasMetadata( key ) &&
                 pattern.matcher( ((TextValue) response.metadata( key )).stringValue() ).matches(),
-                "SUCCESS " + format( " with metadata %s ~ %s", key, pattern.toString() ) );
+                "SUCCESS " + format( " with metadata %s ~ %s", key, pattern ) );
     }
 
     public static Condition<RecordedBoltResponse> wasIgnored()

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeExpressionVisitor.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeExpressionVisitor.java
@@ -991,7 +991,7 @@ class ByteCodeExpressionVisitor implements ExpressionVisitor
         if ( !lhs.type().equals( rhs.type() ) )
         {
             throw new IllegalArgumentException(
-                    String.format( "Can only %s values of the same type (lhs: %s, rhs: %s)", operation, lhs.type().toString(), rhs.type().toString() )
+                    String.format( "Can only %s values of the same type (lhs: %s, rhs: %s)", operation, lhs.type(), rhs.type() )
             );
         }
     }

--- a/community/collections/src/main/java/org/neo4j/internal/helpers/collection/Iterables.java
+++ b/community/collections/src/main/java/org/neo4j/internal/helpers/collection/Iterables.java
@@ -203,7 +203,7 @@ public final class Iterables
         StringBuilder sb = new StringBuilder();
         while ( it.hasNext() )
         {
-            sb.append( it.next().toString() );
+            sb.append( it.next() );
             if ( it.hasNext() )
             {
                 sb.append( separator );

--- a/community/common/src/main/java/org/neo4j/internal/utils/DumpUtils.java
+++ b/community/common/src/main/java/org/neo4j/internal/utils/DumpUtils.java
@@ -71,7 +71,7 @@ public final class DumpUtils
             for ( int i = 0; i < stackTrace.length; i++ )
             {
                 StackTraceElement e = stackTrace[i];
-                sb.append( "\tat " ).append( e.toString() ).append( '\n' );
+                sb.append( "\tat " ).append( e ).append( '\n' );
 
                 // First stack element info can be found in the thread state
                 if ( i == 0 && threadInfo.getLockInfo() != null )

--- a/community/common/src/main/java/org/neo4j/kernel/lifecycle/LifeSupport.java
+++ b/community/common/src/main/java/org/neo4j/kernel/lifecycle/LifeSupport.java
@@ -367,7 +367,7 @@ public class LifeSupport implements Lifecycle
             else
             {
                 sb.append( " ".repeat( Math.max( 0, indent + 3 ) ) );
-                sb.append( instance.toString() ).append( '\n' );
+                sb.append( instance ).append( '\n' );
 
             }
         }
@@ -525,7 +525,7 @@ public class LifeSupport implements Lifecycle
         @Override
         public String toString()
         {
-            return instance.toString() + ": " + currentStatus.name();
+            return instance + ": " + currentStatus.name();
         }
 
         public boolean isInstance( Lifecycle instance )

--- a/community/common/src/main/java/org/neo4j/util/LocalIntCounter.java
+++ b/community/common/src/main/java/org/neo4j/util/LocalIntCounter.java
@@ -57,6 +57,6 @@ public class LocalIntCounter extends MutableInt
     @Override
     public String toString()
     {
-        return "local:" + super.toString() + ",global:" + global.toString();
+        return "local:" + super.toString() + ",global:" + global;
     }
 }

--- a/community/community-it/algo-it/src/test/java/common/Neo4jAlgoTestCase.java
+++ b/community/community-it/algo-it/src/test/java/common/Neo4jAlgoTestCase.java
@@ -170,7 +170,7 @@ public abstract class Neo4jAlgoTestCase
         }
         assertTrue( unexpectedDefs.isEmpty(), "These unexpected paths were found: " + unexpectedDefs +
                 ". In addition these expected paths weren't found:" + pathDefs );
-        assertTrue( pathDefs.isEmpty(), "These were expected, but not found: " + pathDefs.toString() );
+        assertTrue( pathDefs.isEmpty(), "These were expected, but not found: " + pathDefs );
     }
 
     protected static void assertPaths( Iterable<? extends Path> paths, String... pathDefinitions )

--- a/community/community-it/algo-it/src/test/java/org/neo4j/kernel/impl/traversal/TraversalTestBase.java
+++ b/community/community-it/algo-it/src/test/java/org/neo4j/kernel/impl/traversal/TraversalTestBase.java
@@ -309,7 +309,7 @@ abstract class TraversalTestBase
             {
                 buffer.append( delimiter );
             }
-            buffer.append( item.toString() );
+            buffer.append( item );
         }
         return buffer.toString();
     }

--- a/community/community-it/community-it/src/test/java/org/neo4j/server/CommandLineArgsTest.java
+++ b/community/community-it/community-it/src/test/java/org/neo4j/server/CommandLineArgsTest.java
@@ -61,7 +61,7 @@ public class CommandLineArgsTest
         File homeDir = new File( "/some/absolute/homedir" ).getAbsoluteFile();
 
         assertEquals( homeDir, parse( "--home-dir", homeDir.toString() ).homeDir() );
-        assertEquals( homeDir, parse( "--home-dir=" + homeDir.toString() ).homeDir() );
+        assertEquals( homeDir, parse( "--home-dir=" + homeDir ).homeDir() );
     }
 
     @Test

--- a/community/community-it/community-it/src/test/java/org/neo4j/server/StartupLoggingIT.java
+++ b/community/community-it/community-it/src/test/java/org/neo4j/server/StartupLoggingIT.java
@@ -73,7 +73,7 @@ public class StartupLoggingIT extends ExclusiveWebContainerTestBase
                 warn( "Config file \\[nonexistent-file.conf\\] does not exist." ),
                 info( "Starting..." ),
                 info( NEO4J_IS_STARTING_MESSAGE ),
-                info( "Remote interface available at " + uri.toString() ),
+                info( "Remote interface available at " + uri ),
                 info( "Started." ),
                 info( "Stopping..." ),
                 info( "Stopped." )

--- a/community/community-it/community-it/src/test/java/org/neo4j/server/TransactionTimeoutIT.java
+++ b/community/community-it/community-it/src/test/java/org/neo4j/server/TransactionTimeoutIT.java
@@ -67,7 +67,7 @@ public class TransactionTimeoutIT extends ExclusiveWebContainerTestBase
 
     private String txURI()
     {
-        return testWebContainer.getBaseUri().toString() + txEndpoint();
+        return testWebContainer.getBaseUri() + txEndpoint();
     }
 
 }

--- a/community/community-it/index-it/src/test/java/org/neo4j/index/Neo4jTestCase.java
+++ b/community/community-it/index-it/src/test/java/org/neo4j/index/Neo4jTestCase.java
@@ -179,7 +179,7 @@ public abstract class Neo4jTestCase
             {
                 buffer.append( delimiter );
             }
-            buffer.append( item.toString() );
+            buffer.append( item );
         }
         return buffer.toString();
     }

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/internal/batchimport/input/csv/CsvInputBatchImportIT.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/internal/batchimport/input/csv/CsvInputBatchImportIT.java
@@ -537,9 +537,9 @@ class CsvInputBatchImportIT
                 PointValue v = (PointValue) actualValue;
                 double actualY = v.getCoordinates().get( 0 ).getCoordinate().get( 1 );
                 double expectedY = indexOf( node ) % 90;
-                String message = actualValue.toString() + " does not have y=" + expectedY;
+                String message = actualValue + " does not have y=" + expectedY;
                 assertEquals( expectedY, actualY, 0.1, message );
-                message = actualValue.toString() + " does not have crs=wgs-84";
+                message = actualValue + " does not have crs=wgs-84";
                 assertEquals( CoordinateReferenceSystem.WGS84.getName(), v.getCoordinateReferenceSystem().getName(), message );
             };
             propertyVerifiers.put( "pointA", verifyPointA );
@@ -551,9 +551,9 @@ class CsvInputBatchImportIT
                 PointValue v = (PointValue) actualValue;
                 double actualY = v.getCoordinates().get( 0 ).getCoordinate().get( 1 );
                 double expectedY = indexOf( node );
-                String message = actualValue.toString() + " does not have y=" + expectedY;
+                String message = actualValue + " does not have y=" + expectedY;
                 assertEquals( expectedY, actualY, 0.1, message );
-                message = actualValue.toString() + " does not have crs=cartesian";
+                message = actualValue + " does not have crs=cartesian";
                 assertEquals( CoordinateReferenceSystem.Cartesian.getName(), v.getCoordinateReferenceSystem().getName(), message );
             };
             propertyVerifiers.put( "pointB", verifyPointB );

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/api/index/CompositeIndexAccessorCompatibility.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/api/index/CompositeIndexAccessorCompatibility.java
@@ -670,7 +670,7 @@ public abstract class CompositeIndexAccessorCompatibility extends IndexAccessorC
         {
             // then
             List<Long> hits = query( exact( 0, update.values()[0] ), exact( 1, update.values()[1] ) );
-            assertEquals( update.describe( tokenNameLookup ) + " " + hits.toString(), 1, hits.size() );
+            assertEquals( update.describe( tokenNameLookup ) + " " + hits, 1, hits.size() );
             assertThat( single( hits ) ).isEqualTo( update.getEntityId() );
         }
     }

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/api/index/CompositeRandomizedIndexAccessorCompatibility.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/api/index/CompositeRandomizedIndexAccessorCompatibility.java
@@ -107,7 +107,7 @@ public class CompositeRandomizedIndexAccessorCompatibility extends IndexAccessor
                         exact( 101, update.values()[1] ),
                         exact( 102, update.values()[2] ),
                         exact( 103, update.values()[3] ) );
-                assertEquals( update.describe( tokens ) + " " + hits.toString(), 1, hits.size() );
+                assertEquals( update.describe( tokens ) + " " + hits, 1, hits.size() );
                 assertThat( single( hits ), equalTo( update.getEntityId() ) );
             }
         }

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/api/index/SimpleIndexPopulatorCompatibility.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/api/index/SimpleIndexPopulatorCompatibility.java
@@ -300,7 +300,7 @@ public class SimpleIndexPopulatorCompatibility extends IndexProviderCompatibilit
                         anyHits = true;
                         nodesStillLeft.add( Long.toString( nodes.next() ) );
                     }
-                    assertFalse( "Expected this query to have zero hits but found " + nodesStillLeft.toString(), anyHits );
+                    assertFalse( "Expected this query to have zero hits but found " + nodesStillLeft, anyHits );
                 }
             }
         }

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/event/TestTransactionEvents.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/event/TestTransactionEvents.java
@@ -784,7 +784,7 @@ class TestTransactionEvents
         }
 
         assertEquals( 1, changedRelationships.size() );
-        assertTrue( changedRelationships.contains( livesIn.name() ), livesIn + " not in " + changedRelationships.toString() );
+        assertTrue( changedRelationships.contains( livesIn.name() ), livesIn + " not in " + changedRelationships );
     }
 
     @Test

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/newapi/ManagedTestCursors.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/newapi/ManagedTestCursors.java
@@ -53,7 +53,7 @@ public class ManagedTestCursors implements CursorFactory
         {
             if ( !n.isClosed() )
             {
-                fail( "The Cursor " + n.toString() + " was not closed properly." );
+                fail( "The Cursor " + n + " was not closed properly." );
             }
         }
 

--- a/community/configuration/src/main/java/org/neo4j/configuration/SettingValueParsers.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/SettingValueParsers.java
@@ -291,7 +291,7 @@ public final class SettingValueParsers
                     }
                 }
 
-                throw new IllegalArgumentException( format( "'%s' not one of %s", value, values.toString() ) );
+                throw new IllegalArgumentException( format( "'%s' not one of %s", value, values ) );
             }
 
             @Override
@@ -299,14 +299,14 @@ public final class SettingValueParsers
             {
                 if ( !values.contains( value ) )
                 {
-                    throw new IllegalArgumentException( format( "'%s' not one of %s", value, values.toString() ) );
+                    throw new IllegalArgumentException( format( "'%s' not one of %s", value, values ) );
                 }
             }
 
             @Override
             public String getDescription()
             {
-                return "one of " + values.toString();
+                return "one of " + values;
             }
 
             @Override

--- a/community/configuration/src/main/java/org/neo4j/configuration/helpers/DurationRange.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/helpers/DurationRange.java
@@ -93,7 +93,7 @@ public class DurationRange
     @Override
     public String toString()
     {
-        return '[' + min.toString() + '-' + max.toString() + ']';
+        return '[' + min.toString() + '-' + max + ']';
     }
 
     @Override

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/report/InconsistencyMessageLogger.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/report/InconsistencyMessageLogger.java
@@ -94,7 +94,7 @@ public class InconsistencyMessageLogger implements InconsistencyLogger
         }
         catch ( Exception e )
         {
-            return String.format( "%s[%d,Error generating toString: %s]", record.getClass().getSimpleName(), record.getId(), e.toString() );
+            return String.format( "%s[%d,Error generating toString: %s]", record.getClass().getSimpleName(), record.getId(), e );
         }
     }
 

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -92,7 +92,7 @@ public abstract class CompiledConversionUtils
         {
             return Array.getLength( value ) > 0;
         }
-        throw new CypherTypeException( "Don't know how to treat that as a predicate: " + value.toString(), null );
+        throw new CypherTypeException( "Don't know how to treat that as a predicate: " + value, null );
     }
 
     public static Set<?> toSet( Object value )
@@ -274,7 +274,7 @@ public abstract class CompiledConversionUtils
         {
             return ((BooleanValue) o).booleanValue();
         }
-        throw new CypherTypeException( "Don't know how to treat that as a boolean: " + o.toString(), null );
+        throw new CypherTypeException( "Don't know how to treat that as a boolean: " + o, null );
     }
 
     @SuppressWarnings( {"unchecked", "WeakerAccess"} )

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledMathHelper.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledMathHelper.java
@@ -561,11 +561,11 @@ public final class CompiledMathHelper
             Number number = (Number) value;
             if ( number.longValue() > Integer.MAX_VALUE )
             {
-                throw new CypherTypeException( value.toString() + " is too large to cast to an int32", null );
+                throw new CypherTypeException( value + " is too large to cast to an int32", null );
             }
             return number.intValue();
         }
-        throw new CypherTypeException( String.format( "Expected a numeric value but got %s", value.toString() ), null );
+        throw new CypherTypeException( String.format( "Expected a numeric value but got %s", value ), null );
     }
 
     public static long transformToLong( Object value )
@@ -585,7 +585,7 @@ public final class CompiledMathHelper
             return number.longValue();
         }
 
-        throw new CypherTypeException( String.format( "Expected a numeric value but got %s", value.toString() ), null );
+        throw new CypherTypeException( String.format( "Expected a numeric value but got %s", value ), null );
     }
 
     public static long transformToLongOrFail( Object value, String errorOnFloatingPoint )
@@ -613,7 +613,7 @@ public final class CompiledMathHelper
             return number.longValue();
         }
 
-        throw new CypherTypeException( String.format( "Expected a numeric value but got %s", value.toString() ), null );
+        throw new CypherTypeException( String.format( "Expected a numeric value but got %s", value ), null );
     }
 
     /**

--- a/community/cypher/front-end/util/src/main/java/org/neo4j/cypher/internal/util/DumpUtils.java
+++ b/community/cypher/front-end/util/src/main/java/org/neo4j/cypher/internal/util/DumpUtils.java
@@ -68,7 +68,7 @@ public final class DumpUtils
             for ( int i = 0; i < stackTrace.length; i++ )
             {
                 StackTraceElement e = stackTrace[i];
-                sb.append( "\tat " ).append( e.toString() ).append( '\n' );
+                sb.append( "\tat " ).append( e ).append( '\n' );
 
                 // First stack element info can be found in the thread state
                 if ( i == 0 && threadInfo.getLockInfo() != null )

--- a/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CursorUtils.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CursorUtils.java
@@ -339,7 +339,7 @@ public final class CursorUtils
         }
         else
         {
-            throw new CypherTypeException( format( "Type mismatch: expected a map but was %s", container.toString() ),
+            throw new CypherTypeException( format( "Type mismatch: expected a map but was %s", container ),
                     null );
         }
     }

--- a/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherFunctions.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherFunctions.java
@@ -540,7 +540,7 @@ public final class CypherFunctions
         }
         else
         {
-            throw new CypherTypeException( format( "Type mismatch: expected a map but was %s", container.toString() ), null );
+            throw new CypherTypeException( format( "Type mismatch: expected a map but was %s", container ), null );
         }
     }
 
@@ -1094,7 +1094,7 @@ public final class CypherFunctions
         }
         else
         {
-            throw new ParameterWrongTypeException( "Expected a Boolean or String, got: " + in.toString(), null );
+            throw new ParameterWrongTypeException( "Expected a Boolean or String, got: " + in, null );
         }
     }
 
@@ -1122,7 +1122,7 @@ public final class CypherFunctions
         }
         else
         {
-            throw new ParameterWrongTypeException( "Expected a String or Number, got: " + in.toString(), null );
+            throw new ParameterWrongTypeException( "Expected a String or Number, got: " + in, null );
         }
     }
 
@@ -1143,7 +1143,7 @@ public final class CypherFunctions
         }
         else
         {
-            throw new ParameterWrongTypeException( "Expected a String or Number, got: " + in.toString(), null );
+            throw new ParameterWrongTypeException( "Expected a String or Number, got: " + in, null );
         }
     }
 
@@ -1169,7 +1169,7 @@ public final class CypherFunctions
         else
         {
             throw new ParameterWrongTypeException(
-                    "Expected a String, Number, Boolean, Temporal or Duration, got: " + in.toString(), null );
+                    "Expected a String, Number, Boolean, Temporal or Duration, got: " + in, null );
         }
     }
 
@@ -1426,7 +1426,7 @@ public final class CypherFunctions
         }
         else
         {
-            throw new CypherTypeException( "Expected a numeric value but got: " + value.toString(), null );
+            throw new CypherTypeException( "Expected a numeric value but got: " + value, null );
         }
     }
 

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/CannotWriteException.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/CannotWriteException.java
@@ -27,6 +27,6 @@ public class CannotWriteException extends Exception
 {
     CannotWriteException( Path file )
     {
-        super( format( "Could not write to: %s", file.toAbsolutePath().toString() ) );
+        super( format( "Could not write to: %s", file.toAbsolutePath() ) );
     }
 }

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommand.java
@@ -118,7 +118,7 @@ public class DiagnosticsReportCommand extends AbstractCommand
                  reportDir = Path.of( System.getProperty( "java.io.tmpdir" ) ).resolve( "reports" ).toAbsolutePath();
             }
             Path reportFile = reportDir.resolve( getDefaultFilename() );
-            ctx.out().println( "Writing report to " + reportFile.toAbsolutePath().toString() );
+            ctx.out().println( "Writing report to " + reportFile.toAbsolutePath() );
             reporter.dump( classifiers, reportFile, progress, force );
         }
         catch ( IOException e )

--- a/community/dbms/src/main/java/org/neo4j/dbms/archive/Dumper.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/archive/Dumper.java
@@ -186,7 +186,7 @@ public class Dumper
 
         private ArchiveEntry createEntry( Path file, Path root, ArchiveOutputStream archive ) throws IOException
         {
-            return archive.createArchiveEntry( file.toFile(), "./" + root.relativize( file ).toString() );
+            return archive.createArchiveEntry( file.toFile(), "./" + root.relativize( file ) );
         }
     }
 }

--- a/community/dbms/src/main/java/org/neo4j/dbms/archive/Utils.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/archive/Utils.java
@@ -45,7 +45,7 @@ public class Utils
         }
         if ( isRegularFile( directory ) )
         {
-            throw new FileSystemException( directory.toString() + ": Not a directory" );
+            throw new FileSystemException( directory + ": Not a directory" );
         }
         if ( !isWritable( directory ) )
         {

--- a/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/JMXDumper.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/JMXDumper.java
@@ -130,7 +130,7 @@ public class JMXDumper
 
                 catch ( NumberFormatException e )
                 {
-                    printError( pidFile.toString() + " does not contain a valid id. Found: " + pidFileContent );
+                    printError( pidFile + " does not contain a valid id. Found: " + pidFileContent );
                 }
             }
             catch ( IOException e )

--- a/community/dbms/src/test/java/org/neo4j/dbms/archive/DumperTest.java
+++ b/community/dbms/src/test/java/org/neo4j/dbms/archive/DumperTest.java
@@ -88,7 +88,7 @@ class DumperTest
         Files.write( archive.getParent(), new byte[0] );
         FileSystemException exception =
                 assertThrows( FileSystemException.class, () -> new Dumper().dump( directory, directory, archive, GZIP, Predicates.alwaysFalse() ) );
-        assertEquals( archive.getParent().toString() + ": Not a directory", exception.getMessage() );
+        assertEquals( archive.getParent() + ": Not a directory", exception.getMessage() );
     }
 
     @Test

--- a/community/dbms/src/test/java/org/neo4j/dbms/archive/LoaderTest.java
+++ b/community/dbms/src/test/java/org/neo4j/dbms/archive/LoaderTest.java
@@ -179,7 +179,7 @@ class LoaderTest
         DatabaseLayout databaseLayout = DatabaseLayout.ofFlat( destination.toFile() );
 
         FileSystemException exception = assertThrows( FileSystemException.class, () -> new Loader().load( archive, databaseLayout ) );
-        assertEquals( destination.getParent().toString() + ": Not a directory", exception.getMessage() );
+        assertEquals( destination.getParent() + ": Not a directory", exception.getMessage() );
     }
 
     @Test

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/PathImpl.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/PathImpl.java
@@ -95,7 +95,7 @@ public final class PathImpl implements Path
             }
             else
             {
-                return relToString( relationship ) + ":" + previous.toString();
+                return relToString( relationship ) + ":" + previous;
             }
         }
     }

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/WeightedPathImpl.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/WeightedPathImpl.java
@@ -108,7 +108,7 @@ public class WeightedPathImpl implements WeightedPath
     @Override
     public String toString()
     {
-        return path.toString() + " weight:" + this.weight;
+        return path + " weight:" + this.weight;
     }
 
     @Override

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/impl/OrderedByTypeExpander.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/impl/OrderedByTypeExpander.java
@@ -75,7 +75,7 @@ public final class OrderedByTypeExpander extends StandardExpander.RegularExpande
     @Override
     void buildString( StringBuilder result )
     {
-        result.append( orderedTypes.toString() );
+        result.append( orderedTypes );
     }
 
     @Override

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/impl/StandardExpander.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/impl/StandardExpander.java
@@ -480,7 +480,7 @@ public abstract class StandardExpander implements PathExpander
         @Override
         void buildString( StringBuilder result )
         {
-            result.append( typesMap.toString() );
+            result.append( typesMap );
         }
 
         @Override

--- a/community/id-generator/src/main/java/org/neo4j/internal/id/indexed/IndexedIdGenerator.java
+++ b/community/id-generator/src/main/java/org/neo4j/internal/id/indexed/IndexedIdGenerator.java
@@ -689,7 +689,7 @@ public class IndexedIdGenerator implements IdGenerator
                     @Override
                     public void value( IdRange value )
                     {
-                        System.out.println( format( "%s [%d]", value.toString(), key.getIdRangeIdx() ) );
+                        System.out.println( format( "%s [%d]", value, key.getIdRangeIdx() ) );
                     }
                 }, cursorTracer );
                 System.out.println( header );

--- a/community/import-util/src/main/java/org/neo4j/internal/batchimport/cache/PageCacheNumberArray.java
+++ b/community/import-util/src/main/java/org/neo4j/internal/batchimport/cache/PageCacheNumberArray.java
@@ -178,7 +178,7 @@ public abstract class PageCacheNumberArray<N extends NumberArray<N>> implements 
         if ( cursor.checkAndClearBoundsFlag() )
         {
             throw new IllegalStateException(
-                    String.format( "Cursor %s access out of bounds, page id %d, offset %d", cursor.toString(),
+                    String.format( "Cursor %s access out of bounds, page id %d, offset %d", cursor,
                             cursor.getCurrentPageId(), cursor.getOffset() ) );
         }
     }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTreeCleanupJob.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTreeCleanupJob.java
@@ -95,7 +95,7 @@ class GBPTreeCleanupJob implements CleanupJob
         StringJoiner joiner = new StringJoiner( ", ", "CleanupJob(", ")" );
         joiner.add( "file=" + indexFile.getAbsolutePath() );
         joiner.add( "needed=" + needed );
-        joiner.add( "failure=" + (failure == null ? null : failure.toString()) );
+        joiner.add( "failure=" + failure );
         return joiner.toString();
     }
 }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/RecoveryCleanupWorkCollector.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/RecoveryCleanupWorkCollector.java
@@ -67,7 +67,7 @@ public abstract class RecoveryCleanupWorkCollector extends LifecycleAdapter
         List<Runnable> leakedTasks = executor.shutdownNow();
         if ( !leakedTasks.isEmpty() )
         {
-            throw new IllegalStateException( "Tasks leaked from CleanupJob. Tasks where " + leakedTasks.toString() );
+            throw new IllegalStateException( "Tasks leaked from CleanupJob. Tasks where " + leakedTasks );
         }
     }
 

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeReadWriteTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeReadWriteTestBase.java
@@ -211,6 +211,6 @@ abstract class GBPTreeReadWriteTestBase<KEY,VALUE>
     private void assertEqualsKey( KEY expected, KEY actual )
     {
         assertEquals( 0, layout.compare( expected, actual ),
-                format( "expected equal, expected=%s, actual=%s", expected.toString(), actual.toString() ) );
+                format( "expected equal, expected=%s, actual=%s", expected, actual ) );
     }
 }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicDynamicSizeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicDynamicSizeTest.java
@@ -111,6 +111,6 @@ class InternalTreeLogicDynamicSizeTest extends InternalTreeLogicTestBase<RawByte
         RawBytes rawBytes = keyAt( root.id(), 0, INTERNAL );
 
         // then
-        assertEquals( Long.BYTES, rawBytes.bytes.length, "expected no tail on internal key but was " + rawBytes.toString() );
+        assertEquals( Long.BYTES, rawBytes.bytes.length, "expected no tail on internal key but was " + rawBytes );
     }
 }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTestBase.java
@@ -2093,12 +2093,12 @@ abstract class InternalTreeLogicTestBase<KEY, VALUE>
     private void assertEqualsKey( KEY expected, KEY actual )
     {
         assertEquals( 0,
-            layout.compare( expected, actual ), String.format( "expected equal, expected=%s, actual=%s", expected.toString(), actual.toString() ) );
+            layout.compare( expected, actual ), String.format( "expected equal, expected=%s, actual=%s", expected, actual ) );
     }
 
     private void assertEqualsValue( VALUE expected, VALUE actual )
     {
         assertEquals( 0,
-            layout.compareValue( expected, actual ), String.format( "expected equal, expected=%s, actual=%s", expected.toString(), actual.toString() ) );
+            layout.compareValue( expected, actual ), String.format( "expected equal, expected=%s, actual=%s", expected, actual ) );
     }
 }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTestBase.java
@@ -2333,13 +2333,13 @@ abstract class SeekCursorTestBase<KEY, VALUE>
     private void assertEqualsKey( KEY expected, KEY actual )
     {
         assertEquals( 0, layout.compare( expected, actual ),
-                format( "expected equal, expected=%s, actual=%s", expected.toString(), actual.toString() ) );
+                format( "expected equal, expected=%s, actual=%s", expected, actual ) );
     }
 
     private void assertEqualsValue( VALUE expected, VALUE actual )
     {
         assertEquals( 0, layout.compareValue( expected, actual ),
-                format( "expected equal, expected=%s, actual=%s", expected.toString(), actual.toString() ) );
+                format( "expected equal, expected=%s, actual=%s", expected, actual ) );
     }
 
     private void insertKeysAndValues( int keyCount ) throws IOException

--- a/community/kernel-api/src/main/java/org/neo4j/kernel/api/index/LoggingMonitor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/kernel/api/index/LoggingMonitor.java
@@ -91,6 +91,6 @@ public class LoggingMonitor implements IndexProvider.Monitor
 
     private static String indexDescription( File indexFile, IndexDescriptor indexDescriptor )
     {
-        return "descriptor=" + indexDescriptor.toString() + ", indexFile=" + indexFile.getAbsolutePath();
+        return "descriptor=" + indexDescriptor + ", indexFile=" + indexFile.getAbsolutePath();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/extension/AbstractExtensions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/extension/AbstractExtensions.java
@@ -60,7 +60,7 @@ public abstract class AbstractExtensions extends DependencyResolver.Adapter impl
             {
                 Object extensionDependencies = getExtensionDependencies( extensionFactory );
                 Lifecycle dependency = newInstance( extensionContext, extensionFactory, extensionDependencies );
-                Objects.requireNonNull( dependency, extensionFactory.toString() + " returned a null extension." );
+                Objects.requireNonNull( dependency, extensionFactory + " returned a null extension." );
                 life.add( dependencies.satisfyDependency( dependency ) );
             }
             catch ( UnsatisfiedDependencyException exception )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -933,7 +933,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         AccessMode accessMode = securityContext().mode();
         if ( !accessMode.allowsTokenCreates( action ) )
         {
-            throw accessMode.onViolation( format( "'%s' operations are not allowed for %s.", action.toString(), securityContext().description() ) );
+            throw accessMode.onViolation( format( "'%s' operations are not allowed for %s.", action, securityContext().description() ) );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/RestrictedSchemaWrite.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/RestrictedSchemaWrite.java
@@ -52,7 +52,7 @@ public class RestrictedSchemaWrite implements SchemaWrite
         AccessMode accessMode = securityContext.mode();
         if ( !accessMode.allowsSchemaWrites( action ) )
         {
-            throw accessMode.onViolation( format( "Schema operation '%s' is not allowed for %s.", action.toString(), securityContext.description() ) );
+            throw accessMode.onViolation( format( "Schema operation '%s' is not allowed for %s.", action, securityContext.description() ) );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractDelegatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractDelegatingIndexProxy.java
@@ -137,7 +137,7 @@ public abstract class AbstractDelegatingIndexProxy implements IndexProxy
     @Override
     public String toString()
     {
-        return String.format( "%s -> %s", getClass().getSimpleName(), getDelegate().toString() );
+        return String.format( "%s -> %s", getClass().getSimpleName(), getDelegate() );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/LoggingPhaseTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/LoggingPhaseTracker.java
@@ -213,7 +213,7 @@ public class LoggingPhaseTracker implements PhaseTracker
         @Override
         public String toString()
         {
-            StringJoiner joiner = new StringJoiner( ", ", phase.toString() + "[", "]" );
+            StringJoiner joiner = new StringJoiner( ", ", phase + "[", "]" );
             if ( nbrOfReports == 0 )
             {
                 addToString( "nbrOfReports", nbrOfReports, joiner, false );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeCursor.java
@@ -377,7 +377,7 @@ class DefaultNodeCursor extends TraceableCursor implements NodeCursor
         }
         else
         {
-            return "NodeCursor[id=" + nodeReference() + ", " + storeCursor.toString() + "]";
+            return "NodeCursor[id=" + nodeReference() + ", " + storeCursor + "]";
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultPropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultPropertyCursor.java
@@ -247,7 +247,7 @@ public class DefaultPropertyCursor extends TraceableCursor implements PropertyCu
         else
         {
             return "PropertyCursor[id=" + propertyKey() +
-                   ", " + storeCursor.toString() + " ]";
+                   ", " + storeCursor + " ]";
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipScanCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipScanCursor.java
@@ -167,7 +167,7 @@ class DefaultRelationshipScanCursor extends DefaultRelationshipCursor<StorageRel
             return "RelationshipScanCursor[id=" + storeCursor.entityReference() +
                     ", open state with: single=" + single +
                     ", type=" + type +
-                    ", " + storeCursor.toString() + "]";
+                    ", " + storeCursor + "]";
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
@@ -222,7 +222,7 @@ class DefaultRelationshipTraversalCursor extends DefaultRelationshipCursor<Stora
         else
         {
             return "RelationshipTraversalCursor[id=" + storeCursor.entityReference() +
-                    ", " + storeCursor.toString() + "]";
+                    ", " + storeCursor + "]";
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MultipleUnderlyingStorageExceptions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MultipleUnderlyingStorageExceptions.java
@@ -50,7 +50,7 @@ public class MultipleUnderlyingStorageExceptions extends UnderlyingStorageExcept
 
         for ( Pair<IndexDescriptor, UnderlyingStorageException> pair : exceptions )
         {
-            builder.append( format( " (%s) %s", pair.first().toString(), pair.other().getMessage() ) );
+            builder.append( format( " (%s) %s", pair.first(), pair.other().getMessage() ) );
         }
 
         return builder.toString();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/SpatialConfigExtractor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/SpatialConfigExtractor.java
@@ -100,7 +100,7 @@ final class SpatialConfigExtractor
                     }
                     catch ( BufferUnderflowException e )
                     {
-                        logExtractionFailure( "Got an exception, " + e.toString() + ".", log, spatialFile.getIndexFile() );
+                        logExtractionFailure( "Got an exception, " + e + ".", log, spatialFile.getIndexFile() );
                     }
                 }
                 else

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DebugUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DebugUtil.java
@@ -306,7 +306,7 @@ public class DebugUtil
                     .append( message != null ? message : "" );
             for ( StackTraceElement element : elements )
             {
-                builder.append( format( "%n" ) ).append( "    at " ).append( element.toString() );
+                builder.append( format( "%n" ) ).append( "    at " ).append( element );
             }
             return builder.toString();
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
@@ -1087,7 +1087,7 @@ class IndexingServiceTest
             exceptionBarrier.await();
 
             assertThat( internalLogProvider ).containsMessages( expectedCause.getMessage() )
-                    .containsMessages( format( "Index %s entered %s state ", indexRule.toString(), FAILED ) );
+                    .containsMessages( format( "Index %s entered %s state ", indexRule, FAILED ) );
         }
         finally
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/TxStateIndexChangesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/TxStateIndexChangesTest.java
@@ -868,7 +868,7 @@ class TxStateIndexChangesTest
 
     private static void assertContainsInOrder( LongIterable iterable, long... nodeIds )
     {
-        assertTrue( iterable.containsAll( nodeIds ), "Expected: " + iterable.toString() + " to contains: " + Arrays.toString( nodeIds ) );
+        assertTrue( iterable.containsAll( nodeIds ), "Expected: " + iterable + " to contains: " + Arrays.toString( nodeIds ) );
     }
 
     private static void assertContainsInOrder( Iterable<NodeWithPropertyValues> iterable, NodeWithPropertyValues... expected )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureInvocationTracingAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureInvocationTracingAcceptanceTest.java
@@ -192,7 +192,7 @@ class DbStructureInvocationTracingAcceptanceTest
             builder.append( "\n\n" );
             for ( Diagnostic<?> diagnostic : diagnostics )
             {
-                builder.append( diagnostic.toString() );
+                builder.append( diagnostic );
                 builder.append( "\n" );
             }
             throw new AssertionError( builder.toString() );

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/FixturesTestIT.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/FixturesTestIT.java
@@ -67,7 +67,7 @@ class FixturesTestIT
         try ( Neo4j server = getServerBuilder( targetFolder ).withFixture( fixture ).build() )
         {
             // Then
-            HTTP.Response response = HTTP.POST( server.httpURI().toString() + "db/neo4j/tx/commit",
+            HTTP.Response response = HTTP.POST( server.httpURI() + "db/neo4j/tx/commit",
                     quotedJson( "{'statements':[{'statement':'MATCH (n:User) RETURN n'}]}" ) );
 
             assertThat( response.status() ).isEqualTo( 200 );
@@ -95,7 +95,7 @@ class FixturesTestIT
         try ( Neo4j server = getServerBuilder( targetFolder ).withFixture( targetFolder ).build() )
         {
             // Then
-            HTTP.Response response = HTTP.POST( server.httpURI().toString() + "db/neo4j/tx/commit",
+            HTTP.Response response = HTTP.POST( server.httpURI() + "db/neo4j/tx/commit",
                     quotedJson( "{'statements':[{'statement':'MATCH (n:User) RETURN n'}]}" ) );
 
             assertThat( response.get( "results" ).get( 0 ).get( "data" ).size() ).as( response.toString() ).isEqualTo( 3 );
@@ -123,7 +123,7 @@ class FixturesTestIT
                 .build() )
         {
             // Then
-            HTTP.Response response = HTTP.POST( server.httpURI().toString() + "db/neo4j/tx/commit",
+            HTTP.Response response = HTTP.POST( server.httpURI() + "db/neo4j/tx/commit",
                     quotedJson( "{'statements':[{'statement':'MATCH (n:User) RETURN n'}]}" ) );
 
             assertThat( response.get( "results" ).get( 0 ).get( "data" ).size() ).isEqualTo( 2 );
@@ -142,7 +142,7 @@ class FixturesTestIT
                 .build() )
         {
             // Then
-            HTTP.Response response = HTTP.POST( server.httpURI().toString() + "db/neo4j/tx/commit",
+            HTTP.Response response = HTTP.POST( server.httpURI() + "db/neo4j/tx/commit",
                     quotedJson( "{'statements':[{'statement':'MATCH (n:User) RETURN n'}]}" ) );
 
             assertThat( response.get( "results" ).get( 0 ).get( "data" ).size() ).isEqualTo( 1 );
@@ -163,7 +163,7 @@ class FixturesTestIT
                 .withFixture( targetFolder ).build() )
         {
             // Then
-            HTTP.Response response = HTTP.POST( server.httpURI().toString() + "db/neo4j/tx/commit",
+            HTTP.Response response = HTTP.POST( server.httpURI() + "db/neo4j/tx/commit",
                     quotedJson( "{'statements':[{'statement':'MATCH (n:User) RETURN n'}]}" ) );
 
             assertThat( response.get( "results" ).get( 0 ).get( "data" ).size() ).isEqualTo( 1 );
@@ -211,7 +211,7 @@ class FixturesTestIT
                 .build() )
         {
             // Then
-            HTTP.Response response = HTTP.POST( server.httpURI().toString() + "db/neo4j/tx/commit",
+            HTTP.Response response = HTTP.POST( server.httpURI() + "db/neo4j/tx/commit",
                     quotedJson( "{'statements':[{'statement':'MATCH (n:User) RETURN n'}]}" ) );
 
             assertThat( response.get( "results" ).get( 0 ).get( "data" ).size() ).isEqualTo( 1 );

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessServerBuilderIT.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessServerBuilderIT.java
@@ -160,7 +160,7 @@ class InProcessServerBuilderIT
                 .build() )
         {
             // Then
-            assertThat( HTTP.GET( neo4j.httpURI().toString() + "path/to/my/extension/myExtension" ).status() ).isEqualTo( 234 );
+            assertThat( HTTP.GET( neo4j.httpURI() + "path/to/my/extension/myExtension" ).status() ).isEqualTo( 234 );
         }
     }
 
@@ -173,7 +173,7 @@ class InProcessServerBuilderIT
                 .build() )
         {
             // Then
-            assertThat( HTTP.GET( neo4j.httpURI().toString() + "path/to/my/extension/myExtension" ).status() ).isEqualTo( 234 );
+            assertThat( HTTP.GET( neo4j.httpURI() + "path/to/my/extension/myExtension" ).status() ).isEqualTo( 234 );
         }
     }
 

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/JUnitRuleTestIT.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/JUnitRuleTestIT.java
@@ -94,7 +94,7 @@ public class JUnitRuleTestIT
         // When I run this test
 
         // Then
-        HTTP.Response response = HTTP.POST( neo4j.httpURI().toString() + "db/neo4j/tx/commit",
+        HTTP.Response response = HTTP.POST( neo4j.httpURI() + "db/neo4j/tx/commit",
                 quotedJson( "{'statements':[{'statement':'MATCH (n:User) RETURN n'}]}" ) );
 
         assertThat( response.get( "results" ).get( 0 ).get( "data" ).size() ).isEqualTo( 2 );

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/junit/extension/Neo4jExtensionRegisterIT.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/junit/extension/Neo4jExtensionRegisterIT.java
@@ -112,7 +112,7 @@ class Neo4jExtensionRegisterIT
     void fixturesRegistered( Neo4j neo4j ) throws Exception
     {
         // Then
-        HTTP.Response response = HTTP.POST( neo4j.httpURI().toString() + "db/neo4j/tx/commit",
+        HTTP.Response response = HTTP.POST( neo4j.httpURI() + "db/neo4j/tx/commit",
                 quotedJson( "{'statements':[{'statement':'MATCH (n:User) RETURN n'}]}" ) );
 
         assertThat( response.get( "results" ).get( 0 ).get( "data" ).size() ).isEqualTo( 2 );

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/validators/DuplicatedExtensionValidator.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/validators/DuplicatedExtensionValidator.java
@@ -91,7 +91,7 @@ public class DuplicatedExtensionValidator<T extends Annotation>
 
     private String defaultQualifiedName( Element procedure )
     {
-        return String.format( "%s.%s", elements.getPackageOf( procedure ).toString(), procedure.getSimpleName() );
+        return String.format( "%s.%s", elements.getPackageOf( procedure ), procedure.getSimpleName() );
     }
 
     private Stream<CompilationMessage> asErrors( Map.Entry<String,List<Element>> indexedProcedures )

--- a/community/procedure/src/test/java/org/neo4j/procedure/impl/ProcedureCompilationTest.java
+++ b/community/procedure/src/test/java/org/neo4j/procedure/impl/ProcedureCompilationTest.java
@@ -672,7 +672,7 @@ public class ProcedureCompilationTest
         StringBuilder builder = new StringBuilder();
         for ( Object o : list )
         {
-            builder.append( o.toString() );
+            builder.append( o );
         }
         return builder.toString();
     }

--- a/community/record-storage-engine/src/main/java/org/neo4j/internal/recordstorage/Command.java
+++ b/community/record-storage-engine/src/main/java/org/neo4j/internal/recordstorage/Command.java
@@ -655,7 +655,7 @@ public abstract class Command implements StorageCommand
             String beforeAndAfterRecords = super.toString();
             if ( schemaRule != null )
             {
-                return beforeAndAfterRecords + " : " + schemaRule.toString();
+                return beforeAndAfterRecords + " : " + schemaRule;
             }
             return beforeAndAfterRecords;
         }

--- a/community/record-storage-engine/src/test/java/org/neo4j/internal/batchimport/RelationshipGroupDefragmenterTest.java
+++ b/community/record-storage-engine/src/test/java/org/neo4j/internal/batchimport/RelationshipGroupDefragmenterTest.java
@@ -284,7 +284,7 @@ class RelationshipGroupDefragmenterTest
             assertTrue(
                 groupRecord.getNext() == groupRecord.getId() + 1 ||
                     groupRecord.getNext() == Record.NO_NEXT_RELATIONSHIP.intValue(), "Expected this group to have a next of current + " + units + " OR NULL, " +
-                    "but was " + groupRecord.toString() );
+                    "but was " + groupRecord );
             assertTrue(
                 groupRecord.getType() > currentTypeId, "Expected " + groupRecord + " to have type > " + currentTypeId );
             currentTypeId = groupRecord.getType();

--- a/community/record-storage-engine/src/test/java/org/neo4j/internal/batchimport/input/csv/StringDeserialization.java
+++ b/community/record-storage-engine/src/test/java/org/neo4j/internal/batchimport/input/csv/StringDeserialization.java
@@ -105,7 +105,7 @@ public class StringDeserialization implements Deserialization<String>
         }
         else
         {
-            throw new IllegalArgumentException( value.toString() + " " + value.getClass().getSimpleName() );
+            throw new IllegalArgumentException( value + " " + value.getClass().getSimpleName() );
         }
     }
 

--- a/community/record-storage-engine/src/test/java/org/neo4j/internal/recordstorage/LogTruncationTest.java
+++ b/community/record-storage-engine/src/test/java/org/neo4j/internal/recordstorage/LogTruncationTest.java
@@ -146,7 +146,7 @@ class LogTruncationTest
         }
         catch ( Exception e )
         {
-            throw new AssertionError( "Failed to deserialize " + cmd.toString() + ", because: ", e );
+            throw new AssertionError( "Failed to deserialize " + cmd + ", because: ", e );
         }
         bytesSuccessfullyWritten--;
         while ( bytesSuccessfullyWritten-- > 0 )

--- a/community/server/src/main/java/org/neo4j/server/http/cypher/format/common/Neo4jJsonCodec.java
+++ b/community/server/src/main/java/org/neo4j/server/http/cypher/format/common/Neo4jJsonCodec.java
@@ -243,7 +243,7 @@ public class Neo4jJsonCodec extends ObjectMapper
         }
         else
         {
-            throw new IllegalArgumentException( "Expected a Node or Relationship, but got a " + value.toString() );
+            throw new IllegalArgumentException( "Expected a Node or Relationship, but got a " + value );
         }
     }
 

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/HilbertSpaceFillingCurve3D.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/HilbertSpaceFillingCurve3D.java
@@ -245,7 +245,7 @@ public class HilbertSpaceFillingCurve3D extends SpaceFillingCurve
         @Override
         public String toString()
         {
-            return firstMove.toString() + secondMove.toString() + overallDirection.toString();
+            return firstMove.toString() + secondMove + overallDirection;
         }
     }
 

--- a/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveTest.java
+++ b/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveTest.java
@@ -551,7 +551,7 @@ public class SpaceFillingCurveTest
                                             if ( debug )
                                             {
                                                 final long end = System.currentTimeMillis();
-                                                logger.debug( String.format( "Results for level %d, with search %s.", level, searchEnvelope.toString() ) );
+                                                logger.debug( String.format( "Results for level %d, with search %s.", level, searchEnvelope ) );
                                                 logger.debug( String.format( "Search size vs covered size: %d vs %d (%f x). Ranges: %d. Took %d ms\n",
                                                         monitor.getSearchArea(), monitor.getCoveredArea(),
                                                         (double) (monitor.getCoveredArea()) / monitor.getSearchArea(), ranges.size(), end - start ) );
@@ -581,7 +581,7 @@ public class SpaceFillingCurveTest
                 if ( debug )
                 {
                     // Average over all runs on this level
-                    logger.debug( String.format( formatBody, level, config.toString(),
+                    logger.debug( String.format( formatBody, level, config,
                             areaStats.avg(), areaStats.min, areaStats.max,
                             rangeStats.avg(), rangeStats.min, rangeStats.max,
                             maxDepthStats.avg(), maxDepthStats.min, maxDepthStats.max ) );

--- a/community/testing/io-utils/src/main/java/org/neo4j/adversaries/pagecache/AdversarialReadPageCursor.java
+++ b/community/testing/io-utils/src/main/java/org/neo4j/adversaries/pagecache/AdversarialReadPageCursor.java
@@ -486,7 +486,7 @@ class AdversarialReadPageCursor extends DelegatingPageCursor
         StringBuilder sb = new StringBuilder();
         for ( Object o : s.inconsistentReadHistory )
         {
-            sb.append( o.toString() ).append( '\n' );
+            sb.append( o ).append( '\n' );
             if ( o instanceof NumberValue )
             {
                 NumberValue v = (NumberValue) o;

--- a/community/testing/test-utils/src/main/java/org/neo4j/test/OtherThreadExecutor.java
+++ b/community/testing/test-utils/src/main/java/org/neo4j/test/OtherThreadExecutor.java
@@ -300,7 +300,7 @@ public class OtherThreadExecutor<T> implements ThreadFactory, Closeable
             StringBuilder builder = new StringBuilder();
             for ( StackTraceElement element : stackTrace )
             {
-                builder.append( format( element.toString() + "%n" ) );
+                builder.append( format( element + "%n" ) );
             }
             return builder.toString();
         }

--- a/community/testing/test-utils/src/main/java/org/neo4j/test/extension/ThreadLeakageGuardExtension.java
+++ b/community/testing/test-utils/src/main/java/org/neo4j/test/extension/ThreadLeakageGuardExtension.java
@@ -110,7 +110,7 @@ public class ThreadLeakageGuardExtension implements AfterAllCallback, BeforeAllC
 
         if ( !leakedThreads.isEmpty() )
         {
-            String message = format( "%d leaked thread(s) detected:%n%s", leakedThreads.size(), leakedThreads.toString() );
+            String message = format( "%d leaked thread(s) detected:%n%s", leakedThreads.size(), leakedThreads );
             if ( PRINT_ONLY )
             {
                 printError( context, message );

--- a/community/testing/test-utils/src/main/java/org/neo4j/test/rule/concurrent/ThreadingRule.java
+++ b/community/testing/test-utils/src/main/java/org/neo4j/test/rule/concurrent/ThreadingRule.java
@@ -91,7 +91,7 @@ public class ThreadingRule extends ExternalResource
         for ( int i = 0; i < threads; i++ )
         {
             result.add( executor.submit( task(
-                    function, function.toString() + ":task=" + i, parameter, NULL_CONSUMER ) ) );
+                    function, function + ":task=" + i, parameter, NULL_CONSUMER ) ) );
         }
         return result;
     }

--- a/community/values/src/main/java/org/neo4j/values/storable/BooleanValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/BooleanValue.java
@@ -129,7 +129,7 @@ public abstract class BooleanValue extends ScalarValue
         @Override
         public String toString()
         {
-            return format( "%s('%s')", getTypeName(), Boolean.toString( true ) );
+            return format( "%s('%s')", getTypeName(), true );
         }
     };
 
@@ -187,7 +187,7 @@ public abstract class BooleanValue extends ScalarValue
         @Override
         public String toString()
         {
-            return format( "%s('%s')", getTypeName(), Boolean.toString( false ) );
+            return format( "%s('%s')", getTypeName(), false );
         }
     };
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
@@ -1083,24 +1083,24 @@ public final class DurationValue extends ScalarValue implements TemporalAmount, 
     private InvalidArgumentException invalidDurationAdd( DurationValue o1, DurationValue o2, Exception e )
     {
         return new InvalidArgumentException(
-                String.format( "Can not add duration %s and %s without causing overflow.", o1.toString(), o2.toString() ), e );
+                String.format( "Can not add duration %s and %s without causing overflow.", o1, o2 ), e );
     }
 
     private InvalidArgumentException invalidDurationSubtract( DurationValue o1, DurationValue o2, Exception e )
     {
         return new InvalidArgumentException(
-                String.format( "Can not subtract duration %s and %s without causing overflow.", o1.toString(), o2.toString() ), e );
+                String.format( "Can not subtract duration %s and %s without causing overflow.", o1, o2 ), e );
     }
 
     private InvalidArgumentException invalidDurationMultiply( DurationValue o1, NumberValue numberValue, Exception e )
     {
         return new InvalidArgumentException(
-                String.format( "Can not multiply duration %s with %s without causing overflow.", o1.toString(), numberValue.toString() ), e );
+                String.format( "Can not multiply duration %s with %s without causing overflow.", o1, numberValue ), e );
     }
 
     private InvalidArgumentException invalidDurationDivision( DurationValue o1, NumberValue numberValue, Exception e )
     {
         return new InvalidArgumentException(
-                String.format( "Can not divide duration %s with %s without causing overflow.", o1.toString(), numberValue.toString() ), e );
+                String.format( "Can not divide duration %s with %s without causing overflow.", o1, numberValue ), e );
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/Values.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Values.java
@@ -241,7 +241,7 @@ public final class Values
             return shortValue( number.shortValue() );
         }
 
-        throw new UnsupportedOperationException( "Unsupported type of Number " + number.toString() );
+        throw new UnsupportedOperationException( "Unsupported type of Number " + number );
     }
 
     public static LongValue longValue( long value )
@@ -477,7 +477,7 @@ public final class Values
             return NO_VALUE;
         }
 
-        throw new UnsupportedOperationException( "Unsupported type of Temporal " + value.toString() );
+        throw new UnsupportedOperationException( "Unsupported type of Temporal " + value );
     }
 
     public static DurationValue durationValue( TemporalAmount value )

--- a/community/values/src/test/java/org/neo4j/values/utils/AnyValueTestUtil.java
+++ b/community/values/src/test/java/org/neo4j/values/utils/AnyValueTestUtil.java
@@ -38,7 +38,7 @@ public class AnyValueTestUtil
 
     private static String formatMessage( String should, AnyValue a, AnyValue b )
     {
-        return String.format( "%s(%s) %s %s(%s)", a.getClass().getSimpleName(), a.toString(), should, b.getClass().getSimpleName(), b.toString() );
+        return String.format( "%s(%s) %s %s(%s)", a.getClass().getSimpleName(), a, should, b.getClass().getSimpleName(), b );
     }
 
     public static void assertEqualValues( AnyValue a, AnyValue b )

--- a/community/wal/src/main/java/org/neo4j/kernel/impl/transaction/log/LogPositionMarker.java
+++ b/community/wal/src/main/java/org/neo4j/kernel/impl/transaction/log/LogPositionMarker.java
@@ -58,6 +58,6 @@ public class LogPositionMarker
     @Override
     public String toString()
     {
-        return "Mark:" + newPosition().toString();
+        return "Mark:" + newPosition();
     }
 }


### PR DESCRIPTION
This PR removes unnecessary `.toString()`, since it is already used by the compiler when concatenating objects.

Of course, `.toString()` must exist when concatenating numbers, otherwise the compiler would add them as integers.

Also, same applies for `String.format("", object)` and `StringBuilder.append(object)`