### PR TITLE
Remove unnecessary throws

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/packstream/Neo4jPackV1Test.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/packstream/Neo4jPackV1Test.java
@@ -214,14 +214,14 @@ public class Neo4jPackV1Test
     }
 
     @Test
-    void shouldNotBeAbleToUnpackNode() throws IOException
+    void shouldNotBeAbleToUnpackNode()
     {
         var ex = assertThrows( BoltIOException.class, () -> unpacked( packed( ALICE ) ) );
         assertEquals( Neo4jError.from( TypeError, "Node values cannot be unpacked with this version of bolt." ), Neo4jError.from( ex ) );
     }
 
     @Test
-    void shouldNotBeAbleToUnpackRelationship() throws IOException
+    void shouldNotBeAbleToUnpackRelationship()
     {
         var ex = assertThrows( BoltIOException.class, () -> unpacked( packed( ALICE_KNOWS_BOB ) ) );
         assertEquals( Neo4jError.from( TypeError, "Relationship values cannot be unpacked with this version of bolt." ),
@@ -246,7 +246,7 @@ public class Neo4jPackV1Test
     }
 
     @Test
-    void shouldNotBeAbleToUnpackPaths() throws IOException
+    void shouldNotBeAbleToUnpackPaths()
     {
         for ( PathValue path : ALL_PATHS )
         {

--- a/community/bolt/src/test/java/org/neo4j/bolt/runtime/statemachine/impl/TransactionStateMachineTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/runtime/statemachine/impl/TransactionStateMachineTest.java
@@ -75,7 +75,6 @@ class TransactionStateMachineTest
 
     private TransactionStateMachineSPI stateMachineSPI;
     private MutableTransactionState mutableState;
-    private TransactionStateMachine stateMachine;
     private static final EmptyResultConsumer EMPTY = new EmptyResultConsumer();
     private static final EmptyResultConsumer ERROR = new EmptyResultConsumer()
     {
@@ -92,7 +91,6 @@ class TransactionStateMachineTest
         FakeClock clock = new FakeClock();
         stateMachineSPI = mock( TransactionStateMachineSPI.class );
         mutableState = new MutableTransactionState( AUTH_DISABLED, clock, null );
-        stateMachine = new TransactionStateMachine( ABSENT_DB_NAME, stateMachineSPI, AUTH_DISABLED, clock, null );
     }
 
     @Test
@@ -117,7 +115,7 @@ class TransactionStateMachineTest
     }
 
     @Test
-    void shouldThrowOnBeginInExplicitTransaction() throws Exception
+    void shouldThrowOnBeginInExplicitTransaction()
     {
         QueryExecutionKernelException e = assertThrows( QueryExecutionKernelException.class, () ->
                 TransactionStateMachine.State.EXPLICIT_TRANSACTION.beginTransaction( mutableState, stateMachineSPI, null, null, AccessMode.WRITE, null ) );
@@ -133,7 +131,7 @@ class TransactionStateMachineTest
     }
 
     @Test
-    void shouldThrowOnCommitInAutoCommit() throws Exception
+    void shouldThrowOnCommitInAutoCommit()
     {
         QueryExecutionKernelException e = assertThrows( QueryExecutionKernelException.class, () ->
                 TransactionStateMachine.State.AUTO_COMMIT.commitTransaction( mutableState, stateMachineSPI ) );
@@ -471,7 +469,7 @@ class TransactionStateMachineTest
     }
 
     private static TransactionStateMachineSPI newTransactionStateMachineSPI( BoltTransaction transaction,
-            BoltResultHandle resultHandle ) throws KernelException
+            BoltResultHandle resultHandle )
     {
         TransactionStateMachineSPI stateMachineSPI = mock( TransactionStateMachineSPI.class );
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/v3/messaging/BoltRequestMessageReaderV3Test.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v3/messaging/BoltRequestMessageReaderV3Test.java
@@ -51,7 +51,7 @@ class BoltRequestMessageReaderV3Test
 
     @ParameterizedTest
     @MethodSource( "boltV3UnsupportedMessages" )
-    void shouldNotDecodeUnsupportedMessages( RequestMessage message ) throws Exception
+    void shouldNotDecodeUnsupportedMessages( RequestMessage message )
     {
         assertThrows( Exception.class, () -> testMessageDecoding( message ) );
     }
@@ -71,7 +71,7 @@ class BoltRequestMessageReaderV3Test
         verify( stateMachine ).process( eq( message ), any() );
     }
 
-    private static Stream<RequestMessage> boltV3Messages() throws BoltIOException
+    private static Stream<RequestMessage> boltV3Messages()
     {
         return BoltV3Messages.supported();
     }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v4/messaging/BoltV4Messages.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v4/messaging/BoltV4Messages.java
@@ -56,14 +56,14 @@ public class BoltV4Messages
         return Stream.of( hello(), goodbye(), run(), discard( 10 ), pull( 10 ), begin(), commit(), rollback(), reset() );
     }
 
