### PR TITLE
Fix deprecation warning on Double ranges

### DIFF
--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
@@ -247,7 +247,7 @@ sealed class TransactionBoundQueryContext(val transactionalContext: Transactiona
     try {
       val read = reads()
       val cursors = transactionalContext.cursors
-      val cursorTracer = transactionalContext.kernelTransaction.pageCursorTracer();
+      val cursorTracer = transactionalContext.kernelTransaction.pageCursorTracer()
       read.singleNode(node, cursor)
       if (!cursor.next()) RelationshipIterator.EMPTY
       else {

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ValueConversion.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ValueConversion.scala
@@ -96,7 +96,7 @@ object ValueConversion {
   }
 
   def asValues(params: Map[String, Any]): MapValue = {
-    if (params.isEmpty) return VirtualValues.EMPTY_MAP;
+    if (params.isEmpty) return VirtualValues.EMPTY_MAP
     val builder = new MapValueBuilder(params.size)
     params.foreach {
       case (key,value) => builder.add(key, asValue(value))

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/DistanceFunctionTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/DistanceFunctionTest.scala
@@ -241,8 +241,8 @@ class DistanceFunctionTest extends CypherFunSuite {
     val northPole = makePoint(0, 90)
 
     val points =
-      for (x <- -180.0 to 180.0 by 36.0; y <- -75.0 to 75.0 by 30.0) yield {
-        makePoint(x, y)
+      for (x <- -180 to 180 by 36; y <- -75 to 75 by 30) yield {
+        makePoint(x.toDouble, y.toDouble)
       }
     val distances = Seq(1.0, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0)
 
@@ -256,8 +256,8 @@ class DistanceFunctionTest extends CypherFunSuite {
         var maxLong = -90.0
 
         // Test that points on the circle lie inside the bounding box
-        for (brng <- 0.0 to 2.0 * Math.PI by 0.01) {
-          val dest = destinationPoint(point, distance, brng)
+        for (brng <- BigDecimal(0) to 2.0 * Math.PI by 0.01) {
+          val dest = destinationPoint(point, distance, brng.doubleValue)
           dest should beInsideOneBoundingBox(boxes, tolerant = true)
           val destLat = dest.coordinate()(1)
           val destLong = dest.coordinate()(0)

--- a/community/cypher/runtime-spec-suite/src/test/scala/org/neo4j/cypher/internal/runtime/spec/tests/UndirectedRelationshipByIdSeekTestBase.scala
+++ b/community/cypher/runtime-spec-suite/src/test/scala/org/neo4j/cypher/internal/runtime/spec/tests/UndirectedRelationshipByIdSeekTestBase.scala
@@ -141,7 +141,7 @@ abstract class UndirectedRelationshipByIdSeekTestBase[CONTEXT <: RuntimeContext]
     val toFind = toSeekFor(random.nextInt(toSeekFor.length))
     restartTx()
 
-    val attachedToFind = tx.getRelationshipById(toFind.getId);
+    val attachedToFind = tx.getRelationshipById(toFind.getId)
     // when
     val logicalQuery = new LogicalQueryBuilder(this)
       .produceResults("r", "x", "y")


### PR DESCRIPTION
The [to](https://www.scala-lang.org/api/2.12.7/scala/Double.html#to(end:T,step:T):scala.collection.immutable.NumericRange.Inclusive[T]) method on `Double` is deprecated in 2.12.6

I explored the `BigDecimal` replacement for `0.0 to 2.0 * Math.PI by 0.01` and there **is** a difference. The new range is stepping by precisely 0.01. For this test this is immaterial if I understand the test correctly.

![image](https://user-images.githubusercontent.com/1123855/78690924-f455c500-78ef-11ea-8618-55f1f83de780.png)

This Scala worksheet code I tried in the image above,
```
val s = 0.0 to 2.0 * Math.PI by 0.01
s.size
s.head
s.last

val t = (BigDecimal(0) to 2.0 * Math.PI by 0.01).map(_.toDouble)
t.size
t.head
t.last

s.toList == t.toList

(s.toList zip t.toList).filter {
  case (a, b) => a != b
}
  .take(10)
.mkString("\n")
```
