### PR TITLE
Overridden methods should have same signature

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/v41/messaging/BoltV41Messages.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v41/messaging/BoltV41Messages.java
@@ -54,7 +54,7 @@ public class BoltV41Messages
     private static final String USER_AGENT = "BoltV41Messages/0.0";
     private static final RequestMessage HELLO = new HelloMessage( map( "user_agent", USER_AGENT ),
                                                                   new RoutingContext( true,
-                                                                                      stringMap(  "policy", "fast", "region", "europe" ) ) );
+                                                                                      stringMap( "policy", "fast", "region", "europe" ) ) );
     private static final RequestMessage RUN_RETURN_ONE = new RunMessage( "RETURN 1" );
     private static final RequestMessage BEGIN = new BeginMessage();
 

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeGenerator.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeGenerator.java
@@ -45,7 +45,7 @@ class ByteCodeGenerator extends CodeGenerator
     }
 
     @Override
-    protected ClassWriter generate( TypeReference type, TypeReference base, TypeReference[] interfaces )
+    protected ClassWriter generate( TypeReference type, TypeReference base, TypeReference... interfaces )
     {
         ByteCodeClassWriter codeWriter = new ByteCodeClassWriter( type, base, interfaces );
         synchronized ( this )

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/JavaSourceGenerator.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/JavaSourceGenerator.java
@@ -52,7 +52,7 @@ class JavaSourceGenerator extends CodeGenerator
     }
 
     @Override
-    protected ClassWriter generate( TypeReference type, TypeReference base, TypeReference[] interfaces )
+    protected ClassWriter generate( TypeReference type, TypeReference base, TypeReference... interfaces )
     {
         StringBuilder target = new StringBuilder();
         synchronized ( this )

--- a/community/common/src/main/java/org/neo4j/internal/helpers/Args.java
+++ b/community/common/src/main/java/org/neo4j/internal/helpers/Args.java
@@ -129,7 +129,7 @@ public class Args
         return new ArgsParser( flags );
     }
 
-    public static Args parse( String...args )
+    public static Args parse( String... args )
     {
         return withFlags().parse( args );
     }

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/v41/runtime/BoltV41TransportIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/v41/runtime/BoltV41TransportIT.java
@@ -256,7 +256,7 @@ public class BoltV41TransportIT
 
         // execute query #2
         connection.send( util.chunk( new RunMessage( "UNWIND range(21, 30) AS x RETURN x" ) ) );
-        assertThat( connection ).satisfies(  util.eventuallyReceives(
+        assertThat( connection ).satisfies( util.eventuallyReceives(
                 msgSuccess( message -> assertThat( message ).containsEntry( "qid", 2L ).containsKeys( "fields", "t_first" ) ) ) );
 
         // request 4 records for query #2

--- a/community/community-it/community-it/src/test/java/org/neo4j/server/rest/AbstractRestFunctionalTestBase.java
+++ b/community/community-it/community-it/src/test/java/org/neo4j/server/rest/AbstractRestFunctionalTestBase.java
@@ -125,7 +125,7 @@ public class AbstractRestFunctionalTestBase extends SharedWebContainerTestBase i
         return connectorPortRegister.getLocalAddress( "http" ).getPort();
     }
 
-    public static HTTP.Response runQuery( String query, String...contentTypes )
+    public static HTTP.Response runQuery( String query, String... contentTypes )
     {
         String resultDataContents = "";
         if ( contentTypes.length > 0 )

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/internal/kernel/api/helpers/CachingExpandIntoTest.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/internal/kernel/api/helpers/CachingExpandIntoTest.java
@@ -455,7 +455,7 @@ class CachingExpandIntoTest
         }
     }
 