-    public static Stream<RequestMessage> unsupported() throws BoltIOException
+    public static Stream<RequestMessage> unsupported()
     {
         return Stream.of( // bolt v3 only messages
                 BoltV3Messages.pullAll(), BoltV3Messages.discardAll() );
 
     }
 
-    public static RequestMessage begin() throws BoltIOException
+    public static RequestMessage begin()
     {
         return BEGIN;
     }

--- a/community/community-it/community-it/src/test/java/org/neo4j/server/BaseBootstrapperIT.java
+++ b/community/community-it/community-it/src/test/java/org/neo4j/server/BaseBootstrapperIT.java
@@ -26,7 +26,6 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -74,7 +73,7 @@ public abstract class BaseBootstrapperIT extends ExclusiveWebContainerTestBase
     protected NeoBootstrapper bootstrapper;
 
     @Before
-    public void before() throws IOException
+    public void before()
     {
         bootstrapper = newBootstrapper();
         SelfSignedCertificateFactory.create( testDirectory.homeDir() );
@@ -92,7 +91,7 @@ public abstract class BaseBootstrapperIT extends ExclusiveWebContainerTestBase
     protected abstract NeoBootstrapper newBootstrapper();
 
     @Test
-    public void shouldStartStopNeoServerWithoutAnyConfigFiles() throws Throwable
+    public void shouldStartStopNeoServerWithoutAnyConfigFiles()
     {
         // When
         int resultCode = NeoBootstrapper.start( bootstrapper, withConnectorsOnRandomPortsConfig( getAdditionalArguments() ) );
@@ -102,7 +101,7 @@ public abstract class BaseBootstrapperIT extends ExclusiveWebContainerTestBase
         assertEventually( "Server was not started", bootstrapper::isRunning, Conditions.TRUE, 1, TimeUnit.MINUTES );
     }
 
-    protected String[] getAdditionalArguments() throws IOException
+    protected String[] getAdditionalArguments()
     {
         return new String[]{"--home-dir", testDirectory.directory( "home-dir" ).getAbsolutePath(),
                 "-c", configOption( data_directory, testDirectory.homeDir().getAbsolutePath() ),
@@ -155,43 +154,43 @@ public abstract class BaseBootstrapperIT extends ExclusiveWebContainerTestBase
     }
 
     @Test
-    public void shouldStartWithHttpHttpsAndBoltDisabled() throws Exception
+    public void shouldStartWithHttpHttpsAndBoltDisabled()
     {
         testStartupWithConnectors( false, false, false );
     }
 
     @Test
-    public void shouldStartWithHttpEnabledAndHttpsBoltDisabled() throws Exception
+    public void shouldStartWithHttpEnabledAndHttpsBoltDisabled()
     {
         testStartupWithConnectors( true, false, false );
     }
 
     @Test
-    public void shouldStartWithHttpsEnabledAndHttpBoltDisabled() throws Exception
+    public void shouldStartWithHttpsEnabledAndHttpBoltDisabled()
     {
         testStartupWithConnectors( false, true, false );
     }
 
     @Test
-    public void shouldStartWithBoltEnabledAndHttpHttpsDisabled() throws Exception
+    public void shouldStartWithBoltEnabledAndHttpHttpsDisabled()
     {
         testStartupWithConnectors( false, false, true );
     }
 
     @Test
-    public void shouldStartWithHttpHttpsEnabledAndBoltDisabled() throws Exception
+    public void shouldStartWithHttpHttpsEnabledAndBoltDisabled()
     {
         testStartupWithConnectors( true, true, false );
     }
 
     @Test
-    public void shouldStartWithHttpBoltEnabledAndHttpsDisabled() throws Exception
+    public void shouldStartWithHttpBoltEnabledAndHttpsDisabled()
     {
         testStartupWithConnectors( true, false, true );
     }
 
     @Test
-    public void shouldStartWithHttpsBoltEnabledAndHttpDisabled() throws Exception
+    public void shouldStartWithHttpsBoltEnabledAndHttpDisabled()
     {
         testStartupWithConnectors( false, true, true );
     }
@@ -219,7 +218,7 @@ public abstract class BaseBootstrapperIT extends ExclusiveWebContainerTestBase
 
     protected abstract DatabaseManagementService newEmbeddedDbms( File homeDir );
 
-    private void testStartupWithConnectors( boolean httpEnabled, boolean httpsEnabled, boolean boltEnabled ) throws Exception
+    private void testStartupWithConnectors( boolean httpEnabled, boolean httpsEnabled, boolean boltEnabled )
     {
         SslPolicyConfig httpsPolicy = SslPolicyConfig.forScope( SslPolicyScope.HTTPS );
         if ( httpsEnabled )

--- a/community/community-it/community-it/src/test/java/org/neo4j/server/http/cypher/TransactionTestIT.java
+++ b/community/community-it/community-it/src/test/java/org/neo4j/server/http/cypher/TransactionTestIT.java
@@ -21,7 +21,6 @@ package org.neo4j.server.http.cypher;
 
 import org.junit.Test;
 
-import java.text.ParseException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -124,7 +123,7 @@ public class TransactionTestIT extends AbstractRestFunctionalTestBase
                  "This request will reset the transaction timeout and return the new time at which the transaction will\n" +
                  "expire as an RFC1123 formatted timestamp value in the ``transaction'' section of the response." )
     public void reset_transaction_timeout_of_an_open_transaction()
-            throws JsonParseException, ParseException, InterruptedException
+            throws JsonParseException, InterruptedException
     {
         // Given
         HTTP.Response initialResponse = POST( txUri() );

--- a/community/community-it/consistency-it/src/test/java/org/neo4j/consistency/checking/full/PropertyReaderIT.java
+++ b/community/community-it/consistency-it/src/test/java/org/neo4j/consistency/checking/full/PropertyReaderIT.java
@@ -22,8 +22,6 @@ package org.neo4j.consistency.checking.full;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-
 import org.neo4j.internal.recordstorage.RecordStorageEngine;
 import org.neo4j.io.pagecache.tracing.DefaultPageCacheTracer;
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer;
@@ -65,7 +63,7 @@ class PropertyReaderIT
     }
 
     @Test
-    void shouldDetectAndAbortPropertyChainLoadingOnCircularReference() throws IOException
+    void shouldDetectAndAbortPropertyChainLoadingOnCircularReference()
     {
         // Create property chain 1 --> 2 --> 3 --> 4
         //                             ↑           │

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/core/TestPropertyTypes.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/core/TestPropertyTypes.java
@@ -1198,7 +1198,7 @@ class TestPropertyTypes extends AbstractNeo4jTestCase
             assertEquals( array2.length, propertyValue.length );
             for ( int i = 0; i < array2.length; i++ )
             {
-                assertEquals( array2[i], new Double( propertyValue[i] ) );
+                assertEquals( array2[i], Double.valueOf( propertyValue[i] ) );
             }
 
             node1.removeProperty( key );
@@ -1248,7 +1248,7 @@ class TestPropertyTypes extends AbstractNeo4jTestCase
             assertEquals( array2.length, propertyValue.length );
             for ( int i = 0; i < array2.length; i++ )
             {
-                assertEquals( array2[i], new Float( propertyValue[i] ) );
+                assertEquals( array2[i], Float.valueOf( propertyValue[i] ) );
             }
 
             node1.removeProperty( key );
@@ -1398,7 +1398,7 @@ class TestPropertyTypes extends AbstractNeo4jTestCase
             assertEquals( array2.length, propertyValue.length );
             for ( int i = 0; i < array2.length; i++ )
             {
-                assertEquals( array2[i], new Character( propertyValue[i] ) );
+                assertEquals( array2[i], Character.valueOf( propertyValue[i] ) );
             }
 
             node1.removeProperty( key );

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeReadWriteTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeReadWriteTestBase.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -168,7 +167,7 @@ abstract class GBPTreeReadWriteTestBase<KEY,VALUE>
         }
     }
 
-    private GBPTree<KEY,VALUE> index() throws IOException
+    private GBPTree<KEY,VALUE> index()
     {
         return new GBPTreeBuilder<>( pageCache, indexFile, layout ).build();
     }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicDynamicSizeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicDynamicSizeTest.java
@@ -56,7 +56,7 @@ class InternalTreeLogicDynamicSizeTest extends InternalTreeLogicTestBase<RawByte
     }
 
     @Test
