### PR TITLE
Support multiple "Injected" fields

### DIFF
--- a/community/community-it/it-test-support/src/main/java/org/neo4j/bolt/transport/Neo4jWithSocketSupportExtension.java
+++ b/community/community-it/it-test-support/src/main/java/org/neo4j/bolt/transport/Neo4jWithSocketSupportExtension.java
@@ -76,6 +76,9 @@ public class Neo4jWithSocketSupportExtension extends StatefulFieldExtension<Neo4
     @Override
     public void afterEach( ExtensionContext context )
     {
-        getStoredValue( context ).shutdownDatabase();
+        for ( var value : getStoredValues( context ) )
+        {
+            value.shutdownDatabase();
+        }
     }
 }

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/graphdb/GraphDatabaseShutdownTest.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/graphdb/GraphDatabaseShutdownTest.java
@@ -19,10 +19,10 @@
  */
 package org.neo4j.graphdb;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
@@ -33,34 +33,39 @@ import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.community.CommunityLockClient;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.TestDatabaseManagementServiceBuilder;
+import org.neo4j.test.extension.Inject;
+import org.neo4j.test.extension.OtherThreadExtension;
 import org.neo4j.test.rule.OtherThreadRule;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCause;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.neo4j.configuration.GraphDatabaseSettings.DEFAULT_DATABASE_NAME;
 import static org.neo4j.graphdb.Label.label;
 
+@ExtendWith( OtherThreadExtension.class )
 public class GraphDatabaseShutdownTest
 {
     private GraphDatabaseAPI db;
 
-    @Rule
-    public final OtherThreadRule t2 = new OtherThreadRule( "T2" );
-    @Rule
-    public final OtherThreadRule t3 = new OtherThreadRule( "T3" );
+    @Inject
+    public OtherThreadRule t2;
+    @Inject
+    public OtherThreadRule t3;
     private DatabaseManagementService managementService;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         db = newDb();
+        t2.set( "T2", 60, SECONDS );
+        t3.set( "T3", 60, SECONDS );
     }
 
-    @After
+    @AfterEach
     public void tearDown()
     {
         managementService.shutdown();
@@ -98,7 +103,7 @@ public class GraphDatabaseShutdownTest
     }
 
     @Test
