### PR TITLE
Remove extra space

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/testing/TestNotification.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/testing/TestNotification.java
@@ -65,7 +65,7 @@ public class TestNotification implements Notification
         return new TestNotification( (String) notification.get("code"),
                 (String) notification.get("title"),
                 (String) notification.get("description"),
-                SeverityLevel.valueOf(  (String) notification.get( "severity")), position );
+                SeverityLevel.valueOf( (String) notification.get( "severity")), position );
     }
 
     @Override

--- a/community/bolt/src/test/java/org/neo4j/bolt/testing/client/SocketConnectionTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/testing/client/SocketConnectionTest.java
@@ -74,7 +74,7 @@ public class SocketConnectionTest
         connection.recv( 10 );
 
         // THEN
-        verify(stream, times(3)).read(  any(byte[].class), anyInt(), anyInt() );
+        verify(stream, times(3)).read( any(byte[].class), anyInt(), anyInt() );
     }
 
     @Test

--- a/community/bolt/src/test/java/org/neo4j/bolt/v3/messaging/decoder/MessageDecoderTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v3/messaging/decoder/MessageDecoderTest.java
@@ -289,7 +289,7 @@ public class MessageDecoderTest
             throws Exception
     {
         String statement = "RETURN $x";
-        MapValue parameters = VirtualValues.map(  new String[]{"x"}, new AnyValue[]{parameterValue } );
+        MapValue parameters = VirtualValues.map( new String[]{"x"}, new AnyValue[]{parameterValue } );
 
         BoltStateMachine stateMachine = mock( BoltStateMachine.class );
         SynchronousBoltConnection connection = new SynchronousBoltConnection( stateMachine );

--- a/community/bolt/src/test/java/org/neo4j/bolt/v3/messaging/encoder/RecordMessageEncoderTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v3/messaging/encoder/RecordMessageEncoderTest.java
@@ -40,7 +40,7 @@ class RecordMessageEncoderTest
         RecordMessageEncoder encoder = new RecordMessageEncoder();
 
         // When
-        encoder.encode( packer, new RecordMessage(  new AnyValue[0] ) );
+        encoder.encode( packer, new RecordMessage( new AnyValue[0] ) );
 
         // Then
         verify( packer ).packStructHeader( anyInt(), eq( RecordMessage.SIGNATURE ) );

--- a/community/codegen/src/main/java/org/neo4j/codegen/ByteCodeUtils.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ByteCodeUtils.java
@@ -96,7 +96,7 @@ public final class ByteCodeUtils
 
     public static String desc( MethodReference reference )
     {
-        StringBuilder builder = new StringBuilder(  );
+        StringBuilder builder = new StringBuilder();
         builder.append( "(" );
         for ( TypeReference parameter : reference.parameters() )
         {

--- a/community/codegen/src/main/java/org/neo4j/codegen/TypeReference.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/TypeReference.java
@@ -293,7 +293,7 @@ public class TypeReference
 
     List<TypeReference> declaringClasses()
     {
-        LinkedList<TypeReference> parents = new LinkedList<>(  );
+        LinkedList<TypeReference> parents = new LinkedList<>();
         TypeReference parent = declaringClass;
         while ( parent != null )
         {

--- a/community/collections/src/test/java/org/neo4j/internal/helpers/collection/LruCacheTest.java
+++ b/community/collections/src/test/java/org/neo4j/internal/helpers/collection/LruCacheTest.java
@@ -87,15 +87,15 @@ class LruCacheTest
         cache.put( key3, s3 );
         cache.get( key2 );
 
-        assertEquals( new HashSet<>(  Arrays.asList(key1, key2, key3) ), cache.keySet());
+        assertEquals( new HashSet<>( Arrays.asList(key1, key2, key3) ), cache.keySet());
 
         cache.put( key4, s4 );
 
-        assertEquals( new HashSet<>(  Arrays.asList(key2, key3, key4) ), cache.keySet());
+        assertEquals( new HashSet<>( Arrays.asList(key2, key3, key4) ), cache.keySet());
 
         cache.put( key5, s5 );
 
-        assertEquals( new HashSet<>(  Arrays.asList(key2, key4, key5) ), cache.keySet());
+        assertEquals( new HashSet<>( Arrays.asList(key2, key4, key5) ), cache.keySet());
 
         int size = cache.size();
 

--- a/community/common/src/main/java/org/neo4j/kernel/lifecycle/LifeSupport.java
+++ b/community/common/src/main/java/org/neo4j/kernel/lifecycle/LifeSupport.java
@@ -349,7 +349,7 @@ public class LifeSupport implements Lifecycle
     @Override
     public String toString()
     {
-        StringBuilder sb = new StringBuilder(  );
+        StringBuilder sb = new StringBuilder();
         toString( 0, sb );
         return sb.toString();
     }

--- a/community/community-it/algo-it/src/test/java/org/neo4j/kernel/impl/traversal/TestTraversalWithIterable.java
+++ b/community/community-it/algo-it/src/test/java/org/neo4j/kernel/impl/traversal/TestTraversalWithIterable.java
@@ -49,7 +49,7 @@ class TestTraversalWithIterable extends TraversalTestBase
         {
             TraversalDescription basicTraverser = tx.traversalDescription().evaluator( Evaluators.atDepth(2) );
 
-            Collection<Node> startNodes = new ArrayList<>(  );
+            Collection<Node> startNodes = new ArrayList<>();
             startNodes.add( getNodeWithName( tx, "a" ) );
             startNodes.add( getNodeWithName( tx, "d" ) );
 

--- a/community/community-it/batch-insert-it/src/test/java/org/neo4j/batchinsert/internal/BatchInsertTest.java
+++ b/community/community-it/batch-insert-it/src/test/java/org/neo4j/batchinsert/internal/BatchInsertTest.java
@@ -1329,7 +1329,7 @@ class BatchInsertTest
             var schema = tx.schema();
             IndexDefinition index = schema.getIndexes( label ).iterator().next();
             String indexFailure = schema.getIndexFailure( index );
-            assertThat( indexFailure ).contains(  "IndexEntryConflictException" );
+            assertThat( indexFailure ).contains( "IndexEntryConflictException" );
             assertThat( indexFailure ).contains( value );
             tx.commit();
         }

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/v4/runtime/BoltV4TransportIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/v4/runtime/BoltV4TransportIT.java
@@ -229,7 +229,7 @@ public class BoltV4TransportIT
 
         // execute query #2
         connection.send( util.chunk( new RunMessage( "UNWIND range(21, 30) AS x RETURN x" ) ) );
-        assertThat( connection ).satisfies(  util.eventuallyReceives(
+        assertThat( connection ).satisfies( util.eventuallyReceives(
                 msgSuccess( message -> assertThat( message ).containsEntry( "qid", 2L ).containsKeys( "fields", "t_first" ) ) ) );
 
         // request 4 records for query #2

--- a/community/community-it/community-it/src/test/java/org/neo4j/db/DatabaseStartupTest.java
+++ b/community/community-it/community-it/src/test/java/org/neo4j/db/DatabaseStartupTest.java
@@ -211,7 +211,7 @@ class DatabaseStartupTest
     {
         File directory = new File( "notAbsoluteDirectory" );
         EphemeralCommunityManagementServiceFactory factory = new EphemeralCommunityManagementServiceFactory();
-        DatabaseManagementServiceBuilder databaseFactory = new EphemeralDatabaseManagementServiceBuilder(  directory, factory );
+        DatabaseManagementServiceBuilder databaseFactory = new EphemeralDatabaseManagementServiceBuilder( directory, factory );
         DatabaseManagementService managementService = databaseFactory.build();
         managementService.database( DEFAULT_DATABASE_NAME );
         managementService.shutdown();

--- a/community/community-it/community-it/src/test/java/org/neo4j/server/rest/RESTRequestGenerator.java
+++ b/community/community-it/community-it/src/test/java/org/neo4j/server/rest/RESTRequestGenerator.java
@@ -54,7 +54,7 @@ public class RESTRequestGenerator
     private MediaType payloadMediaType = MediaType.APPLICATION_JSON_TYPE;
     private final List<Pair<String,Predicate<String>>> expectedHeaderFields = new ArrayList<>();
     private String payload;
-    private final Map<String, String> addedRequestHeaders = new TreeMap<>(  );
+    private final Map<String, String> addedRequestHeaders = new TreeMap<>();
 
     private RESTRequestGenerator()
     {

--- a/community/community-it/consistency-it/src/test/java/org/neo4j/consistency/checking/GraphStoreFixture.java
+++ b/community/community-it/consistency-it/src/test/java/org/neo4j/consistency/checking/GraphStoreFixture.java
@@ -605,12 +605,12 @@ public abstract class GraphStoreFixture implements AutoCloseable
             writer.create( group );
         }
 
-        public void update(  RelationshipGroupRecord before, RelationshipGroupRecord after )
+        public void update( RelationshipGroupRecord before, RelationshipGroupRecord after )
         {
             writer.update( before, after );
         }
 
-        public void delete(  RelationshipGroupRecord group )
+        public void delete( RelationshipGroupRecord group )
         {
             writer.delete( group );
         }

--- a/community/community-it/consistency-it/src/test/java/org/neo4j/consistency/checking/TransactionWriter.java
+++ b/community/community-it/consistency-it/src/test/java/org/neo4j/consistency/checking/TransactionWriter.java
@@ -139,7 +139,7 @@ public class TransactionWriter
         add( node, new NodeRecord( node.getId(), false, NO_PREV_RELATIONSHIP.intValue(), NO_NEXT_PROPERTY.intValue() ) );
     }
 
-    public void create(  RelationshipRecord record  )
+    public void create( RelationshipRecord record  )
     {
         record.setCreated();
         update( new RelationshipRecord( record.getId() ), record );
@@ -175,7 +175,7 @@ public class TransactionWriter
         add( before, after );
     }
 
-    public void delete(  RelationshipRecord record  )
+    public void delete( RelationshipRecord record  )
     {
         record.setInUse( false );
         add( record, new RelationshipRecord( record.getId() ) );

--- a/community/community-it/index-it/src/test/java/org/neo4j/kernel/impl/newapi/ConstraintTest.java
+++ b/community/community-it/index-it/src/test/java/org/neo4j/kernel/impl/newapi/ConstraintTest.java
@@ -41,6 +41,6 @@ public class ConstraintTest extends ConstraintTestBase<WriteTestSupport>
     @Override
     protected ConstraintDescriptor uniqueConstraintDescriptor( int labelId, int... propertyIds )
     {
-        return ConstraintDescriptorFactory.uniqueForLabel(  labelId, propertyIds  );
+        return ConstraintDescriptorFactory.uniqueForLabel( labelId, propertyIds  );
     }
 }

--- a/community/community-it/index-it/src/test/java/org/neo4j/schema/DynamicIndexStoreViewIT.java
+++ b/community/community-it/index-it/src/test/java/org/neo4j/schema/DynamicIndexStoreViewIT.java
@@ -118,7 +118,7 @@ class DynamicIndexStoreViewIT
         {
             managementService.shutdown();
             ConsistencyCheckService consistencyCheckService = new ConsistencyCheckService();
-            Config config = Config.defaults(  GraphDatabaseSettings.pagecache_memory, "8m" );
+            Config config = Config.defaults( GraphDatabaseSettings.pagecache_memory, "8m" );
             consistencyCheckService.runFullConsistencyCheck( databaseLayout, config,
                     ProgressMonitorFactory.NONE, FormattedLogProvider.toOutputStream( System.out ), false );
         }

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
@@ -319,7 +319,7 @@ class SchemaAcceptanceTest extends SchemaAcceptanceTestBase
             }
             catch ( ConstraintViolationException e )
             {
-                assertThat( e ).hasMessageContaining(  "Unable to drop index: Index does not exist: " +
+                assertThat( e ).hasMessageContaining( "Unable to drop index: Index does not exist: " +
                         "Index( id=1, name='index_a0d2924', type='GENERAL BTREE', schema=(:MY_LABEL {my_property_key}), indexProvider='native-btree-1.0' )" );
             }
             tx.commit();

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/api/index/SimpleIndexAccessorCompatibility.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/api/index/SimpleIndexAccessorCompatibility.java
@@ -1008,8 +1008,8 @@ public abstract class SimpleIndexAccessorCompatibility extends IndexAccessorComp
                     add( 2L, descriptor.schema(), "a" ),
                     add( 3L, descriptor.schema(), "b" ) ) );
 
-            assertThat( query( exact( 1, "a" ) ) ).containsExactly(  1L, 2L );
-            assertThat( query( exists( 1 ) ) ).containsExactly(  1L, 2L, 3L );
+            assertThat( query( exact( 1, "a" ) ) ).containsExactly( 1L, 2L );
+            assertThat( query( exists( 1 ) ) ).containsExactly( 1L, 2L, 3L );
         }
 
         @Test
@@ -1022,11 +1022,11 @@ public abstract class SimpleIndexAccessorCompatibility extends IndexAccessorComp
                     add( 4L, descriptor.schema(), 5 ),
                     add( 5L, descriptor.schema(), 5 ) ) );
 
-            assertThat( query( range( 1, -5, true, 5, true ) ) ).containsExactly(  1L, 2L, 3L, 4L, 5L );
+            assertThat( query( range( 1, -5, true, 5, true ) ) ).containsExactly( 1L, 2L, 3L, 4L, 5L );
             assertThat( query( range( 1, -3, true, -1, true ) ) ).isEmpty();
-            assertThat( query( range( 1, -5, true, 4, true ) ) ).containsExactly(  1L, 2L, 3L );
-            assertThat( query( range( 1, -4, true, 5, true ) ) ).containsExactly(  3L, 4L, 5L );
-            assertThat( query( range( 1, -5, true, 5, true ) ) ).containsExactly(  1L, 2L, 3L, 4L, 5L );
+            assertThat( query( range( 1, -5, true, 4, true ) ) ).containsExactly( 1L, 2L, 3L );
+            assertThat( query( range( 1, -4, true, 5, true ) ) ).containsExactly( 3L, 4L, 5L );
+            assertThat( query( range( 1, -5, true, 5, true ) ) ).containsExactly( 1L, 2L, 3L, 4L, 5L );
         }
 
         @Test
@@ -1041,9 +1041,9 @@ public abstract class SimpleIndexAccessorCompatibility extends IndexAccessorComp
 
             assertThat( query( range( 1, "Anna", false, "William", false ) ) ).containsExactly( 3L );
             assertThat( query( range( 1, "Arabella", false, "Bob", false ) ) ).isEmpty();
-            assertThat( query( range( 1, "Anna", true, "William", false ) ) ).containsExactly(  1L, 2L, 3L );
-            assertThat( query( range( 1, "Anna", false, "William", true ) ) ).containsExactly(  3L, 4L, 5L );
-            assertThat( query( range( 1, "Anna", true, "William", true ) ) ).containsExactly(  1L, 2L, 3L, 4L, 5L );
+            assertThat( query( range( 1, "Anna", true, "William", false ) ) ).containsExactly( 1L, 2L, 3L );
+            assertThat( query( range( 1, "Anna", false, "William", true ) ) ).containsExactly( 3L, 4L, 5L );
+            assertThat( query( range( 1, "Anna", true, "William", true ) ) ).containsExactly( 1L, 2L, 3L, 4L, 5L );
         }
 
         @Test