-    void shouldFailToInsertTooLargeKeys() throws IOException
+    void shouldFailToInsertTooLargeKeys()
     {
         RawBytes key = layout.newKey();
         RawBytes value = layout.newValue();
@@ -67,7 +67,7 @@ class InternalTreeLogicDynamicSizeTest extends InternalTreeLogicTestBase<RawByte
     }
 
     @Test
-    void shouldFailToInsertTooLargeKeyAndValueLargeKey() throws IOException
+    void shouldFailToInsertTooLargeKeyAndValueLargeKey()
     {
         RawBytes key = layout.newKey();
         RawBytes value = layout.newValue();
@@ -78,7 +78,7 @@ class InternalTreeLogicDynamicSizeTest extends InternalTreeLogicTestBase<RawByte
     }
 
     @Test
-    void shouldFailToInsertTooLargeKeyAndValueLargeValue() throws IOException
+    void shouldFailToInsertTooLargeKeyAndValueLargeValue()
     {
         RawBytes key = layout.newKey();
         RawBytes value = layout.newValue();
@@ -88,7 +88,7 @@ class InternalTreeLogicDynamicSizeTest extends InternalTreeLogicTestBase<RawByte
         shouldFailToInsertTooLargeKeyAndValue( key, value );
     }
 
-    private void shouldFailToInsertTooLargeKeyAndValue( RawBytes key, RawBytes value ) throws IOException
+    private void shouldFailToInsertTooLargeKeyAndValue( RawBytes key, RawBytes value )
     {
         initialize();
         var e = assertThrows( IllegalArgumentException.class, () -> insert( key, value ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
@@ -24,7 +24,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.neo4j.collection.Dependencies;
 import org.neo4j.collection.pool.Pool;
 import org.neo4j.configuration.Config;
-import org.neo4j.exceptions.KernelException;
 import org.neo4j.internal.index.label.LabelScanStore;
 import org.neo4j.internal.index.label.RelationshipTypeScanStore;
 import org.neo4j.internal.kernel.api.security.LoginContext;
@@ -106,7 +105,7 @@ public class KernelTransactionFactory
         return new Instances( transaction );
     }
 
-    static KernelTransaction kernelTransaction( LoginContext loginContext ) throws KernelException
+    static KernelTransaction kernelTransaction( LoginContext loginContext )
     {
         return kernelTransactionWithInternals( loginContext ).transaction;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/IndexKeyStorageTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/IndexKeyStorageTest.java
@@ -215,17 +215,17 @@ class IndexKeyStorageTest
         return key;
     }
 
-    private IndexKeyStorage<GenericKey> keyStorage() throws IOException
+    private IndexKeyStorage<GenericKey> keyStorage()
     {
         return keyStorage( directory.file( "file" ) );
     }
 
-    private IndexKeyStorage<GenericKey> keyStorage( File file ) throws IOException
+    private IndexKeyStorage<GenericKey> keyStorage( File file )
     {
         return keyStorage( file, HEAP_ALLOCATOR );
     }
 
-    private IndexKeyStorage<GenericKey> keyStorage( File file, ByteBufferFactory.Allocator bufferFactory ) throws IOException
+    private IndexKeyStorage<GenericKey> keyStorage( File file, ByteBufferFactory.Allocator bufferFactory )
     {
         return new IndexKeyStorage<>( directory.getFileSystem(), file, bufferFactory, BLOCK_SIZE, layout );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexUpdaterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexUpdaterTest.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.index.schema.fusion;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.util.EnumMap;
 import java.util.function.Function;
 
@@ -210,7 +209,7 @@ abstract class FusionIndexUpdaterTest
     }
 
     private void verifyAddWithCorrectUpdater( IndexUpdater correctPopulator, Value... numberValues )
-            throws IndexEntryConflictException, IOException
+            throws IndexEntryConflictException
     {
         IndexEntryUpdate<LabelSchemaDescriptor> update = add( numberValues );
         fusionIndexUpdater.process( update );
@@ -225,7 +224,7 @@ abstract class FusionIndexUpdaterTest
     }
 
     private void verifyRemoveWithCorrectUpdater( IndexUpdater correctPopulator, Value... numberValues )
-            throws IndexEntryConflictException, IOException
+            throws IndexEntryConflictException
     {
         IndexEntryUpdate<LabelSchemaDescriptor> update = FusionIndexTestHelp.remove( numberValues );
         fusionIndexUpdater.process( update );
@@ -240,7 +239,7 @@ abstract class FusionIndexUpdaterTest
     }
 
     private void verifyChangeWithCorrectUpdaterNotMixed( IndexUpdater correctPopulator, Value before,
-            Value after ) throws IndexEntryConflictException, IOException
+            Value after ) throws IndexEntryConflictException
     {
         IndexEntryUpdate<LabelSchemaDescriptor> update = FusionIndexTestHelp.change( before, after );
         fusionIndexUpdater.process( update );
@@ -254,7 +253,7 @@ abstract class FusionIndexUpdaterTest
         }
     }
 
