### PR TITLE
No need to close wrapped IO streams

### DIFF
--- a/annotations/src/main/java/org/neo4j/annotations/api/PublicApiAnnotationProcessor.java
+++ b/annotations/src/main/java/org/neo4j/annotations/api/PublicApiAnnotationProcessor.java
@@ -166,10 +166,9 @@ public class PublicApiAnnotationProcessor extends AbstractProcessor
 
             // Write new signature
             final FileObject file = processingEnv.getFiler().createResource( CLASS_OUTPUT, "", GENERATED_SIGNATURE_DESTINATION );
-            try ( Writer writer = file.openWriter();
-                    BufferedWriter out = new BufferedWriter( writer ) )
+            try ( BufferedWriter writer = new BufferedWriter( file.openWriter() ) )
             {
-                out.write( newSignature );
+                writer.write( newSignature );
             }
 
             if ( !testExecution )

--- a/annotations/src/main/java/org/neo4j/annotations/service/ServiceAnnotationProcessor.java
+++ b/annotations/src/main/java/org/neo4j/annotations/service/ServiceAnnotationProcessor.java
@@ -184,14 +184,13 @@ public class ServiceAnnotationProcessor extends AbstractProcessor
             newProviders.addAll( oldProviders );
 
             final FileObject file = processingEnv.getFiler().createResource( CLASS_OUTPUT, "", path );
-            try ( Writer writer = file.openWriter();
-                  BufferedWriter out = new BufferedWriter( writer ) )
+            try ( BufferedWriter writer = new BufferedWriter( file.openWriter() ) )
             {
                 info( "Writing service providers: " + newProviders );
                 for ( final String provider : newProviders )
                 {
-                    out.write( provider );
-                    out.write( "\n" );
+                    writer.write( provider );
+                    writer.write( "\n" );
                 }
             }
         }
@@ -204,8 +203,7 @@ public class ServiceAnnotationProcessor extends AbstractProcessor
         {
             final FileObject file = processingEnv.getFiler().getResource( CLASS_OUTPUT, "", path );
             final List<String> lines = new ArrayList<>();
-            try ( InputStream is = file.openInputStream();
-                  BufferedReader in = new BufferedReader( new InputStreamReader( is, StandardCharsets.UTF_8 ) ) )
+            try ( BufferedReader in = new BufferedReader( new InputStreamReader( file.openInputStream(), StandardCharsets.UTF_8 ) ) )
             {
                 String line;
                 while ( (line = in.readLine()) != null )

--- a/community/kernel/src/main/java/org/neo4j/kernel/diagnostics/DiagnosticsReporter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/diagnostics/DiagnosticsReporter.java
@@ -77,8 +77,7 @@ public class DiagnosticsReporter
         }
 
         progress.setTotalSteps( sources.size() );
-        try ( OutputStream out = newOutputStream( destination, CREATE_NEW, WRITE );
-                ZipOutputStream zip = new ZipOutputStream( new BufferedOutputStream( out ), UTF_8 ) )
+        try ( ZipOutputStream zip = new ZipOutputStream( new BufferedOutputStream( newOutputStream( destination, CREATE_NEW, WRITE ) ), UTF_8 ) )
         {
             writeDiagnostics( zip, sources, progress );
         }

--- a/community/ssl/src/test/java/org/neo4j/ssl/PkiUtilsTest.java
+++ b/community/ssl/src/test/java/org/neo4j/ssl/PkiUtilsTest.java
@@ -121,12 +121,7 @@ class PkiUtilsTest
         try ( InputStream is = in.openStream();
                 OutputStream os = testDirectory.getFileSystem().openAsOutputStream( outFile, false ) )
         {
-            while ( is.available() > 0 )
-            {
-                byte[] buf = new byte[8192];
-                int nBytes = is.read( buf );
-                os.write( buf, 0, nBytes );
-            }
+            is.transferTo( os );
         }
     }
 }

--- a/community/ssl/src/test/java/org/neo4j/ssl/SslResourceBuilder.java
+++ b/community/ssl/src/test/java/org/neo4j/ssl/SslResourceBuilder.java
@@ -170,12 +170,7 @@ public class SslResourceBuilder
         try ( InputStream is = in.openStream();
               OutputStream os = fsa.openAsOutputStream( outFile, false ) )
         {
-            while ( is.available() > 0 )
-            {
-                byte[] buf = new byte[8192];
-                int nBytes = is.read( buf );
-                os.write( buf, 0, nBytes );
-            }
+            is.transferTo( os );
         }
     }
 }

--- a/community/testing/test-utils/src/main/java/org/neo4j/test/jar/JarBuilder.java
+++ b/community/testing/test-utils/src/main/java/org/neo4j/test/jar/JarBuilder.java
@@ -38,8 +38,7 @@ public class JarBuilder
 {
     public URL createJarFor( File f, Class<?>... classesToInclude ) throws IOException
     {
-        try ( OutputStream fout = Files.newOutputStream( f.toPath() );
-              JarOutputStream jarOut = new JarOutputStream( fout ) )
+        try ( JarOutputStream jarOut = new JarOutputStream( Files.newOutputStream( f.toPath() ) ) )
         {
             for ( Class<?> target : classesToInclude )
             {


### PR DESCRIPTION
The pattern of `try ( OutputStream os; WrapperOutputStream( os ) );` is not optimal. Since all wrapper objects ensure the underlying stream is closed.

This applies to `BufferedWriter`, `BufferedReader`, `ZipOutputStream` and `JarOutputStream`.

Also, two places where changed to use [inputStream.transferTo](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/InputStream.html#transferTo(java.io.OutputStream)) instead of manually copying from `in` to `out`.