### PR TITLE
Allow constraint to have multiple labels

### DIFF
--- a/community/cypher/cypher-logical-plans/src/main/scala/org/neo4j/cypher/internal/logical/plans/ProceduralLogicalPlan.scala
+++ b/community/cypher/cypher-logical-plans/src/main/scala/org/neo4j/cypher/internal/logical/plans/ProceduralLogicalPlan.scala
@@ -41,8 +41,8 @@ abstract class ProceduralLogicalPlan(idGen: IdGen) extends LogicalPlan(idGen) {
 case class CreateNodeKeyConstraint(node: String, label: LabelName, props: Seq[Property], name: Option[String])(implicit idGen: IdGen) extends ProceduralLogicalPlan(idGen)
 case class DropNodeKeyConstraint(label: LabelName, props: Seq[Property])(implicit idGen: IdGen) extends ProceduralLogicalPlan(idGen)
 
-case class CreateUniquePropertyConstraint(node: String, label: LabelName, props: Seq[Property], name: Option[String])(implicit idGen: IdGen) extends ProceduralLogicalPlan(idGen)
-case class DropUniquePropertyConstraint(label: LabelName, props: Seq[Property])(implicit idGen: IdGen) extends ProceduralLogicalPlan(idGen)
+case class CreateUniquePropertyConstraint(node: String, labels: Seq[LabelName], props: Seq[Property], name: Option[String])(implicit idGen: IdGen) extends ProceduralLogicalPlan(idGen)
+case class DropUniquePropertyConstraint(labels: Seq[LabelName], props: Seq[Property])(implicit idGen: IdGen) extends ProceduralLogicalPlan(idGen)
 
 case class CreateNodePropertyExistenceConstraint(label: LabelName, prop: Property, name: Option[String])(implicit idGen: IdGen) extends ProceduralLogicalPlan(idGen)
 case class DropNodePropertyExistenceConstraint(label: LabelName, prop: Property)(implicit idGen: IdGen) extends ProceduralLogicalPlan(idGen)

--- a/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/SchemaCommandPlanBuilder.scala
+++ b/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/SchemaCommandPlanBuilder.scala
@@ -68,13 +68,13 @@ case object SchemaCommandPlanBuilder extends Phase[PlannerContext, BaseState, Lo
 
       // CREATE CONSTRAINT ON (node:Label) ASSERT node.prop IS UNIQUE
       // CREATE CONSTRAINT ON (node:Label) ASSERT (node.prop1,node.prop2) IS UNIQUE
-      case CreateUniquePropertyConstraint(node, label, props, name) =>
-        Some(plans.CreateUniquePropertyConstraint(node.name, label, props, name))
+      case CreateUniquePropertyConstraint(node, labels, props, name) =>
+        Some(plans.CreateUniquePropertyConstraint(node.name, labels, props, name))
 
       // DROP CONSTRAINT ON (node:Label) ASSERT node.prop IS UNIQUE
       // DROP CONSTRAINT ON (node:Label) ASSERT (node.prop1,node.prop2) IS UNIQUE
-      case DropUniquePropertyConstraint(_, label, props) =>
-        Some(plans.DropUniquePropertyConstraint(label, props))
+      case DropUniquePropertyConstraint(_, labels, props) =>
+        Some(plans.DropUniquePropertyConstraint(labels, props))
 
       // CREATE CONSTRAINT ON (node:Label) ASSERT node.prop EXISTS
       case CreateNodePropertyExistenceConstraint(_, label, prop, name) =>

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/SchemaCommandRuntime.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/SchemaCommandRuntime.scala
@@ -87,20 +87,20 @@ object SchemaCommandRuntime extends CypherRuntime[RuntimeContext] {
 
     // CREATE CONSTRAINT ON (node:Label) ASSERT node.prop IS UNIQUE
     // CREATE CONSTRAINT ON (node:Label) ASSERT (node.prop1,node.prop2) IS UNIQUE
-    case CreateUniquePropertyConstraint(_, label, props, name) => (_, _) =>
+    case CreateUniquePropertyConstraint(_, labels, props, name) => (_, _) =>
       SchemaWriteExecutionPlan("CreateUniqueConstraint", ctx => {
-        val labelId = ctx.getOrCreateLabelId(label.name)
+        val labelIds = labels.map( l => ctx.getOrCreateLabelId(l.name) )
         val propertyKeyIds = props.map(p => propertyToId(ctx)(p.propertyKey).id)
-        ctx.createUniqueConstraint(labelId, propertyKeyIds, name)
+        ctx.createUniqueConstraint(labelIds, propertyKeyIds, name)
       })
 
     // DROP CONSTRAINT ON (node:Label) ASSERT node.prop IS UNIQUE
     // DROP CONSTRAINT ON (node:Label) ASSERT (node.prop1,node.prop2) IS UNIQUE
-    case DropUniquePropertyConstraint(label, props) => (_, _) =>
+    case DropUniquePropertyConstraint(labels, props) => (_, _) =>
       SchemaWriteExecutionPlan("DropUniqueConstraint", ctx => {
-        val labelId = ctx.getOrCreateLabelId(label.name)
+        val labelIds = labels.map( l => ctx.getOrCreateLabelId(l.name) )
         val propertyKeyIds = props.map(p => propertyToId(ctx)(p.propertyKey).id)
-        ctx.dropUniqueConstraint(labelId, propertyKeyIds)
+        ctx.dropUniqueConstraint(labelIds, propertyKeyIds)
       })
 
     // CREATE CONSTRAINT ON (node:Label) ASSERT node.prop EXISTS

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/planning/ExceptionTranslatingQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/planning/ExceptionTranslatingQueryContext.scala
@@ -177,10 +177,10 @@ class ExceptionTranslatingQueryContext(val inner: QueryContext) extends QueryCon
   override def dropNodeKeyConstraint(labelId: Int, propertyKeyIds: Seq[Int]): Unit =
     translateException(tokenNameLookup, inner.dropNodeKeyConstraint(labelId, propertyKeyIds))
 
-  override def createUniqueConstraint(labelId: Int, propertyKeyIds: Seq[Int], name: Option[String]): Unit =
-    translateException(tokenNameLookup, inner.createUniqueConstraint(labelId, propertyKeyIds, name))
+  override def createUniqueConstraint(labelIds: Seq[Int], propertyKeyIds: Seq[Int], name: Option[String]): Unit =
+    translateException(tokenNameLookup, inner.createUniqueConstraint(labelIds, propertyKeyIds, name))
 
-  override def dropUniqueConstraint(labelId: Int, propertyKeyIds: Seq[Int]): Unit =
+  override def dropUniqueConstraint(labelId: Seq[Int], propertyKeyIds: Seq[Int]): Unit =
     translateException(tokenNameLookup, inner.dropUniqueConstraint(labelId, propertyKeyIds))
 
   override def createNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int, name: Option[String]): Unit =

--- a/community/cypher/front-end/ast/src/main/scala/org/neo4j/cypher/internal/ast/Command.scala
+++ b/community/cypher/front-end/ast/src/main/scala/org/neo4j/cypher/internal/ast/Command.scala
@@ -109,7 +109,7 @@ trait UniquePropertyConstraintCommand extends CompositePropertyConstraintCommand
 
   val entityType = CTNode
 
-  def label: LabelName
+  def labels: Seq[LabelName]
 
   override def restrictedToSingleProperty: Boolean = true
 }
@@ -134,9 +134,9 @@ case class CreateNodeKeyConstraint(variable: Variable, label: LabelName, propert
 
 case class DropNodeKeyConstraint(variable: Variable, label: LabelName, properties: Seq[Property])(val position: InputPosition) extends NodeKeyConstraintCommand
 
-case class CreateUniquePropertyConstraint(variable: Variable, label: LabelName, properties: Seq[Property], name: Option[String])(val position: InputPosition) extends UniquePropertyConstraintCommand
+case class CreateUniquePropertyConstraint(variable: Variable, labels: Seq[LabelName], properties: Seq[Property], name: Option[String])(val position: InputPosition) extends UniquePropertyConstraintCommand
 
-case class DropUniquePropertyConstraint(variable: Variable, label: LabelName, properties: Seq[Property])(val position: InputPosition) extends UniquePropertyConstraintCommand
+case class DropUniquePropertyConstraint(variable: Variable, labels: Seq[LabelName], properties: Seq[Property])(val position: InputPosition) extends UniquePropertyConstraintCommand
 
 case class CreateNodePropertyExistenceConstraint(variable: Variable, label: LabelName, property: Property, name: Option[String])(val position: InputPosition) extends NodePropertyConstraintCommand
 

--- a/community/cypher/front-end/ast/src/main/scala/org/neo4j/cypher/internal/ast/prettifier/Prettifier.scala
+++ b/community/cypher/front-end/ast/src/main/scala/org/neo4j/cypher/internal/ast/prettifier/Prettifier.scala
@@ -190,22 +190,22 @@ case class Prettifier(
     case DropNodeKeyConstraint(Variable(variable), LabelName(label), properties) =>
       s"DROP CONSTRAINT ON ($variable:$label) ASSERT ${properties.map(_.asCanonicalStringVal).mkString("(", ", ", ")")} IS NODE KEY"
 
-    case CreateUniquePropertyConstraint(Variable(variable), LabelName(label), properties, None) =>
-      s"CREATE CONSTRAINT ON ($variable:$label) ASSERT ${properties.map(_.asCanonicalStringVal).mkString("(", ", ", ")")} IS UNIQUE"
+    case CreateUniquePropertyConstraint(Variable(variable), labels, properties, None) =>
+      s"CREATE CONSTRAINT ON ($variable:${labels.map(_.asCanonicalStringVal).mkString("(", ", ", ")")}) ASSERT ${properties.map(_.asCanonicalStringVal).mkString("(", ", ", ")")} IS UNIQUE"
 
-    case CreateUniquePropertyConstraint(Variable(variable), LabelName(label), properties, Some(name)) =>
-      s"CREATE CONSTRAINT ${Prettifier.escapeName(name)} ON ($variable:$label) ASSERT ${properties.map(_.asCanonicalStringVal).mkString("(", ", ", ")")} IS UNIQUE"
+    case CreateUniquePropertyConstraint(Variable(variable), labels, properties, Some(name)) =>
+      s"CREATE CONSTRAINT ${Prettifier.escapeName(name)} ON ($variable:${labels.map(_.asCanonicalStringVal).mkString("(", ", ", ")")}) ASSERT ${properties.map(_.asCanonicalStringVal).mkString("(", ", ", ")")} IS UNIQUE"
 
-    case DropUniquePropertyConstraint(Variable(variable), LabelName(label), properties) =>
-      s"DROP CONSTRAINT ON ($variable:$label) ASSERT ${properties.map(_.asCanonicalStringVal).mkString("(", ", ", ")")} IS UNIQUE"
+    case DropUniquePropertyConstraint(Variable(variable), labels, properties) =>
+      s"DROP CONSTRAINT ON ($variable:${labels.map(_.asCanonicalStringVal).mkString("(", ", ", ")")}) ASSERT ${properties.map(_.asCanonicalStringVal).mkString("(", ", ", ")")} IS UNIQUE"
 
-    case CreateNodePropertyExistenceConstraint(Variable(variable), LabelName(label), property, None) =>
+    case CreateNodePropertyExistenceConstraint(Variable(variable), label, property, None) =>
       s"CREATE CONSTRAINT ON ($variable:$label) ASSERT exists(${property.asCanonicalStringVal})"
 
-    case CreateNodePropertyExistenceConstraint(Variable(variable), LabelName(label), property, Some(name)) =>
+    case CreateNodePropertyExistenceConstraint(Variable(variable), label, property, Some(name)) =>
       s"CREATE CONSTRAINT ${Prettifier.escapeName(name)} ON ($variable:$label) ASSERT exists(${property.asCanonicalStringVal})"
 
-    case DropNodePropertyExistenceConstraint(Variable(variable), LabelName(label), property) =>
+    case DropNodePropertyExistenceConstraint(Variable(variable), label, property) =>
       s"DROP CONSTRAINT ON ($variable:$label) ASSERT exists(${property.asCanonicalStringVal})"
 
     case CreateRelationshipPropertyExistenceConstraint(Variable(variable), RelTypeName(relType), property, None) =>

--- a/community/cypher/front-end/parser/src/main/scala/org/neo4j/cypher/internal/parser/Command.scala
+++ b/community/cypher/front-end/parser/src/main/scala/org/neo4j/cypher/internal/parser/Command.scala
@@ -78,9 +78,9 @@ trait Command extends Parser
 
   def CreateUniqueConstraint: Rule1[ast.CreateUniquePropertyConstraint] = rule {
     group(keyword("CREATE CONSTRAINT") ~~ UniqueConstraintSyntax) ~~>>
-      ((variable, label, property) => ast.CreateUniquePropertyConstraint(variable, label, Seq(property), None)) |
+      ((variable, labels, property) => ast.CreateUniquePropertyConstraint(variable, labels, Seq(property), None)) |
     group(keyword("CREATE CONSTRAINT") ~~ SymbolicNameString ~~ UniqueConstraintSyntax) ~~>>
-      ((name, variable, label, property) => ast.CreateUniquePropertyConstraint(variable, label, Seq(property), Some(name)))
+      ((name, variable, labels, property) => ast.CreateUniquePropertyConstraint(variable, labels, Seq(property), Some(name)))
   }
 
   def CreateUniqueCompositeConstraint: Rule1[ast.CreateUniquePropertyConstraint] = rule {
@@ -109,7 +109,7 @@ trait Command extends Parser
 
   def DropUniqueConstraint: Rule1[ast.DropUniquePropertyConstraint] = rule {
     group(keyword("DROP CONSTRAINT") ~~ UniqueConstraintSyntax) ~~>>
-      ((variable, label, property) => ast.DropUniquePropertyConstraint(variable, label, Seq(property)))
+      ((variable, labels, property) => ast.DropUniquePropertyConstraint(variable, labels, Seq(property)))
   }
 
   def DropUniqueCompositeConstraint: Rule1[ast.DropUniquePropertyConstraint] = rule {
@@ -135,10 +135,10 @@ trait Command extends Parser
   private def NodeKeyConstraintSyntax: Rule3[Variable, LabelName, Seq[Property]] = keyword("ON") ~~ "(" ~~ Variable ~~ NodeLabel ~~ ")" ~~
     keyword("ASSERT") ~~ "(" ~~ PropertyExpressions ~~ ")" ~~ keyword("IS NODE KEY")
 
-  private def UniqueConstraintSyntax: Rule3[Variable, LabelName, Property] = keyword("ON") ~~ "(" ~~ Variable ~~ NodeLabel ~~ ")" ~~
+  private def UniqueConstraintSyntax: Rule3[Variable, Seq[LabelName], Property] = keyword("ON") ~~ "(" ~~ Variable ~~ NodeLabels ~~ ")" ~~
     keyword("ASSERT") ~~ PropertyExpression ~~ keyword("IS UNIQUE")
 
-  private def UniqueCompositeConstraintSyntax: Rule3[Variable, LabelName, Seq[Property]] = keyword("ON") ~~ "(" ~~ Variable ~~ NodeLabel ~~ ")" ~~
+  private def UniqueCompositeConstraintSyntax: Rule3[Variable, Seq[LabelName], Seq[Property]] = keyword("ON") ~~ "(" ~~ Variable ~~ NodeLabels ~~ ")" ~~
     keyword("ASSERT") ~~ "(" ~~ PropertyExpressions ~~ ")" ~~ keyword("IS UNIQUE")
 
   private def NodePropertyExistenceConstraintSyntax = keyword("ON") ~~ "(" ~~ Variable ~~ NodeLabel ~~ ")" ~~

--- a/community/cypher/front-end/parser/src/test/scala/org/neo4j/cypher/internal/parser/CommandParserTest.scala
+++ b/community/cypher/front-end/parser/src/test/scala/org/neo4j/cypher/internal/parser/CommandParserTest.scala
@@ -111,15 +111,15 @@ class CommandParserTest
   }
 
   test("CREATE CONSTRAINT ON (node:Label) ASSERT node.prop IS UNIQUE") {
-    yields(ast.CreateUniquePropertyConstraint(varFor("node"), labelName("Label"), Seq(prop("node", "prop")), None))
+    yields(ast.CreateUniquePropertyConstraint(varFor("node"), Seq(labelName("Label")), Seq(prop("node", "prop")), None))
   }
 
   test("CREATE CONSTRAINT ON (node:Label) ASSERT (node.prop) IS UNIQUE") {
-    yields(ast.CreateUniquePropertyConstraint(varFor("node"), labelName("Label"), Seq(prop("node", "prop")), None))
+    yields(ast.CreateUniquePropertyConstraint(varFor("node"), Seq(labelName("Label")), Seq(prop("node", "prop")), None))
   }
 
   test("CREATE CONSTRAINT ON (node:Label) ASSERT (node.prop1,node.prop2) IS UNIQUE") {
-    yields(ast.CreateUniquePropertyConstraint(varFor("node"), labelName("Label"),
+    yields(ast.CreateUniquePropertyConstraint(varFor("node"), Seq(labelName("Label")),
       Seq(prop("node", "prop1"), prop("node", "prop2")), None))
   }
 
@@ -161,15 +161,15 @@ class CommandParserTest
   }
 
   test("CREATE CONSTRAINT my_constraint ON (node:Label) ASSERT node.prop IS UNIQUE") {
-    yields(ast.CreateUniquePropertyConstraint(varFor("node"), labelName("Label"), Seq(prop("node", "prop")), Some("my_constraint")))
+    yields(ast.CreateUniquePropertyConstraint(varFor("node"), Seq(labelName("Label")), Seq(prop("node", "prop")), Some("my_constraint")))
   }
 
   test("CREATE CONSTRAINT my_constraint ON (node:Label) ASSERT (node.prop) IS UNIQUE") {
-    yields(ast.CreateUniquePropertyConstraint(varFor("node"), labelName("Label"), Seq(prop("node", "prop")), Some("my_constraint")))
+    yields(ast.CreateUniquePropertyConstraint(varFor("node"), Seq(labelName("Label")), Seq(prop("node", "prop")), Some("my_constraint")))
   }
 
   test("CREATE CONSTRAINT my_constraint ON (node:Label) ASSERT (node.prop1,node.prop2) IS UNIQUE") {
-    yields(ast.CreateUniquePropertyConstraint(varFor("node"), labelName("Label"),
+    yields(ast.CreateUniquePropertyConstraint(varFor("node"), Seq(labelName("Label")),
       Seq(prop("node", "prop1"), prop("node", "prop2")), Some("my_constraint")))
   }
 
@@ -197,15 +197,15 @@ class CommandParserTest
   }
 
   test("DROP CONSTRAINT ON (node:Label) ASSERT node.prop IS UNIQUE") {
-    yields(ast.DropUniquePropertyConstraint(varFor("node"), labelName("Label"), Seq(prop("node", "prop"))))
+    yields(ast.DropUniquePropertyConstraint(varFor("node"), Seq(labelName("Label")), Seq(prop("node", "prop"))))
   }
 
   test("DROP CONSTRAINT ON (node:Label) ASSERT (node.prop) IS UNIQUE") {
-    yields(ast.DropUniquePropertyConstraint(varFor("node"), labelName("Label"), Seq(prop("node", "prop"))))
+    yields(ast.DropUniquePropertyConstraint(varFor("node"), Seq(labelName("Label")), Seq(prop("node", "prop"))))
   }
 
   test("DROP CONSTRAINT ON (node:Label) ASSERT (node.prop1,node.prop2) IS UNIQUE") {
-    yields(ast.DropUniquePropertyConstraint(varFor("node"), labelName("Label"),
+    yields(ast.DropUniquePropertyConstraint(varFor("node"), Seq(labelName("Label")),
       Seq(prop("node", "prop1"), prop("node", "prop2"))))
   }
 

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/DelegatingQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/DelegatingQueryContext.scala
@@ -199,10 +199,10 @@ abstract class DelegatingQueryContext(val inner: QueryContext) extends QueryCont
   override def dropNodeKeyConstraint(labelId: Int, propertyKeyIds: Seq[Int]): Unit =
     singleDbHit(inner.dropNodeKeyConstraint(labelId, propertyKeyIds))
 
-  override def createUniqueConstraint(labelId: Int, propertyKeyIds: Seq[Int], name: Option[String]): Unit =
-    singleDbHit(inner.createUniqueConstraint(labelId, propertyKeyIds, name))
+  override def createUniqueConstraint(labelIds: Seq[Int], propertyKeyIds: Seq[Int], name: Option[String]): Unit =
+    singleDbHit(inner.createUniqueConstraint(labelIds, propertyKeyIds, name))
 
-  override def dropUniqueConstraint(labelId: Int, propertyKeyIds: Seq[Int]): Unit =
+  override def dropUniqueConstraint(labelId: Seq[Int], propertyKeyIds: Seq[Int]): Unit =
     singleDbHit(inner.dropUniqueConstraint(labelId, propertyKeyIds))
 
   override def createNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int, name: Option[String]): Unit =

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
@@ -775,13 +775,13 @@ sealed class TransactionBoundQueryContext(val transactionalContext: Transactiona
     transactionalContext.kernelTransaction.schemaWrite()
       .constraintDrop(SchemaDescriptor.forLabel(labelId, propertyKeyIds: _*), ConstraintType.UNIQUE_EXISTS)
 
-  override def createUniqueConstraint(labelId: Int, propertyKeyIds: Seq[Int], name: Option[String]): Unit =
+  override def createUniqueConstraint(labelIds: Seq[Int], propertyKeyIds: Seq[Int], name: Option[String]): Unit =
     transactionalContext.kernelTransaction.schemaWrite().uniquePropertyConstraintCreate(
-      IndexPrototype.uniqueForSchema(SchemaDescriptor.forLabel(labelId, propertyKeyIds: _*)).withName(name.orNull))
+      IndexPrototype.uniqueForSchema(SchemaDescriptor.forLabels(labelIds.toArray, propertyKeyIds: _*)).withName(name.orNull))
 
-  override def dropUniqueConstraint(labelId: Int, propertyKeyIds: Seq[Int]): Unit =
+  override def dropUniqueConstraint(labelId: Seq[Int], propertyKeyIds: Seq[Int]): Unit =
     transactionalContext.kernelTransaction.schemaWrite()
-      .constraintDrop(SchemaDescriptor.forLabel(labelId, propertyKeyIds: _*), ConstraintType.UNIQUE)
+      .constraintDrop(SchemaDescriptor.forLabels(labelId.toArray, propertyKeyIds: _*), ConstraintType.UNIQUE)
 
   override def createNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int, name: Option[String]): Unit =
     transactionalContext.kernelTransaction.schemaWrite().nodePropertyExistenceConstraintCreate(

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/UpdateCountingQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/UpdateCountingQueryContext.scala
@@ -135,13 +135,13 @@ class UpdateCountingQueryContext(inner: QueryContext) extends DelegatingQueryCon
     nodekeyConstraintsRemoved.increase()
   }
 
-  override def createUniqueConstraint(labelId: Int, propertyKeyIds: Seq[Int], name: Option[String]): Unit = {
-    inner.createUniqueConstraint(labelId, propertyKeyIds, name)
+  override def createUniqueConstraint(labelIds: Seq[Int], propertyKeyIds: Seq[Int], name: Option[String]): Unit = {
+    inner.createUniqueConstraint(labelIds, propertyKeyIds, name)
     uniqueConstraintsAdded.increase()
   }
 
-  override def dropUniqueConstraint(labelId: Int, propertyKeyIds: Seq[Int]): Unit = {
-    inner.dropUniqueConstraint(labelId, propertyKeyIds)
+  override def dropUniqueConstraint(labelIds: Seq[Int], propertyKeyIds: Seq[Int]): Unit = {
+    inner.dropUniqueConstraint(labelIds, propertyKeyIds)
     uniqueConstraintsRemoved.increase()
   }
 

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/UpdateCountingQueryContextTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/UpdateCountingQueryContextTest.scala
@@ -159,19 +159,19 @@ class UpdateCountingQueryContextTest extends CypherFunSuite {
   }
 
   test("create_unique_constraint") {
-    context.createUniqueConstraint(0, Array(1), None)
+    context.createUniqueConstraint( Array(0), Array(1), None)
 
     context.getStatistics should equal(QueryStatistics(uniqueConstraintsAdded = 1))
   }
 
   test("create_unique_constraint with name") {
-    context.createUniqueConstraint(0, Array(1), Some("name"))
+    context.createUniqueConstraint(Array(0), Array(1), Some("name"))
 
     context.getStatistics should equal(QueryStatistics(uniqueConstraintsAdded = 1))
   }
 
   test("constraint_dropped") {
-    context.dropUniqueConstraint(0, Array(1))
+    context.dropUniqueConstraint(Array(0), Array(1))
 
     context.getStatistics should equal(QueryStatistics(uniqueConstraintsRemoved = 1))
   }

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryContext.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryContext.scala
@@ -149,9 +149,9 @@ trait QueryContext extends TokenContext with DbAccess {
   def dropNodeKeyConstraint(labelId: Int, propertyKeyIds: Seq[Int]): Unit
 
   /* return true if the constraint was created, false if preexisting, throws if failed */
-  def createUniqueConstraint(labelId: Int, propertyKeyIds: Seq[Int], name: Option[String]): Unit
+  def createUniqueConstraint(labelIds: Seq[Int], propertyKeyIds: Seq[Int], name: Option[String]): Unit
 
-  def dropUniqueConstraint(labelId: Int, propertyKeyIds: Seq[Int]): Unit
+  def dropUniqueConstraint(labelId: Seq[Int], propertyKeyIds: Seq[Int]): Unit
 
   /* return true if the constraint was created, false if preexisting, throws if failed */
   def createNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int, name: Option[String]): Unit

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
@@ -501,14 +501,14 @@ public class Operations implements Write, SchemaWrite
             assertIndexOnline( index );
             SchemaDescriptor schema = index.schema();
             long[] labelIds = schema.lockingKeys();
-            if ( labelIds.length != 1 )
+/*            if ( labelIds.length != 1 )
             {
                 throw new UnableToValidateConstraintException( constraint, new AssertionError(
                         format( "Constraint indexes are not expected to be multi-token indexes, " +
                                         "but the constraint %s was referencing an index with the following schema: %s.",
                                 constraint.userDescription( token ), schema.userDescription( token ) ) ), token );
             }
-
+*/
             //Take a big fat lock, and check for existing node in index
             ktx.statementLocks().optimistic().acquireExclusive(
                     ktx.lockTracer(), INDEX_ENTRY,

--- a/community/schema/src/main/java/org/neo4j/internal/schema/SchemaDescriptor.java
+++ b/community/schema/src/main/java/org/neo4j/internal/schema/SchemaDescriptor.java
@@ -59,6 +59,13 @@ public interface SchemaDescriptor extends SchemaDescriptorSupplier
         return new SchemaDescriptorImplementation( NODE, COMPLETE_ALL_TOKENS, new int[]{labelId}, propertyIds );
     }
 
+    static LabelSchemaDescriptor forLabels( int[] labelIds, int... propertyIds )
+    {
+        validateLabelIds( labelIds );
+        validatePropertyIds( propertyIds );
+        return new SchemaDescriptorImplementation( NODE, COMPLETE_ALL_TOKENS, labelIds, propertyIds );
+    }
+
     static RelationTypeSchemaDescriptor forRelType( int relTypeId, int... propertyIds )
     {
         validateRelationshipTypeIds( relTypeId );


### PR DESCRIPTION
Fixes #7814

**WIP:**
This is shared after implementing the basic functionality of letting `create constraint is unique` to allow having multiple labels, however, there are some questions:

1. Is this feature approved as a requirement?
1. Should other constraints also allow multiple labels? I guess yes, and `Schema.constraintFor(Label)` should allow multiple labels.
1. There is an existing explicit check in `Operations.java` that doesn't expect constraint to have multiple indexes.
1. In `Prettifier.scala` implementation, I am not comfortable with separating the labels with `,`, but it works in PrettierIT with `"create CONSTRAINT ON (n:A:B) ASSERT (n.p) IS UNIQUE"`
1. Anything else I should take care of?

Remaining tasks:

- [ ] Add multiple label to other constraints
- [ ] Implement functionality with Java API
- [ ] Add test cases