### PR TITLE
correct usage in JUnitUsageGuardExtension

### DIFF
--- a/community/testing/test-utils/src/main/java/org/neo4j/test/extension/guard/JUnitUsageGuardExtension.java
+++ b/community/testing/test-utils/src/main/java/org/neo4j/test/extension/guard/JUnitUsageGuardExtension.java
@@ -76,7 +76,7 @@ public class JUnitUsageGuardExtension implements BeforeAllCallback
     {
         ClassReader classReader = new ClassReader( clazz.getName() );
         DependenciesCollector dependenciesCollector = new DependenciesCollector();
-        classReader.accept( dependenciesCollector, SKIP_DEBUG & SKIP_CODE & SKIP_FRAMES );
+        classReader.accept( dependenciesCollector, SKIP_DEBUG | SKIP_CODE | SKIP_FRAMES );
         return dependenciesCollector.getJunitTestClasses();
     }
 }


### PR DESCRIPTION
The parameters used to call `ClassReader`.`accept()` is joining multiple options, however it should be bitwise `OR`, not `AND`.

This can be checked by comparing the value of 

    System.out.println( SKIP_DEBUG & SKIP_CODE & SKIP_FRAMES );

against

    System.out.println( SKIP_DEBUG | SKIP_CODE | SKIP_FRAMES );