### PR TITLE
Fix argument adaption compiler warning

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/PreParser.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/PreParser.scala
@@ -210,11 +210,11 @@ object PreParser {
     if (runtime.isSelected && expressionEngine.isSelected && ILLEGAL_EXPRESSION_ENGINE_RUNTIME_COMBINATIONS((expressionEngine.pick, runtime.pick)))
       throw new InvalidPreparserOption(s"Cannot combine EXPRESSION ENGINE '${expressionEngine.pick.name}' with RUNTIME '${runtime.pick.name}'")
 
-    if (runtime.isSelected && operatorEngine.isSelected && ILLEGAL_OPERATOR_ENGINE_RUNTIME_COMBINATIONS(operatorEngine.pick, runtime.pick)) {
+    if (runtime.isSelected && operatorEngine.isSelected && ILLEGAL_OPERATOR_ENGINE_RUNTIME_COMBINATIONS((operatorEngine.pick, runtime.pick))) {
       throw new InvalidPreparserOption(s"Cannot combine OPERATOR ENGINE '${operatorEngine.pick.name}' with RUNTIME '${runtime.pick.name}'")
     }
 
-    if (runtime.isSelected && interpretedPipesFallback.isSelected && ILLEGAL_INTERPRETED_PIPES_FALLBACK_RUNTIME_COMBINATIONS(interpretedPipesFallback.pick, runtime.pick)) {
+    if (runtime.isSelected && interpretedPipesFallback.isSelected && ILLEGAL_INTERPRETED_PIPES_FALLBACK_RUNTIME_COMBINATIONS((interpretedPipesFallback.pick, runtime.pick))) {
       throw new InvalidPreparserOption(s"Cannot combine INTERPRETED PIPES FALLBACK '${interpretedPipesFallback.pick.name}' with RUNTIME '${runtime.pick.name}'")
     }
 


### PR DESCRIPTION
This removes two compiler warnings from this list,

```
janek@nwave:~/neo4j/community/cypher$ grep -i warn build.txt-01-pre-arg-list-adaption |grep -Pio '[a-z]++\.scala.*Adapting.+'|column -t -s:
ProcedureCallPipeTest.scala           79    Adapting argument list by creating a 2-tuple   this may not be what you want.
ProcedureCallPipeTest.scala           102   Adapting argument list by creating a 2-tuple   this may not be what you want.
CallClauseTest.scala                  72    Adapting argument list by creating a 2-tuple   this may not be what you want.
CallClauseTest.scala                  72    Adapting argument list by creating a 2-tuple   this may not be what you want.
CallClauseTest.scala                  124   Adapting argument list by creating a 2-tuple   this may not be what you want.
CallClauseTest.scala                  124   Adapting argument list by creating a 2-tuple   this may not be what you want.
CallClauseTest.scala                  150   Adapting argument list by creating a 2-tuple   this may not be what you want.
CallClauseTest.scala                  150   Adapting argument list by creating a 2-tuple   this may not be what you want.
CallClauseTest.scala                  203   Adapting argument list by creating a 2-tuple   this may not be what you want.
CallClauseTest.scala                  203   Adapting argument list by creating a 2-tuple   this may not be what you want.
CallClauseTest.scala                  240   Adapting argument list by creating a 2-tuple   this may not be what you want.
CallClauseTest.scala                  240   Adapting argument list by creating a 2-tuple   this may not be what you want.
PreParser.scala                       213   Adapting argument list by creating a 2-tuple   this may not be what you want.
PreParser.scala                       217   Adapting argument list by creating a 2-tuple   this may not be what you want.

```
I had a go at removing the warnings in `CallClauseTest.scala` and then reverted it because the left the source code looking inconsistent so I've left the test code warnings for now. Something for another day!