-    private void verifyChangeWithCorrectUpdaterNotMixed( IndexUpdater updater, Value[] supportedValues ) throws IndexEntryConflictException, IOException
+    private void verifyChangeWithCorrectUpdaterNotMixed( IndexUpdater updater, Value[] supportedValues ) throws IndexEntryConflictException
     {
         for ( Value before : supportedValues )
         {
@@ -266,7 +265,7 @@ abstract class FusionIndexUpdaterTest
     }
 
     private void verifyChangeWithCorrectUpdaterMixed( IndexUpdater expectRemoveFrom, IndexUpdater expectAddTo, Value[] beforeValues,
-            Value[] afterValues ) throws IOException, IndexEntryConflictException
+            Value[] afterValues ) throws IndexEntryConflictException
     {
         for ( int beforeIndex = 0; beforeIndex < beforeValues.length; beforeIndex++ )
         {
@@ -334,7 +333,7 @@ abstract class FusionIndexUpdaterTest
     }
 
     @Test
-    void shouldInstantiatePartLazilyForSpecificValueGroupUpdates() throws IOException, IndexEntryConflictException
+    void shouldInstantiatePartLazilyForSpecificValueGroupUpdates() throws IndexEntryConflictException
     {
         // given
         EnumMap<IndexSlot,Value[]> values = FusionIndexTestHelp.valuesByGroup();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/IndexEntryResourceTypesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/IndexEntryResourceTypesTest.java
@@ -94,7 +94,7 @@ public class IndexEntryResourceTypesTest
         hasher.hash( 42, array( exact( 1, new boolean[]{} ) ) );
         hasher.hash( 42, array( exact( 1, new boolean[]{true} ) ) );
         hasher.hash( 42, array( exact( 1, new boolean[]{true, false} ) ) );
-        hasher.hash( 42, array( exact( 1, new Boolean( true ) ) ) );
+        hasher.hash( 42, array( exact( 1, Boolean.valueOf( true ) ) ) );
         hasher.hash( 42, array( exact( 1, new Boolean[]{} ) ) );
         hasher.hash( 42, array( exact( 1, new Boolean[]{true} ) ) );
         hasher.hash( 42, array( exact( 1, new Boolean[]{true, false} ) ) );
@@ -118,7 +118,7 @@ public class IndexEntryResourceTypesTest
         hasher.hash( 42, array( exact( 1, new char[]{} ) ) );
         hasher.hash( 42, array( exact( 1, new char[]{'a'} ) ) );
         hasher.hash( 42, array( exact( 1, new char[]{'a', 'b'} ) ) );
-        hasher.hash( 42, array( exact( 1, new Character( 'a' ) ) ) );
+        hasher.hash( 42, array( exact( 1, Character.valueOf( 'a' ) ) ) );
         hasher.hash( 42, array( exact( 1, new Character[]{} ) ) );
         hasher.hash( 42, array( exact( 1, new Character[]{'a'} ) ) );
         hasher.hash( 42, array( exact( 1, new Character[]{'a', 'b'} ) ) );
@@ -126,7 +126,7 @@ public class IndexEntryResourceTypesTest
         hasher.hash( 42, array( exact( 1, new float[]{} ) ) );
         hasher.hash( 42, array( exact( 1, new float[]{1} ) ) );
         hasher.hash( 42, array( exact( 1, new float[]{1, 2} ) ) );
-        hasher.hash( 42, array( exact( 1, new Float( (float) 1 ) ) ) );
+        hasher.hash( 42, array( exact( 1, Float.valueOf( 1 ) ) ) );
         hasher.hash( 42, array( exact( 1, new Float[]{} ) ) );
         hasher.hash( 42, array( exact( 1, new Float[]{1.0f} ) ) );
         hasher.hash( 42, array( exact( 1, new Float[]{1.0f, 2.0f} ) ) );
@@ -150,7 +150,7 @@ public class IndexEntryResourceTypesTest
         hasher.hash( 42, array( exact( 1, new double[]{} ) ) );
         hasher.hash( 42, array( exact( 1, new double[]{1} ) ) );
         hasher.hash( 42, array( exact( 1, new double[]{1, 2} ) ) );
-        hasher.hash( 42, array( exact( 1, new Double( 1.0 ) ) ) );
+        hasher.hash( 42, array( exact( 1, Double.valueOf( 1.0 ) ) ) );
         hasher.hash( 42, array( exact( 1, new Double[]{} ) ) );
         hasher.hash( 42, array( exact( 1, new Double[]{1.0} ) ) );
         hasher.hash( 42, array( exact( 1, new Double[]{1.0, 2.0} ) ) );
@@ -165,7 +165,7 @@ public class IndexEntryResourceTypesTest
         hasher.hash( 42, array( exact( 1, new boolean[]{} ), exact( ~1, new boolean[]{} ) ) );
         hasher.hash( 42, array( exact( 1, new boolean[]{true} ), exact( ~1, new boolean[]{true} ) ) );
         hasher.hash( 42, array( exact( 1, new boolean[]{true, false} ), exact( ~1, new boolean[]{true, false} ) ) );
-        hasher.hash( 42, array( exact( 1, new Boolean( true ) ), exact( ~1, new Boolean( true ) ) ) );
+        hasher.hash( 42, array( exact( 1, Boolean.valueOf( true ) ), exact( ~1, Boolean.valueOf( true ) ) ) );
         hasher.hash( 42, array( exact( 1, new Boolean[]{} ), exact( ~1, new Boolean[]{} ) ) );
         hasher.hash( 42, array( exact( 1, new Boolean[]{true} ), exact( ~1, new Boolean[]{true} ) ) );
         hasher.hash( 42, array( exact( 1, new Boolean[]{true, false} ), exact( ~1, new Boolean[]{true, false} ) ) );
@@ -189,7 +189,7 @@ public class IndexEntryResourceTypesTest
         hasher.hash( 42, array( exact( 1, new char[]{} ), exact( ~1, new char[]{} ) ) );
         hasher.hash( 42, array( exact( 1, new char[]{'a'} ), exact( ~1, new char[]{'a'} ) ) );
         hasher.hash( 42, array( exact( 1, new char[]{'a', 'b'} ), exact( ~1, new char[]{'a', 'b'} ) ) );
-        hasher.hash( 42, array( exact( 1, new Character( 'a' ) ), exact( ~1, new Character( 'a' ) ) ) );
+        hasher.hash( 42, array( exact( 1, Character.valueOf( 'a' ) ), exact( ~1, Character.valueOf( 'a' ) ) ) );
         hasher.hash( 42, array( exact( 1, new Character[]{} ), exact( ~1, new Character[]{} ) ) );
         hasher.hash( 42, array( exact( 1, new Character[]{'a'} ), exact( ~1, new Character[]{'a'} ) ) );
         hasher.hash( 42, array( exact( 1, new Character[]{'a', 'b'} ), exact( ~1, new Character[]{'a', 'b'} ) ) );
@@ -197,7 +197,7 @@ public class IndexEntryResourceTypesTest
         hasher.hash( 42, array( exact( 1, new float[]{} ), exact( ~1, new float[]{} ) ) );
         hasher.hash( 42, array( exact( 1, new float[]{1} ), exact( ~1, new float[]{1} ) ) );
         hasher.hash( 42, array( exact( 1, new float[]{1, 2} ), exact( ~1, new float[]{1, 2} ) ) );
-        hasher.hash( 42, array( exact( 1, new Float( (float) 1 ) ), exact( ~1, new Float( (float) 1 ) ) ) );
+        hasher.hash( 42, array( exact( 1, Float.valueOf( 1 ) ), exact( ~1, Float.valueOf( 1 ) ) ) );
         hasher.hash( 42, array( exact( 1, new Float[]{} ), exact( ~1, new Float[]{} ) ) );
         hasher.hash( 42, array( exact( 1, new Float[]{1.0f} ), exact( ~1, new Float[]{1.0f} ) ) );
         hasher.hash( 42, array( exact( 1, new Float[]{1.0f, 2.0f} ), exact( ~1, new Float[]{1.0f, 2.0f} ) ) );
@@ -221,7 +221,7 @@ public class IndexEntryResourceTypesTest
         hasher.hash( 42, array( exact( 1, new double[]{} ), exact( ~1, new double[]{} ) ) );
         hasher.hash( 42, array( exact( 1, new double[]{1} ), exact( ~1, new double[]{1} ) ) );
         hasher.hash( 42, array( exact( 1, new double[]{1, 2} ), exact( ~1, new double[]{1, 2} ) ) );
-        hasher.hash( 42, array( exact( 1, new Double( 1.0 ) ), exact( ~1, new Double( 1.0 ) ) ) );
+        hasher.hash( 42, array( exact( 1, Double.valueOf( 1.0 ) ), exact( ~1, Double.valueOf( 1.0 ) ) ) );
         hasher.hash( 42, array( exact( 1, new Double[]{} ), exact( ~1, new Double[]{} ) ) );
         hasher.hash( 42, array( exact( 1, new Double[]{1.0} ), exact( ~1, new Double[]{1.0} ) ) );
         hasher.hash( 42, array( exact( 1, new Double[]{1.0, 2.0} ), exact( ~1, new Double[]{1.0, 2.0} ) ) );

--- a/community/procedure/src/main/java/org/neo4j/procedure/builtin/BuiltInProcedures.java
+++ b/community/procedure/src/main/java/org/neo4j/procedure/builtin/BuiltInProcedures.java
@@ -394,14 +394,7 @@ public class BuiltInProcedures
 
         //Resample indexes
         IndexProcedures indexProcedures = indexProcedures();
-        try
-        {
-            indexProcedures.resampleOutdatedIndexes( timeOutSeconds );
-        }
-        catch ( TimeoutException e )
-        {
-            throw new ProcedureException( Status.Procedure.ProcedureTimedOut, e, "Index resampling timed out" );
-        }
+        indexProcedures.resampleOutdatedIndexes( timeOutSeconds );
 
         //now that index-stats are up-to-date, clear caches so that we are ready to re-plan
         graphDatabaseAPI.getDependencyResolver()

--- a/community/procedure/src/main/java/org/neo4j/procedure/builtin/IndexProcedures.java
+++ b/community/procedure/src/main/java/org/neo4j/procedure/builtin/IndexProcedures.java
@@ -80,7 +80,7 @@ public class IndexProcedures
         indexingService.triggerIndexSampling( backgroundRebuildUpdated() );
     }
 
-    void resampleOutdatedIndexes( long timeOutSeconds ) throws TimeoutException
+    void resampleOutdatedIndexes( long timeOutSeconds )
     {
         long millis = TimeUnit.SECONDS.toMillis( timeOutSeconds );
         IndexSamplingMode mode = foregroundRebuildUpdated( millis );

--- a/community/record-storage-engine/src/test/java/org/neo4j/internal/counts/GBPTreeCountsStoreTest.java
+++ b/community/record-storage-engine/src/test/java/org/neo4j/internal/counts/GBPTreeCountsStoreTest.java
@@ -148,7 +148,7 @@ class GBPTreeCountsStoreTest
     }
 
     @Test
-    void tracePageCacheAccessOnNodeCount() throws IOException
+    void tracePageCacheAccessOnNodeCount()
     {
         var pageCacheTracer = new DefaultPageCacheTracer();
         var cursorTracer = pageCacheTracer.createPageCursorTracer( "tracePageCacheAccessOnNodeCount" );
@@ -161,7 +161,7 @@ class GBPTreeCountsStoreTest
     }
 
     @Test
-    void tracePageCacheAccessOnRelationshipCount() throws IOException
+    void tracePageCacheAccessOnRelationshipCount()
     {
         var pageCacheTracer = new DefaultPageCacheTracer();
         var cursorTracer = pageCacheTracer.createPageCursorTracer( "tracePageCacheAccessOnRelationshipCount" );

--- a/community/server/src/main/java/org/neo4j/server/http/cypher/format/output/json/ExecutionResultSerializer.java
+++ b/community/server/src/main/java/org/neo4j/server/http/cypher/format/output/json/ExecutionResultSerializer.java
@@ -246,7 +246,7 @@ class ExecutionResultSerializer
         }
     }
 