-    private LongSet connections( long start, Direction direction, long end, String...types )
+    private LongSet connections( long start, Direction direction, long end, String... types )
             throws TransactionFailureException
     {
         try ( KernelTransaction tx = transaction();

--- a/community/configuration/src/main/java/org/neo4j/configuration/GraphDatabaseSettings.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/GraphDatabaseSettings.java
@@ -863,7 +863,7 @@ public class GraphDatabaseSettings implements SettingsDeclaration
             "Hence, this parameter tunes a balance between the likelihood of experiencing connection problems and performance\n" +
             "Normally, this parameter should not need tuning.\n" +
             "Value 0 means connections will always be tested for validity" )
-    @DocumentedDefaultValue(  "No connection liveliness check is done by default." )
+    @DocumentedDefaultValue( "No connection liveliness check is done by default." )
     public static final Setting<Duration> routing_driver_idle_time_before_connection_test =
             newBuilder( "dbms.routing.driver.connection.pool.idle_test", DURATION, null ).build();
 

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/CheckDecorator.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/CheckDecorator.java
@@ -125,7 +125,7 @@ public interface CheckDecorator
     {
         private final CheckDecorator[] decorators;
 
-        public ChainCheckDecorator( CheckDecorator...decorators )
+        public ChainCheckDecorator( CheckDecorator... decorators )
         {
             this.decorators = decorators;
         }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/NeoStoreCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/NeoStoreCheck.java
@@ -26,7 +26,7 @@ import org.neo4j.kernel.impl.store.record.NeoStoreRecord;
 class NeoStoreCheck extends PrimitiveRecordCheck<NeoStoreRecord,ConsistencyReport.NeoStoreConsistencyReport>
 {
     @SafeVarargs
-    NeoStoreCheck( RecordField<NeoStoreRecord,NeoStoreConsistencyReport>...fields )
+    NeoStoreCheck( RecordField<NeoStoreRecord,NeoStoreConsistencyReport>... fields )
     {
         super( fields );
     }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReporter.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReporter.java
@@ -338,9 +338,9 @@ public class ConsistencyReporter implements ConsistencyReport.Reporter
             return args;
         }
 
-        protected abstract void logError( String message, Object[] args );
+        protected abstract void logError( String message, Object... args );
 
-        protected abstract void logWarning( String message, Object[] args );
+        protected abstract void logWarning( String message, Object... args );
 
         abstract void checkReference( CheckerEngine engine, ComparativeRecordChecker checker,
                                       AbstractBaseRecord referenced, RecordAccess records, PageCursorTracer cursorTracer );
@@ -370,13 +370,13 @@ public class ConsistencyReporter implements ConsistencyReport.Reporter
         }
 
         @Override
-        protected void logError( String message, Object[] args )
+        protected void logError( String message, Object... args )
         {
             report.error( type, record, message, args );
         }
 
         @Override
-        protected void logWarning( String message, Object[] args )
+        protected void logWarning( String message, Object... args )
         {
             report.warning( type, record, message, args );
         }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/report/InconsistencyLogger.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/report/InconsistencyLogger.java
@@ -24,17 +24,17 @@ import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 
 public interface InconsistencyLogger
 {
-    void error( RecordType recordType, AbstractBaseRecord record, String message, Object[] args );
+    void error( RecordType recordType, AbstractBaseRecord record, String message, Object... args );
 
     void error( RecordType recordType, AbstractBaseRecord oldRecord, AbstractBaseRecord newRecord, String message,
-                Object[] args );
+                Object... args );
 
     void error( String message );
 
-    void warning( RecordType recordType, AbstractBaseRecord record, String message, Object[] args );
+    void warning( RecordType recordType, AbstractBaseRecord record, String message, Object... args );
 
     void warning( RecordType recordType, AbstractBaseRecord oldRecord, AbstractBaseRecord newRecord, String message,
-                  Object[] args );
+                  Object... args );
 
     void warning( String message );
 }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/report/InconsistencyMessageLogger.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/report/InconsistencyMessageLogger.java
@@ -79,7 +79,7 @@ public class InconsistencyMessageLogger implements InconsistencyLogger
         return builder.toString();
     }
 
-    private static String buildMessage( String message, AbstractBaseRecord record, Object[] args )
+    private static String buildMessage( String message, AbstractBaseRecord record, Object... args )
     {
         StringBuilder builder = joinLines( message ).append( System.lineSeparator() ).append( TAB ).append( safeToString( record ) );
         appendArgs( builder, args );
@@ -98,7 +98,7 @@ public class InconsistencyMessageLogger implements InconsistencyLogger
         }
     }
 
-    private static String buildMessage( String message, AbstractBaseRecord oldRecord, AbstractBaseRecord newRecord, Object[] args )
+    private static String buildMessage( String message, AbstractBaseRecord oldRecord, AbstractBaseRecord newRecord, Object... args )
     {
         StringBuilder builder = joinLines( message );
         builder.append( System.lineSeparator() ).append( TAB ).append( "- " ).append( oldRecord );

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/report/InconsistencyReport.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/report/InconsistencyReport.java
@@ -34,14 +34,14 @@ public class InconsistencyReport implements InconsistencyLogger
     }
 
     @Override
