### PR TITLE
Remove usage of deprecated RelationshipRecord constructors

### DIFF
--- a/community/community-it/consistency-it/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
+++ b/community/community-it/consistency-it/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
@@ -609,7 +609,8 @@ public class FullCheckIntegrationTest
                         NO_LABELS_FIELD.intValue() );
 
                 // structurally correct, but does not have the 'mandatory' property with the 'M' rel type
-                RelationshipRecord relationship = new RelationshipRecord( relId, true, nodeId1, nodeId2, M,
+                RelationshipRecord relationship = new RelationshipRecord( relId );
+                relationship.initialize( true, 0, nodeId1, nodeId2, M,
                         1, NO_NEXT_RELATIONSHIP.intValue(), 1, NO_NEXT_RELATIONSHIP.intValue(), true, true );
                 relationship.setNextProp( propId );
 
@@ -815,7 +816,9 @@ public class FullCheckIntegrationTest
             protected void transactionData( GraphStoreFixture.TransactionDataBuilder tx,
                                             GraphStoreFixture.IdGenerator next )
             {
-                tx.create( new RelationshipRecord( next.relationship(), 1, 2, C ) );
+                RelationshipRecord relationship = new RelationshipRecord( next.relationship() );
+                relationship.setLinks( 1, 2, C );
+                tx.create( relationship );
             }
         } );
 
@@ -841,7 +844,10 @@ public class FullCheckIntegrationTest
                 long node1 = next.node();
                 long node2 = next.node();
                 long rel = next.relationship();
-                tx.create( inUse( new RelationshipRecord( rel, node1, node2, 0 ) ) );
+
+                RelationshipRecord relationship = new  RelationshipRecord( rel );
+                relationship.setLinks( node1, node2, 0 );
+                tx.create( inUse( relationship ) );
                 tx.create( inUse( new NodeRecord( node1, false, rel + 1, -1 ) ) );
                 tx.create( inUse( new NodeRecord( node2, false, rel + 2, -1 ) ) );
             }
@@ -1398,8 +1404,13 @@ public class FullCheckIntegrationTest
                 long relB = next.relationship();
                 tx.create( inUse( new NodeRecord( node, true, group, NO_NEXT_PROPERTY.intValue() ) ) );
                 tx.create( inUse( new NodeRecord( otherNode, false, relA, NO_NEXT_PROPERTY.intValue() ) ) );
-                tx.create( withNext( inUse( new RelationshipRecord( relA, otherNode, node, C ) ), relB ) );
-                tx.create( withPrev( inUse( new RelationshipRecord( relB, node, otherNode, C ) ), relA ) );
+
+                RelationshipRecord relationshipA = new RelationshipRecord( relA );
+                relationshipA.setLinks( otherNode, node, C );
+                tx.create( withNext( inUse( relationshipA ), relB ) );
+                RelationshipRecord relationshipB = new RelationshipRecord( relB );
+                relationshipB.setLinks( node , otherNode, C);
+                tx.create( withPrev( inUse( relationshipB ), relA ) );
                 tx.create( withOwner( withRelationships( inUse( new RelationshipGroupRecord( group, C ) ), relB, relB, relB ), node ) );
                 tx.incrementRelationshipCount( ANY_LABEL, ANY_RELATIONSHIP_TYPE, ANY_LABEL, 2 );
                 tx.incrementRelationshipCount( ANY_LABEL, C, ANY_LABEL, 2 );
@@ -1569,7 +1580,9 @@ public class FullCheckIntegrationTest
                 long rel = next.relationship();
                 tx.create( new NodeRecord( node, true, group, NO_NEXT_PROPERTY.intValue() ) );
                 tx.create( new NodeRecord( otherNode, false, rel, NO_NEXT_PROPERTY.intValue() ) );
-                tx.create( new RelationshipRecord( rel, node, otherNode, T ) );
+                RelationshipRecord relationship = new RelationshipRecord( rel );
+                relationship.setLinks( node, otherNode, T );
+                tx.create( relationship );
                 tx.create( withOwner( withRelationships( new RelationshipGroupRecord( group, C ),
                         rel, rel, rel ), node ) );
                 tx.incrementRelationshipCount( ANY_LABEL, ANY_RELATIONSHIP_TYPE, ANY_LABEL, 1 );
@@ -1612,7 +1625,9 @@ public class FullCheckIntegrationTest
 
                 tx.create( new NodeRecord( nodeA, true, groupA, NO_NEXT_PROPERTY.intValue() ) );
                 tx.create( new NodeRecord( nodeB, false, rel, NO_NEXT_PROPERTY.intValue() ) );
-                tx.create( firstInChains( new RelationshipRecord( rel, nodeA, nodeB, C ), 1 ) );
+                RelationshipRecord relationship = new RelationshipRecord( rel );
+                relationship.setLinks( nodeA, nodeB, C );
+                tx.create( firstInChains( relationship, 1 ) );
                 tx.incrementRelationshipCount( ANY_LABEL, ANY_RELATIONSHIP_TYPE, ANY_LABEL, 1 );
                 tx.incrementRelationshipCount( ANY_LABEL, C, ANY_LABEL, 1 );
 

--- a/community/community-it/consistency-it/src/test/java/org/neo4j/consistency/newchecker/full/ExperimentalFullCheckIntegrationTest.java
+++ b/community/community-it/consistency-it/src/test/java/org/neo4j/consistency/newchecker/full/ExperimentalFullCheckIntegrationTest.java
@@ -98,8 +98,12 @@ public class ExperimentalFullCheckIntegrationTest extends FullCheckIntegrationTe
             protected void transactionData( GraphStoreFixture.TransactionDataBuilder tx,
                     GraphStoreFixture.IdGenerator next )
             {
-                tx.create( new RelationshipRecord( next.relationship(), 1, 2, C ) );
-                tx.create( new RelationshipRecord( next.relationship(), 1, 2, C ) );
+                RelationshipRecord relationshipA = new RelationshipRecord( next.relationship() );
+                relationshipA.setLinks(1, 2, C );
+                tx.create( relationshipA );
+                RelationshipRecord relationshipB = new RelationshipRecord( next.relationship() );
+                relationshipB.setLinks(1, 2, C );
+                tx.create( relationshipB );
             }
         } );
         extraSettings.put( experimental_consistency_checker_stop_threshold, 1 );
@@ -136,7 +140,9 @@ public class ExperimentalFullCheckIntegrationTest extends FullCheckIntegrationTe
                 long rel = next.relationship();
                 tx.create( new NodeRecord( node, true, group, NO_NEXT_PROPERTY.intValue() ) );
                 tx.create( new NodeRecord( otherNode, false, rel, NO_NEXT_PROPERTY.intValue() ) );
