### PR TITLE
Support -dev suffix for console dev bolt uris

### DIFF
--- a/community/push-to-cloud/src/main/java/org/neo4j/pushtocloud/PushToCloudCommand.java
+++ b/community/push-to-cloud/src/main/java/org/neo4j/pushtocloud/PushToCloudCommand.java
@@ -172,7 +172,7 @@ public class PushToCloudCommand extends AbstractCommand
         //   bolt+routing://rogue.databases.neo4j.io  --> https://console.neo4j.io/v1/databases/rogue
         //   bolt+routing://rogue-mattias.databases.neo4j.io  --> https://console-mattias.neo4j.io/v1/databases/rogue
 
-        Pattern pattern = Pattern.compile( "(?:bolt(?:\\+routing)?|neo4j(?:\\+s|\\+ssc)?)://([^-]+)(-(.+))?.databases.neo4j.io$" );
+        Pattern pattern = Pattern.compile( "(?:bolt(?:\\+routing)?|neo4j(?:\\+s|\\+ssc)?)://([^-]+)(-(.+))?.databases.neo4j(?:-dev)?.io$" );
         Matcher matcher = pattern.matcher( boltURI );
         if ( !matcher.matches() )
         {


### PR DESCRIPTION
Aura has changed its dev domain to neo4j-dev.io so we need to update the regex to support console bolt urls for dev environments.