-    public void error( RecordType recordType, AbstractBaseRecord record, String message, Object[] args )
+    public void error( RecordType recordType, AbstractBaseRecord record, String message, Object... args )
     {
         logger.error( recordType, record, message, args );
     }
 
     @Override
     public void error( RecordType recordType, AbstractBaseRecord oldRecord, AbstractBaseRecord newRecord,
-                       String message, Object[] args )
+                       String message, Object... args )
     {
         logger.error( recordType, oldRecord, newRecord, message, args );
     }
@@ -53,14 +53,14 @@ public class InconsistencyReport implements InconsistencyLogger
     }
 
     @Override
-    public void warning( RecordType recordType, AbstractBaseRecord record, String message, Object[] args )
+    public void warning( RecordType recordType, AbstractBaseRecord record, String message, Object... args )
     {
         logger.warning( recordType, record, message, args );
     }
 
     @Override
     public void warning( RecordType recordType, AbstractBaseRecord oldRecord, AbstractBaseRecord newRecord,
-                         String message, Object[] args )
+                         String message, Object... args )
     {
         logger.warning( recordType, oldRecord, newRecord, message, args );
     }

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/report/ConsistencyReporterTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/report/ConsistencyReporterTest.java
@@ -73,6 +73,7 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyVararg;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -149,14 +150,14 @@ class ConsistencyReporterTest
             InconsistencyLogger logger = new InconsistencyLogger()
             {
                 @Override
-                public void error( RecordType recordType, AbstractBaseRecord record, String message, Object[] args )
+                public void error( RecordType recordType, AbstractBaseRecord record, String message, Object... args )
                 {
                     assertTrue( loggedError.compareAndSet( null, message ) );
                 }
 
                 @Override
                 public void error( RecordType recordType, AbstractBaseRecord oldRecord, AbstractBaseRecord newRecord,
-                        String message, Object[] args )
+                        String message, Object... args )
                 {
                     assertTrue( loggedError.compareAndSet( null, message ) );
                 }
@@ -168,13 +169,13 @@ class ConsistencyReporterTest
                 }
 
                 @Override
-                public void warning( RecordType recordType, AbstractBaseRecord record, String message, Object[] args )
+                public void warning( RecordType recordType, AbstractBaseRecord record, String message, Object... args )
                 {
                 }
 
                 @Override
                 public void warning( RecordType recordType, AbstractBaseRecord oldRecord, AbstractBaseRecord newRecord,
-                        String message, Object[] args )
+                        String message, Object... args )
                 {
                 }
 
@@ -230,7 +231,7 @@ class ConsistencyReporterTest
                 else
                 {
                     verify( report ).error( any( RecordType.class ),
-                                            any( AbstractBaseRecord.class ), argThat( expectedFormat() ), nullSafeAny() );
+                                            any( AbstractBaseRecord.class ), argThat( expectedFormat() ), anyVararg() );
                 }
             }
             else
@@ -245,7 +246,7 @@ class ConsistencyReporterTest
                 {
                     verify( report ).error( any( RecordType.class ),
                                               any( AbstractBaseRecord.class ),
-                                              argThat( expectedFormat() ), nullSafeAny() );
+                                              argThat( expectedFormat() ), anyVararg() );
                 }
             }
         }

--- a/community/cypher/runtime-util/src/test/java/org/neo4j/cypher/internal/kernel/api/helpers/CachingExpandIntoTest.java
+++ b/community/cypher/runtime-util/src/test/java/org/neo4j/cypher/internal/kernel/api/helpers/CachingExpandIntoTest.java
@@ -161,7 +161,7 @@ class CachingExpandIntoTest
         assertReleasesHeap( expandInto );
     }
 
-    private void findConnections( CachingExpandInto expandInto, NodeCursor cursor, long from, long to, int...types )
+    private void findConnections( CachingExpandInto expandInto, NodeCursor cursor, long from, long to, int... types )
     {
         RelationshipTraversalCursor relationships =
                 expandInto.connectingRelationships( cursor, mock( RelationshipTraversalCursor.class ), from,

--- a/community/cypher/runtime-util/src/test/java/org/neo4j/cypher/result/NaiveQuerySubscriptionTest.java
+++ b/community/cypher/runtime-util/src/test/java/org/neo4j/cypher/result/NaiveQuerySubscriptionTest.java
@@ -176,7 +176,7 @@ class NaiveQuerySubscriptionTest
         }
     }
 
