### PR TITLE
newTransactionsLock should be released while shutdown

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -298,6 +298,7 @@ public class KernelTransactions extends LifecycleAdapter implements Supplier<IdC
     {
         transactionMemoryPool.close();
         disposeAll();
+		unblockNewTransactions();
     }
 
     @Override


### PR DESCRIPTION
This pr is to fix https://github.com/neo4j/neo4j/issues/12623