### PR TITLE
Consistently use diamond operator

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/packstream/struct/ImmutableStructRegistry.java
+++ b/community/bolt/src/main/java/org/neo4j/packstream/struct/ImmutableStructRegistry.java
@@ -58,7 +58,7 @@ public class ImmutableStructRegistry<CTX, S> extends AbstractStructRegistry<CTX,
 
         @Override
         public ImmutableStructRegistry<CTX, S> build() {
-            return new ImmutableStructRegistry<CTX, S>(
+            return new ImmutableStructRegistry<>(
                     Map.copyOf(this.tagToReaderMap), Map.copyOf(this.typeToWriterMap));
         }
     }

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/newapi/PartitionedScanTestSuite.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/impl/newapi/PartitionedScanTestSuite.java
@@ -355,7 +355,7 @@ abstract class PartitionedScanTestSuite<QUERY extends Query<?>, SESSION, CURSOR 
                             .isLessThanOrEqualTo(maxNumberOfPartitions);
 
                     // given  each partition distributed over multiple threads
-                    final var allFound = Collections.synchronizedSet(new HashSet<Long>());
+                    final var allFound = Collections.synchronizedSet(new HashSet<>());
                     final var workerContexts =
                             TestUtils.createContexts(tx, factory.getCursor(kernel.cursors())::with, numberOfThreads);
                     final var race = new Race();

--- a/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/recovery/ParallelRecoveryIT.java
+++ b/community/community-it/kernel-it/src/test/java/org/neo4j/kernel/recovery/ParallelRecoveryIT.java
@@ -65,7 +65,7 @@ class ParallelRecoveryIT extends RecoveryIT {
                         mock(LockService.class),
                         mock(LockGroup.class),
                         TransactionApplicationMode.EXTERNAL))
-                .is(new Condition<Throwable>(
+                .is(new Condition<>(
                         not(UnsupportedOperationException.class::isInstance), "Supported operation"));
     }
 }

--- a/community/cypher-shell/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/TableOutputFormatter.java
+++ b/community/cypher-shell/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/TableOutputFormatter.java
@@ -68,7 +68,7 @@ public class TableOutputFormatter implements OutputFormatter {
 
     private int formatResultAndCountRows(String[] columns, Iterator<Record> records, LinePrinter output) {
 
-        ArrayList<Record> topRecords = new ArrayList<Record>(numSampleRows);
+        ArrayList<Record> topRecords = new ArrayList<>(numSampleRows);
         try {
             take(records, topRecords, numSampleRows);
         } catch (RuntimeException e) {

--- a/community/cypher-shell/cypher-shell/src/test/java/org/neo4j/shell/MainTest.java
+++ b/community/cypher-shell/cypher-shell/src/test/java/org/neo4j/shell/MainTest.java
@@ -85,7 +85,7 @@ class MainTest {
         testWithMocks()
                 .run()
                 .assertFailure("bla")
-                .assertThatOutput(new Condition<String>(s -> s.isEmpty(), "String is empty"));
+                .assertThatOutput(new Condition<>(s -> s.isEmpty(), "String is empty"));
 
         verify(mockShell, times(1)).connect(any());
     }

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/DijkstraPriorityQueueFibonacciImpl.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/DijkstraPriorityQueueFibonacciImpl.java
@@ -84,7 +84,7 @@ public class DijkstraPriorityQueueFibonacciImpl<CostType> implements DijkstraPri
     }
 
     Map<Node, FibonacciHeap<HeapObject>.FibonacciHeapNode> heapNodes =
-            new HashMap<Node, FibonacciHeap<HeapObject>.FibonacciHeapNode>();
+            new HashMap<>();
     FibonacciHeap<HeapObject> heap;
 
     public DijkstraPriorityQueueFibonacciImpl(final Comparator<CostType> costComparator) {

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/PriorityMap.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/PriorityMap.java
@@ -56,7 +56,7 @@ public class PriorityMap<E, K, P> {
 
     @SuppressWarnings("unchecked")
     public static <K, P> PriorityMap<K, K, P> withSelfKey(Comparator<P> priority) {
-        return new PriorityMap<K, K, P>(SELF_KEY, priority, true);
+        return new PriorityMap<>(SELF_KEY, priority, true);
     }
 
     private static class NaturalPriority<P extends Comparable<P>> implements Comparator<P> {
@@ -99,7 +99,7 @@ public class PriorityMap<E, K, P> {
     public static <K, P extends Comparable<P>> PriorityMap<K, K, P> withSelfKeyNaturalOrder(
             boolean reversed, boolean onlyKeepBestPriorities) {
         Comparator<P> priority = new NaturalPriority<>(reversed);
-        return new PriorityMap<K, K, P>(SELF_KEY, priority, onlyKeepBestPriorities);
+        return new PriorityMap<>(SELF_KEY, priority, onlyKeepBestPriorities);
     }
 
     private final Converter<K, E> keyFunction;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/EagerBuffer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/EagerBuffer.java
@@ -70,7 +70,7 @@ public class EagerBuffer<T extends Measurable> extends DefaultCloseListenable {
         MemoryTracker scopedMemoryTracker = memoryTracker.getScopedMemoryTracker();
         scopedMemoryTracker.allocateHeap(
                 SHALLOW_SIZE + SCOPED_MEMORY_TRACKER_SHALLOW_SIZE + shallowSizeOfInstance(IntUnaryOperator.class));
-        return new EagerBuffer<T>(scopedMemoryTracker, initialChunkSize, maxChunkSize, growthStrategy);
+        return new EagerBuffer<>(scopedMemoryTracker, initialChunkSize, maxChunkSize, growthStrategy);
     }
 
     private EagerBuffer(


### PR DESCRIPTION
Hi! Noticed there's still a few instances in the code base where diamond operators are not used to their full extend, through [Use diamond operator](https://docs.openrewrite.org/reference/recipes/java/cleanup/usediamondoperator).

```
mvn org.openrewrite.maven:rewrite-maven-plugin:4.38.2:run \
  -DactiveRecipes=org.openrewrite.java.cleanup.UseDiamondOperator
```

Figured open a pull request to gauge if there's any interest in this and similar mostly automated improvements. If not do please let me know! Certainly would not want to overwhelm you guys with review work if it's not appreciated at this time. :)

Other potential [cleanups listed here](https://docs.openrewrite.org/reference/recipes/java/cleanup), and [and more here](https://docs.openrewrite.org/reference/recipes/java/migrate/lang/stringformatted).