-    ResultRecord record( AnyValue...fields )
+    ResultRecord record( AnyValue... fields )
     {
         return new ResultRecord( fields );
     }

--- a/community/kernel-api/src/main/java/org/neo4j/kernel/api/index/BridgingIndexProgressor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/kernel/api/index/BridgingIndexProgressor.java
@@ -103,7 +103,7 @@ public class BridgingIndexProgressor implements IndexProgressor.EntityValueClien
     }
 
     @Override
-    public boolean acceptEntity( long reference, float score, Value[] values )
+    public boolean acceptEntity( long reference, float score, Value... values )
     {
         return client.acceptEntity( reference, score, values );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/PropertyNameUtils.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/PropertyNameUtils.java
@@ -36,7 +36,7 @@ public class PropertyNameUtils
     {
     }
 
-    public static String[] getPropertyKeysOrThrow( TokenRead tokenRead, int...properties )
+    public static String[] getPropertyKeysOrThrow( TokenRead tokenRead, int... properties )
             throws PropertyKeyIdNotFoundKernelException
     {
         String[] propertyKeys = new String[properties.length];

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeValueIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeValueIndexCursor.java
@@ -224,7 +224,7 @@ class DefaultNodeValueIndexCursor extends IndexCursor<IndexProgressor>
     }
 
     @Override
-    public boolean acceptEntity( long reference, float score, Value[] values )
+    public boolean acceptEntity( long reference, float score, Value... values )
     {
         if ( isRemoved( reference ) || !allowed( reference ) )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Labels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Labels.java
@@ -38,7 +38,7 @@ public class Labels implements TokenSet
         this.labelIds = labelIds;
     }
 
-    public static Labels from( long...labels )
+    public static Labels from( long... labels )
     {
         return new Labels( labels );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeValueClientFilter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeValueClientFilter.java
@@ -96,7 +96,7 @@ class NodeValueClientFilter implements EntityValueClient, IndexProgressor
     }
 
     @Override
-    public boolean acceptEntity( long reference, float score, Value[] values )
+    public boolean acceptEntity( long reference, float score, Value... values )
     {
         // First filter on these values, which come from the index. Some values will be NO_VALUE, because some indexed values cannot be read back.
         // Those values will have to be read from the store using the propertyCursor and is done in one pass after this loop, if needed.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueClientFilterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueClientFilterTest.java
@@ -254,7 +254,7 @@ class NodeValueClientFilterTest implements IndexProgressor, EntityValueClient
     }
 
     @Override
-    public boolean acceptEntity( long reference, float score, Value[] values )
+    public boolean acceptEntity( long reference, float score, Value... values )
     {
         events.add( new Event.Node( reference, score, values ) );
         return true;

--- a/community/procedure/src/test/java/org/neo4j/procedure/builtin/BuiltInProceduresTest.java
+++ b/community/procedure/src/test/java/org/neo4j/procedure/builtin/BuiltInProceduresTest.java
@@ -476,7 +476,7 @@ class BuiltInProceduresTest
         constraints.add( constraint );
     }
 
-    private void givenNodeKeys( String label, String...props )
+    private void givenNodeKeys( String label, String... props )
     {
         int labelId = token( label, labels );
         int[] propIds = new int[props.length];

--- a/community/record-storage-engine/src/test/java/org/neo4j/internal/recordstorage/ApplyRecoveredTransactionsTest.java
+++ b/community/record-storage-engine/src/test/java/org/neo4j/internal/recordstorage/ApplyRecoveredTransactionsTest.java
@@ -118,7 +118,7 @@ class ApplyRecoveredTransactionsTest
         return relationship;
     }
 
-    private void applyExternalTransaction( long transactionId, Command...commands ) throws Exception
+    private void applyExternalTransaction( long transactionId, Command... commands ) throws Exception
     {
         LockService lockService = mock( LockService.class );
         when( lockService.acquireNodeLock( anyLong(), any( LockType.class ) ) ).thenReturn( LockService.NO_LOCK );

--- a/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizationEnabledFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizationEnabledFilter.java
@@ -157,37 +157,37 @@ public class AuthorizationEnabledFilter extends AuthorizationFilter
     }
 
     private static final ThrowingConsumer<HttpServletResponse, IOException> noHeader =
-            error(  401,
+            error( 401,
                     map( "errors", singletonList( map(
                             "code", Status.Security.Unauthorized.code().serialize(),
                             "message", "No authentication header supplied." ) ) ) );
 
     private static final ThrowingConsumer<HttpServletResponse, IOException> badHeader =
-            error(  400,
+            error( 400,
                     map( "errors", singletonList( map(
                             "code", Status.Request.InvalidFormat.code().serialize(),
                             "message", "Invalid authentication header." ) ) ) );
 
     private static final ThrowingConsumer<HttpServletResponse, IOException> invalidCredential =
-            error(  401,
+            error( 401,
                     map( "errors", singletonList( map(
                             "code", Status.Security.Unauthorized.code().serialize(),
                             "message", "Invalid username or password." ) ) ) );
 
     private static final ThrowingConsumer<HttpServletResponse, IOException> tooManyAttempts =
-            error(  429,
+            error( 429,
                     map( "errors", singletonList( map(
                             "code", Status.Security.AuthenticationRateLimit.code().serialize(),
                             "message", "Too many failed authentication requests. Please wait 5 seconds and try again." ) ) ) );
 
     private static final ThrowingConsumer<HttpServletResponse, IOException> authProviderFailed =
-            error(  502,
+            error( 502,
                     map( "errors", singletonList( map(
                             "code", Status.Security.AuthProviderFailed.code().serialize(),
                             "message", "An auth provider request failed." ) ) ) );
 
     private static final ThrowingConsumer<HttpServletResponse, IOException> authProviderTimeout =
-            error(  504,
+            error( 504,
                     map( "errors", singletonList( map(
                             "code", Status.Security.AuthProviderTimeout.code().serialize(),
                             "message", "An auth provider request timed out." ) ) ) );

--- a/community/storage-engine-api/src/main/java/org/neo4j/storageengine/api/IndexUpdateListener.java
+++ b/community/storage-engine-api/src/main/java/org/neo4j/storageengine/api/IndexUpdateListener.java
@@ -66,7 +66,7 @@ public interface IndexUpdateListener
     class Adapter implements IndexUpdateListener
     {
         @Override
-        public void createIndexes( IndexDescriptor[] indexes )
+        public void createIndexes( IndexDescriptor... indexes )
         {
         }
 

--- a/community/testing/kernel-api-utils/src/main/java/org/neo4j/internal/kernel/api/helpers/StubCursorFactory.java
+++ b/community/testing/kernel-api-utils/src/main/java/org/neo4j/internal/kernel/api/helpers/StubCursorFactory.java
@@ -127,7 +127,7 @@ public class StubCursorFactory implements CursorFactory
         return poll( relationshipTypeIndexCursors );
     }
 
-    public StubCursorFactory withRelationshipTraversalCursors( RelationshipTraversalCursor...cursors )
+    public StubCursorFactory withRelationshipTraversalCursors( RelationshipTraversalCursor... cursors )
     {
         relationshipTraversalCursors.addAll( Arrays.asList( cursors ) );
         return this;

--- a/community/testing/kernel-api-utils/src/main/java/org/neo4j/internal/kernel/api/helpers/StubNodeValueIndexCursor.java
+++ b/community/testing/kernel-api-utils/src/main/java/org/neo4j/internal/kernel/api/helpers/StubNodeValueIndexCursor.java
@@ -35,9 +35,9 @@ public class StubNodeValueIndexCursor extends DefaultCloseListenable implements 
 {
     private int position = -1;
     private final List<NodeData> nodes = new ArrayList<>();
-    private List<Value[]> values = new ArrayList<>(  );
+    private List<Value[]> values = new ArrayList<>();
 
-    public StubNodeValueIndexCursor withNode( long id, Value...vs )
+    public StubNodeValueIndexCursor withNode( long id, Value... vs )
     {
         nodes.add( new NodeData( id, new long[]{}, Collections.emptyMap() ) );
         values.add( vs );


### PR DESCRIPTION
Also, change the type of methods of `InconsistencyLogger` to have varargs instead of array, since its usage (e.g. in MessageConsistencyLoggerTest) uses it as varargs.