### PR TITLE
Remove deprecation usage

### DIFF
--- a/community/cypher/cypher-planner/src/test/scala/org/neo4j/cypher/internal/compiler/test_helpers/ContextHelper.scala
+++ b/community/cypher/cypher-planner/src/test/scala/org/neo4j/cypher/internal/compiler/test_helpers/ContextHelper.scala
@@ -40,7 +40,7 @@ import org.neo4j.cypher.internal.util.CypherExceptionFactory
 import org.neo4j.cypher.internal.util.attribution.IdGen
 import org.neo4j.cypher.internal.util.attribution.SequentialIdGen
 import org.neo4j.values.virtual.MapValue
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 object ContextHelper extends MockitoSugar {
   def create(cypherExceptionFactory: CypherExceptionFactory = Neo4jCypherExceptionFactory("<QUERY>", None),

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/QueryCacheTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/QueryCacheTest.scala
@@ -29,7 +29,7 @@ import org.neo4j.cypher.internal.util.InternalNotification
 import org.neo4j.cypher.internal.util.test_helpers.CypherFunSuite
 import org.neo4j.internal.helpers.collection.Pair
 import org.neo4j.kernel.impl.query.TransactionalContext
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import QueryCacheTest.newTracer
 import QueryCacheTest.newKey
 import QueryCacheTest.alwaysStale

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/plandescription/CompactedPlanDescriptionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/plandescription/CompactedPlanDescriptionTest.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.plandescription.Arguments.DbHits
 import org.neo4j.cypher.internal.plandescription.Arguments.Rows
 import org.neo4j.cypher.internal.plandescription.Arguments.Time
 import org.neo4j.cypher.internal.util.test_helpers.CypherFunSuite
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 class CompactedPlanDescriptionTest extends CypherFunSuite with MockitoSugar {
   test("empty in empty out") {

--- a/community/cypher/front-end/frontend/src/test/scala/org/neo4j/cypher/internal/frontend/helpers/TestContext.scala
+++ b/community/cypher/front-end/frontend/src/test/scala/org/neo4j/cypher/internal/frontend/helpers/TestContext.scala
@@ -22,7 +22,7 @@ import org.neo4j.cypher.internal.frontend.phases.InternalNotificationLogger
 import org.neo4j.cypher.internal.frontend.phases.Monitors
 import org.neo4j.cypher.internal.util.CypherExceptionFactory
 import org.neo4j.cypher.internal.util.OpenCypherExceptionFactory
-import org.scalatest.mock.MockitoSugar.mock
+import org.scalatest.mockito.MockitoSugar.mock
 
 //noinspection TypeAnnotation
 case class TestContext(override val notificationLogger: InternalNotificationLogger = mock[InternalNotificationLogger]) extends BaseContext {

--- a/community/cypher/front-end/frontend/src/test/scala/org/neo4j/cypher/internal/frontend/phases/ContextHelper.scala
+++ b/community/cypher/front-end/frontend/src/test/scala/org/neo4j/cypher/internal/frontend/phases/ContextHelper.scala
@@ -21,7 +21,7 @@ import org.neo4j.cypher.internal.frontend.phases.CompilationPhaseTracer.NO_TRACI
 import org.neo4j.cypher.internal.frontend.phases.ContextHelper.mock
 import org.neo4j.cypher.internal.util.CypherExceptionFactory
 import org.neo4j.cypher.internal.util.OpenCypherExceptionFactory
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 object ContextHelper extends MockitoSugar {
   def create(): BaseContext = {

--- a/community/cypher/front-end/frontend/src/test/scala/org/neo4j/cypher/internal/frontend/phases/rewriting/CNFNormalizerTest.scala
+++ b/community/cypher/front-end/frontend/src/test/scala/org/neo4j/cypher/internal/frontend/phases/rewriting/CNFNormalizerTest.scala
@@ -31,7 +31,7 @@ import org.neo4j.cypher.internal.rewriting.PredicateTestSupport
 import org.neo4j.cypher.internal.util.CypherExceptionFactory
 import org.neo4j.cypher.internal.util.Rewriter
 import org.neo4j.cypher.internal.util.test_helpers.CypherFunSuite
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 class CNFNormalizerTest extends CypherFunSuite with PredicateTestSupport {
 

--- a/community/cypher/front-end/parser/src/main/scala/org/neo4j/cypher/internal/parser/InvalidInputErrorFormatter.scala
+++ b/community/cypher/front-end/parser/src/main/scala/org/neo4j/cypher/internal/parser/InvalidInputErrorFormatter.scala
@@ -24,9 +24,8 @@ import org.parboiled.matchers.TestNotMatcher
 import org.parboiled.support.Chars
 import org.parboiled.support.MatcherPath
 
-import scala.collection.JavaConversions.`deprecated asScalaBuffer`
-import scala.collection.JavaConversions.`deprecated seqAsJavaList`
-
+import scala.collection.JavaConverters.asScalaBufferConverter
+import scala.collection.JavaConverters.seqAsJavaListConverter
 
 class InvalidInputErrorFormatter extends DefaultInvalidInputErrorFormatter {
 
@@ -59,7 +58,7 @@ class InvalidInputErrorFormatter extends DefaultInvalidInputErrorFormatter {
   override def getExpectedString(error: InvalidInputError) : String = {
     val pathStartIndex = error.getStartIndex - error.getIndexDelta
 
-    val labels = error.getFailedMatchers.toList.flatMap(path => {
+    val labels = error.getFailedMatchers.asScala.toList.flatMap(path => {
       val labelMatcher = findProperLabelMatcher(path, pathStartIndex)
       if (labelMatcher == null) {
         List()
@@ -72,7 +71,7 @@ class InvalidInputErrorFormatter extends DefaultInvalidInputErrorFormatter {
       }
     }).distinct
 
-    join(labels)
+    join(labels.asJava)
   }
 
   private def findProperLabelMatcher(path: MatcherPath, errorIndex: Int) : Matcher = {

--- a/community/cypher/front-end/parser/src/test/scala/org/neo4j/cypher/internal/parser/ParserFixture.scala
+++ b/community/cypher/front-end/parser/src/test/scala/org/neo4j/cypher/internal/parser/ParserFixture.scala
@@ -18,7 +18,7 @@ package org.neo4j.cypher.internal.parser
 
 import org.neo4j.cypher.internal.ast
 import org.neo4j.cypher.internal.util.OpenCypherExceptionFactory
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 object ParserFixture extends MockitoSugar {
 

--- a/community/cypher/front-end/util/src/main/scala/org/neo4j/cypher/internal/util/Rewritable.scala
+++ b/community/cypher/front-end/util/src/main/scala/org/neo4j/cypher/internal/util/Rewritable.scala
@@ -26,19 +26,19 @@ import scala.collection.mutable
 
 object Rewriter {
   def lift(f: PartialFunction[AnyRef, AnyRef]): Rewriter =
-    f.orElse(PartialFunction(identity[AnyRef]))
+    f.orElse({ case x => x })
 
   val noop: Rewriter = Rewriter.lift(PartialFunction.empty)
 }
 
 object RewriterWithArgs {
   def lift(f: PartialFunction[(AnyRef, Seq[AnyRef]), AnyRef]): RewriterWithArgs =
-    f.orElse(PartialFunction({
+    f.orElse({
       // We need to dup anything not matched by f given the children
       case (p: Product, children) => Rewritable.dupProduct(p, children).asInstanceOf[AnyRef]
       case (a: AnyRef, children) => Rewritable.dupAny(a, children)
       case (null, _) => null
-    }))
+    })
 }
 
 object Rewritable {

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/QueryStateHelper.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/QueryStateHelper.scala
@@ -47,7 +47,7 @@ import org.neo4j.monitoring.Monitors
 import org.neo4j.values.AnyValue
 import org.neo4j.values.storable.CoordinateReferenceSystem
 import org.neo4j.values.virtual.VirtualValues.EMPTY_MAP
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 object QueryStateHelper extends MockitoSugar {
   def empty: QueryState = emptyWith()

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/PartialSortPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/PartialSortPipeTest.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.runtime.interpreted.Ascending
 import org.neo4j.cypher.internal.runtime.interpreted.InterpretedExecutionContextOrdering
 import org.neo4j.cypher.internal.runtime.interpreted.QueryStateHelper
 import org.neo4j.cypher.internal.util.test_helpers.CypherFunSuite
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 import scala.collection.mutable
 

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/PipeTestSupport.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/PipeTestSupport.scala
@@ -32,7 +32,7 @@ import org.neo4j.cypher.internal.util.test_helpers.CypherTestSupport
 import org.neo4j.graphdb.Node
 import org.neo4j.graphdb.Relationship
 import org.neo4j.kernel.impl.util.ValueUtils
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 trait PipeTestSupport extends CypherTestSupport with MockitoSugar {
 

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SortPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SortPipeTest.scala
@@ -28,7 +28,7 @@ import org.neo4j.cypher.internal.runtime.interpreted.ValueComparisonHelper.beEqu
 import org.neo4j.cypher.internal.util.test_helpers.CypherFunSuite
 import org.neo4j.values.storable.Values
 import org.neo4j.values.storable.Values.intValue
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 import scala.collection.mutable
 


### PR DESCRIPTION
This PR removes deprecated usage.

  - `PartialFunction.apply` usage is removed
  - `scala.collection.JavaConverters` instead of `scala.collection.JavaConversions`
  - `org.scalatest.mockito.MockitoSugar` instead of `org.scalatest.mock.MockitoSugar`