-                tx.create( new RelationshipRecord( rel, otherNode, otherNode, C ) );
+                RelationshipRecord relationship = new RelationshipRecord( rel );
+                relationship.setLinks( otherNode, otherNode, C );
+                tx.create( relationship );
                 tx.create( withOwner( withRelationships( new RelationshipGroupRecord( group, C ),
                         rel, rel, rel ), node ) );
                 tx.incrementRelationshipCount( ANY_LABEL, ANY_RELATIONSHIP_TYPE, ANY_LABEL, 1 );
@@ -168,7 +174,8 @@ public class ExperimentalFullCheckIntegrationTest extends FullCheckIntegrationTe
                 tx.create( new NodeRecord( node, false, rel, NO_NEXT_PROPERTY.intValue() ) );
                 tx.create( new NodeRecord( otherNode, false, rel, NO_NEXT_PROPERTY.intValue() ) );
 
-                RelationshipRecord relationship = new RelationshipRecord( rel, node, otherNode, C );
+                RelationshipRecord relationship = new RelationshipRecord( rel );
+                relationship.setLinks( node, otherNode, C );
                 relationship.setFirstNextRel( -3 ); //Set some negative pointers
                 relationship.setFirstPrevRel( -4 );
                 relationship.setSecondNextRel( -5 );
