### PR TITLE
Update jetty to 12.0.15 to fix URI parsing of invalid authority

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
     <jamm.version>0.4.0</jamm.version>
     <lucene.version>9.11.1</lucene.version>
     <bouncycastle.version>1.78.1</bouncycastle.version>
-    <jetty.version>10.0.24</jetty.version>
+    <jetty.version>12.0.15</jetty.version>
     <scala-maven-plugin.version>4.9.2</scala-maven-plugin.version>
     <scala.version>2.13.11</scala.version>
     <scala.binary.version>2.13</scala.binary.version>


### PR DESCRIPTION
# Summary
The HttpURI class does insufficient validation on the authority segment of a URI. However the behaviour of HttpURI differs from the common browsers in how it handles a URI that would be considered invalid if fully validated against the RRC. Specifically HttpURI and the browser may differ on the value of the host extracted from an invalid URI and thus a combination of Jetty and a vulnerable browser may be vulnerable to a open redirect attack or to a SSRF attack if the URI is used after passing validation checks.

# Details
## Affected components
The vulnerable component is the HttpURI class when used as a utility class in an application. The Jetty usage of the class is not vulnerable.

## Attack overview
The HttpURI class does not well validate the authority section of a URI. When presented with an illegal authority that may contain user info (eg username:password#@hostname:port), then the parsing of the URI is not failed. Moreover, the interpretation of what part of the authority is the host name differs from a common browser in that they also do not fail, but they select a different host name from the illegal URI.

## Attack scenario
A typical attack scenario is illustrated in the diagram below. The Validator checks whether the attacker-supplied URL is on the blocklist. If not, the URI is passed to the Requester for redirection. The Requester is responsible for sending requests to the hostname specified by the URI.

This attack occurs when the Validator is the org.eclipse.jetty.http.HttpURI class and the Requester is the Browser (include chrome, firefox and Safari). An attacker can send a malformed URI to the Validator (e.g., http://browser.check%23%40vulndetector.com/ ). After validation, the Validator finds that the hostname is not on the blocklist. However, the Requester can still send requests to the domain with the hostname vulndetector.com.