### PR TITLE
Migrate Neo4jWithSocket to JUnit 5

### DIFF
--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/MultipleBoltServerPortsStressTest.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/MultipleBoltServerPortsStressTest.java
@@ -20,7 +20,6 @@
 package org.neo4j.bolt;
 
 import org.assertj.core.api.Condition;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -91,12 +90,6 @@ class MultipleBoltServerPortsStressTest
         server.init( testInfo );
 
         util = new TransportTestUtil( newMessageEncoder() );
-    }
-
-    @AfterEach
-    void tearDown()
-    {
-        server.shutdownDatabase();
     }
 
     @Test

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/ShutdownSequenceIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/ShutdownSequenceIT.java
@@ -20,10 +20,12 @@
 package org.neo4j.bolt;
 
 import org.assertj.core.api.Condition;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.RuleChain;
 
 import java.time.Duration;
@@ -37,6 +39,7 @@ import org.neo4j.bolt.testing.TransportTestUtil;
 import org.neo4j.bolt.testing.client.SocketConnection;
 import org.neo4j.bolt.testing.client.TransportConnection;
 import org.neo4j.bolt.transport.Neo4jWithSocket;
+import org.neo4j.bolt.transport.Neo4jWithSocketExtension;
 import org.neo4j.configuration.connectors.BoltConnector;
 import org.neo4j.configuration.helpers.SocketAddress;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -52,6 +55,10 @@ import org.neo4j.logging.SpiedAssertableLogProvider;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Procedure;
 import org.neo4j.test.TestDatabaseManagementServiceBuilder;
+import org.neo4j.test.extension.Inject;
+import org.neo4j.test.extension.OtherThreadExtension;
+import org.neo4j.test.extension.SuppressOutputExtension;
+import org.neo4j.test.extension.testdirectory.EphemeralTestDirectoryExtension;
 import org.neo4j.test.rule.OtherThreadRule;
 import org.neo4j.test.rule.SuppressOutput;
 import org.neo4j.test.rule.TestDirectory;
@@ -61,8 +68,8 @@ import org.neo4j.values.AnyValue;
 import static java.lang.String.valueOf;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doAnswer;
 import static org.neo4j.bolt.testing.MessageConditions.either;
 import static org.neo4j.bolt.testing.MessageConditions.msgFailure;
@@ -76,6 +83,9 @@ import static org.neo4j.logging.LogAssertions.assertThat;
 import static org.neo4j.procedure.Mode.READ;
 import static org.neo4j.values.storable.Values.stringValue;
 
+@EphemeralTestDirectoryExtension
+@Neo4jWithSocketExtension
+@ExtendWith( {SuppressOutputExtension.class, OtherThreadExtension.class} )
 public class ShutdownSequenceIT
 {
     private static final Duration THREAD_POOL_SHUTDOWN_WAIT_TIME = Duration.ofSeconds( 10 );
@@ -83,23 +93,19 @@ public class ShutdownSequenceIT
     private final AssertableLogProvider internalLogProvider =
             new SpiedAssertableLogProvider( ExecutorBoltScheduler.class );
     private final AssertableLogProvider userLogProvider = new AssertableLogProvider();
-    private final EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
-    private final Neo4jWithSocket server =
-            new Neo4jWithSocket( getTestGraphDatabaseFactory(), () -> TestDirectory.testDirectory( getClass(), fsRule.get() ), getSettingsFunction() );
+    @Inject
+    private Neo4jWithSocket server;
     private final TransportTestUtil util = new TransportTestUtil();
     private HostnamePort address;
     private CountDownLatch txStarted;
     private CountDownLatch boltWorkerThreadPoolShuttingDown;
 
-    @Rule
-    public RuleChain ruleChain = RuleChain.outerRule( SuppressOutput.suppressAll() ).around( fsRule ).around( server );
-
-    @Rule
-    public OtherThreadRule<Void> otherThread = new OtherThreadRule<>();
-
-    @Before
-    public void setup() throws Exception
+    @BeforeEach
+    public void setup( TestInfo testInfo ) throws Exception
     {
+        server.setGraphDatabaseFactory( getTestGraphDatabaseFactory() );
+        server.setConfigure( getSettingsFunction() );
+        server.init( testInfo );
         address = server.lookupDefaultConnector();
         txStarted = new CountDownLatch( 1 );
         boltWorkerThreadPoolShuttingDown = new CountDownLatch( 1 );
@@ -109,7 +115,7 @@ public class ShutdownSequenceIT
         procedures.registerProcedure( TestProcedures.class );
     }
 
-    @After
+    @AfterEach
     public void tearDown()
     {
         userLogProvider.print( System.out );

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/runtime/BoltSchedulerBusyIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/runtime/BoltSchedulerBusyIT.java
@@ -101,7 +101,6 @@ class BoltSchedulerBusyIT extends AbstractBoltTransportsTest
         close( connection2 );
         close( connection3 );
         close( connection4 );
-        server.shutdownDatabase();
     }
 
     @ParameterizedTest( name = "{displayName} {2}" )

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/AuthenticationIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/AuthenticationIT.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.bolt.transport;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -92,12 +91,6 @@ public class AuthenticationIT extends AbstractBoltTransportsTest
         server.setConfigure( getSettingsFunction() );
         server.init( testInfo );
         address = server.lookupDefaultConnector();
-    }
-
-    @AfterEach
-    public void cleanup()
-    {
-        server.shutdownDatabase();
     }
 
     @Override

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/BoltChannelAutoReadLimiterIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/BoltChannelAutoReadLimiterIT.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.bolt.transport;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -81,12 +80,6 @@ class BoltChannelAutoReadLimiterIT
         util = new TransportTestUtil();
 
         installSleepProcedure( server.graphDatabaseService() );
