### PR TITLE
LogPruningImpl.cleanupCheckpointLogFiles() unintended String concat

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruningImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruningImpl.java
@@ -116,7 +116,7 @@ public class LogPruningImpl implements LogPruning
                     filesDeleted++;
                 }
             }
-            log.info( "Pruned " + filesDeleted + " checkpoint log files. Lowest preserved version: " + highestVersionToRemove + 1 );
+            log.info( "Pruned " + filesDeleted + " checkpoint log files. Lowest preserved version: " + (highestVersionToRemove + 1) );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruningImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruningImpl.java
@@ -116,7 +116,7 @@ public class LogPruningImpl implements LogPruning
                     filesDeleted++;
                 }
             }
-            log.info( "Pruned " + filesDeleted + " checkpoint log files. Lowest preserved version: " + (highestVersionToRemove + 1) );
+            log.info( "Pruned " + filesDeleted + " checkpoint log files. Lowest preserved version: " + ( highestVersionToRemove + 1 ) );
         }
     }
 


### PR DESCRIPTION
Closes #12656. LogPruningTest uses a NullLogProvider with an implementation that discards all messages thus no test added. 