### PR TITLE
Remove usage of deprecated methods

### DIFF
--- a/community/community-it/cypher-it/src/test/java/org/neo4j/cypher/QueryInvalidationIT.java
+++ b/community/community-it/cypher-it/src/test/java/org/neo4j/cypher/QueryInvalidationIT.java
@@ -44,8 +44,8 @@ import org.neo4j.test.rule.ImpermanentDbmsRule;
 import static java.util.Collections.singletonMap;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class QueryInvalidationIT

--- a/community/community-it/cypher-it/src/test/scala/org/neo4j/cypher/ErrorMessagesTest.scala
+++ b/community/community-it/cypher-it/src/test/scala/org/neo4j/cypher/ErrorMessagesTest.scala
@@ -23,7 +23,7 @@ import java.util.Optional
 
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.equalTo
-import org.junit.Assert.assertThat
+import org.hamcrest.MatcherAssert.assertThat
 import org.neo4j.cypher.internal.util.helpers.StringHelper.RichString
 import org.neo4j.exceptions.Neo4jException
 import org.neo4j.exceptions.SyntaxException

--- a/community/community-it/cypher-it/src/test/scala/org/neo4j/cypher/internal/planning/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/community-it/cypher-it/src/test/scala/org/neo4j/cypher/internal/planning/CypherCompilerAstCacheAcceptanceTest.scala
@@ -343,7 +343,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
   }
 
   test("should not find query in cache with different parameter types") {
-    val map1: scala.Predef.Map[String, AnyRef] = scala.Predef.Map("number" -> new Integer(42))
+    val map1: scala.Predef.Map[String, AnyRef] = scala.Predef.Map("number" -> Integer.valueOf(42))
     val map2: scala.Predef.Map[String, AnyRef] = scala.Predef.Map("number" -> "nope")
     runQuery("return $number", params = map1)
     runQuery("return $number", params = map2)
@@ -352,8 +352,8 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
   }
 
   test("should find query in cache with same parameter types") {
-    val map1: scala.Predef.Map[String, AnyRef] = scala.Predef.Map("number" -> new Integer(42))
-    val map2: scala.Predef.Map[String, AnyRef] = scala.Predef.Map("number" -> new Integer(43))
+    val map1: scala.Predef.Map[String, AnyRef] = scala.Predef.Map("number" -> Integer.valueOf(42))
+    val map2: scala.Predef.Map[String, AnyRef] = scala.Predef.Map("number" -> Integer.valueOf(43))
     runQuery("return $number", params = map1)
     runQuery("return $number", params = map2)
 
@@ -361,8 +361,8 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
   }
 
   test("should find query in cache with same parameter types, ignoring unused parameters") {
-    val map1: scala.Predef.Map[String, AnyRef] = scala.Predef.Map("number" -> new Integer(42), "foo" -> "bar")
-    val map2: scala.Predef.Map[String, AnyRef] = scala.Predef.Map("number" -> new Integer(43), "bar" -> new Integer(10))
+    val map1: scala.Predef.Map[String, AnyRef] = scala.Predef.Map("number" -> Integer.valueOf(42), "foo" -> "bar")
+    val map2: scala.Predef.Map[String, AnyRef] = scala.Predef.Map("number" -> Integer.valueOf(43), "bar" -> Integer.valueOf(10))
     runQuery("return $number", params = map1)
     runQuery("return $number", params = map2)
 

--- a/community/community-it/cypher-it/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContextTest.scala
+++ b/community/community-it/cypher-it/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContextTest.scala
@@ -24,7 +24,7 @@ import java.net.URL
 import java.util.concurrent.atomic.AtomicReference
 
 import org.hamcrest.Matchers.greaterThan
-import org.junit.Assert.assertThat
+import org.hamcrest.MatcherAssert.assertThat
 import org.mockito.Mockito.RETURNS_DEEP_STUBS
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/api/index/CompositeRandomizedIndexAccessorCompatibility.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/api/index/CompositeRandomizedIndexAccessorCompatibility.java
@@ -46,8 +46,8 @@ import org.neo4j.values.storable.Values;
 
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.neo4j.internal.helpers.collection.Iterables.single;
 import static org.neo4j.internal.kernel.api.IndexQuery.exact;
 import static org.neo4j.internal.schema.SchemaDescriptor.forLabel;

--- a/community/cypher/front-end/ast/src/main/scala/org/neo4j/cypher/internal/ast/semantics/SemanticPatternCheck.scala
+++ b/community/cypher/front-end/ast/src/main/scala/org/neo4j/cypher/internal/ast/semantics/SemanticPatternCheck.scala
@@ -351,7 +351,7 @@ object SemanticPatternCheck extends SemanticAnalysisTooling {
   }
 
   private def checkValidTokenName(name: String): Option[String] = {
-    if (name == null || name.isEmpty || name.contains("\0") || name.contains("`")) {
+    if (name == null || name.isEmpty || name.contains("\u0000") || name.contains("`")) {
       Some(String.format("%s is not a valid token name. " + "Token names cannot be empty, or contain any null-bytes or back-ticks.",
         if (name != null) "'" + name + "'" else "Null"))
     } else {


### PR DESCRIPTION
- `org.junit.Assert.assertThat` to `org.hamcrest.MatcherAssert.assertThat`
- `new Integer()` to `Integer.valueOf()`
- `"\0"` to `"\u0000"`