### PR TITLE
Backporting ignore_dot_files settings

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslSystemInternalSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslSystemInternalSettings.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.configuration.ssl;
+
+import org.neo4j.configuration.Description;
+import org.neo4j.configuration.Internal;
+import org.neo4j.configuration.LoadableConfig;
+import org.neo4j.graphdb.config.Setting;
+import org.neo4j.kernel.configuration.Settings;
+
+import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
+import static org.neo4j.kernel.configuration.Settings.FALSE;
+
+@Description( "Internal SSL settings" )
+public class SslSystemInternalSettings implements LoadableConfig
+{
+    @Internal
+    @Description( "Don't try and read dot-prefixed files or dot-prefixed directories in ssl policy directories" )
+    public static final Setting<Boolean> ignore_dotfiles = Settings.setting( "unsupported.dbms.ssl.system.ignore_dot_files", BOOLEAN, FALSE );
+}


### PR DESCRIPTION
This PR is backporting `unsupported.dbms.ssl.system.ignore_dot_files` settings introduced in https://github.com/neo4j/neo4j/commit/39a1233572c737a788221e5dc7350783666a8e98. Without this setting, it's not possible to run Neo4j v3.5 on Kubernetes because Kubernetes creates dotted directories when mounting secrets from a volume. When using Kubernetes secrets for setting up Neo3j SSL, without this patch the following exception occurs:

```
...
2021-01-12 23:41:03.587+0000 INFO  ======== Neo4j 3.5.26 ========
2021-01-12 23:41:03.597+0000 INFO  Starting...
2021-01-12 23:41:04.663+0000 ERROR Failed to start Neo4j: Starting Neo4j failed: Component 'org.neo4j.server.database.LifecycleManagingDatabase@4ebff610' was successfully initialized, but failed to start. Please see the attached cause exception "Is a directory". Starting Neo4j failed: Component 'org.neo4j.server.database.LifecycleManagingDatabase@4ebff610' was successfully initialized, but failed to start. Please see the attached cause exception "Is a directory".
org.neo4j.server.ServerStartupException: Starting Neo4j failed: Component 'org.neo4j.server.database.LifecycleManagingDatabase@4ebff610' was successfully initialized, but failed to start. Please see the attached cause exception "Is a directory".
	at org.neo4j.server.exception.ServerStartupErrors.translateToServerStartupError(ServerStartupErrors.java:45)
	at org.neo4j.server.AbstractNeoServer.start(AbstractNeoServer.java:187)
	at org.neo4j.server.ServerBootstrapper.start(ServerBootstrapper.java:124)
	at org.neo4j.server.ServerBootstrapper.start(ServerBootstrapper.java:91)
	at com.neo4j.server.enterprise.CommercialEntryPoint.main(CommercialEntryPoint.java:22)
Caused by: org.neo4j.kernel.lifecycle.LifecycleException: Component 'org.neo4j.server.database.LifecycleManagingDatabase@4ebff610' was successfully initialized, but failed to start. Please see the attached cause exception "Is a directory".
	at org.neo4j.kernel.lifecycle.LifeSupport$LifecycleInstance.start(LifeSupport.java:473)
	at org.neo4j.kernel.lifecycle.LifeSupport.start(LifeSupport.java:111)
	at org.neo4j.server.AbstractNeoServer.start(AbstractNeoServer.java:180)
	... 3 more
Caused by: java.lang.RuntimeException: Failed to create trust manager based on: /ssl/bolt/trusted
	at org.neo4j.kernel.configuration.ssl.SslPolicyLoader.load(SslPolicyLoader.java:222)
	at org.neo4j.kernel.configuration.ssl.SslPolicyLoader.create(SslPolicyLoader.java:99)
	at com.neo4j.causalclustering.core.CommercialCoreEditionModule.getClusteringModule(CommercialCoreEditionModule.java:62)
	at org.neo4j.causalclustering.core.EnterpriseCoreEditionModule.<init>(EnterpriseCoreEditionModule.java:237)
	at com.neo4j.causalclustering.core.CommercialCoreEditionModule.<init>(CommercialCoreEditionModule.java:53)
	at com.neo4j.causalclustering.core.CommercialCoreGraphDatabase.lambda$new$0(CommercialCoreGraphDatabase.java:27)
	at org.neo4j.graphdb.facade.GraphDatabaseFacadeFactory.initFacade(GraphDatabaseFacadeFactory.java:181)
	at com.neo4j.causalclustering.core.CommercialCoreGraphDatabase.<init>(CommercialCoreGraphDatabase.java:28)
	at com.neo4j.server.database.CommercialGraphFactory.newGraphDatabase(CommercialGraphFactory.java:36)
	at org.neo4j.server.database.LifecycleManagingDatabase.start(LifecycleManagingDatabase.java:90)
	at org.neo4j.kernel.lifecycle.LifeSupport$LifecycleInstance.start(LifeSupport.java:452)
	... 5 more
Caused by: java.security.cert.CertificateException: Error loading certificate file: /ssl/bolt/trusted/..2021_01_12_00_13_54.094251346
	at org.neo4j.kernel.configuration.ssl.SslPolicyLoader.createTrustManagerFactory(SslPolicyLoader.java:363)
	at org.neo4j.kernel.configuration.ssl.SslPolicyLoader.load(SslPolicyLoader.java:218)
	... 15 more
Caused by: java.security.cert.CertificateException: Could not parse certificate: java.io.IOException: Is a directory
	at sun.security.provider.X509Factory.engineGenerateCertificate(X509Factory.java:110)
	at java.security.cert.CertificateFactory.generateCertificate(CertificateFactory.java:339)
	at org.neo4j.kernel.configuration.ssl.SslPolicyLoader.createTrustManagerFactory(SslPolicyLoader.java:358)
	... 16 more
Caused by: java.io.IOException: Is a directory
	at sun.nio.ch.FileDispatcherImpl.read0(Native Method)
	at sun.nio.ch.FileDispatcherImpl.read(FileDispatcherImpl.java:46)
	at sun.nio.ch.IOUtil.readIntoNativeBuffer(IOUtil.java:223)
	at sun.nio.ch.IOUtil.read(IOUtil.java:197)
	at sun.nio.ch.FileChannelImpl.read(FileChannelImpl.java:159)
	at sun.nio.ch.ChannelInputStream.read(ChannelInputStream.java:65)
	at sun.nio.ch.ChannelInputStream.read(ChannelInputStream.java:109)
	at sun.nio.ch.ChannelInputStream.read(ChannelInputStream.java:103)
	at java.io.InputStream.read(InputStream.java:101)
	at sun.nio.ch.ChannelInputStream.read(ChannelInputStream.java:81)
	at sun.security.provider.X509Factory.readOneBlock(X509Factory.java:545)
	at sun.security.provider.X509Factory.engineGenerateCertificate(X509Factory.java:96)
	... 18 more
2021-01-12 23:41:04.670+0000 INFO  Neo4j Server shutdown initiated by request
failed to signal command: os: process already finished
process exited non-zero: exit status 1
```