### PR TITLE
Replace try online console link with sandbox

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -6,7 +6,7 @@ Learn more on the https://neo4j.com[Neo4j website].
 
 == Using Neo4j ==
 
-Neo4j is available both as a standalone server, or an embeddable component. You can https://neo4j.com/download/[download] or https://console.neo4j.org[try online].
+Neo4j is available both as a standalone server, or an embeddable component. You can https://neo4j.com/download/[download] or https://neo4j.com/sandbox/[try online].
 
 == Extending Neo4j ==
 


### PR DESCRIPTION
This is a suggestion based on my initial experience of working through the Neo4j starter materials. The console gives intermediate access to a Cypher console but the sandbox experience is much richer.