@@ -1123,9 +1123,9 @@ public abstract class SimpleIndexAccessorCompatibility extends IndexAccessorComp
 
             assertThat( query( range( 1, v1, false, v4, false ) ) ).containsExactly( 3L );
             assertThat( query( range( 1, v2, false, v3, false ) ) ).isEmpty();
-            assertThat( query( range( 1, v1, true, v4, false ) ) ).containsExactly(  1L, 2L, 3L );
-            assertThat( query( range( 1, v1, false, v4, true ) ) ).containsExactly(  3L, 4L, 5L );
-            assertThat( query( range( 1, v1, true, v4, true ) ) ).containsExactly(  1L, 2L, 3L, 4L, 5L );
+            assertThat( query( range( 1, v1, true, v4, false ) ) ).containsExactly( 1L, 2L, 3L );
+            assertThat( query( range( 1, v1, false, v4, true ) ) ).containsExactly( 3L, 4L, 5L );
+            assertThat( query( range( 1, v1, true, v4, true ) ) ).containsExactly( 1L, 2L, 3L, 4L, 5L );
         }
 
         @Test
@@ -1138,8 +1138,8 @@ public abstract class SimpleIndexAccessorCompatibility extends IndexAccessorComp
                     add( 4L, descriptor.schema(), "apa" ),
                     add( 5L, descriptor.schema(), "apa" ) ) );
 