-    }
-
-    @AfterEach
-    public void cleanup()
-    {
-        server.shutdownDatabase();
     }
 
     protected TestDatabaseManagementServiceBuilder getTestGraphDatabaseFactory()

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/BoltThrottleMaxDurationIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/BoltThrottleMaxDurationIT.java
@@ -105,7 +105,6 @@ public class BoltThrottleMaxDurationIT
         {
             client.disconnect();
         }
-        server.shutdownDatabase();
     }
 
     protected TestDatabaseManagementServiceBuilder getTestGraphDatabaseFactory()

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/CertificatesIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/CertificatesIT.java
@@ -20,7 +20,6 @@
 package org.neo4j.bolt.transport;
 
 import org.bouncycastle.operator.OperatorCreationException;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -75,12 +74,6 @@ public class CertificatesIT
         } );
 
         server.init( testInfo );
-    }
-
-    @AfterEach
-    public void cleanup()
-    {
-        server.shutdownDatabase();
     }
 
     @Test

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/ConcurrentAccessIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/ConcurrentAccessIT.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.bolt.transport;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -61,12 +60,6 @@ public class ConcurrentAccessIT extends AbstractBoltTransportsTest
     {
         server.setConfigure( getSettingsFunction() );
         server.init( testInfo );
-    }
-
-    @AfterEach
-    public void cleanup()
-    {
-        server.shutdownDatabase();
     }
 
     @ParameterizedTest( name = "{displayName} {2}" )

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/ConnectionIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/ConnectionIT.java
@@ -67,7 +67,6 @@ public class ConnectionIT
         {
             connection.disconnect();
         }
-        server.shutdownDatabase();
     }
 
     public static Stream<Arguments> transportFactory()

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/RejectTransportEncryptionIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/RejectTransportEncryptionIT.java
@@ -58,12 +58,6 @@ public class RejectTransportEncryptionIT
         server.init( testInfo );
     }
 
-    @AfterEach
-    public void cleanup()
-    {
-        server.shutdownDatabase();
-    }
-
     private TransportConnection client;
     private TransportTestUtil util;
 

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/RequiredTransportEncryptionIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/RequiredTransportEncryptionIT.java
@@ -75,7 +75,6 @@ public class RequiredTransportEncryptionIT
         {
             client.disconnect();
         }
-        server.shutdownDatabase();
     }
 
     @ParameterizedTest( name = "{displayName} {index}" )

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/SupportedStructTypesV2IT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/SupportedStructTypesV2IT.java
@@ -89,7 +89,6 @@ public class SupportedStructTypesV2IT
         {
             connection.disconnect();
         }
-        server.shutdownDatabase();
     }
 
     public static Stream<Arguments> classProvider()

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/TransportErrorIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/TransportErrorIT.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.bolt.transport;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -56,12 +55,6 @@ public class TransportErrorIT extends AbstractBoltTransportsTest
         server.init( testInfo );
 
         address = server.lookupDefaultConnector();