-    private void writeNotifications( Iterable<Notification> notifications ) throws IOException
+    private void writeNotifications( Iterable<Notification> notifications )
     {
         //don't add anything if notifications are empty
         if ( !notifications.iterator().hasNext() )

--- a/community/storage-engine-api/src/main/java/org/neo4j/storageengine/api/IndexUpdateListener.java
+++ b/community/storage-engine-api/src/main/java/org/neo4j/storageengine/api/IndexUpdateListener.java
@@ -71,7 +71,7 @@ public interface IndexUpdateListener
         }
 
         @Override
-        public void activateIndex( IndexDescriptor index ) throws KernelException
+        public void activateIndex( IndexDescriptor index )
         {
         }
 
@@ -81,12 +81,12 @@ public interface IndexUpdateListener
         }
 
         @Override
-        public void applyUpdates( Iterable<IndexEntryUpdate<IndexDescriptor>> updates, PageCursorTracer cursorTracer ) throws IOException, KernelException
+        public void applyUpdates( Iterable<IndexEntryUpdate<IndexDescriptor>> updates, PageCursorTracer cursorTracer )
         {
         }
 
         @Override
-        public void validateIndex( long indexReference ) throws KernelException
+        public void validateIndex( long indexReference )
         {
         }
     }


### PR DESCRIPTION
This PR tackles the following:

1. Removes unnecessary throws from methods, probably the most dangerous change is in `BuiltInProcedures`
2. Replace usage of construction of `Boolean()`, `Float()` and `Double()`, since they are deprecated