-            assertThat( query( stringPrefix( 1, stringValue( "a" ) ) ) ).containsExactly(  1L, 3L, 4L, 5L );
-            assertThat( query( stringPrefix( 1, stringValue( "apa" ) ) ) ).containsExactly(  3L, 4L, 5L );
+            assertThat( query( stringPrefix( 1, stringValue( "a" ) ) ) ).containsExactly( 1L, 3L, 4L, 5L );
+            assertThat( query( stringPrefix( 1, stringValue( "apa" ) ) ) ).containsExactly( 3L, 4L, 5L );
         }
 
         @Test
@@ -1154,8 +1154,8 @@ public abstract class SimpleIndexAccessorCompatibility extends IndexAccessorComp
                     add( 6L, descriptor.schema(), "apa apa" )
             ) );
 
-            assertThat( query( stringContains( 1, stringValue( "a" ) ) ) ).containsExactly(  1L, 3L, 4L, 5L, 6L );
-            assertThat( query( stringContains( 1, stringValue( "apa" ) ) ) ).containsExactly(  3L, 4L, 5L, 6L );
+            assertThat( query( stringContains( 1, stringValue( "a" ) ) ) ).containsExactly( 1L, 3L, 4L, 5L, 6L );
+            assertThat( query( stringContains( 1, stringValue( "apa" ) ) ) ).containsExactly( 3L, 4L, 5L, 6L );
             assertThat( query( stringContains( 1, stringValue( "apa*" ) ) ) ).isEmpty();
             assertThat( query( stringContains( 1, stringValue( "pa ap" ) ) ) ).containsExactly( 6L );
         }
@@ -1173,10 +1173,10 @@ public abstract class SimpleIndexAccessorCompatibility extends IndexAccessorComp
                     add( 7L, descriptor.schema(), "apa apa" )
                     ) );
 
-            assertThat( query( stringSuffix( 1, stringValue( "a" ) ) ) ).containsExactly(  1L, 3L, 4L, 5L, 7L );
-            assertThat( query( stringSuffix( 1, stringValue( "apa" ) ) ) ).containsExactly(  3L, 4L, 5L, 7L );
+            assertThat( query( stringSuffix( 1, stringValue( "a" ) ) ) ).containsExactly( 1L, 3L, 4L, 5L, 7L );
+            assertThat( query( stringSuffix( 1, stringValue( "apa" ) ) ) ).containsExactly( 3L, 4L, 5L, 7L );
             assertThat( query( stringSuffix( 1, stringValue( "apa*" ) ) ) ).isEmpty();
-            assertThat( query( stringSuffix( 1, stringValue( "a apa" ) ) ) ).containsExactly(  7L );
+            assertThat( query( stringSuffix( 1, stringValue( "a apa" ) ) ) ).containsExactly( 7L );
         }
 
         @Test
@@ -1236,7 +1236,7 @@ public abstract class SimpleIndexAccessorCompatibility extends IndexAccessorComp
                     add( 1L, descriptor.schema(), "a" ),
                     add( 2L, descriptor.schema(), "a" ) ) );
 
-            assertThat( query( exact( 1, "a" ) ) ).containsExactly(  1L, 2L );
+            assertThat( query( exact( 1, "a" ) ) ).containsExactly( 1L, 2L );
         }
 
         @Test
@@ -1248,7 +1248,7 @@ public abstract class SimpleIndexAccessorCompatibility extends IndexAccessorComp
                     add( 3L, descriptor.schema(), "c" ) ) );
 
             assertThat( query( exact( 1, "a" ) ) ).containsExactly( 1L );
-            assertThat( query( IndexQuery.exists( 1 ) ) ).containsExactly(  1L, 2L, 3L );
+            assertThat( query( IndexQuery.exists( 1 ) ) ).containsExactly( 1L, 2L, 3L );
         }
     }
 

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/builtinprocs/SchemaProcedureIT.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/builtinprocs/SchemaProcedureIT.java
@@ -117,7 +117,7 @@ class SchemaProcedureIT extends KernelIntegrationTest
         int labelIdLocation = transaction.tokenWrite().labelGetOrCreateForName( "Location" );
         transaction.dataWrite().nodeAddLabel( nodeIdLocation, labelIdLocation );
         int relationshipTypeId = transaction.tokenWrite().relationshipTypeGetOrCreateForName( "LIVES_IN" );
-        transaction.dataWrite().relationshipCreate(  nodeIdPerson, relationshipTypeId, nodeIdLocation );
+        transaction.dataWrite().relationshipCreate( nodeIdPerson, relationshipTypeId, nodeIdLocation );
         commit();
 
         RawIterator<AnyValue[],ProcedureException> stream =

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/counts/RelationshipCountsTest.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/counts/RelationshipCountsTest.java
@@ -214,7 +214,7 @@ class RelationshipCountsTest
         }
 
         // when
-        long total = numberOfRelationships(  );
+        long total = numberOfRelationships();
         long foo = numberOfRelationships( withName( "FOO" ) );
         long bar = numberOfRelationships( withName( "BAR" ) );
         long baz = numberOfRelationships( withName( "BAZ" ) );

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/api/index/IndexRecoveryIT.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/api/index/IndexRecoveryIT.java
@@ -454,7 +454,7 @@ class IndexRecoveryIT
                         break;
 
                     default:
-                        throw new UnsupportedOperationException(  );
+                        throw new UnsupportedOperationException();
                 }
             } );
         }

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ProcedureITBase.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ProcedureITBase.java
@@ -99,7 +99,7 @@ public interface ProcedureITBase
                 proc( "dbms.queryJmx", "(query :: STRING?) :: (name :: STRING?, " + "description :: STRING?, attributes :: MAP?)",
                         "Query JMX management data by domain and name." + " For instance, \"org.neo4j:*\"",
                         stringArray( "reader", "editor", "publisher", "architect", "admin" ), "DBMS" ),
