### PR TITLE
Update EditionLocksFactories.java

### DIFF
--- a/community/neo4j/src/main/java/org/neo4j/graphdb/factory/EditionLocksFactories.java
+++ b/community/neo4j/src/main/java/org/neo4j/graphdb/factory/EditionLocksFactories.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.graphdb.factory;
 
-import org.eclipse.jetty.util.StringUtil;
-
 import org.neo4j.configuration.Config;
 import org.neo4j.configuration.GraphDatabaseInternalSettings;
 import org.neo4j.kernel.impl.locking.Locks;
@@ -56,7 +54,7 @@ public final class EditionLocksFactories
     {
         // we can have community lock manager configured in the wild. Ignore that and log warning message.
         var factoryKey = checkForOldCommunityValue( lockFactoriesLog, key );
-        if ( StringUtil.isEmpty( factoryKey ) )
+        if ( factoryKey.isBlank() )
         {
             return Services.loadByPriority( LocksFactory.class ).orElseThrow( () -> new IllegalArgumentException( "No lock manager found" ) );
         }


### PR DESCRIPTION
The org.eclipse.jetty.util.StringUtil.isEmpty doesn't exists and cause the embedded usage to not work. The used class contains a isBlank method that checks if the string is empty or contains only whitespace characters. Since java 11, the java core String class contains a isBlank method that checks the same. So, I removed the StringUtils dependence and changed the isEmpty to java String default isBlank.