-    }
-
-    @AfterEach
-    public void cleanup()
-    {
-        server.shutdownDatabase();
     }
 
     @ParameterizedTest( name = "{displayName} {2}" )

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/TransportSessionIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/TransportSessionIT.java
@@ -20,7 +20,6 @@
 package org.neo4j.bolt.transport;
 
 import org.assertj.core.api.Condition;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -68,12 +67,6 @@ public class TransportSessionIT extends AbstractBoltTransportsTest
         server.setConfigure( getSettingsFunction() );
         server.init( testInfo );
         address = server.lookupDefaultConnector();
-    }
-
-    @AfterEach
-    public void cleanup()
-    {
-        server.shutdownDatabase();
     }
 
     @ParameterizedTest( name = "{displayName} {2}" )

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/TransportUnauthenticatedConnectionTimeoutErrorIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/TransportUnauthenticatedConnectionTimeoutErrorIT.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.bolt.transport;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -69,12 +68,6 @@ public class TransportUnauthenticatedConnectionTimeoutErrorIT extends AbstractBo
         server.setConfigure( getSettingsFunction() );
         server.init( testInfo );
         address = server.lookupDefaultConnector();
-    }
-
-    @AfterEach
-    public void cleanup()
-    {
-        server.shutdownDatabase();
     }
 
     protected Consumer<Map<Setting<?>,Object>> getSettingsFunction()

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/UnsupportedStructTypesV1V2IT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/UnsupportedStructTypesV1V2IT.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.bolt.transport;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -63,12 +62,6 @@ public class UnsupportedStructTypesV1V2IT extends AbstractBoltTransportsTest
         server.setConfigure( getSettingsFunction() );
         server.init( testInfo );
         address = server.lookupDefaultConnector();
-    }
-
-    @AfterEach
-    public void cleanup()
-    {
-        server.shutdownDatabase();
     }
 
     @ParameterizedTest( name = "{displayName} {2}" )

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/UnsupportedStructTypesV2IT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/transport/UnsupportedStructTypesV2IT.java
@@ -81,7 +81,6 @@ public class UnsupportedStructTypesV2IT
         {
             connection.disconnect();
         }
-        server.shutdownDatabase();
     }
 
     public static Stream<Arguments> classProvider()

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/v3/runtime/GoodbyeMessageIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/v3/runtime/GoodbyeMessageIT.java
@@ -20,12 +20,14 @@
 package org.neo4j.bolt.v3.runtime;
 
 import org.assertj.core.api.Condition;
-import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 
+import org.neo4j.bolt.testing.client.TransportConnection;
 import org.neo4j.bolt.transport.Neo4jWithSocket;
 import org.neo4j.bolt.v3.messaging.request.BeginMessage;
 import org.neo4j.bolt.v3.messaging.request.ResetMessage;
