### PR TITLE
Augment Throwable message with suppressed

### DIFF
--- a/community/common/src/main/java/org/neo4j/internal/helpers/Exceptions.java
+++ b/community/common/src/main/java/org/neo4j/internal/helpers/Exceptions.java
@@ -226,30 +226,9 @@ public final class Exceptions
         return false;
     }
 
-    private static final Field THROWABLE_MESSAGE_FIELD;
-    static
-    {
-        try
-        {
-            THROWABLE_MESSAGE_FIELD = Throwable.class.getDeclaredField( "detailMessage" );
-            THROWABLE_MESSAGE_FIELD.setAccessible( true );
-        }
-        catch ( Exception e )
-        {
-            throw new LinkageError( "Could not get Throwable message field", e );
-        }
-    }
-
     public static <T extends Throwable> T withMessage( T cause, String message )
     {
-        try
-        {
-            THROWABLE_MESSAGE_FIELD.set( cause, message );
-        }
-        catch ( IllegalArgumentException | IllegalAccessException e )
-        {
-            throw new RuntimeException( e );
-        }
+        cause.addSuppressed(new AdditionalInfo(message));
         return cause;
     }
 
@@ -296,4 +275,10 @@ public final class Exceptions
         }
         return exception;
     }
+
+	public static class AdditionalInfo extends RuntimeException {
+		public AdditionalInfo(String info) {
+			super(info, null, true, false);
+		}
+	}
 }


### PR DESCRIPTION
See [JEP396](https://openjdk.java.net/jeps/396): can't use such reflection reliably in the future.
Instead the augmented message is added as a suppressed RTE without a stacktrace.

I've stumbled across this after upgrading my local JDK to 16 and starting a new database. Neo4j tried to catch an IOException on access to yet-absent file, but failed because of the failed 'augmenting'.

Noop if the given Throwable was created with 'enableSuppression = false'.