@@ -221,7 +228,9 @@ public class ExperimentalFullCheckIntegrationTest extends FullCheckIntegrationTe
             protected void transactionData( GraphStoreFixture.TransactionDataBuilder tx,
                     GraphStoreFixture.IdGenerator next )
             {
-                tx.create( new RelationshipRecord( next.relationship(), -2, -3, C ) );
+                RelationshipRecord relationship = new RelationshipRecord( next.relationship() );
+                relationship.setLinks( -2, -3, C );
+                tx.create( relationship );
 
                 tx.incrementRelationshipCount( ANY_LABEL, ANY_RELATIONSHIP_TYPE, ANY_LABEL, 1 );
                 tx.incrementRelationshipCount( ANY_LABEL, C, ANY_LABEL, 1 );

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/NodeRecordCheckTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/NodeRecordCheckTest.java
@@ -89,7 +89,8 @@ class NodeRecordCheckTest
     {
         // given
         NodeRecord node = inUse( new NodeRecord( 42, false, 7, 11 ) );
-        add( inUse( new RelationshipRecord( 7, 42, 0, 0 ) ) );
+        RelationshipRecord relationship = add( inUse( new RelationshipRecord( 7 ) ) );
+        relationship.setLinks( 42,  0, 0 );
         add( inUse( new PropertyRecord( 11 ) ) );
 
         // when
@@ -104,7 +105,8 @@ class NodeRecordCheckTest
     {
         // given
         NodeRecord node = inUse( new NodeRecord( 42, false, 7, 11 ) );
-        RelationshipRecord relationship = add( notInUse( new RelationshipRecord( 7, 0, 0, 0 ) ) );
+        RelationshipRecord relationship = add( notInUse( new RelationshipRecord( 7 ) ) );
+        relationship.setLinks( 0, 0, 0 );
         add( inUse( new PropertyRecord( 11 ) ) );
 
         // when
@@ -151,7 +153,8 @@ class NodeRecordCheckTest
     {
         // given
         NodeRecord node = inUse( new NodeRecord( 42, false, 7, NONE ) );
-        RelationshipRecord relationship = add( inUse( new RelationshipRecord( 7, 1, 2, 0 ) ) );
+        RelationshipRecord relationship = add( inUse( new RelationshipRecord( 7 ) ) );
+        relationship.setLinks( 1, 2, 0 );
 
         // when
         ConsistencyReport.NodeConsistencyReport report = check( node );
@@ -166,7 +169,8 @@ class NodeRecordCheckTest
     {
         // given
         NodeRecord node = inUse( new NodeRecord( 42, false, 7, NONE ) );
-        RelationshipRecord relationship = add( inUse( new RelationshipRecord( 7, 42, 0, 0 ) ) );
+        RelationshipRecord relationship = add( inUse( new RelationshipRecord( 7 ) ) );
+        relationship.setLinks( 42, 0, 0 );
         relationship.setFirstPrevRel( 6 );
         relationship.setFirstInFirstChain( false );
         relationship.setSecondPrevRel( 8 );
@@ -185,7 +189,8 @@ class NodeRecordCheckTest
     {
         // given
         NodeRecord node = inUse( new NodeRecord( 42, false, 7, NONE ) );
-        RelationshipRecord relationship = add( inUse( new RelationshipRecord( 7, 0, 42, 0 ) ) );
+        RelationshipRecord relationship = add( inUse( new RelationshipRecord( 7 ) ) );
+        relationship.setLinks( 0, 42, 0 );
         relationship.setFirstPrevRel( 6 );
         relationship.setFirstInFirstChain( false );
         relationship.setSecondPrevRel( 8 );
@@ -204,7 +209,8 @@ class NodeRecordCheckTest
     {
         // given
         NodeRecord node = inUse( new NodeRecord( 42, false, 7, NONE ) );
-        RelationshipRecord relationship = add( inUse( new RelationshipRecord( 7, 42, 42, 0 ) ) );
+        RelationshipRecord relationship = add( inUse( new RelationshipRecord( 7 ) ) );
+        relationship.setLinks( 42, 42, 0 );
         relationship.setFirstPrevRel( 8 );
         relationship.setFirstInFirstChain( false );
         relationship.setSecondPrevRel( 8 );

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/RelationshipRecordCheckTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/RelationshipRecordCheckTest.java
@@ -78,7 +78,8 @@ class RelationshipRecordCheckTest extends
     void shouldNotReportAnythingForRelationshipNotInUse()
     {
         // given
-        RelationshipRecord relationship = notInUse( new RelationshipRecord( 42, 0, 0, 0 ) );
+        RelationshipRecord relationship = notInUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 0, 0, 0 );
 
         // when
         RelationshipConsistencyReport report = check( relationship );
@@ -91,7 +92,8 @@ class RelationshipRecordCheckTest extends
     void shouldNotReportAnythingForRelationshipThatDoesNotReferenceOtherRecords()
     {
         // given
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         add( inUse( new NodeRecord( 1, false, 42, NONE ) ) );
         add( inUse( new NodeRecord( 2, false, 42, NONE ) ) );
@@ -110,16 +112,21 @@ class RelationshipRecordCheckTest extends
         /*
          * (1) --> (3) <==> (2)
          */
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         add( inUse( new NodeRecord( 1, false, relationship.getId(), NONE ) ) );
         add( inUse( new NodeRecord( 2, false, 53, NONE ) ) );
         add( inUse( new NodeRecord( 3, false, NONE, NONE ) ) );
         add( inUse( new PropertyRecord( 101 ) ) );
         relationship.setNextProp( 101 );
-        RelationshipRecord sNext = add( inUse( new RelationshipRecord( 51, 1, 3, 4 ) ) );
-        RelationshipRecord tNext = add( inUse( new RelationshipRecord( 52, 2, 3, 4 ) ) );
-        RelationshipRecord tPrev = add( inUse( new RelationshipRecord( 53, 3, 2, 4 ) ) );
+
+        RelationshipRecord sNext = add( inUse( new RelationshipRecord( 51 ) ) );
+        sNext.setLinks( 1, 3, 4 );
+        RelationshipRecord tNext = add( inUse( new RelationshipRecord( 52 ) ) );
+        tNext.setLinks( 2, 3, 4 );
+        RelationshipRecord tPrev = add( inUse( new RelationshipRecord( 53 ) ) );
+        tPrev.setLinks( 3, 2, 4 );
 
         relationship.setFirstNextRel( sNext.getId() );
         sNext.setFirstPrevRel( relationship.getId() );
@@ -143,7 +150,8 @@ class RelationshipRecordCheckTest extends
     {
         // given
         checkSingleDirection();
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, NONE ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, NONE );
         add( inUse( new NodeRecord( 1, false, 42, NONE ) ) );
         add( inUse( new NodeRecord( 2, false, 42, NONE ) ) );
 
@@ -160,7 +168,8 @@ class RelationshipRecordCheckTest extends
     {
         // given
         checkSingleDirection();
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         RelationshipTypeTokenRecord relationshipType = add( notInUse( new RelationshipTypeTokenRecord( 4 ) ) );
         add( inUse( new NodeRecord( 1, false, 42, NONE ) ) );
         add( inUse( new NodeRecord( 2, false, 42, NONE ) ) );
@@ -178,7 +187,8 @@ class RelationshipRecordCheckTest extends
     {
         // given
         checkSingleDirection();
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, NONE, 1, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( NONE, 1, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         add( inUse( new NodeRecord( 1, false, 42, NONE ) ) );
 
@@ -196,7 +206,8 @@ class RelationshipRecordCheckTest extends
         // given
         checkSingleDirection();
         initialize( RELATIONSHIPS, NODES );
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         NodeRecord node = add( notInUse( new NodeRecord( 1, false, NONE, NONE ) ) );
         add( inUse( new NodeRecord( 2, false, 42, NONE ) ) );
@@ -214,7 +225,8 @@ class RelationshipRecordCheckTest extends
     {
         // given
         checkSingleDirection();
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, NONE, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, NONE, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         add( inUse( new NodeRecord( 1, false, 42, NONE ) ) );
 
@@ -232,7 +244,8 @@ class RelationshipRecordCheckTest extends
         // given
         checkSingleDirection();
         initialize( RELATIONSHIPS, NODES );
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         add( inUse( new NodeRecord( 1, false, 42, NONE ) ) );
         NodeRecord node = add( notInUse( new NodeRecord( 2, false, NONE, NONE ) ) );
@@ -250,7 +263,8 @@ class RelationshipRecordCheckTest extends
     {
         // given
         checkSingleDirection();
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         relationship.setNextProp( 11 );
         add( inUse( new NodeRecord( 1, false, 42, NONE ) ) );
@@ -270,7 +284,8 @@ class RelationshipRecordCheckTest extends
     {
         // given
         checkSingleDirection();
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         relationship.setNextProp( 11 );
         add( inUse( new NodeRecord( 1, false, 42, NONE ) ) );
@@ -292,7 +307,8 @@ class RelationshipRecordCheckTest extends
         // given
         checkSingleDirection();
         initialize( RELATIONSHIPS, NODES );
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         NodeRecord source = add( inUse( new NodeRecord( 1, false, 7, NONE ) ) );
         add( inUse( new NodeRecord( 2, false, 42, NONE ) ) );
@@ -311,7 +327,8 @@ class RelationshipRecordCheckTest extends
         // given
         checkSingleDirection();
         initialize( RELATIONSHIPS, NODES );
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         add( inUse( new NodeRecord( 1, false, 42, NONE ) ) );
         NodeRecord target = add( inUse( new NodeRecord( 2, false, 7, NONE ) ) );
@@ -330,7 +347,8 @@ class RelationshipRecordCheckTest extends
         // given
         checkSingleDirection();
         initialize( RELATIONSHIPS, NODES );
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         NodeRecord source = add( inUse( new NodeRecord( 1, false, NONE, NONE ) ) );
         NodeRecord target = add( inUse( new NodeRecord( 2, false, NONE, NONE ) ) );
@@ -350,11 +368,13 @@ class RelationshipRecordCheckTest extends
         // given
         checkSingleDirection();
         initialize( RELATIONSHIPS, NODES );
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         NodeRecord source = add( inUse( new NodeRecord( 1, false, NONE, NONE ) ) );
         add( inUse( new NodeRecord( 2, false, 42, NONE ) ) );
-        RelationshipRecord sPrev = add( inUse( new RelationshipRecord( 51, 1, 0, 0 ) ) );
+        RelationshipRecord sPrev = add( inUse( new RelationshipRecord( 51 ) ) );
+        sPrev.setLinks( 1, 0, 0 );
         relationship.setFirstPrevRel( sPrev.getId() );
         relationship.setFirstInFirstChain( false );
         sPrev.setFirstNextRel( relationship.getId() );
@@ -373,11 +393,13 @@ class RelationshipRecordCheckTest extends
         // given
         checkSingleDirection();
         initialize( RELATIONSHIPS, NODES );
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         add( inUse( new NodeRecord( 1, false, 42, NONE ) ) );
         NodeRecord target = add( inUse( new NodeRecord( 2, false, NONE, NONE ) ) );
-        RelationshipRecord tPrev = add( inUse( new RelationshipRecord( 51, 0, 2, 0 ) ) );
+        RelationshipRecord tPrev = add( inUse( new RelationshipRecord( 51 ) ) );
+        tPrev.setLinks( 0, 2, 0 );
         relationship.setSecondPrevRel( tPrev.getId() );
         relationship.setFirstInSecondChain( false );
         tPrev.setSecondNextRel( relationship.getId() );
@@ -394,11 +416,13 @@ class RelationshipRecordCheckTest extends
     void shouldReportSourcePrevReferencingOtherNodes()
     {
         // given
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         add( inUse( new NodeRecord( 1, false, 0, NONE ) ) );
         add( inUse( new NodeRecord( 2, false, 42, NONE ) ) );
-        RelationshipRecord sPrev = add( inUse( new RelationshipRecord( 51, 8, 9, 0 ) ) );
+        RelationshipRecord sPrev = add( inUse( new RelationshipRecord( 51 ) ) );
+        sPrev.setLinks( 8, 9, 0 );
         relationship.setFirstPrevRel( sPrev.getId() );
         relationship.setFirstInFirstChain( false );
 
@@ -414,11 +438,13 @@ class RelationshipRecordCheckTest extends
     void shouldReportTargetPrevReferencingOtherNodes()
     {
         // given
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         add( inUse( new NodeRecord( 1, false, 42, NONE ) ) );
         add( inUse( new NodeRecord( 2, false, 0, NONE ) ) );
-        RelationshipRecord tPrev = add( inUse( new RelationshipRecord( 51, 8, 9, 0 ) ) );
+        RelationshipRecord tPrev = add( inUse( new RelationshipRecord( 51 ) ) );
+        tPrev.setLinks( 8, 9, 0 );
         relationship.setSecondPrevRel( tPrev.getId() );
         relationship.setFirstInSecondChain( false );
 
@@ -434,11 +460,13 @@ class RelationshipRecordCheckTest extends
     void shouldReportSourceNextReferencingOtherNodes()
     {
         // given
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         add( inUse( new NodeRecord( 1, false, 42, NONE ) ) );
         add( inUse( new NodeRecord( 2, false, 42, NONE ) ) );
-        RelationshipRecord sNext = add( inUse( new RelationshipRecord( 51, 8, 9, 0 ) ) );
+        RelationshipRecord sNext = add( inUse( new RelationshipRecord( 51 ) ) );
+        sNext.setLinks( 8, 9, 0 );
         relationship.setFirstNextRel( sNext.getId() );
 
         // when
@@ -453,11 +481,13 @@ class RelationshipRecordCheckTest extends
     void shouldReportTargetNextReferencingOtherNodes()
     {
         // given
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         add( inUse( new NodeRecord( 1, false, 42, NONE ) ) );
         add( inUse( new NodeRecord( 2, false, 42, NONE ) ) );
-        RelationshipRecord tNext = add( inUse( new RelationshipRecord( 51, 8, 9, 0 ) ) );
+        RelationshipRecord tNext = add( inUse( new RelationshipRecord( 51 ) ) );
+        tNext.setLinks( 8, 9, 0 );
         relationship.setSecondNextRel( tNext.getId() );
 
         // when
@@ -472,11 +502,13 @@ class RelationshipRecordCheckTest extends
     void shouldReportSourcePrevReferencingOtherNodesWhenReferencingTargetNode()
     {
         // given
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         add( inUse( new NodeRecord( 1, false, 0, NONE ) ) );
         add( inUse( new NodeRecord( 2, false, 42, NONE ) ) );
-        RelationshipRecord sPrev = add( inUse( new RelationshipRecord( 51, 2, 0, 0 ) ) );
+        RelationshipRecord sPrev = add( inUse( new RelationshipRecord( 51 ) ) );
+        sPrev.setLinks( 2, 0, 0 );
         relationship.setFirstPrevRel( sPrev.getId() );
         relationship.setFirstInFirstChain( false );
 
@@ -492,11 +524,13 @@ class RelationshipRecordCheckTest extends
     void shouldReportTargetPrevReferencingOtherNodesWhenReferencingSourceNode()
     {
         // given
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         add( inUse( new NodeRecord( 1, false, 42, NONE ) ) );
         add( inUse( new NodeRecord( 2, false, 0, NONE ) ) );
-        RelationshipRecord tPrev = add( inUse( new RelationshipRecord( 51, 1, 0, 0 ) ) );
+        RelationshipRecord tPrev = add( inUse( new RelationshipRecord( 51 ) ) );
+        tPrev.setLinks( 1, 0, 0 );
         relationship.setSecondPrevRel( tPrev.getId() );
         relationship.setFirstInSecondChain( false );
 
@@ -512,11 +546,13 @@ class RelationshipRecordCheckTest extends
     void shouldReportSourceNextReferencingOtherNodesWhenReferencingTargetNode()
     {
         // given
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         add( inUse( new NodeRecord( 1, false, 42, NONE ) ) );
         add( inUse( new NodeRecord( 2, false, 42, NONE ) ) );
-        RelationshipRecord sNext = add( inUse( new RelationshipRecord( 51, 2, 0, 0 ) ) );
+        RelationshipRecord sNext = add( inUse( new RelationshipRecord( 51 ) ) );
+        sNext.setLinks( 2, 0, 0 );
         relationship.setFirstNextRel( sNext.getId() );
 
         // when
@@ -531,11 +567,13 @@ class RelationshipRecordCheckTest extends
     void shouldReportTargetNextReferencingOtherNodesWhenReferencingSourceNode()
     {
         // given
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         add( inUse( new NodeRecord( 1, false, 42, NONE ) ) );
         add( inUse( new NodeRecord( 2, false, 42, NONE ) ) );
-        RelationshipRecord tNext = add( inUse( new RelationshipRecord( 51, 1, 0, 0 ) ) );
+        RelationshipRecord tNext = add( inUse( new RelationshipRecord( 51 ) ) );
+        tNext.setLinks( 1, 0, 0 );
         relationship.setSecondNextRel( tNext.getId() );
 
         // when
@@ -550,11 +588,13 @@ class RelationshipRecordCheckTest extends
     void shouldReportSourcePrevNotReferencingBack()
     {
         // given
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         add( inUse( new NodeRecord( 1, false, 0, NONE ) ) );
         add( inUse( new NodeRecord( 2, false, 42, NONE ) ) );
-        RelationshipRecord sPrev = add( inUse( new RelationshipRecord( 51, 1, 3, 0 ) ) );
+        RelationshipRecord sPrev = add( inUse( new RelationshipRecord( 51 ) ) );
+        sPrev.setLinks( 1, 3, 0 );
         relationship.setFirstPrevRel( sPrev.getId() );
         relationship.setFirstInFirstChain( false );
 
@@ -570,11 +610,13 @@ class RelationshipRecordCheckTest extends
     void shouldReportTargetPrevNotReferencingBack()
     {
         // given
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         add( inUse( new NodeRecord( 1, false, 42, NONE ) ) );
         add( inUse( new NodeRecord( 2, false, 0, NONE ) ) );
-        RelationshipRecord tPrev = add( inUse( new RelationshipRecord( 51, 2, 3, 0 ) ) );
+        RelationshipRecord tPrev = add( inUse( new RelationshipRecord( 51 ) ) );
+        tPrev.setLinks( 2, 3, 0 );
         relationship.setSecondPrevRel( tPrev.getId() );
         relationship.setFirstInSecondChain( false );
 
@@ -590,11 +632,13 @@ class RelationshipRecordCheckTest extends
     void shouldReportSourceNextNotReferencingBack()
     {
         // given
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         add( inUse( new NodeRecord( 1, false, 42, NONE ) ) );
         add( inUse( new NodeRecord( 2, false, 42, NONE ) ) );
-        RelationshipRecord sNext = add( inUse( new RelationshipRecord( 51, 3, 1, 0 ) ) );
+        RelationshipRecord sNext = add( inUse( new RelationshipRecord( 51 ) ) );
+        sNext.setLinks( 3, 1, 0 );
         relationship.setFirstNextRel( sNext.getId() );
 
         // when
@@ -609,11 +653,13 @@ class RelationshipRecordCheckTest extends
     void shouldReportTargetNextNotReferencingBack()
     {
         // given
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 42, 1, 2, 4 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 42 ) );
+        relationship.setLinks( 1, 2, 4 );
         add( inUse( new RelationshipTypeTokenRecord( 4 ) ) );
         add( inUse( new NodeRecord( 1, false, 42, NONE ) ) );
         add( inUse( new NodeRecord( 2, false, 42, NONE ) ) );
-        RelationshipRecord tNext = add( inUse( new RelationshipRecord( 51, 3, 2, 0 ) ) );
+        RelationshipRecord tNext = add( inUse( new RelationshipRecord( 51 ) ) );
+        tNext.setLinks( 3, 2, 0 );
         relationship.setSecondNextRel( tNext.getId() );
 
         // when

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/DuplicatePropertyTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/DuplicatePropertyTest.java
@@ -85,7 +85,8 @@ class DuplicatePropertyTest
 
         RecordAccessStub records = new RecordAccessStub();
 
-        RelationshipRecord master = records.add( inUse( new RelationshipRecord( 1, 2, 3, 4 ) ) );
+        RelationshipRecord master = records.add( inUse( new RelationshipRecord( 1 ) ) );
+        master.setLinks( 2, 3, 4 );
         master.setNextProp( 1 );
 
         PropertyRecord firstRecord = inUse( new PropertyRecord( 1 ) );
@@ -137,7 +138,8 @@ class DuplicatePropertyTest
 
         RecordAccessStub records = new RecordAccessStub();
 
-        RelationshipRecord master = records.add( inUse( new RelationshipRecord( 1, 2, 3, 4 ) ) );
+        RelationshipRecord master = records.add( inUse( new RelationshipRecord( 1 ) ) );
+        master.setLinks( 2, 3, 4 );
         master.setNextProp( 1 );
 
         PropertyRecord firstRecord = inUse( new PropertyRecord( 1 ) );

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/OwnerCheckTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/OwnerCheckTest.java
@@ -130,9 +130,11 @@ class OwnerCheckTest
 
         RecordAccessStub records = new RecordAccessStub();
 
-        RelationshipRecord relationship1 = records.add( inUse( new RelationshipRecord( 1, 0, 1, 0 ) ) );
+        RelationshipRecord relationship1 = records.add( inUse( new RelationshipRecord( 1 ) ) );
+        relationship1.setLinks( 0, 1, 0 );
         relationship1.setNextProp( 7 );
-        RelationshipRecord relationship2 = records.add( inUse( new RelationshipRecord( 2, 0, 1, 0 ) ) );
+        RelationshipRecord relationship2 = records.add( inUse( new RelationshipRecord( 2 ) ) );
+        relationship2.setLinks( 0, 1, 0 );
         relationship2.setNextProp( 8 );
 
         // when
@@ -182,9 +184,11 @@ class OwnerCheckTest
 
         RecordAccessStub records = new RecordAccessStub();
 
-        RelationshipRecord relationship1 = records.add( inUse( new RelationshipRecord( 1, 0, 1, 0 ) ) );
+        RelationshipRecord relationship1 = records.add( inUse( new RelationshipRecord( 1 ) ) );
+        relationship1.setLinks( 0, 1, 0 );
         relationship1.setNextProp( 7 );
-        RelationshipRecord relationship2 = records.add( inUse( new RelationshipRecord( 2, 0, 1, 0 ) ) );
+        RelationshipRecord relationship2 = records.add( inUse( new RelationshipRecord( 2 ) ) );
+        relationship2.setLinks( 0, 1, 0 );
         relationship2.setNextProp( relationship1.getNextProp() );
 
         // when
@@ -213,7 +217,8 @@ class OwnerCheckTest
         RecordAccessStub records = new RecordAccessStub();
 
         NodeRecord node = records.add( inUse( new NodeRecord( 1, false, NONE, 7 ) ) );
-        RelationshipRecord relationship = records.add( inUse( new RelationshipRecord( 1, 0, 1, 0 ) ) );
+        RelationshipRecord relationship = records.add( inUse( new RelationshipRecord( 1 ) ) );
+        relationship.setLinks( 0, 1, 0 );
         relationship.setNextProp( node.getNextProp() );
 
         // when
@@ -241,7 +246,8 @@ class OwnerCheckTest
         RecordAccessStub records = new RecordAccessStub();
 
         NodeRecord node = records.add( inUse( new NodeRecord( 1, false, NONE, 7 ) ) );
-        RelationshipRecord relationship = records.add( inUse( new RelationshipRecord( 1, 0, 1, 0 ) ) );
+        RelationshipRecord relationship = records.add( inUse( new RelationshipRecord( 1 ) ) );
+        relationship.setLinks( 0, 1, 0 );
         relationship.setNextProp( node.getNextProp() );
 
         // when
@@ -317,7 +323,8 @@ class OwnerCheckTest
                 check( ConsistencyReport.PropertyConsistencyReport.class,
                        decorator.decoratePropertyChecker( dummyPropertyChecker() ),
                        record, records );
-        RelationshipRecord relationship = inUse( new RelationshipRecord( 10, 1, 1, 0 ) );
+        RelationshipRecord relationship = inUse( new RelationshipRecord( 10 ) );
+        relationship.setLinks( 1, 1, 0 );
         relationship.setNextProp( 42 );
         ConsistencyReport.RelationshipConsistencyReport relationshipReport =
                 check( ConsistencyReport.RelationshipConsistencyReport.class,

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/report/ConsistencyReporterTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/report/ConsistencyReporterTest.java
@@ -275,7 +275,9 @@ class ConsistencyReporterTest
             }
             if ( type == RelationshipRecord.class )
             {
-                return new RelationshipRecord( 0, 1, 2, 3 );
+                RelationshipRecord relationship = new RelationshipRecord( 0 );
+                relationship.setLinks( 1, 2, 3 );
+                return relationship;
             }
             if ( type == PropertyRecord.class )
             {

--- a/community/record-storage-engine/src/main/java/org/neo4j/internal/recordstorage/PhysicalLogCommandReaderV3_0_10.java
+++ b/community/record-storage-engine/src/main/java/org/neo4j/internal/recordstorage/PhysicalLogCommandReaderV3_0_10.java
@@ -457,7 +457,8 @@ public class PhysicalLogCommandReaderV3_0_10 extends BaseCommandReader
         RelationshipRecord record;
         if ( inUse )
         {
-            record = new RelationshipRecord( id, channel.getLong(), channel.getLong(), channel.getInt() );
+            record = new RelationshipRecord( id );
+            record.setLinks( channel.getLong(), channel.getLong(), channel.getInt() );
             record.setInUse( true );
             record.setRequiresSecondaryUnit( requiresSecondaryUnit );
             record.setFirstPrevRel( channel.getLong() );
@@ -476,7 +477,8 @@ public class PhysicalLogCommandReaderV3_0_10 extends BaseCommandReader
         }
         else
         {
-            record = new RelationshipRecord( id, -1, -1, channel.getInt() );
+            record = new RelationshipRecord( id );
+            record.setLinks( -1, -1, channel.getInt() );
             record.setInUse( false );
         }
         if ( bitFlag( flags, Record.CREATED_IN_TX ) )

--- a/community/record-storage-engine/src/main/java/org/neo4j/internal/recordstorage/PhysicalLogCommandReaderV4_0.java
+++ b/community/record-storage-engine/src/main/java/org/neo4j/internal/recordstorage/PhysicalLogCommandReaderV4_0.java
@@ -610,7 +610,8 @@ public class PhysicalLogCommandReaderV4_0 extends BaseCommandReader
         RelationshipRecord record;
         if ( inUse )
         {
-            record = new RelationshipRecord( id, channel.getLong(), channel.getLong(), channel.getInt() );
+            record = new RelationshipRecord( id );
+            record.setLinks( channel.getLong(), channel.getLong(), channel.getInt() );
             record.setInUse( true );
             record.setRequiresSecondaryUnit( requiresSecondaryUnit );
             record.setFirstPrevRel( channel.getLong() );
@@ -629,7 +630,8 @@ public class PhysicalLogCommandReaderV4_0 extends BaseCommandReader
         }
         else
         {
-            record = new RelationshipRecord( id, -1, -1, channel.getInt() );
+            record = new RelationshipRecord( id );
+            record.setLinks( -1, -1, channel.getInt() );
             record.setInUse( false );
         }
         if ( bitFlag( flags, Record.CREATED_IN_TX ) )

--- a/community/record-storage-engine/src/test/java/org/neo4j/internal/recordstorage/Commands.java
+++ b/community/record-storage-engine/src/test/java/org/neo4j/internal/recordstorage/Commands.java
@@ -90,7 +90,8 @@ public class Commands
     {
         RelationshipRecord before = new RelationshipRecord( id );
         before.setInUse( false );
-        RelationshipRecord after = new RelationshipRecord( id, startNode, endNode, type );
+        RelationshipRecord after = new RelationshipRecord( id );
+        after.setLinks( startNode, endNode, type );
         after.setInUse( true );
         after.setCreated();
         return new RelationshipCommand( before, after );

--- a/community/record-storage-engine/src/test/java/org/neo4j/internal/recordstorage/LogTruncationTest.java
+++ b/community/record-storage-engine/src/test/java/org/neo4j/internal/recordstorage/LogTruncationTest.java
@@ -64,13 +64,15 @@ class LogTruncationTest
         NeoStoreRecord after = new NeoStoreRecord();
         after.setNextProp( 42 );
         permutations.put( Command.NodeCommand.class, new Command[] { new Command.NodeCommand(
-                new NodeRecord( 12L, false, 13L, 13L ), new NodeRecord( 0, false, 0, 0 ) ) } );
+                new NodeRecord( 12, false, 13, 13 ), new NodeRecord( 0, false, 0, 0 ) ) } );
+        RelationshipRecord relationship = new RelationshipRecord( 1 );
+        relationship.setLinks( 2, 3, 4 );
         permutations.put( Command.RelationshipCommand.class,
-                new Command[] { new Command.RelationshipCommand( new RelationshipRecord( 1L ),
-                        new RelationshipRecord( 1L, 2L, 3L, 4 ) ) } );
+                new Command[] { new Command.RelationshipCommand( new RelationshipRecord( 1 ),
+                        relationship ) } );
         permutations.put( Command.PropertyCommand.class, new Command[] { new Command.PropertyCommand(
-                new PropertyRecord( 1, new NodeRecord( 12L, false, 13L, 13 ) ), new PropertyRecord( 1, new NodeRecord(
-                        12L, false, 13L, 13 ) ) ) } );
+                new PropertyRecord( 1, new NodeRecord( 12, false, 13, 13 ) ), new PropertyRecord( 1, new NodeRecord(
+                        12, false, 13, 13 ) ) ) } );
         permutations.put( Command.RelationshipGroupCommand.class,
                 new Command[] { new Command.LabelTokenCommand( new LabelTokenRecord( 1 ),
                         createLabelTokenRecord( 1 ) ) } );

--- a/community/record-storage-engine/src/test/java/org/neo4j/internal/recordstorage/NeoStoreTransactionApplierTest.java
+++ b/community/record-storage-engine/src/test/java/org/neo4j/internal/recordstorage/NeoStoreTransactionApplierTest.java
@@ -249,7 +249,8 @@ class NeoStoreTransactionApplierTest
         // given
         TransactionApplierFactory applier = newApplier( false );
         RelationshipRecord before = new RelationshipRecord( 12 );
-        RelationshipRecord record = new RelationshipRecord( 12, 3, 4, 5 );
+        RelationshipRecord record = new RelationshipRecord( 12 );
+        record.setLinks( 3, 4, 5 );
         record.setInUse( true );
 
         Command command = new Command.RelationshipCommand( before, record );
@@ -268,7 +269,8 @@ class NeoStoreTransactionApplierTest
         // given
         TransactionApplierFactory applier = newApplier( false );
         RelationshipRecord before = new RelationshipRecord( 12 );
-        RelationshipRecord record = new RelationshipRecord( 12, 3, 4, 5 );
+        RelationshipRecord record = new RelationshipRecord( 12 );
+        record.setLinks( 3, 4, 5 );
         record.setInUse( false );
 
         Command command = new Command.RelationshipCommand( before, record );
@@ -288,7 +290,8 @@ class NeoStoreTransactionApplierTest
         // given
         TransactionApplierFactory applier = newApplier( true );
         RelationshipRecord before = new RelationshipRecord( 12 );
-        RelationshipRecord record = new RelationshipRecord( 12, 3, 4, 5 );
+        RelationshipRecord record = new RelationshipRecord( 12 );
+        record.setLinks( 3, 4, 5 );
         record.setInUse( true );
         Command command = new Command.RelationshipCommand( before, record );
 

--- a/community/record-storage-engine/src/test/java/org/neo4j/internal/recordstorage/PhysicalLogCommandReaderV3_0Test.java
+++ b/community/record-storage-engine/src/test/java/org/neo4j/internal/recordstorage/PhysicalLogCommandReaderV3_0Test.java
@@ -43,8 +43,10 @@ class PhysicalLogCommandReaderV3_0Test
     {
         // Given
         InMemoryClosableChannel channel = new InMemoryClosableChannel();
-        RelationshipRecord before = new RelationshipRecord( 42, -1, -1, -1 );
-        RelationshipRecord after = new RelationshipRecord( 42, true, 1, 2, 3, 4, 5, 6, 7, true, true );
+        RelationshipRecord before = new RelationshipRecord( 42 );
+        before.setLinks( -1, -1, -1 );
+        RelationshipRecord after = new RelationshipRecord( 42 );
+        after.initialize( true, 0, 1, 2, 3, 4, 5, 6, 7, true, true );
         new Command.RelationshipCommand( before, after ).serialize( channel );
 
         // When
@@ -63,9 +65,11 @@ class PhysicalLogCommandReaderV3_0Test
     void readRelationshipCommandWithSecondaryUnit() throws IOException
     {
         InMemoryClosableChannel channel = new InMemoryClosableChannel();
-        RelationshipRecord before = new RelationshipRecord( 42, true, 1, 2, 3, 4, 5, 6, 7, true, true );
+        RelationshipRecord before = new RelationshipRecord( 42 );
+        before.initialize( true, 0, 1, 2, 3, 4, 5, 6, 7, true, true );
         before.setSecondaryUnitIdOnLoad( 47 );
-        RelationshipRecord after = new RelationshipRecord( 42, true, 1, 8, 3, 4, 5, 6, 7, true, true );
+        RelationshipRecord after = new RelationshipRecord( 42 );
+        after.initialize( true, 0, 1, 8, 3, 4, 5, 6, 7, true, true );
         new Command.RelationshipCommand( before, after ).serialize( channel );
 
         PhysicalLogCommandReaderV3_0_10 reader = new PhysicalLogCommandReaderV3_0_10();
@@ -82,9 +86,11 @@ class PhysicalLogCommandReaderV3_0Test
     void readRelationshipCommandWithNonRequiredSecondaryUnit() throws IOException
     {
         InMemoryClosableChannel channel = new InMemoryClosableChannel();
-        RelationshipRecord before = new RelationshipRecord( 42, true, 1, 2, 3, 4, 5, 6, 7, true, true );
+        RelationshipRecord before = new RelationshipRecord( 42 );
+        before.initialize( true, 0, 1, 2, 3, 4, 5, 6, 7, true, true );
         before.setSecondaryUnitIdOnLoad( 52 );
-        RelationshipRecord after = new RelationshipRecord( 42, true, 1, 8, 3, 4, 5, 6, 7, true, true );
+        RelationshipRecord after = new RelationshipRecord( 42 );
+        after.initialize( true, 0, 1, 8, 3, 4, 5, 6, 7, true, true );
         new Command.RelationshipCommand( before, after ).serialize( channel );
 
         PhysicalLogCommandReaderV3_0_10 reader = new PhysicalLogCommandReaderV3_0_10();
@@ -101,9 +107,11 @@ class PhysicalLogCommandReaderV3_0Test
     void readRelationshipCommandWithFixedReferenceFormat300() throws IOException
     {
         InMemoryClosableChannel channel = new InMemoryClosableChannel();
-        RelationshipRecord before = new RelationshipRecord( 42, true, 1, 2, 3, 4, 5, 6, 7, true, true );
+        RelationshipRecord before = new RelationshipRecord( 42 );
+        before.initialize( true, 0, 1, 2, 3, 4, 5, 6, 7, true, true );
         before.setUseFixedReferences( true );
-        RelationshipRecord after = new RelationshipRecord( 42, true, 1, 8, 3, 4, 5, 6, 7, true, true );
+        RelationshipRecord after = new RelationshipRecord( 42 );
+        after.initialize( true, 0, 1, 8, 3, 4, 5, 6, 7, true, true );
         after.setUseFixedReferences( true );
         new Command.RelationshipCommand( before, after ).serialize( channel );
 
@@ -122,9 +130,11 @@ class PhysicalLogCommandReaderV3_0Test
     void readRelationshipCommandWithFixedReferenceFormat302() throws IOException
     {
         InMemoryClosableChannel channel = new InMemoryClosableChannel();
-        RelationshipRecord before = new RelationshipRecord( 42, true, 1, 2, 3, 4, 5, 6, 7, true, true );
+        RelationshipRecord before = new RelationshipRecord( 42 );
+        before.initialize( true, 0, 1, 2, 3, 4, 5, 6, 7, true, true );
         before.setUseFixedReferences( true );
-        RelationshipRecord after = new RelationshipRecord( 42, true, 1, 8, 3, 4, 5, 6, 7, true, true );
+        RelationshipRecord after = new RelationshipRecord( 42 );
+        after.initialize( true, 0, 1, 8, 3, 4, 5, 6, 7, true, true );
         after.setUseFixedReferences( true );
         new Command.RelationshipCommand( before, after ).serialize( channel );
 

--- a/community/record-storage-engine/src/test/java/org/neo4j/internal/recordstorage/PhysicalLogCommandReaderV4_0Test.java
+++ b/community/record-storage-engine/src/test/java/org/neo4j/internal/recordstorage/PhysicalLogCommandReaderV4_0Test.java
@@ -187,8 +187,10 @@ class PhysicalLogCommandReaderV4_0Test
     {
         // Given
         InMemoryClosableChannel channel = new InMemoryClosableChannel();
-        RelationshipRecord before = new RelationshipRecord( 42, -1, -1, -1 );
-        RelationshipRecord after = new RelationshipRecord( 42, true, 1, 2, 3, 4, 5, 6, 7, true, true );
+        RelationshipRecord before = new RelationshipRecord( 42 );
+        before.setLinks( -1, -1, -1 );
+        RelationshipRecord after = new RelationshipRecord( 42 );
+        after.initialize( true, 0, 1, 2, 3, 4, 5, 6, 7, true, true );
         after.setCreated();
         new Command.RelationshipCommand( before, after ).serialize( channel );
 
@@ -207,9 +209,11 @@ class PhysicalLogCommandReaderV4_0Test
     void readRelationshipCommandWithSecondaryUnit() throws IOException
     {
         InMemoryClosableChannel channel = new InMemoryClosableChannel();
-        RelationshipRecord before = new RelationshipRecord( 42, true, 1, 2, 3, 4, 5, 6, 7, true, true );
+        RelationshipRecord before = new RelationshipRecord( 42 );
+        before.initialize( true, 0, 1, 2, 3, 4, 5, 6, 7, true, true );
         before.setSecondaryUnitIdOnLoad( 47 );
-        RelationshipRecord after = new RelationshipRecord( 42, true, 1, 8, 3, 4, 5, 6, 7, true, true );
+        RelationshipRecord after = new RelationshipRecord( 42 );
+        after.initialize( true, 0, 1, 8, 3, 4, 5, 6, 7, true, true );
         new Command.RelationshipCommand( before, after ).serialize( channel );
 
         BaseCommandReader reader = createReader();
@@ -224,9 +228,11 @@ class PhysicalLogCommandReaderV4_0Test
     void readRelationshipCommandWithNonRequiredSecondaryUnit() throws IOException
     {
         InMemoryClosableChannel channel = new InMemoryClosableChannel();
-        RelationshipRecord before = new RelationshipRecord( 42, true, 1, 2, 3, 4, 5, 6, 7, true, true );
+        RelationshipRecord before = new RelationshipRecord( 42 );
+        before.initialize( true, 0, 1, 2, 3, 4, 5, 6, 7, true, true );
         before.setSecondaryUnitIdOnLoad( 52 );
-        RelationshipRecord after = new RelationshipRecord( 42, true, 1, 8, 3, 4, 5, 6, 7, true, true );
+        RelationshipRecord after = new RelationshipRecord( 42 );
+        after.initialize( true, 0, 1, 8, 3, 4, 5, 6, 7, true, true );
         new Command.RelationshipCommand( before, after ).serialize( channel );
 
         BaseCommandReader reader = createReader();
@@ -241,9 +247,11 @@ class PhysicalLogCommandReaderV4_0Test
     void readRelationshipCommandWithFixedReferenceFormat() throws IOException
     {
         InMemoryClosableChannel channel = new InMemoryClosableChannel();
-        RelationshipRecord before = new RelationshipRecord( 42, true, 1, 2, 3, 4, 5, 6, 7, true, true );
+        RelationshipRecord before = new RelationshipRecord( 42 );
+        before.initialize( true, 0, 1, 2, 3, 4, 5, 6, 7, true, true );
         before.setUseFixedReferences( true );
-        RelationshipRecord after = new RelationshipRecord( 42, true, 1, 8, 3, 4, 5, 6, 7, true, true );
+        RelationshipRecord after = new RelationshipRecord( 42 );
+        after.initialize( true, 0, 1, 8, 3, 4, 5, 6, 7, true, true );
         after.setUseFixedReferences( true );
         new Command.RelationshipCommand( before, after ).serialize( channel );
 

--- a/community/record-storage-engine/src/test/java/org/neo4j/internal/recordstorage/RecordRelationshipTraversalCursorTest.java
+++ b/community/record-storage-engine/src/test/java/org/neo4j/internal/recordstorage/RecordRelationshipTraversalCursorTest.java
@@ -64,6 +64,7 @@ import static org.junit.jupiter.params.provider.Arguments.of;
 import static org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector.immediate;
 import static org.neo4j.internal.helpers.ArrayUtil.concatArrays;
 import static org.neo4j.internal.recordstorage.RecordNodeCursor.relationshipsReferenceWithDenseMarker;
+import static org.neo4j.kernel.impl.store.record.Record.NO_NEXT_PROPERTY;
 import static org.neo4j.kernel.impl.store.record.Record.NO_NEXT_RELATIONSHIP;
 import static org.neo4j.storageengine.api.RelationshipDirection.INCOMING;
 import static org.neo4j.storageengine.api.RelationshipDirection.LOOP;
@@ -365,8 +366,11 @@ public class RecordRelationshipTraversalCursorTest
 
     protected RelationshipRecord createRelationship( long id, long nextRelationship, RelationshipSpec relationshipSpec )
     {
-        return new RelationshipRecord( id, true, getFirstNode( relationshipSpec.direction ), getSecondNode( relationshipSpec.direction ), relationshipSpec.type,
-                NO_NEXT_RELATIONSHIP.intValue(), nextRelationship, NO_NEXT_RELATIONSHIP.intValue(), nextRelationship, false, false );
+        RelationshipRecord relationship = new RelationshipRecord( id );
+        relationship.initialize( true, NO_NEXT_PROPERTY.intValue(), getFirstNode( relationshipSpec.direction ),
+                getSecondNode( relationshipSpec.direction ), relationshipSpec.type, NO_NEXT_RELATIONSHIP.intValue(), nextRelationship,
+                NO_NEXT_RELATIONSHIP.intValue(), nextRelationship, false, false );
+        return relationship;
     }
 
     protected long getSecondNode( RelationshipDirection direction )

--- a/community/record-storage-engine/src/test/java/org/neo4j/kernel/impl/store/RelationshipStoreConsistentReadTest.java
+++ b/community/record-storage-engine/src/test/java/org/neo4j/kernel/impl/store/RelationshipStoreConsistentReadTest.java
@@ -40,17 +40,18 @@ class RelationshipStoreConsistentReadTest extends RecordStoreConsistentReadTest<
     @Override
     protected RelationshipRecord createNullRecord( long id )
     {
-        RelationshipRecord record = new RelationshipRecord( id, false, 0, 0, 0, 0, 0, 0, 0, false, false );
-        record.setNextProp( 0 );
+        RelationshipRecord record = new RelationshipRecord( id );
+        record.initialize( false, 0, 0, 0, 0, 0, 0, 0, 0, false, false );
         return record;
     }
 
     @Override
     protected RelationshipRecord createExistingRecord( boolean light )
     {
-        return new RelationshipRecord(
-                ID, true, FIRST_NODE, SECOND_NODE, TYPE, FIRST_PREV_REL,
+        RelationshipRecord record = new RelationshipRecord( ID );
+        record.initialize( true, 0, FIRST_NODE, SECOND_NODE, TYPE, FIRST_PREV_REL,
                 FIRST_NEXT_REL, SECOND_PREV_REL, SECOND_NEXT_REL, true, true );
+        return record;
     }
 
     @Override


### PR DESCRIPTION
I suggest that the `@Deprecated` methods are documented, at which version they are deprecated and/or which version to be removed.