### PR TITLE
Migrate tests to JUnit 5

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/packstream/FragmentedMessageDeliveryTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/packstream/FragmentedMessageDeliveryTest.java
@@ -21,14 +21,12 @@ package org.neo4j.bolt.packstream;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 
 import org.neo4j.bolt.BoltChannel;
 import org.neo4j.bolt.BoltProtocol;
@@ -46,8 +44,6 @@ import org.neo4j.common.HexPrinter;
 import org.neo4j.logging.internal.NullLogService;
 
 import static io.netty.buffer.Unpooled.wrappedBuffer;
-import static org.junit.runners.Parameterized.Parameter;
-import static org.junit.runners.Parameterized.Parameters;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -70,7 +66,6 @@ import static org.neo4j.values.virtual.VirtualValues.EMPTY_MAP;
  * For each permutation, it delivers the fragments to the protocol implementation, and asserts the protocol handled
  * them properly.
  */
-@RunWith( Parameterized.class )
 public class FragmentedMessageDeliveryTest
 {
     private EmbeddedChannel channel;
@@ -80,16 +75,7 @@ public class FragmentedMessageDeliveryTest
     // Only test one message for now. This can be parameterized later to test lots of different ones
     private RequestMessage[] messages = new RequestMessage[]{new RunMessage( "Mjölnir" )};
 
-    @Parameter
-    public Neo4jPack neo4jPack;
-
-    @Parameters( name = "{0}" )
-    public static List<Neo4jPack> parameters()
-    {
-        return Arrays.asList( new Neo4jPackV1(), new Neo4jPackV2() );
-    }
-
-    @After
+    @AfterEach
     public void cleanup()
     {
         if ( channel != null )

--- a/community/bolt/src/test/java/org/neo4j/bolt/runtime/scheduling/CachedThreadPoolExecutorFactoryTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/runtime/scheduling/CachedThreadPoolExecutorFactoryTest.java
@@ -19,14 +19,13 @@
  */
 package org.neo4j.bolt.runtime.scheduling;
 
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
@@ -39,24 +38,22 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import org.neo4j.function.Predicates;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.runners.Parameterized.Parameter;
-import static org.junit.runners.Parameterized.Parameters;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.neo4j.bolt.runtime.scheduling.CachedThreadPoolExecutorFactory.SYNCHRONOUS_QUEUE;
 import static org.neo4j.bolt.runtime.scheduling.CachedThreadPoolExecutorFactory.UNBOUNDED_QUEUE;
 
-@RunWith( Parameterized.class )
 public class CachedThreadPoolExecutorFactoryTest
 {
     private static final int TEST_BOUNDED_QUEUE_SIZE = 5;
@@ -64,20 +61,14 @@ public class CachedThreadPoolExecutorFactoryTest
     private final ExecutorFactory factory = new CachedThreadPoolExecutorFactory();
     private ExecutorService executorService;
 
-    @Parameter( 0 )
-    public int queueSize;
-
-    @Parameter( 1 )
-    public String name;
-
-    @Parameters( name = "{1}" )
-    public static List<Object[]> parameters()
+    private static Stream<Arguments> argumentsProvider()
     {
-        return Arrays.asList( new Object[]{UNBOUNDED_QUEUE, "Unbounded Queue"}, new Object[]{SYNCHRONOUS_QUEUE, "Synchronous Queue"},
-                new Object[]{TEST_BOUNDED_QUEUE_SIZE, "Bounded Queue"} );
+        return Stream.of( Arguments.of( UNBOUNDED_QUEUE, "Unbounded Queue" ), Arguments.of( SYNCHRONOUS_QUEUE, "Synchronous Queue" ),
+                Arguments.of( TEST_BOUNDED_QUEUE_SIZE, "Bounded Queue" ) );
+
     }
 
-    @After
+    @AfterEach
     public void cleanup()
     {
         if ( executorService != null && !executorService.isTerminated() )
@@ -86,8 +77,9 @@ public class CachedThreadPoolExecutorFactoryTest
         }
     }
 
-    @Test
-    public void createShouldAssignCorrectQueue()
+    @ParameterizedTest
+    @MethodSource( "argumentsProvider" )
+    public void createShouldAssignCorrectQueue( int queueSize, String name )
     {
         executorService = factory.create( 0, 1, Duration.ZERO, queueSize, false, newThreadFactory() );
 
@@ -114,8 +106,9 @@ public class CachedThreadPoolExecutorFactoryTest
         }
     }
 
-    @Test
-    public void createShouldCreateExecutor()
+    @ParameterizedTest
+    @MethodSource( "argumentsProvider" )
+    public void createShouldCreateExecutor( int queueSize, String name )
     {
         executorService = factory.create( 0, 1, Duration.ZERO, queueSize, false, newThreadFactory() );
 

--- a/community/community-it/index-it/src/test/java/org/neo4j/kernel/api/impl/index/DatabaseIndexConstraintProviderApprovalTest.java
+++ b/community/community-it/index-it/src/test/java/org/neo4j/kernel/api/impl/index/DatabaseIndexConstraintProviderApprovalTest.java
@@ -23,8 +23,4 @@ import org.neo4j.kernel.api.index.SchemaConstraintProviderApprovalTest;
 
 public class DatabaseIndexConstraintProviderApprovalTest extends SchemaConstraintProviderApprovalTest
 {
-    public DatabaseIndexConstraintProviderApprovalTest( TestValue value )
-    {
-        super( value );
-    }
 }

--- a/community/community-it/index-it/src/test/java/org/neo4j/kernel/api/impl/index/DatabaseIndexIndexProviderApprovalTest.java
+++ b/community/community-it/index-it/src/test/java/org/neo4j/kernel/api/impl/index/DatabaseIndexIndexProviderApprovalTest.java
@@ -23,8 +23,4 @@ import org.neo4j.kernel.api.index.IndexProviderApprovalTest;
 
 public class DatabaseIndexIndexProviderApprovalTest extends IndexProviderApprovalTest
 {
-    public DatabaseIndexIndexProviderApprovalTest( TestValue value )
-    {
-        super( value );
-    }
 }

--- a/community/community-it/index-it/src/test/java/org/neo4j/kernel/api/index/SchemaConstraintProviderApprovalTest.java
+++ b/community/community-it/index-it/src/test/java/org/neo4j/kernel/api/index/SchemaConstraintProviderApprovalTest.java
@@ -20,14 +20,10 @@
 package org.neo4j.kernel.api.index;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -59,7 +55,6 @@ import static org.neo4j.internal.helpers.collection.Iterators.asSet;
  * Indexes should always produce the same result as scanning all nodes and checking properties. By extending this
  * class in the index provider module, all value types will be checked against the index provider.
  */
-@RunWith( value = Parameterized.class )
 public abstract class SchemaConstraintProviderApprovalTest
 {
     // These are the values that will be checked.
@@ -118,20 +113,7 @@ public abstract class SchemaConstraintProviderApprovalTest
     private static Map<TestValue, Set<Object>> noIndexRun;
     private static Map<TestValue, Set<Object>> constraintRun;
 
-    private final TestValue currentValue;
-
-    public SchemaConstraintProviderApprovalTest( TestValue value )
-    {
-        currentValue = value;
-    }
-
-    @Parameters( name = "{0}" )
-    public static Collection<TestValue> data()
-    {
-        return Arrays.asList( TestValue.values() );
-    }
-
-    @BeforeClass
+    @BeforeAll
     public static void init()
     {
         DatabaseManagementService managementService = new TestDatabaseManagementServiceBuilder().impermanent().build();
@@ -159,8 +141,9 @@ public abstract class SchemaConstraintProviderApprovalTest
         return value;
     };
 
-    @Test
-    public void test()
+    @ParameterizedTest
+    @EnumSource( TestValue.class )
+    public void test( TestValue currentValue )
     {
         Set<Object> noIndexResult = Iterables.asSet( noIndexRun.get( currentValue ) );
         Set<Object> constraintResult = Iterables.asSet( constraintRun.get( currentValue ) );

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/api/index/IndexProviderApprovalTest.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/api/index/IndexProviderApprovalTest.java
@@ -20,14 +20,10 @@
 package org.neo4j.kernel.api.index;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -62,7 +58,6 @@ import static org.neo4j.internal.helpers.collection.Iterators.asSet;
  * Indexes should always produce the same result as scanning all nodes and checking properties. By extending this
  * class in the index provider module, all value types will be checked against the index provider.
  */
-@RunWith( value = Parameterized.class )
 public abstract class IndexProviderApprovalTest
 {
     // These are the values that will be checked.
@@ -125,20 +120,7 @@ public abstract class IndexProviderApprovalTest
     private static Map<TestValue, Set<Object>> noIndexRun;
     private static Map<TestValue, Set<Object>> indexRun;
 
-    private final TestValue currentValue;
-
-    public IndexProviderApprovalTest( TestValue value )
-    {
-        currentValue = value;
-    }
-
-    @Parameters( name = "{0}" )
-    public static Collection<TestValue> data()
-    {
-        return Arrays.asList( TestValue.values() );
-    }
-
-    @BeforeClass
+    @BeforeAll
     public static void init()
     {
         DatabaseManagementService managementService = new TestDatabaseManagementServiceBuilder().impermanent().build();
@@ -166,8 +148,9 @@ public abstract class IndexProviderApprovalTest
         return value;
     };
 
-    @Test
-    public void test()
+    @ParameterizedTest
+    @EnumSource( TestValue.class )
+    public void test( TestValue currentValue )
     {
         Set<Object> noIndexResult = Iterables.asSet( noIndexRun.get( currentValue ) );
         Set<Object> indexResult = Iterables.asSet( indexRun.get( currentValue ) );

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/core/TestRelationshipCount.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/core/TestRelationshipCount.java
@@ -19,20 +19,20 @@
  */
 package org.neo4j.kernel.impl.core;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import org.neo4j.configuration.Config;
 import org.neo4j.configuration.GraphDatabaseSettings;
@@ -51,37 +51,30 @@ import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.TestDatabaseManagementServiceBuilder;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.neo4j.configuration.GraphDatabaseSettings.DEFAULT_DATABASE_NAME;
 
-@RunWith( Parameterized.class )
 public class TestRelationshipCount
 {
     private static DatabaseManagementService managementService;
 
-    @Parameterized.Parameters( name = "denseNodeThreshold={0}" )
-    public static Collection<Object[]> data()
+    private static Stream<Arguments> argumentsProvider()
     {
-        Collection<Object[]> data = new ArrayList<>();
         int max = GraphDatabaseSettings.dense_node_threshold.defaultValue();
-        for ( int i = 1; i < max; i++ )
-        {
-            data.add( new Object[] {i} );
-        }
-        return data;
+        return IntStream.range( 1, max ).mapToObj( i -> Arguments.of( i ) );
     }
 
     private static GraphDatabaseAPI db;
     private Transaction tx;
 
-    @AfterClass
+    @AfterAll
     public static void shutdownDb()
     {
         managementService.shutdown();
     }
 
-    public TestRelationshipCount( final int denseNodeThreshold )
+    public void init( final int denseNodeThreshold )
     {
         // This code below basically turns "db" into a ClassRule, but per dense node threshold
         if ( db == null || db.getDependencyResolver().resolveDependency( Config.class )
@@ -95,11 +88,37 @@ public class TestRelationshipCount
                         .setConfig( GraphDatabaseSettings.dense_node_threshold, denseNodeThreshold ).build();
             db = (GraphDatabaseAPI) managementService.database( DEFAULT_DATABASE_NAME );
         }
+
+        newTransaction();
     }
 
-    @Test
-    public void convertNodeToDense()
+    public void newTransaction()
     {
+        if ( tx != null )
+        {
+            closeTransaction();
+        }
+        tx = getGraphDb().beginTx();
+    }
+
+    @AfterEach
+    public void closeTransaction()
+    {
+        assert tx != null;
+        tx.commit();
+    }
+
+    private GraphDatabaseService getGraphDb()
+    {
+        return db;
+    }
+
+    @ParameterizedTest( name = "denseNodeThreshold={0}" )
+    @MethodSource( "argumentsProvider" )
+    public void convertNodeToDense( int denseNodeThreshold )
+    {
+        init( denseNodeThreshold );
+
         Node node = tx.createNode();
         EnumMap<MyRelTypes,Set<Relationship>> rels = new EnumMap<>( MyRelTypes.class );
         for ( MyRelTypes type : MyRelTypes.values() )
@@ -136,15 +155,21 @@ public class TestRelationshipCount
         return result;
     }
 
-    @Test
-    public void testGetRelationshipTypesOnDiscreteNode()
+    @ParameterizedTest( name = "denseNodeThreshold={0}" )
+    @MethodSource( "argumentsProvider" )
+    public void testGetRelationshipTypesOnDiscreteNode( int denseNodeThreshold )
     {
+        init( denseNodeThreshold );
+
         testGetRelationshipTypes( tx.createNode(), new HashSet<>() );
     }
 
-    @Test
-    public void testGetRelationshipTypesOnDenseNode()
+    @ParameterizedTest( name = "denseNodeThreshold={0}" )
+    @MethodSource( "argumentsProvider" )
+    public void testGetRelationshipTypesOnDenseNode( int denseNodeThreshold )
     {
+        init( denseNodeThreshold );
+
         Node node = tx.createNode();
         Node otherNode = tx.createNode();
         for ( int i = 0; i < 300; i++ )
@@ -212,9 +237,12 @@ public class TestRelationshipCount
         };
     }
 
-    @Test
-    public void withoutLoops()
+    @ParameterizedTest( name = "denseNodeThreshold={0}" )
+    @MethodSource( "argumentsProvider" )
+    public void withoutLoops( int denseNodeThreshold )
     {
+        init( denseNodeThreshold );
+
         Node node1 = tx.createNode();
         Node node2 = tx.createNode();
         assertEquals( 0, node1.getDegree() );
@@ -286,9 +314,12 @@ public class TestRelationshipCount
         newTransaction();
     }
 
-    @Test
-    public void withLoops()
+    @ParameterizedTest( name = "denseNodeThreshold={0}" )
+    @MethodSource( "argumentsProvider" )
+    public void withLoops( int denseNodeThreshold )
     {
+        init( denseNodeThreshold );
+
         // Just to make sure it doesn't work by accident what with ids aligning with count
         for ( int i = 0; i < 10; i++ )
         {
@@ -318,9 +349,12 @@ public class TestRelationshipCount
         assertEquals( 1, node.getDegree() );
     }
 
-    @Test
-    public void ensureRightDegree()
+    @ParameterizedTest( name = "denseNodeThreshold={0}" )
+    @MethodSource( "argumentsProvider" )
+    public void ensureRightDegree( int denseNodeThreshold )
     {
+        init( denseNodeThreshold );
+
         for ( int initialSize : new int[] { 0, 95, 200 } )
         {
             ensureRightDegree( initialSize,
@@ -605,27 +639,5 @@ public class TestRelationshipCount
         {
             this.measure = measure;
         }
-    }
-
-    @Before
-    public void newTransaction()
-    {
-        if ( tx != null )
-        {
-            closeTransaction();
-        }
-        tx = getGraphDb().beginTx();
-    }
-
-    @After
-    public void closeTransaction()
-    {
-        assert tx != null;
-        tx.commit();
-    }
-
-    private GraphDatabaseService getGraphDb()
-    {
-        return db;
     }
 }


### PR DESCRIPTION
This PR migrates `Parameterized` tests, which don't have `Rule` dependencies, to JUnit 5.

Some notes on specific tests:
    - `FragmentedMessageDeliveryTest`: it doesn't need to be parameterized, since `neo4jPack` parameter is simply not used.
    - `CachedThreadPoolExecutorFactoryTest`: interestingly, not all tests use the parameter `queueSize` (they use hardcoded value of `0`), so they were not migrated to `@ParameterizedTest` and remained as `@Test`
    - `CappedLoggerTest`: the `LogMethod`s used all have `.debug()`, it was changed to match the specific log level
    - `ByteArrayTest`: the parameter was changed from `Supplier<ByteArray>` to `ByteArray`, since the supplier is used only once, and its complexity is not needed.