### PR TITLE
Use non-deprecated MockitoSugar

### DIFF
--- a/community/cypher/cypher-planner/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/QueryGraphProducer.scala
+++ b/community/cypher/cypher-planner/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/QueryGraphProducer.scala
@@ -36,7 +36,7 @@ import org.neo4j.cypher.internal.v4_0.frontend.phases.Namespacer
 import org.neo4j.cypher.internal.v4_0.frontend.phases.rewriteEqualityToInPredicate
 import org.neo4j.cypher.internal.v4_0.rewriting.rewriters._
 import org.neo4j.cypher.internal.v4_0.util.inSequence
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 trait QueryGraphProducer extends MockitoSugar {
 

--- a/community/cypher/cypher-planner/src/test/scala/org/neo4j/cypher/internal/compiler/test_helpers/ContextHelper.scala
+++ b/community/cypher/cypher-planner/src/test/scala/org/neo4j/cypher/internal/compiler/test_helpers/ContextHelper.scala
@@ -31,7 +31,7 @@ import org.neo4j.cypher.internal.v4_0.rewriting.rewriters.GeneratingNamer
 import org.neo4j.cypher.internal.v4_0.util.attribution.{IdGen, SequentialIdGen}
 import org.neo4j.cypher.internal.v4_0.util.{CypherException, CypherExceptionFactory, InputPosition}
 import org.neo4j.values.virtual.MapValue
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 object ContextHelper extends MockitoSugar {
   def create(cypherExceptionFactory: CypherExceptionFactory = Neo4jCypherExceptionFactory("<QUERY>", None),

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryStatisticsTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryStatisticsTestSupport.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher
 import org.neo4j.cypher.internal.RewindableExecutionResult
 import org.neo4j.cypher.internal.runtime.QueryStatistics
 import org.scalatest.Assertions
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 trait QueryStatisticsTestSupport extends MockitoSugar {
   self: Assertions =>

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/QueryCacheTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/QueryCacheTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.v4_0.util.InternalNotification
 import org.neo4j.cypher.internal.v4_0.util.test_helpers.CypherFunSuite
 import org.neo4j.internal.helpers.collection.Pair
 import org.neo4j.kernel.impl.query.TransactionalContext
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 class QueryCacheTest extends CypherFunSuite {
   import QueryCacheTest._

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/plandescription/CompactedPlanDescriptionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/plandescription/CompactedPlanDescriptionTest.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.plandescription
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.plandescription.Arguments.{DbHits, Rows, Time}
 import org.neo4j.cypher.internal.v4_0.util.test_helpers.CypherFunSuite
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 class CompactedPlanDescriptionTest extends CypherFunSuite with MockitoSugar {
   test("empty in empty out") {

--- a/community/cypher/front-end/frontend/src/test/scala/org/neo4j/cypher/internal/v4_0/frontend/helpers/TestContext.scala
+++ b/community/cypher/front-end/frontend/src/test/scala/org/neo4j/cypher/internal/v4_0/frontend/helpers/TestContext.scala
@@ -18,7 +18,7 @@ package org.neo4j.cypher.internal.v4_0.frontend.helpers
 
 import org.neo4j.cypher.internal.v4_0.frontend.phases.{BaseContext, CompilationPhaseTracer, InternalNotificationLogger, Monitors}
 import org.neo4j.cypher.internal.v4_0.util.{CypherException, CypherExceptionFactory, InputPosition, OpenCypherExceptionFactory}
-import org.scalatest.mock.MockitoSugar.mock
+import org.scalatest.mockito.MockitoSugar.mock
 
 //noinspection TypeAnnotation
 case class TestContext(override val notificationLogger: InternalNotificationLogger = mock[InternalNotificationLogger]) extends BaseContext {

--- a/community/cypher/front-end/frontend/src/test/scala/org/neo4j/cypher/internal/v4_0/frontend/phases/ContextHelper.scala
+++ b/community/cypher/front-end/frontend/src/test/scala/org/neo4j/cypher/internal/v4_0/frontend/phases/ContextHelper.scala
@@ -19,7 +19,7 @@ package org.neo4j.cypher.internal.v4_0.frontend.phases
 import org.neo4j.cypher.internal.v4_0.ast.semantics.SemanticErrorDef
 import org.neo4j.cypher.internal.v4_0.frontend.phases.CompilationPhaseTracer.NO_TRACING
 import org.neo4j.cypher.internal.v4_0.util.{CypherException, CypherExceptionFactory, InputPosition, OpenCypherExceptionFactory}
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 object ContextHelper extends MockitoSugar {
   def create(): BaseContext = {

--- a/community/cypher/front-end/frontend/src/test/scala/org/neo4j/cypher/internal/v4_0/frontend/phases/rewriting/CNFNormalizerTest.scala
+++ b/community/cypher/front-end/frontend/src/test/scala/org/neo4j/cypher/internal/v4_0/frontend/phases/rewriting/CNFNormalizerTest.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.v4_0.frontend.phases.{CNFNormalizer, Compilatio
 import org.neo4j.cypher.internal.v4_0.rewriting.{AstRewritingMonitor, PredicateTestSupport}
 import org.neo4j.cypher.internal.v4_0.util.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.v4_0.util.{CypherException, CypherExceptionFactory, InputPosition, Rewriter}
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 class CNFNormalizerTest extends CypherFunSuite with PredicateTestSupport {
 

--- a/community/cypher/front-end/parser/src/test/scala/org/neo4j/cypher/internal/v4_0/parser/ParserFixture.scala
+++ b/community/cypher/front-end/parser/src/test/scala/org/neo4j/cypher/internal/v4_0/parser/ParserFixture.scala
@@ -18,7 +18,7 @@ package org.neo4j.cypher.internal.v4_0.parser
 
 import org.neo4j.cypher.internal.v4_0.ast
 import org.neo4j.cypher.internal.v4_0.util.OpenCypherExceptionFactory
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 object ParserFixture extends MockitoSugar {
 

--- a/community/cypher/front-end/util/src/test/scala/org/neo4j/cypher/internal/v4_0/util/test_helpers/CypherFunSuite.scala
+++ b/community/cypher/front-end/util/src/test/scala/org/neo4j/cypher/internal/v4_0/util/test_helpers/CypherFunSuite.scala
@@ -20,7 +20,7 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
 import org.scalatest._
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 import scala.reflect.Manifest
 

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/QueryStateHelper.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/QueryStateHelper.scala
@@ -36,7 +36,7 @@ import org.neo4j.monitoring.Monitors
 import org.neo4j.values.AnyValue
 import org.neo4j.values.storable.CoordinateReferenceSystem
 import org.neo4j.values.virtual.VirtualValues.EMPTY_MAP
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 object QueryStateHelper extends MockitoSugar {
   def empty: QueryState = emptyWith()

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/PartialSortPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/PartialSortPipeTest.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.runtime.interpreted.pipes
 
 import org.neo4j.cypher.internal.runtime.interpreted.{Ascending, InterpretedExecutionContextOrdering, QueryStateHelper}
 import org.neo4j.cypher.internal.v4_0.util.test_helpers.CypherFunSuite
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 import scala.collection.mutable.{Map => MutableMap}
 

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/PipeTestSupport.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/PipeTestSupport.scala
@@ -30,7 +30,7 @@ import org.neo4j.cypher.internal.v4_0.util.symbols.{CypherType, _}
 import org.neo4j.cypher.internal.v4_0.util.test_helpers.CypherTestSupport
 import org.neo4j.graphdb.{Node, Relationship}
 import org.neo4j.kernel.impl.util.ValueUtils
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 trait PipeTestSupport extends CypherTestSupport with MockitoSugar {
 

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ProcedureCallPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ProcedureCallPipeTest.scala
@@ -36,7 +36,7 @@ import org.neo4j.internal.kernel.api.procs.ProcedureCallContext
 import org.neo4j.kernel.database.DatabaseIdFactory
 import org.neo4j.values.AnyValue
 import org.neo4j.values.storable.{IntValue, LongValue, NumberValue, Values}
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 class ProcedureCallPipeTest
   extends CypherFunSuite

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SortPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SortPipeTest.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.internal.runtime.interpreted.ValueComparisonHelper._
 import org.neo4j.cypher.internal.v4_0.util.test_helpers.CypherFunSuite
 import org.neo4j.values.storable.Values
 import org.neo4j.values.storable.Values.intValue
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 import scala.collection.mutable.{Map => MutableMap}
 


### PR DESCRIPTION
The deprecation arose from a renaming,

https://github.com/scalatest/scalatest/blob/release-3.0.4/scalatest/src/main/scala/org/scalatest/mock/package.scala