### PR TITLE
refactor: Use `Collections#isEmpty()` instead of comparing `size()`

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/testing/BoltConditions.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/testing/BoltConditions.java
@@ -78,7 +78,7 @@ public final class BoltConditions
 
     public static Condition<RecordedBoltResponse> containsNoRecord()
     {
-        return new Condition<>( response -> response.records().size() == 0, " without record" );
+        return new Condition<>( response -> response.records().isEmpty(), " without record" );
     }
 
     public static Condition<RecordedBoltResponse> containsRecord( final Object... values )

--- a/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/v3/runtime/GoodbyeMessageIT.java
+++ b/community/community-it/bolt-it/src/test/java/org/neo4j/bolt/v3/runtime/GoodbyeMessageIT.java
@@ -188,7 +188,7 @@ public class GoodbyeMessageIT extends BoltV3TransportBase
     {
         return new Condition<>( server ->
         {
-            BooleanSupplier condition = () -> getActiveTransactions( server ).size() == 0;
+            BooleanSupplier condition = () -> getActiveTransactions(server).isEmpty();
             try
             {
                 Predicates.await( condition, 2, TimeUnit.SECONDS );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TokenScanWriteMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/TokenScanWriteMonitor.java
@@ -392,7 +392,7 @@ public class TokenScanWriteMonitor implements TokenIndex.WriteMonitor
     public static void main( String[] args ) throws IOException
     {
         Args arguments = Args.withFlags( ARG_TOFILE ).parse( args );
-        if ( arguments.orphans().size() == 0 )
+        if ( arguments.orphans().isEmpty() )
         {
             System.err.println( "Please supply database directory" );
             return;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
@@ -1463,7 +1463,7 @@ class IndexingServiceTest
                 @Override
                 public void run( ExternalUpdatesCheck externalUpdatesCheck )
                 {
-                    if ( stop || updates.size() == 0 )
+                    if ( stop || updates.isEmpty() )
                     {
                         return;
                     }

--- a/community/procedure/src/main/java/org/neo4j/procedure/impl/ProcedureJarLoader.java
+++ b/community/procedure/src/main/java/org/neo4j/procedure/impl/ProcedureJarLoader.java
@@ -82,7 +82,7 @@ class ProcedureJarLoader
             throw new ZipException( String.format( "Some jar procedure files (%s) are invalid, see log for details.", String.join( ", ", failedJarFiles ) ) );
         }
 
-        if ( jarFiles.size() == 0 )
+        if ( jarFiles.isEmpty() )
         {
             return Callables.empty();
         }

--- a/community/security/src/main/java/org/neo4j/server/security/systemgraph/versions/KnownCommunitySecurityComponentVersion.java
+++ b/community/security/src/main/java/org/neo4j/server/security/systemgraph/versions/KnownCommunitySecurityComponentVersion.java
@@ -81,7 +81,7 @@ public abstract class KnownCommunitySecurityComponentVersion extends KnownSystem
         // The set-initial-password command should only take effect if the only existing user is the default user with the default password.
         ResourceIterator<Node> nodes = tx.findNodes( USER_LABEL );
         List<Node> users = nodes.stream().collect( Collectors.toList() );
-        if ( users.size() == 0 )
+        if ( users.isEmpty() )
         {
             securityLog.warn( String.format( "Unable to update missing initial user password from `auth.ini` file: %s", initialUser.name() ) );
         }


### PR DESCRIPTION
Non functional change to improve the code quality. See https://rules.sonarsource.com/java/RSPEC-1155

This is the result of running the recipe `org.openrewrite.java.cleanup.IsEmptyCallOnCollections` from the OpenRewrite project

Read more : https://docs.openrewrite.org/reference/recipes/java/cleanup/isemptycalloncollections



Created with: [Moderne](https://app.moderne.io)