-                proc( "db.createLabel", "(newLabel :: STRING?) :: VOID", "Create a label", stringArray(  "publisher", "architect", "admin" ), "WRITE",
+                proc( "db.createLabel", "(newLabel :: STRING?) :: VOID", "Create a label", stringArray( "publisher", "architect", "admin" ), "WRITE",
                         false ),
                 proc( "db.createProperty", "(newProperty :: STRING?) :: VOID", "Create a Property", stringArray( "publisher", "architect", "admin" ),
                         "WRITE", false ), proc( "db.createRelationshipType", "(newRelationshipType :: STRING?) :: VOID", "Create a RelationshipType",

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipIT.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipIT.java
@@ -70,12 +70,12 @@ class RelationshipIT extends KernelIntegrationTest
 
         long refNode = transaction.dataWrite().nodeCreate();
         long otherNode = transaction.dataWrite().nodeCreate();
-        long fromRefToOther1 = transaction.dataWrite().relationshipCreate(  refNode, relType1, otherNode );
-        long fromRefToOther2 = transaction.dataWrite().relationshipCreate(  refNode, relType2, otherNode );
-        long fromOtherToRef = transaction.dataWrite().relationshipCreate(  otherNode, relType1, refNode );
-        long fromRefToRef = transaction.dataWrite().relationshipCreate(  refNode, relType2, refNode );
+        long fromRefToOther1 = transaction.dataWrite().relationshipCreate( refNode, relType1, otherNode );
+        long fromRefToOther2 = transaction.dataWrite().relationshipCreate( refNode, relType2, otherNode );
+        long fromOtherToRef = transaction.dataWrite().relationshipCreate( otherNode, relType1, refNode );
+        long fromRefToRef = transaction.dataWrite().relationshipCreate( refNode, relType2, refNode );
         long endNode = transaction.dataWrite().nodeCreate();
-        long fromRefToThird = transaction.dataWrite().relationshipCreate(  refNode, relType2, endNode );
+        long fromRefToThird = transaction.dataWrite().relationshipCreate( refNode, relType2, endNode );
 
         // when & then
         assertRels( nodeGetRelationships( transaction, refNode, BOTH ), fromRefToOther1, fromRefToOther2,
@@ -145,7 +145,7 @@ class RelationshipIT extends KernelIntegrationTest
             // When
             transaction.dataWrite().relationshipDelete( fromRefToOther1 );
             long endNode = transaction.dataWrite().nodeCreate();
-            long localTxRel = transaction.dataWrite().relationshipCreate(  refNode, relType1, endNode );
+            long localTxRel = transaction.dataWrite().relationshipCreate( refNode, relType1, endNode );
 
             // Then
             assertRels( nodeGetRelationships( transaction, refNode, BOTH ), fromRefToOther2, localTxRel);
@@ -164,7 +164,7 @@ class RelationshipIT extends KernelIntegrationTest
 
         long refNode = transaction.dataWrite().nodeCreate();
         long otherNode = transaction.dataWrite().nodeCreate();
-        long theRel = transaction.dataWrite().relationshipCreate(  refNode, relType1, otherNode );
+        long theRel = transaction.dataWrite().relationshipCreate( refNode, relType1, otherNode );
 
         assertRels( nodeGetRelationships( transaction, refNode, OUTGOING, new int[]{relType2,relType1} ), theRel );
         commit();

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/newapi/NodeTransactionStateTestBase.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/newapi/NodeTransactionStateTestBase.java
@@ -564,7 +564,7 @@ public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestS
     void shouldFindUpdatedNodeInInLabelScan() throws Exception
     {
         // Given
-        Node node = createNode(  );
+        Node node = createNode();
 
         try ( KernelTransaction tx = beginTransaction();
               NodeLabelIndexCursor cursor = tx.cursors().allocateNodeLabelIndexCursor() )

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/newapi/PropertyCursorTestBase.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/newapi/PropertyCursorTestBase.java
@@ -392,7 +392,7 @@ public abstract class PropertyCursorTestBase<G extends KernelAPIReadTestSupport>
             assertTrue( values.contains( dateValue.asObject() ), DATE_PROP );
 
             int expected = supportsBigProperties() ? 18 : 15;
-            assertEquals(  expected, values.size(), "number of values" );
+            assertEquals( expected, values.size(), "number of values" );
         }
     }
 
@@ -438,7 +438,7 @@ public abstract class PropertyCursorTestBase<G extends KernelAPIReadTestSupport>
             assertTrue( values.contains( dateValue.asObject() ), DATE_PROP );
 
             int expected = supportsBigProperties() ? 18 : 15;
-            assertEquals(  expected, values.size(), "number of values" );
+            assertEquals( expected, values.size(), "number of values" );
         }
     }
 
@@ -461,7 +461,7 @@ public abstract class PropertyCursorTestBase<G extends KernelAPIReadTestSupport>
 
             read.nodeProperties( node.nodeReference(), node.propertiesReference(), props );
             assertTrue( props.next(), "has properties via property ref" );
-            assertEquals(  expectedValue, props.propertyValue(), "correct value" );
+            assertEquals( expectedValue, props.propertyValue(), "correct value" );
             assertFalse( props.next(), "single property" );
         }
     }
@@ -486,7 +486,7 @@ public abstract class PropertyCursorTestBase<G extends KernelAPIReadTestSupport>
 
             read.relationshipProperties( relationship.relationshipReference(), relationship.propertiesReference(), props );
             assertTrue( props.next(), "has properties via property ref" );
-            assertEquals(  expectedValue, props.propertyValue(), "correct value" );
+            assertEquals( expectedValue, props.propertyValue(), "correct value" );
             assertFalse( props.next(), "single property" );
         }
     }

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/store/NeoStoresTest.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/store/NeoStoresTest.java
@@ -203,7 +203,7 @@ public class NeoStoresTest
                 neoStores.getMetaDataStore();
             }
         } );
-        assertEquals(  "Specified store was not initialized. Please specify " + StoreType.META_DATA.name() +
+        assertEquals( "Specified store was not initialized. Please specify " + StoreType.META_DATA.name() +
                 " as one of the stores types that should be open to be able to use it." , e.getMessage() );
     }
 

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/recovery/UniquenessRecoveryTest.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/recovery/UniquenessRecoveryTest.java
@@ -275,7 +275,7 @@ public class UniquenessRecoveryTest
     {
         if ( USE_CYPHER )
         {
-            db.executeTransactionally(  "create (:Person {name: 'Sneaky Steve'})" );
+            db.executeTransactionally( "create (:Person {name: 'Sneaky Steve'})" );
         }
         else
         {

--- a/community/configuration/src/test/java/org/neo4j/configuration/SettingMigratorsTest.java
+++ b/community/configuration/src/test/java/org/neo4j/configuration/SettingMigratorsTest.java
@@ -382,7 +382,7 @@ class SettingMigratorsTest
         assertTrue( config.get( policyConfig.trust_all ) );
 
         assertThat( logProvider ).forLevel( WARN ).forClass( Config.class )
-                .containsMessageWithArguments(  "Use of deprecated setting %s.", oldGroupnameSetting )
+                .containsMessageWithArguments( "Use of deprecated setting %s.", oldGroupnameSetting )
                 .containsMessageWithArguments( "Use of deprecated setting %s. It is replaced by %s", oldFormatSetting, policyConfig.trust_all.name() );
     }
 

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/NodeRecordCheckTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/NodeRecordCheckTest.java
@@ -329,7 +329,7 @@ class NodeRecordCheckTest
             @Override
             public Collection<DynamicRecord> put( long[] labelIds, NodeStore nodeStore, DynamicRecordAllocator allocator, PageCursorTracer cursorTracer )
             {
-                return putSorted(  node, labelIds, nodeStore, allocator, cursorTracer );
+                return putSorted( node, labelIds, nodeStore, allocator, cursorTracer );
             }
         }.put( new long[]{3, 1, 2}, null, null, NULL );
         LabelTokenRecord label1 = inUse( new LabelTokenRecord( 1 ) );