-    public void shouldBeAbleToShutdownWhenThereAreTransactionsWaitingForLocks() throws Exception
+    public void shouldBeAbleToShutdownWhenThereAreTransactionsWaitingForLocks()
     {
         // GIVEN
         final Node node;

--- a/community/kernel/src/test/java/org/neo4j/test/rule/concurrent/ThreadingExtension.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/concurrent/ThreadingExtension.java
@@ -31,18 +31,23 @@ public class ThreadingExtension extends StatefulFieldExtension<ThreadingRule>
 {
     private static final String THREADING = "threading";
     private static final ExtensionContext.Namespace THREADING_NAMESPACE = ExtensionContext.Namespace.create( THREADING );
+
     @Override
     public void afterEach( ExtensionContext extensionContext )
     {
-        ThreadingRule threadingRule = getStoredValue( extensionContext );
-        threadingRule.after();
+        for ( var threadingRule : getStoredValues( extensionContext ) )
+        {
+            threadingRule.after();
+        }
     }
 
     @Override
     public void beforeEach( ExtensionContext extensionContext )
     {
-        ThreadingRule threadingRule = getStoredValue( extensionContext );
-        threadingRule.before();
+        for ( var threadingRule : getStoredValues( extensionContext ) )
+        {
+            threadingRule.before();
+        }
     }
 
     @Override

--- a/community/testing/io-utils/src/main/java/org/neo4j/test/extension/FileSystemExtension.java
+++ b/community/testing/io-utils/src/main/java/org/neo4j/test/extension/FileSystemExtension.java
@@ -22,6 +22,8 @@ package org.neo4j.test.extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 
+import java.util.List;
+
 import org.neo4j.io.fs.FileSystemAbstraction;
 
 public abstract class FileSystemExtension<T extends FileSystemAbstraction> extends StatefulFieldExtension<T>
@@ -32,10 +34,13 @@ public abstract class FileSystemExtension<T extends FileSystemAbstraction> exten
     @Override
     public void afterAll( ExtensionContext context ) throws Exception
     {
-        T storedValue = getStoredValue( context );
-        if ( storedValue != null )
+        List<T> storedValues = getStoredValues( context );
+        if ( storedValues != null )
         {
-            storedValue.close();
+            for ( var value : storedValues )
+            {
+                value.close();
+            }
         }
         super.afterAll( context );
     }

--- a/community/testing/io-utils/src/main/java/org/neo4j/test/extension/pagecache/PageCacheSupportExtension.java
+++ b/community/testing/io-utils/src/main/java/org/neo4j/test/extension/pagecache/PageCacheSupportExtension.java
@@ -99,10 +99,13 @@ public class PageCacheSupportExtension extends StatefulFieldExtension<PageCache>
     @Override
     public void afterAll( ExtensionContext context ) throws Exception
     {
-        PageCache storedValue = getStoredValue( context );
-        if ( storedValue != null )
+        var storedValues = getStoredValues( context );
+        if ( storedValues != null )
         {
-            storedValue.close();
+            for ( var value : storedValues )
+            {
+                value.close();
+            }
         }
         super.afterAll( context );
     }

--- a/community/testing/test-utils/src/main/java/org/neo4j/test/extension/LifeExtension.java
+++ b/community/testing/test-utils/src/main/java/org/neo4j/test/extension/LifeExtension.java
@@ -58,13 +58,18 @@ public class LifeExtension extends StatefulFieldExtension<LifeSupport> implement
     @Override
     public void afterEach( ExtensionContext context )
     {
-        deepRemoveStoredValue( context ).shutdown();
+        for ( var value : deepRemoveStoredValues( context ) )
+        {
+            value.shutdown();
+        }
     }
 
     @Override
     public void beforeEach( ExtensionContext context )
     {
-        LifeSupport value = getStoredValue( context );
-        value.start();
+        for ( var value : getStoredValues( context ) )
+        {
+            value.start();
+        }
     }
 }

--- a/community/testing/test-utils/src/main/java/org/neo4j/test/extension/OtherThreadExtension.java
+++ b/community/testing/test-utils/src/main/java/org/neo4j/test/extension/OtherThreadExtension.java
@@ -58,14 +58,18 @@ public class OtherThreadExtension extends StatefulFieldExtension<OtherThreadRule
     @Override
     public void beforeEach( ExtensionContext context )
     {
-        var otherThread = getStoredValue( context );
-        otherThread.beforeEach( context );
+        for ( var otherThread : getStoredValues( context ) )
+        {
+            otherThread.beforeEach( context );
+        }
     }
 
     @Override
     public void afterEach( ExtensionContext context )
     {
-        var otherThread = getStoredValue( context );
-        otherThread.afterEach();
+        for ( var otherThread : getStoredValues( context ) )
+        {
+            otherThread.afterEach();
+        }
     }
 }

--- a/community/testing/test-utils/src/main/java/org/neo4j/test/extension/SuppressOutputExtension.java
+++ b/community/testing/test-utils/src/main/java/org/neo4j/test/extension/SuppressOutputExtension.java
@@ -58,13 +58,19 @@ public class SuppressOutputExtension extends StatefulFieldExtension<SuppressOutp
     @Override
     public void afterEach( ExtensionContext context )
     {
-        getStoredValue( context ).releaseVoices( context.getExecutionException().isPresent() );
-        removeStoredValue( context );
+        for ( var value : getStoredValues( context ) )
+        {
+            value.releaseVoices( context.getExecutionException().isPresent() );
+        }
+        removeStoredValues( context );
     }
 
     @Override
     public void beforeEach( ExtensionContext context )
     {
-        getStoredValue( context ).captureVoices();
+        for ( var value : getStoredValues( context ) )
+        {
+            value.captureVoices();
+        }
     }
 }


### PR DESCRIPTION
Currently `StatefulFieldExtension` supports a single "Intjected" field of the same type, however if we have two fields (e.g. in `GraphDatabaseShutdownTest`), we need to have multiple fields different from each other.

This PR changes `StatefulFieldExtension` to store a `List` of the fields.