@@ -46,9 +48,12 @@ import static org.neo4j.bolt.v3.messaging.request.GoodbyeMessage.GOODBYE_MESSAGE
 
 public class GoodbyeMessageIT extends BoltV3TransportBase
 {
-    @Test
-    public void shouldCloseConnectionInConnected() throws Throwable
+    @ParameterizedTest( name = "{0}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldCloseConnectionInConnected( Class<? extends TransportConnection> connectionClass ) throws Exception
     {
+        init( connectionClass );
+
         // Given
         connection.connect( address )
                 .send( util.acceptedVersions( 3, 2, 1, 0 ) );
@@ -61,9 +66,12 @@ public class GoodbyeMessageIT extends BoltV3TransportBase
         assertThat( connection ).satisfies( serverImmediatelyDisconnects() );
     }
 
-    @Test
-    public void shouldCloseConnectionInReady() throws Throwable
+    @ParameterizedTest( name = "{0}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldCloseConnectionInReady( Class<? extends TransportConnection> connectionClass ) throws Exception
     {
+        init( connectionClass );
+
         // Given
         negotiateBoltV3();
 
@@ -74,9 +82,12 @@ public class GoodbyeMessageIT extends BoltV3TransportBase
         assertThat( connection ).satisfies( serverImmediatelyDisconnects() );
     }
 
-    @Test
-    public void shouldCloseConnectionInStreaming() throws Throwable
+    @ParameterizedTest( name = "{0}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldCloseConnectionInStreaming( Class<? extends TransportConnection> connectionClass ) throws Exception
     {
+        init( connectionClass );
+
         // Given
         negotiateBoltV3();
 
@@ -94,9 +105,12 @@ public class GoodbyeMessageIT extends BoltV3TransportBase
         assertThat( server ).satisfies( eventuallyClosesTransaction() );
     }
 
-    @Test
-    public void shouldCloseConnectionInFailed() throws Throwable
+    @ParameterizedTest( name = "{0}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldCloseConnectionInFailed( Class<? extends TransportConnection> connectionClass ) throws Exception
     {
+        init( connectionClass );
+
         // Given
         negotiateBoltV3();
 
@@ -114,9 +128,12 @@ public class GoodbyeMessageIT extends BoltV3TransportBase
         assertThat( connection ).satisfies( serverImmediatelyDisconnects() );
     }
 
-    @Test
-    public void shouldCloseConnectionInTxReady() throws Throwable
+    @ParameterizedTest( name = "{0}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldCloseConnectionInTxReady( Class<? extends TransportConnection> connectionClass ) throws Exception
     {
+        init( connectionClass );
+
         // Given
         negotiateBoltV3();
 
@@ -131,9 +148,12 @@ public class GoodbyeMessageIT extends BoltV3TransportBase
         assertThat( server ).satisfies( eventuallyClosesTransaction() );
     }
 
-    @Test
-    public void shouldCloseConnectionInTxStreaming() throws Throwable
+    @ParameterizedTest( name = "{0}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldCloseConnectionInTxStreaming( Class<? extends TransportConnection> connectionClass ) throws Exception
     {
+        init( connectionClass );
+
         // Given
         negotiateBoltV3();
 
@@ -149,9 +169,12 @@ public class GoodbyeMessageIT extends BoltV3TransportBase
         assertThat( server ).satisfies( eventuallyClosesTransaction() );
     }
 
-    @Test
-    public void shouldDropConnectionImmediatelyAfterGoodbye() throws Throwable
+    @ParameterizedTest( name = "{0}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldDropConnectionImmediatelyAfterGoodbye( Class<? extends TransportConnection> connectionClass ) throws Exception
     {
+        init( connectionClass );
+
         // Given
         negotiateBoltV3();
 

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/v4/runtime/ResetFuzzIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/v4/runtime/ResetFuzzIT.java
@@ -19,10 +19,11 @@
  */
 package org.neo4j.bolt.v4.runtime;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.RuleChain;
 
 import java.io.IOException;
@@ -36,6 +37,7 @@ import org.neo4j.bolt.testing.TransportTestUtil;
 import org.neo4j.bolt.testing.client.SocketConnection;
 import org.neo4j.bolt.testing.client.TransportConnection;
 import org.neo4j.bolt.transport.Neo4jWithSocket;
+import org.neo4j.bolt.transport.Neo4jWithSocketExtension;
 import org.neo4j.bolt.v4.messaging.BoltV4Messages;
 import org.neo4j.configuration.connectors.BoltConnector;
 import org.neo4j.configuration.connectors.BoltConnectorInternalSettings;
@@ -46,6 +48,10 @@ import org.neo4j.internal.helpers.collection.Pair;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.logging.SpiedAssertableLogProvider;
 import org.neo4j.test.TestDatabaseManagementServiceBuilder;
+import org.neo4j.test.extension.Inject;
+import org.neo4j.test.extension.OtherThreadExtension;
+import org.neo4j.test.extension.SuppressOutputExtension;
+import org.neo4j.test.extension.testdirectory.EphemeralTestDirectoryExtension;
 import org.neo4j.test.rule.SuppressOutput;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
@@ -56,6 +62,9 @@ import static org.neo4j.bolt.testing.MessageConditions.msgSuccess;
 import static org.neo4j.configuration.connectors.BoltConnector.EncryptionLevel.OPTIONAL;
 import static org.neo4j.test.rule.TestDirectory.testDirectory;
 
+@EphemeralTestDirectoryExtension
+@Neo4jWithSocketExtension
+@ExtendWith( SuppressOutputExtension.class )
 public class ResetFuzzIT
 {
     private static final int TEST_EXECUTION_TIME = 2000;
@@ -65,9 +74,9 @@ public class ResetFuzzIT
 
     private final AssertableLogProvider internalLogProvider = new SpiedAssertableLogProvider( ExecutorBoltScheduler.class );
     private final AssertableLogProvider userLogProvider = new AssertableLogProvider();
-    private final EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
-    private final Neo4jWithSocket server =
-            new Neo4jWithSocket( getTestGraphDatabaseFactory(), () -> testDirectory( getClass(), fsRule.get() ), getSettingsFunction() );
+
+    @Inject
+    private Neo4jWithSocket server;
     private final TransportTestUtil util = new TransportTestUtil();
     private HostnamePort address;
 
@@ -76,16 +85,16 @@ public class ResetFuzzIT
     private static final String SHORT_QUERY_3 = "RETURN 1";
     private static final String LONG_QUERY = "UNWIND range(0, 10000000) AS i CREATE (n:Node {idx: i}) DELETE n";
 
-    @Rule
-    public RuleChain ruleChain = RuleChain.outerRule( SuppressOutput.suppressAll() ).around( fsRule ).around( server );
-
-    @Before
-    public void setup()
+    @BeforeEach
+    public void setup( TestInfo testInfo ) throws IOException
     {
+        server.setGraphDatabaseFactory( getTestGraphDatabaseFactory() );
+        server.setConfigure( getSettingsFunction() );
+        server.init( testInfo );
         address = server.lookupDefaultConnector();
     }
 
-    @After
+    @AfterEach
     public void tearDown()
     {
         userLogProvider.print( System.out );

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/v41/runtime/BoltV41TransportIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/v41/runtime/BoltV41TransportIT.java
@@ -20,14 +20,18 @@
 package org.neo4j.bolt.v41.runtime;
 
 import org.assertj.core.api.Condition;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.neo4j.bolt.testing.TransportTestUtil;
 import org.neo4j.bolt.testing.client.SecureSocketConnection;
@@ -36,6 +40,7 @@ import org.neo4j.bolt.testing.client.SocketConnection;
 import org.neo4j.bolt.testing.client.TransportConnection;
 import org.neo4j.bolt.testing.client.WebSocketConnection;
 import org.neo4j.bolt.transport.Neo4jWithSocket;
+import org.neo4j.bolt.transport.Neo4jWithSocketExtension;
 import org.neo4j.bolt.v3.messaging.request.CommitMessage;
 import org.neo4j.bolt.v3.messaging.request.HelloMessage;
 import org.neo4j.bolt.v3.messaging.request.RollbackMessage;
@@ -50,6 +55,8 @@ import org.neo4j.kernel.database.Database;
 import org.neo4j.kernel.database.NamedDatabaseId;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.storageengine.api.TransactionIdStore;
+import org.neo4j.test.extension.Inject;
+import org.neo4j.test.extension.testdirectory.EphemeralTestDirectoryExtension;
 import org.neo4j.values.AnyValue;
 
 import static java.util.Arrays.asList;
@@ -66,36 +73,40 @@ import static org.neo4j.internal.helpers.collection.MapUtil.map;
 import static org.neo4j.kernel.impl.util.ValueUtils.asMapValue;
 import static org.neo4j.values.storable.Values.longValue;
 
-@RunWith( Parameterized.class )
+@EphemeralTestDirectoryExtension
+@Neo4jWithSocketExtension
 public class BoltV41TransportIT
 {
     private static final String USER_AGENT = "TestClient/4.1";
 
-    @Rule
-    public final Neo4jWithSocket server = new Neo4jWithSocket( getClass(), withOptionalBoltEncryption() );
+    @Inject
+    public Neo4jWithSocket server;
 
     private HostnamePort address;
     private TransportConnection connection;
     private TransportTestUtil util;
 
-    @Parameterized.Parameter
-    public Class<? extends TransportConnection> connectionClass;
-
-    @Parameterized.Parameters( name = "{0}" )
-    public static List<Class<? extends TransportConnection>> transports()
+    private static Stream<Arguments> argumentsProvider()
     {
-        return asList( SocketConnection.class, WebSocketConnection.class, SecureSocketConnection.class, SecureWebSocketConnection.class );
+        return Stream.of( Arguments.of( SocketConnection.class ), Arguments.of( WebSocketConnection.class ),
+                Arguments.of( SecureSocketConnection.class ), Arguments.of( SecureWebSocketConnection.class ) );
     }
 
-    @Before
-    public void setUp() throws Exception
+    @BeforeEach
+    public void setUp( TestInfo testInfo ) throws IOException
     {
+        server.setConfigure( withOptionalBoltEncryption() );
+        server.init( testInfo );
         address = server.lookupDefaultConnector();
-        connection = connectionClass.newInstance();
         util = new TransportTestUtil( newMessageEncoder() );
     }
 
-    @After
+    protected void init( Class<? extends TransportConnection> connectionClass ) throws Exception
+    {
+        connection = connectionClass.getDeclaredConstructor().newInstance();
+    }
+
+    @AfterEach
     public void tearDown() throws Exception
     {
         if ( connection != null )
@@ -104,9 +115,12 @@ public class BoltV41TransportIT
         }
     }
 
-    @Test
-    public void shouldReturnUpdatedBookmarkAfterAutoCommitTransaction() throws Throwable
+    @ParameterizedTest( name = "{0}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldReturnUpdatedBookmarkAfterAutoCommitTransaction( Class<? extends TransportConnection> connectionClass ) throws Exception
     {
+        init( connectionClass );
+
         assumeFalse( FabricDatabaseManager.fabricByDefault() );
 
         negotiateBoltV41();
@@ -123,9 +137,12 @@ public class BoltV41TransportIT
                         .containsEntry( "bookmark", expectedBookmark ) ) ) );
     }
 
-    @Test
-    public void shouldReturnUpdatedBookmarkAfterExplicitTransaction() throws Throwable
+    @ParameterizedTest( name = "{0}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldReturnUpdatedBookmarkAfterExplicitTransaction( Class<? extends TransportConnection> connectionClass ) throws Exception
     {
+        init( connectionClass );
+
         assumeFalse( FabricDatabaseManager.fabricByDefault() );
 
         negotiateBoltV41();
@@ -148,9 +165,12 @@ public class BoltV41TransportIT
                 msgSuccess( message -> assertThat( message ).containsEntry( "bookmark", expectedBookmark ) ) ) );
     }
 
-    @Test
-    public void shouldStreamWhenStatementIdNotProvided() throws Exception
+    @ParameterizedTest( name = "{0}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldStreamWhenStatementIdNotProvided( Class<? extends TransportConnection> connectionClass ) throws Exception
     {
+        init( connectionClass );
+
         negotiateBoltV41();
 
         // begin a transaction
@@ -201,9 +221,12 @@ public class BoltV41TransportIT
         assertThat( connection ).satisfies( util.eventuallyReceives( msgSuccess() ) );
     }
 
-    @Test
-    public void shouldSendAndReceiveStatementIds() throws Exception
+    @ParameterizedTest( name = "{0}" )
+    @MethodSource( "argumentsProvider" )
+    public void shouldSendAndReceiveStatementIds( Class<? extends TransportConnection> connectionClass ) throws Exception
     {
+        init( connectionClass );
+
         negotiateBoltV41();
 
         // begin a transaction

--- a/community/community-it/it-test-support/src/main/java/org/neo4j/bolt/transport/Neo4jWithSocket.java
+++ b/community/community-it/it-test-support/src/main/java/org/neo4j/bolt/transport/Neo4jWithSocket.java
@@ -20,9 +20,6 @@
 package org.neo4j.bolt.transport;
 
 import org.junit.jupiter.api.TestInfo;
-import org.junit.rules.ExternalResource;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 
 import java.io.File;
 import java.io.IOException;
@@ -41,7 +38,6 @@ import org.neo4j.dbms.api.DatabaseManagementService;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.internal.helpers.HostnamePort;
-import org.neo4j.io.fs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.TestDatabaseManagementServiceBuilder;
@@ -53,28 +49,18 @@ import static org.neo4j.configuration.connectors.BoltConnector.EncryptionLevel.D
 import static org.neo4j.configuration.connectors.BoltConnector.EncryptionLevel.OPTIONAL;
 import static org.neo4j.test.rule.TestDirectory.testDirectory;
 
-public class Neo4jWithSocket extends ExternalResource
+public class Neo4jWithSocket
 {
-    private final Supplier<FileSystemAbstraction> fileSystemProvider;
+    private Supplier<FileSystemAbstraction> fileSystemProvider;
     private Consumer<Map<Setting<?>,Object>> configure;
-    private final TestDirectory testDirectory;
+    private TestDirectory testDirectory;
     private TestDatabaseManagementServiceBuilder graphDatabaseFactory;
     private GraphDatabaseService gdb;
     private File workingDirectory;
     private ConnectorPortRegister connectorRegister;
     private DatabaseManagementService managementService;
 
-    public Neo4jWithSocket( Class<?> testClass )
-    {
-        this( testClass, settings -> { } );
-    }
-
-    public Neo4jWithSocket( Class<?> testClass, Consumer<Map<Setting<?>,Object>> configure )
-    {
-        this( new TestDatabaseManagementServiceBuilder(), () -> testDirectory( testClass, new EphemeralFileSystemAbstraction() ), configure );
-    }
-
-    public Neo4jWithSocket( TestDatabaseManagementServiceBuilder graphDatabaseFactory,
+    Neo4jWithSocket( TestDatabaseManagementServiceBuilder graphDatabaseFactory,
                             Supplier<TestDirectory> testDirectorySupplier, Consumer<Map<Setting<?>,Object>> configure )
     {
         this.testDirectory = testDirectorySupplier.get();
@@ -110,36 +96,6 @@ public class Neo4jWithSocket extends ExternalResource
         workingDirectory = testDirectory.directory( testName );
 
         ensureDatabase( settings -> {} );
-    }
-
-    @Override
-    public Statement apply( final Statement statement, final Description description )
-    {
-        Statement testMethod = new Statement()
-        {
-            @Override
-            public void evaluate() throws Throwable
-            {
-                // If this is used as class rule then getMethodName() returns null, so use
-                // getClassName() instead.
-                String name =
-                        description.getMethodName() != null ? description.getMethodName() : description.getClassName();
-                workingDirectory = testDirectory.directory( name );
-                ensureDatabase( settings -> {} );
-                try
-                {
-                    statement.evaluate();
-                }
-                finally
-                {
-                    shutdownDatabase();
-                }
-            }
-        };
-
-        Statement testMethodWithBeforeAndAfter = super.apply( testMethod, description );
-
-        return testDirectory.apply( testMethodWithBeforeAndAfter, description );
     }
 
     public HostnamePort lookupConnector( String connectorKey )

--- a/community/community-it/it-test-support/src/main/java/org/neo4j/bolt/transport/Neo4jWithSocketSupportExtension.java
+++ b/community/community-it/it-test-support/src/main/java/org/neo4j/bolt/transport/Neo4jWithSocketSupportExtension.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.bolt.transport;
 
+import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import org.neo4j.test.TestDatabaseManagementServiceBuilder;
@@ -30,7 +31,7 @@ import org.neo4j.test.rule.TestDirectory;
 import static org.neo4j.test.extension.testdirectory.TestDirectorySupportExtension.TEST_DIRECTORY;
 import static org.neo4j.test.extension.testdirectory.TestDirectorySupportExtension.TEST_DIRECTORY_NAMESPACE;
 
-public class Neo4jWithSocketSupportExtension extends StatefulFieldExtension<Neo4jWithSocket>
+public class Neo4jWithSocketSupportExtension extends StatefulFieldExtension<Neo4jWithSocket> implements AfterEachCallback
 {
     private static final String FIELD_KEY = "neo4jWithSocket";
     private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create( "org", "neo4j", FIELD_KEY );
@@ -70,5 +71,11 @@ public class Neo4jWithSocketSupportExtension extends StatefulFieldExtension<Neo4
     protected ExtensionContext.Namespace getNameSpace()
     {
         return NAMESPACE;
+    }
+
+    @Override
+    public void afterEach( ExtensionContext context )
+    {
+        getStoredValue( context ).shutdownDatabase();
     }
 }


### PR DESCRIPTION
This PR migrates remaining tests which use `Neo4jWithSocket ` to JUnit 5.

Also:
- `Neo4jWithSocket` does not extend `ExternalResource` anymore
- `Neo4jWithSocketSupportExtension` implements `AfterEachCallback` to `.shutdownDatabase()` to ensure it is always closed, and not relying on individual tests to close it.