--- a/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
@@ -342,7 +342,7 @@ public class BufferedCharSeeker implements CharSeeker
         {
             if ( bufferPos - seekStartPos >= dataCapacity )
             {
-                throw new BufferOverflowException(  "Tried to read a field larger than buffer size " +
+                throw new BufferOverflowException( "Tried to read a field larger than buffer size " +
                         dataLength + ". A common cause of this is that a field has an unterminated " +
                         "quote and so will try to seek until the next quote, which ever line it may be on." +
                         " This should not happen if multi-line fields are disabled, given that the fields contains " +

--- a/community/cypher/cypher-planner/src/test/scala/org/neo4j/cypher/internal/compiler/ast/convert/plannerQuery/PatternExpressionConverterTest.scala
+++ b/community/cypher/cypher-planner/src/test/scala/org/neo4j/cypher/internal/compiler/ast/convert/plannerQuery/PatternExpressionConverterTest.scala
@@ -75,7 +75,7 @@ class PatternExpressionConverterTest extends CypherFunSuite with LogicalPlanning
     qg.patternNodes should equal(Set("a", "b"))
   }
 
-  test("(a)-[r]->(  UNNAMED1)") {
+  test("(a)-[r]->( UNNAMED1)") {
     // Given
     val patternExpression = createPatternExpression(aNode, rRel, anonymousNode)
 

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledEquivalenceUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledEquivalenceUtils.java
@@ -40,7 +40,7 @@ public final class CompiledEquivalenceUtils
      */
     private CompiledEquivalenceUtils()
     {
-        throw new UnsupportedOperationException(  );
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ResultSubscriber.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ResultSubscriber.java
@@ -82,7 +82,7 @@ public class ResultSubscriber extends PrefetchingResourceIterator<Map<String,Obj
     public void materialize( QueryExecution execution )
     {
        this.execution = execution;
-       this.materializeResult = new ArrayList<>(  );
+       this.materializeResult = new ArrayList<>();
        fetchResults( Long.MAX_VALUE );
     }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/plandescription/PlanDescriptionArgumentSerializerTests.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/plandescription/PlanDescriptionArgumentSerializerTests.scala
@@ -86,7 +86,7 @@ class PlanDescriptionArgumentSerializerTests extends CypherFunSuite {
   }
 
   test("serialize something that includes a regex should work") {
-    val value = "GenericCase(Vector((any(  x@40 in n.values where   x@40 =~ Literal(^T-?\\d+$)),SubstringFunction(ContainerIndex(FilterFunction(n.values,  x@106,  x@106 =~ Literal(^T-?\\d+$)),Literal(0)),Literal(1),None))),Some(Literal(1))) == {p0}"
+    val value = "GenericCase(Vector((any( x@40 in n.values where   x@40 =~ Literal(^T-?\\d+$)),SubstringFunction(ContainerIndex(FilterFunction(n.values,  x@106,  x@106 =~ Literal(^T-?\\d+$)),Literal(0)),Literal(1),None))),Some(Literal(1))) == {p0}"
     serialize(KeyNames(Seq(value))) should equal (
       "GenericCase(Vector((any(x in n.values where x =~ Literal(^T-?\\d+$)),SubstringFunction(ContainerIndex(FilterFunction(n.values,x,x =~ Literal(^T-?\\d+$)),Literal(0)),Literal(1),None))),Some(Literal(1))) == {p0}"
     )

--- a/community/cypher/ir/src/main/scala/org/neo4j/cypher/internal/ir/helpers/PatternConverters.scala
+++ b/community/cypher/ir/src/main/scala/org/neo4j/cypher/internal/ir/helpers/PatternConverters.scala
@@ -56,9 +56,9 @@ object PatternConverters {
   }
 
   //RelationshipChain(
-  // NodePattern(Some(Variable(  UNNAMED6)),List(),Some(Variable(  UNNAMED7))),
+  // NodePattern(Some(Variable( UNNAMED6)),List(),Some(Variable( UNNAMED7))),
   // RelationshipPattern(Some(Variable(r)),List(),None,None,OUTGOING,false),
-  // NodePattern(Some(Variable(  UNNAMED8)),List(),Some(Variable(  UNNAMED9))))
+  // NodePattern(Some(Variable( UNNAMED8)),List(),Some(Variable( UNNAMED9))))
   implicit class RelationshipChainDestructor(val chain: RelationshipChain) extends AnyVal {
     def destructedRelationshipChain: DestructResult = chain match {
       // (a)->[r]->(b)

--- a/community/cypher/runtime-util/src/test/java/org/neo4j/cypher/internal/kernel/api/helpers/CachingExpandIntoTest.java
+++ b/community/cypher/runtime-util/src/test/java/org/neo4j/cypher/internal/kernel/api/helpers/CachingExpandIntoTest.java
@@ -134,7 +134,7 @@ class CachingExpandIntoTest
     }
 
     @SuppressWarnings( "StatementWithEmptyBody" )
-    private void findConnections(  CachingExpandInto expandInto, NodeCursor cursor, long from, long to, int...types )
+    private void findConnections( CachingExpandInto expandInto, NodeCursor cursor, long from, long to, int...types )
     {
         RelationshipTraversalCursor relationships =
                 expandInto.connectingRelationships( cursor, mock( RelationshipTraversalCursor.class ), from,

--- a/community/cypher/runtime-util/src/test/java/org/neo4j/cypher/operations/PathValueBuilderTest.java
+++ b/community/cypher/runtime-util/src/test/java/org/neo4j/cypher/operations/PathValueBuilderTest.java
@@ -61,7 +61,7 @@ class PathValueBuilderTest
     {
         // Given
         NodeValue node = node( 42 );
-        PathValueBuilder builder = builder(  node );
+        PathValueBuilder builder = builder( node );
 
         // When
         builder.addNode( node );
@@ -212,7 +212,7 @@ class PathValueBuilderTest
     {
         DbAccess dbAccess = mock( DbAccess.class );
         RelationshipScanCursor cursors = mock( RelationshipScanCursor.class );
-        Map<Long, RelationshipValue> relMap = new HashMap<>(  );
+        Map<Long, RelationshipValue> relMap = new HashMap<>();
         for ( AnyValue value : values )
         {
             if ( value instanceof NodeValue )

--- a/community/cypher/runtime-util/src/test/java/org/neo4j/cypher/result/NaiveQuerySubscriptionTest.java
+++ b/community/cypher/runtime-util/src/test/java/org/neo4j/cypher/result/NaiveQuerySubscriptionTest.java
@@ -178,7 +178,7 @@ class NaiveQuerySubscriptionTest
 
     ResultRecord record( AnyValue...fields )
     {
-        return new ResultRecord(  fields );
+        return new ResultRecord( fields );
     }
 
     private class ResultRecord implements QueryResult.Record

--- a/community/dbms/src/main/java/org/neo4j/dbms/archive/CompressionFormat.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/archive/CompressionFormat.java
@@ -124,14 +124,14 @@ public enum CompressionFormat
             {
                 return decompress( streamSupplier, ZSTD );
             }
-            catch (  IOException zstdIOe )
+            catch ( IOException zstdIOe )
             {
                 //It failed, lets try GZIP
                 try
                 {
                     return decompress( streamSupplier, GZIP );
                 }
-                catch (  IOException gzipIOe )
+                catch ( IOException gzipIOe )
                 {
                     throw Exceptions.chain( zstdIOe, gzipIOe );
                 }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/InternalTreeLogic.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/InternalTreeLogic.java
@@ -1015,7 +1015,7 @@ class InternalTreeLogic<KEY,VALUE>
         // Remove key and child
         if ( leftChild )
         {
-            bTreeNode.removeKeyAndLeftChildAt(  cursor, keyPos, keyCount, stableGeneration, unstableGeneration, cursorTracer );
+            bTreeNode.removeKeyAndLeftChildAt( cursor, keyPos, keyCount, stableGeneration, unstableGeneration, cursorTracer );
         }
         else
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DatabaseSchemaState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DatabaseSchemaState.java
@@ -39,7 +39,7 @@ public class DatabaseSchemaState implements SchemaState
 
     public DatabaseSchemaState( LogProvider logProvider )
     {
-        this.state = new ConcurrentHashMap<>(  );
+        this.state = new ConcurrentHashMap<>();
         this.log = logProvider.getLog( getClass() );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/internal/PrefetchingNodeResourceIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/internal/PrefetchingNodeResourceIterator.java
@@ -55,7 +55,7 @@ abstract class PrefetchingNodeResourceIterator implements ResourceIterator<Node>
         if ( !hasNext() )
         {
             close();
-            throw new NoSuchElementException(  );
+            throw new NoSuchElementException();
         }
         Node node = nodeFactory.make( next );
         next = fetchNext();

--- a/community/kernel/src/test/java/org/neo4j/kernel/availability/CompositeDatabaseAvailabilityGuardTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/availability/CompositeDatabaseAvailabilityGuardTest.java
@@ -117,7 +117,7 @@ class CompositeDatabaseAvailabilityGuardTest
     void availabilityTimeoutSharedAcrossAllGuards()
     {
         compositeGuard.require( requirement );
-        MutableLong counter = new MutableLong(  );
+        MutableLong counter = new MutableLong();
 
         when( mockClock.millis() ).thenAnswer( (Answer<Long>) invocation ->
         {
@@ -139,7 +139,7 @@ class CompositeDatabaseAvailabilityGuardTest
     void awaitCheckTimeoutSharedAcrossAllGuards()
     {
         compositeGuard.require( requirement );
-        MutableLong counter = new MutableLong(  );
+        MutableLong counter = new MutableLong();
 
         when( mockClock.millis() ).thenAnswer( (Answer<Long>) invocation ->
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/diagnostics/DiagnosticsReporterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/diagnostics/DiagnosticsReporterTest.java
@@ -73,7 +73,7 @@ class DiagnosticsReporterTest
     @Test
     void shouldContinueAfterError() throws Exception
     {
-        DiagnosticsReporter reporter = new DiagnosticsReporter(  );
+        DiagnosticsReporter reporter = new DiagnosticsReporter();
         MyProvider myProvider = new MyProvider( fileSystem );
         reporter.registerOfflineProvider( myProvider );
 
@@ -134,7 +134,7 @@ class DiagnosticsReporterTest
 
     private DiagnosticsReporter setupDiagnosticsReporter() throws IOException
     {
-        DiagnosticsReporter reporter = new DiagnosticsReporter(  );
+        DiagnosticsReporter reporter = new DiagnosticsReporter();
         MyProvider myProvider = new MyProvider( fileSystem );
         reporter.registerOfflineProvider( myProvider );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
@@ -969,7 +969,7 @@ class IndexingServiceTest
         assertThat( internalLogProvider ).forClass( IndexPopulationJob.class ).forLevel( ERROR ).assertExceptionForLogMessage(
                 "Failed to populate index: [Index( id=0, name='index', type='GENERAL BTREE', schema=(:TheLabel {propertyKey}), " +
                         "indexProvider='quantum-dex-25.0' )]" )
-                .hasRootCause(  exception );
+                .hasRootCause( exception );
         assertThat( internalLogProvider ).forClass( IndexPopulationJob.class ).forLevel( INFO )
                 .doesNotContainMessageWithArguments( "Index population completed. Index is now online: [%s]",
                 "Index( id=0, name='index', type='GENERAL BTREE', schema=(:TheLabel {propertyKey}), indexProvider='quantum-dex-25.0' )" );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/OperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/OperationsTest.java
@@ -433,7 +433,7 @@ class OperationsTest
         when( nodeCursor.labels() ).thenReturn( TokenSet.NONE );
 
         // WHEN
-        operations.nodeDelete(  123 );
+        operations.nodeDelete( 123 );
 
         //THEN
         order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 123 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/query/RecordingQuerySubscriber.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/query/RecordingQuerySubscriber.java
@@ -28,7 +28,7 @@ import org.neo4j.values.AnyValue;
 
 public class RecordingQuerySubscriber implements QuerySubscriber
 {
-    private List<AnyValue[]> all = new ArrayList<>(  );
+    private List<AnyValue[]> all = new ArrayList<>();
     private AnyValue[] current;
     private Throwable throwable;
     private QueryStatistics statistics;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/BatchingTransactionAppenderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/BatchingTransactionAppenderTest.java
@@ -208,7 +208,7 @@ class BatchingTransactionAppenderTest
 
         when( transactionIdStore.getLastCommittedTransactionId() ).thenReturn( latestCommittedTxWhenStarted );
 
-        LogEntryStart start = new LogEntryStart(  0L, latestCommittedTxWhenStarted, 0, null, LogPosition.UNSPECIFIED );
+        LogEntryStart start = new LogEntryStart( 0L, latestCommittedTxWhenStarted, 0, null, LogPosition.UNSPECIFIED );
         LogEntryCommit commit = new LogEntryCommit( latestCommittedTxWhenStarted + 2, 0L, BASE_TX_CHECKSUM );
         CommittedTransactionRepresentation transaction = new CommittedTransactionRepresentation( start, transactionRepresentation, commit );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/EntryTimespanThresholdTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/EntryTimespanThresholdTest.java
@@ -82,7 +82,7 @@ class EntryTimespanThresholdTest
         // given
         final EntryTimespanThreshold threshold = new EntryTimespanThreshold( logProvider, clock, MILLISECONDS, 100 );
 
-        final IOException ex = new IOException(  );
+        final IOException ex = new IOException();
         when( source.getFirstStartRecordTimestamp( version ) ).thenThrow( ex );
 
         // when

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruningTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruningTest.java
@@ -85,7 +85,7 @@ class LogPruningTest
     void mustHaveLogFilesToPruneIfStrategyFindsFiles()
     {
         when( factory.strategyFromConfigValue( eq( fs ), eq( logFiles ), eq( logProvider ), eq( clock ), anyString() ) )
-                .thenReturn(  upTo -> LongStream.range( 3, upTo ) );
+                .thenReturn( upTo -> LongStream.range( 3, upTo ) );
         when( logFiles.getHighestLogVersion() ).thenReturn( 4L );
         LogPruning pruning = new LogPruningImpl( fs, logFiles, logProvider, factory, clock, config );
         assertTrue( pruning.mightHaveLogsToPrune() );
@@ -95,7 +95,7 @@ class LogPruningTest
     void mustNotHaveLogsFilesToPruneIfStrategyFindsNoFiles()
     {
         when( factory.strategyFromConfigValue( eq( fs ), eq( logFiles ), eq( logProvider ), eq( clock ), anyString() ) )
-                .thenReturn(  x -> LongStream.empty() );
+                .thenReturn( x -> LongStream.empty() );
         LogPruning pruning = new LogPruningImpl( fs, logFiles, logProvider, factory, clock, config );
         assertFalse( pruning.mightHaveLogsToPrune() );
     }

--- a/community/kernel/src/test/java/org/neo4j/storageengine/api/StubStorageCursors.java
+++ b/community/kernel/src/test/java/org/neo4j/storageengine/api/StubStorageCursors.java
@@ -441,7 +441,7 @@ public class StubStorageCursors implements StorageReader
         @Override
         public boolean scanBatch( AllNodeScan scan, int sizeHint )
         {
-            throw new UnsupportedOperationException(  );
+            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -587,7 +587,7 @@ public class StubStorageCursors implements StorageReader
         @Override
         public boolean scanBatch( AllRelationshipsScan scan, int sizeHint )
         {
-            throw new UnsupportedOperationException(  );
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/AbstractLuceneIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/AbstractLuceneIndex.java
@@ -164,7 +164,7 @@ public abstract class AbstractLuceneIndex<READER extends IndexReader>
             {
                 // it is ok for index directory to be empty
                 // this can happen if it is opened and closed without any writes in between
-                if ( ArrayUtils.isNotEmpty(  directory.listAll() ) )
+                if ( ArrayUtils.isNotEmpty( directory.listAll() ) )
                 {
                     try ( CheckIndex checker = new CheckIndex( directory ) )
                     {

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueDatabaseIndexPopulatingUpdaterTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueDatabaseIndexPopulatingUpdaterTest.java
@@ -258,7 +258,7 @@ class NonUniqueDatabaseIndexPopulatingUpdaterTest
 
     private void verifyDocument( LuceneIndexWriter writer, Term eq, String documentString ) throws IOException
     {
-        verify( writer ).updateDocument(  eq(eq), argThat( doc -> documentString.equals( doc.toString() ) ) );
+        verify( writer ).updateDocument( eq(eq), argThat( doc -> documentString.equals( doc.toString() ) ) );
     }
 
     private static void verifySamplingResult( NonUniqueIndexSampler sampler, long expectedIndexSize,

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/UserAggregationFunctionsExamples.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/visitors/examples/UserAggregationFunctionsExamples.java
@@ -57,25 +57,25 @@ public class UserAggregationFunctionsExamples
     }
 
     @UserAggregationFunction( name = "com.acme.foobar" )
-    public StringAggregatorWithWrongUpdateParameterType updateWithWrongParameterType(  )
+    public StringAggregatorWithWrongUpdateParameterType updateWithWrongParameterType()
     {
         return new StringAggregatorWithWrongUpdateParameterType();
     }
 
     @UserAggregationFunction( name = "com.acme.foobar" )
-    public StringAggregatorWithMissingAnnotationOnParameterType missingParameterAnnotation(  )
+    public StringAggregatorWithMissingAnnotationOnParameterType missingParameterAnnotation()
     {
         return new StringAggregatorWithMissingAnnotationOnParameterType();
     }
 
     @UserAggregationFunction( name = "com.acme.foobar" )
-    public StringAggregatorWithWrongResultReturnType resultWithWrongReturnType(  )
+    public StringAggregatorWithWrongResultReturnType resultWithWrongReturnType()
     {
         return new StringAggregatorWithWrongResultReturnType();
     }
 
     @UserAggregationFunction( name = "com.acme.foobar" )
-    public StringAggregatorWithResultMethodWithParameters resultWithParams(  )
+    public StringAggregatorWithResultMethodWithParameters resultWithParams()
     {
         return new StringAggregatorWithResultMethodWithParameters();
     }
@@ -136,7 +136,7 @@ public class UserAggregationFunctionsExamples
         @UserAggregationResult
         public Thread result()
         {
-            return new Thread(  );
+            return new Thread();
         }
     }
 

--- a/community/procedure/src/main/java/org/neo4j/procedure/builtin/JmxQueryProcedure.java
+++ b/community/procedure/src/main/java/org/neo4j/procedure/builtin/JmxQueryProcedure.java
@@ -120,7 +120,7 @@ public class JmxQueryProcedure extends CallableProcedure.BasicProcedure
     private MapValue toNeo4jValue( ObjectName name, MBeanAttributeInfo[] attributes )
             throws JMException
     {
-        MapValueBuilder out = new MapValueBuilder(  );
+        MapValueBuilder out = new MapValueBuilder();
         for ( MBeanAttributeInfo attribute : attributes )
         {
             if ( attribute.isReadable() )
@@ -205,7 +205,7 @@ public class JmxQueryProcedure extends CallableProcedure.BasicProcedure
     {
         // Build a new map with the same keys, but each value passed
         // through `toNeo4jValue`
-        MapValueBuilder builder = new MapValueBuilder(  );
+        MapValueBuilder builder = new MapValueBuilder();
         attributeValue.forEach( ( key, value ) -> builder.add( key.toString(), toNeo4jValue( value ) ) );
         return builder.build();
     }

--- a/community/procedure/src/main/java/org/neo4j/procedure/impl/FieldInjections.java
+++ b/community/procedure/src/main/java/org/neo4j/procedure/impl/FieldInjections.java
@@ -111,7 +111,7 @@ class FieldInjections
     {
         if ( !field.isAnnotationPresent( Context.class ) )
         {
-            throw new ProcedureException(  Status.Procedure.ProcedureRegistrationFailed,
+            throw new ProcedureException( Status.Procedure.ProcedureRegistrationFailed,
                     "Field `%s` on `%s` is not annotated as a @" + Context.class.getSimpleName() +
                             " and is not static. If you want to store state along with your procedure," +
                             " please use a static field.",

--- a/community/procedure/src/main/java/org/neo4j/procedure/impl/ProcedureCompilation.java
+++ b/community/procedure/src/main/java/org/neo4j/procedure/impl/ProcedureCompilation.java
@@ -277,7 +277,7 @@ public final class ProcedureCompilation
             //set all static fields
             setAllStaticFields( signature, fieldSetters, methodToCall, clazz );
 
-            return (CallableUserFunction) clazz.getConstructor(  ).newInstance();
+            return (CallableUserFunction) clazz.getConstructor().newInstance();
         }
         catch ( Throwable e )
         {
@@ -375,7 +375,7 @@ public final class ProcedureCompilation
 
             //set all static fields
             setAllStaticFields( signature, fieldSetters, methodToCall, clazz );
-            return (CallableProcedure) clazz.getConstructor(  ).newInstance();
+            return (CallableProcedure) clazz.getConstructor().newInstance();
         }
         catch ( Throwable e )
         {
@@ -501,7 +501,7 @@ public final class ProcedureCompilation
             //set all static fields
             setAllStaticFields( signature, fieldSetters, create, clazz );
 
-            return (CallableUserAggregationFunction) clazz.getConstructor(  ).newInstance();
+            return (CallableUserAggregationFunction) clazz.getConstructor().newInstance();
         }
         catch ( Throwable e )
         {

--- a/community/procedure/src/main/java/org/neo4j/procedure/impl/temporal/TemporalFunction.java
+++ b/community/procedure/src/main/java/org/neo4j/procedure/impl/temporal/TemporalFunction.java
@@ -290,7 +290,7 @@ public abstract class TemporalFunction<T extends AnyValue> implements CallableUs
             {
                 AnyValue unit = args[0];
 
-                AnyValue input = args.length < 2 || args[1].equals(  DEFAULT_TEMPORAL_ARGUMENT_VALUE ) ?
+                AnyValue input = args.length < 2 || args[1].equals( DEFAULT_TEMPORAL_ARGUMENT_VALUE ) ?
                                  function.apply( ctx, new AnyValue[]{DEFAULT_TEMPORAL_ARGUMENT_VALUE}) : args[1];
 
                 AnyValue fields = args.length < 3 || args[2] == NO_VALUE ? EMPTY_MAP : args[2];

--- a/community/procedure/src/test/java/org/neo4j/procedure/builtin/ResampleOutdatedIndexesProcedureTest.java
+++ b/community/procedure/src/test/java/org/neo4j/procedure/builtin/ResampleOutdatedIndexesProcedureTest.java
@@ -30,7 +30,7 @@ import static org.neo4j.kernel.impl.api.index.sampling.IndexSamplingMode.backgro
 class ResampleOutdatedIndexesProcedureTest
 {
     private final IndexingService indexingService = mock( IndexingService.class );
-    private final IndexProcedures procedure = new IndexProcedures( new StubKernelTransaction(  ), indexingService );
+    private final IndexProcedures procedure = new IndexProcedures( new StubKernelTransaction(), indexingService );
 
     @Test
     void shouldTriggerResampling()

--- a/community/procedure/src/test/java/org/neo4j/procedure/impl/ProcedureCompilationTest.java
+++ b/community/procedure/src/test/java/org/neo4j/procedure/impl/ProcedureCompilationTest.java
@@ -342,7 +342,7 @@ public class ProcedureCompilationTest
     void shouldCallSimpleProcedure() throws ProcedureException
     {
         // Given
-        ProcedureSignature signature = ProcedureSignature.procedureSignature(  "test", "foo" )
+        ProcedureSignature signature = ProcedureSignature.procedureSignature( "test", "foo" )
                 .in( "in", NTInteger )
                 .out( singletonList( inputField( "name", NTInteger ) ) ).build();
         // When
@@ -360,7 +360,7 @@ public class ProcedureCompilationTest
     void shouldExposeProcedureSignature() throws ProcedureException
     {
         // Given
-        ProcedureSignature signature = ProcedureSignature.procedureSignature(  "test", "foo" )
+        ProcedureSignature signature = ProcedureSignature.procedureSignature( "test", "foo" )
                 .in( "in", NTInteger )
                 .out( singletonList( inputField( "name", NTInteger ) ) ).build();
         // When
@@ -375,7 +375,7 @@ public class ProcedureCompilationTest
     void procedureShouldAccessContext() throws ProcedureException, NoSuchFieldException
     {
         // Given
-        ProcedureSignature signature = ProcedureSignature.procedureSignature(  "test", "foo" )
+        ProcedureSignature signature = ProcedureSignature.procedureSignature( "test", "foo" )
                 .in( "in", NTString )
                 .out( singletonList( inputField( "name", NTString ) ) ).build();
         FieldSetter setter1 = createSetter( InnerClass.class, "transaction", Context::internalTransaction );
@@ -399,7 +399,7 @@ public class ProcedureCompilationTest
     {
         // Given
         ResourceTracker tracker = mock( ResourceTracker.class );
-        ProcedureSignature signature = ProcedureSignature.procedureSignature(  "test", "foo" )
+        ProcedureSignature signature = ProcedureSignature.procedureSignature( "test", "foo" )
                 .in( "in", NTString )
                 .out( singletonList( inputField( "name", NTString ) ) ).build();
 
@@ -416,7 +416,7 @@ public class ProcedureCompilationTest
     void shouldCallVoidProcedure() throws ProcedureException, NoSuchFieldException
     {
         // Given
-        ProcedureSignature signature = ProcedureSignature.procedureSignature(  "test", "foo" ).build();
+        ProcedureSignature signature = ProcedureSignature.procedureSignature( "test", "foo" ).build();
         // When
         FieldSetter setter = createSetter( InnerClass.class, "transaction", Context::internalTransaction );
         CallableProcedure voidMethod =
@@ -433,7 +433,7 @@ public class ProcedureCompilationTest
     void shouldHandleNonStaticInnerClasses() throws ProcedureException
     {
         // Given
-        ProcedureSignature signature = ProcedureSignature.procedureSignature(  "test", "foo" )
+        ProcedureSignature signature = ProcedureSignature.procedureSignature( "test", "foo" )
                 .out( singletonList( inputField( "name", NTString ) ) ).build();
         // When
         CallableProcedure stringStream =
@@ -450,7 +450,7 @@ public class ProcedureCompilationTest
     void shouldCheckAccessOnAdminProcedures() throws ProcedureException
     {
         // Given
-        ProcedureSignature signature = ProcedureSignature.procedureSignature(  "test", "foo" )
+        ProcedureSignature signature = ProcedureSignature.procedureSignature( "test", "foo" )
                 .admin( true )
                 .out( singletonList( inputField( "name", NTString ) ) ).build();
         SecurityContext securityContext = mock( SecurityContext.class );
@@ -641,7 +641,7 @@ public class ProcedureCompilationTest
 
         public class Aggregator
         {
-            StringBuilder aggregator = new StringBuilder(  );
+            StringBuilder aggregator = new StringBuilder();
             private boolean first = true;
 
             public void update( String in )

--- a/community/procedure/src/test/java/org/neo4j/procedure/impl/UserAggregationFunctionTest.java
+++ b/community/procedure/src/test/java/org/neo4j/procedure/impl/UserAggregationFunctionTest.java
@@ -694,7 +694,7 @@ public class UserAggregationFunctionTest
             @UserAggregationUpdate
             public void update()
             {
-                throw new IndexOutOfBoundsException(  );
+                throw new IndexOutOfBoundsException();
             }
 
             @UserAggregationResult

--- a/community/record-storage-engine/src/main/java/org/neo4j/internal/batchimport/store/PageCacheFlusher.java
+++ b/community/record-storage-engine/src/main/java/org/neo4j/internal/batchimport/store/PageCacheFlusher.java
@@ -77,7 +77,7 @@ class PageCacheFlusher extends Thread
         if ( error != null )
         {
             throwIfUnchecked( error );
-            throw new RuntimeException(  error );
+            throw new RuntimeException( error );
         }
     }
 }

--- a/community/server/src/main/java/org/neo4j/server/rest/Neo4jError.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/Neo4jError.java
@@ -89,7 +89,7 @@ public class Neo4jError
 
     public String getStackTraceAsString()
     {
-        StringWriter stringWriter = new StringWriter(  );
+        StringWriter stringWriter = new StringWriter();
         PrintWriter printWriter = new PrintWriter( stringWriter );
         cause.printStackTrace( printWriter );
         return stringWriter.toString();

--- a/community/server/src/test/java/org/neo4j/server/http/cypher/format/output/json/ExecutionResultSerializerTest.java
+++ b/community/server/src/test/java/org/neo4j/server/http/cypher/format/output/json/ExecutionResultSerializerTest.java
@@ -418,7 +418,7 @@ class ExecutionResultSerializerTest
         Map<String, Object> row3 = new HashMap<>();
         row3.put( "geom", SpatialMocks.mockPoint( 12.3, 45.6, 78.9, mockWGS84_3D() )  );
         Map<String, Object> row4 = new HashMap<>();
-        row4.put(  "geom", SpatialMocks.mockPoint( 123, 456, 789, mockCartesian_3D() ) );
+        row4.put( "geom", SpatialMocks.mockPoint( 123, 456, 789, mockCartesian_3D() ) );
 
         // when
         writeStatementStart( "geom");

--- a/community/ssl/src/main/java/org/neo4j/ssl/PkiUtils.java
+++ b/community/ssl/src/main/java/org/neo4j/ssl/PkiUtils.java
@@ -90,7 +90,7 @@ public final class PkiUtils
         {
             passPhrase = "";
         }
-        try ( PEMParser r = new PEMParser(  Files.newBufferedReader( privateKeyFile.toPath() ) ) )
+        try ( PEMParser r = new PEMParser( Files.newBufferedReader( privateKeyFile.toPath() ) ) )
         {
             Object pemObject = r.readObject();
             final JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider( PROVIDER );

--- a/community/testing/kernel-api-utils/src/main/java/org/neo4j/internal/kernel/api/helpers/TestRelationshipChain.java
+++ b/community/testing/kernel-api-utils/src/main/java/org/neo4j/internal/kernel/api/helpers/TestRelationshipChain.java
@@ -75,7 +75,7 @@ public class TestRelationshipChain
 
     public TestRelationshipChain tail()
     {
-        return new TestRelationshipChain(  originNodeId, data.subList( 1, data.size() ) );
+        return new TestRelationshipChain( originNodeId, data.subList( 1, data.size() ) );
     }
 
     static class Data

--- a/community/values/src/main/java/org/neo4j/values/SequenceValue.java
+++ b/community/values/src/main/java/org/neo4j/values/SequenceValue.java
@@ -223,7 +223,7 @@ public interface SequenceValue extends Iterable<AnyValue>
             cmp = comparator.ternaryCompare( a.value( i ), b.value( i ) );
             i++;
         }
-        if (  cmp == Comparison.EQUAL )
+        if ( cmp == Comparison.EQUAL )
         {
             cmp = Comparison.from( a.length() - b.length() );
         }

--- a/community/values/src/main/java/org/neo4j/values/storable/TemporalValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TemporalValue.java
@@ -179,7 +179,7 @@ public abstract class TemporalValue<T extends Temporal, V extends TemporalValue<
     @Override
     public final long until( Temporal endExclusive, TemporalUnit unit )
     {
-        if (  !(endExclusive instanceof TemporalValue) )
+        if ( !(endExclusive instanceof TemporalValue) )
         {
             throw new InvalidArgumentException( "Can only compute durations between TemporalValues." );
         }

--- a/community/values/src/main/java/org/neo4j/values/virtual/MapValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/MapValue.java
@@ -728,7 +728,7 @@ public abstract class MapValue extends VirtualValue
         }
     }
 
-    public MapValue updatedWith(  MapValue other )
+    public MapValue updatedWith( MapValue other )
     {
         return new CombinedMapValue( this, other );
     }

--- a/community/values/src/main/java/org/neo4j/values/virtual/MapValueBuilder.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/MapValueBuilder.java
@@ -34,7 +34,7 @@ public class MapValueBuilder
 
     public MapValueBuilder()
     {
-        this.map = new HashMap<>(  );
+        this.map = new HashMap<>();
     }
 
     public MapValueBuilder( int expectedSize )

--- a/community/values/src/test/java/org/neo4j/values/TernaryEqualityTest.java
+++ b/community/values/src/test/java/org/neo4j/values/TernaryEqualityTest.java
@@ -196,8 +196,8 @@ class TernaryEqualityTest
     @Test
     void shouldHandleDurations()
     {
-       assertTernaryEquality(  durationValue( Duration.ofDays( 12 ) ),  durationValue( Duration.ofDays( 12 ) ), Equality.TRUE );
-       assertTernaryEquality(  durationValue( Duration.ofDays( 12 ) ),  durationValue( Duration.ofDays( 13 ) ), Equality.FALSE );
+       assertTernaryEquality( durationValue( Duration.ofDays( 12 ) ),  durationValue( Duration.ofDays( 12 ) ), Equality.TRUE );
+       assertTernaryEquality( durationValue( Duration.ofDays( 12 ) ),  durationValue( Duration.ofDays( 13 ) ), Equality.FALSE );
     }
 
     private void assertTernaryEquality( AnyValue a, AnyValue b, Equality expected )

--- a/community/values/src/test/java/org/neo4j/values/storable/UTF8StringValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/UTF8StringValueTest.java
@@ -182,9 +182,9 @@ class UTF8StringValueTest
         UTF8StringValue b = (UTF8StringValue) utf8Value( bytes, 3, 3 );
 
         // Then
-        assertSame( a.plus( a ), stringValue(  "ⲹⲹ" ) );
-        assertSame( a.plus( b ), stringValue(  "ⲹ楡" ) );
-        assertSame( b.plus( a ), stringValue(  "楡ⲹ") );
+        assertSame( a.plus( a ), stringValue( "ⲹⲹ" ) );
+        assertSame( a.plus( b ), stringValue( "ⲹ楡" ) );
+        assertSame( b.plus( a ), stringValue( "楡ⲹ") );
         assertSame( b.plus( b ), stringValue( "楡楡" ) );
     }
 

--- a/community/wal/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryParserSetV2_3.java
+++ b/community/wal/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryParserSetV2_3.java
@@ -61,7 +61,7 @@ public class LogEntryParserSetV2_3 extends LogEntryParserSet.Adapter
                 return command == null ? null : new LogEntryCommand( version, command );
             }
         } );
-        register(  new LogEntryParser.Adapter( LogEntryTypeCodes.TX_COMMIT )
+        register( new LogEntryParser.Adapter( LogEntryTypeCodes.TX_COMMIT )
         {
             @Override
             public LogEntry parse( byte version, ReadableChecksumChannel channel, LogPositionMarker marker, CommandReaderFactory commandReaderFactory )


### PR DESCRIPTION
- Remove the second space after `(`.

Some places were left as-is to match with other following lines.

- Replace `(  )` with `()`, since the latter is the more commonly used in the code-base.