### PR TITLE
Remove test order dependence in RWLockCompatibility.java

### DIFF
--- a/community/lock/src/test/java/org/neo4j/kernel/impl/locking/forseti/LockWorker.java
+++ b/community/lock/src/test/java/org/neo4j/kernel/impl/locking/forseti/LockWorker.java
@@ -30,9 +30,9 @@ import org.neo4j.test.OtherThreadExecutor;
 public class LockWorker extends OtherThreadExecutor {
     private final LockWorkerState state;
 
-    public LockWorker(String name, LockManager locks) {
+    public LockWorker(String name, LockManager locks, long transactionId) {
         super(name);
-        state = new LockWorkerState(locks);
+        state = new LockWorkerState(locks, transactionId);
     }
 
     private Future<Void> perform(Callable<Void> acquireLockCommand, boolean wait) throws Exception {

--- a/community/lock/src/test/java/org/neo4j/kernel/impl/locking/forseti/LockWorkerManager.java
+++ b/community/lock/src/test/java/org/neo4j/kernel/impl/locking/forseti/LockWorkerManager.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking.forseti;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import org.neo4j.kernel.impl.locking.LockManager;
+
+/**
+ * Manages the creation, lifecycle, and transaction IDs for lock workers.
+ * This class encapsulates the TRANSACTION_ID counter that was previously static,
+ * allowing for per-test isolation and management of transaction IDs.
+ * It also handles creation and cleanup of LockWorker instances.
+ */
+public class LockWorkerManager {
+    private final LockManager locks;
+    private final AtomicLong transactionIdCounter;
+    private final List<LockWorker> workers;
+
+    public LockWorkerManager(LockManager locks) {
+        this.locks = locks;
+        this.transactionIdCounter = new AtomicLong(0);
+        this.workers = new ArrayList<>();
+    }
+
+    private long getNextTransactionId() {
+        return transactionIdCounter.getAndIncrement();
+    }
+
+    /**
+     * Creates a new LockWorker with the given name and adds it to the managed workers list.
+     *
+     * @param name the name of the worker
+     * @return a new LockWorker instance
+     */
+    public LockWorker createWorker(String name) {
+        LockWorker worker = new LockWorker(name, locks, getNextTransactionId());
+        workers.add(worker);
+        return worker;
+    }
+
+    /**
+     * Closes all managed workers.
+     */
+    public void closeAll() {
+        for (LockWorker worker : workers) {
+            worker.close();
+        }
+        workers.clear();
+    }
+}

--- a/community/lock/src/test/java/org/neo4j/kernel/impl/locking/forseti/LockWorkerState.java
+++ b/community/lock/src/test/java/org/neo4j/kernel/impl/locking/forseti/LockWorkerState.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.impl.locking.forseti;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 import org.neo4j.configuration.Config;
 import org.neo4j.configuration.GraphDatabaseInternalSettings;
 import org.neo4j.kernel.impl.api.LeaseService.NoLeaseClient;
@@ -29,18 +28,17 @@ import org.neo4j.kernel.impl.locking.LockManager;
 import org.neo4j.memory.EmptyMemoryTracker;
 
 class LockWorkerState {
-    private static final AtomicLong TRANSACTION_ID = new AtomicLong();
     final LockManager grabber;
     final LockManager.Client client;
     final List<String> completedOperations = new ArrayList<>();
     String doing;
 
-    LockWorkerState(LockManager locks) {
+    LockWorkerState(LockManager locks, long transactionId) {
         this.grabber = locks;
         this.client = locks.newClient();
         this.client.initialize(
                 NoLeaseClient.INSTANCE,
-                TRANSACTION_ID.getAndIncrement(),
+                transactionId,
                 EmptyMemoryTracker.INSTANCE,
                 Config.defaults(GraphDatabaseInternalSettings.lock_manager_verbose_deadlocks, true));
     }
@@ -52,9 +50,5 @@ class LockWorkerState {
     public void done() {
         this.completedOperations.add(this.doing);
         this.doing = null;
-    }
-
-    public static void resetTransactionIdCounter() {
-        TRANSACTION_ID.set(0);
     }
 }

--- a/community/lock/src/test/java/org/neo4j/kernel/impl/locking/forseti/LockWorkerState.java
+++ b/community/lock/src/test/java/org/neo4j/kernel/impl/locking/forseti/LockWorkerState.java
@@ -53,4 +53,8 @@ class LockWorkerState {
         this.completedOperations.add(this.doing);
         this.doing = null;
     }
+
+    public static void resetTransactionIdCounter() {
+        TRANSACTION_ID.set(0);
+    }
 }

--- a/community/lock/src/test/java/org/neo4j/kernel/impl/locking/forseti/RWLockCompatibility.java
+++ b/community/lock/src/test/java/org/neo4j/kernel/impl/locking/forseti/RWLockCompatibility.java
@@ -170,6 +170,7 @@ abstract class RWLockCompatibility extends LockCompatibilityTestSupport {
     @Test
     void shouldIncludeDeadlockCycleForSimpleUpdateDeadlock() throws Exception {
         // given
+        LockWorkerState.resetTransactionIdCounter();
         var resource = 10L;
         try (var t1 = new LockWorker("T1", locks);
                 var t2 = new LockWorker("T1", locks)) {

--- a/community/lock/src/test/java/org/neo4j/kernel/impl/locking/forseti/RWLockCompatibility.java
+++ b/community/lock/src/test/java/org/neo4j/kernel/impl/locking/forseti/RWLockCompatibility.java
@@ -93,10 +93,11 @@ abstract class RWLockCompatibility extends LockCompatibilityTestSupport {
 
     @Test
     void testMultipleThreads() throws Exception {
-        LockWorker t1 = new LockWorker("T1", locks);
-        LockWorker t2 = new LockWorker("T2", locks);
-        LockWorker t3 = new LockWorker("T3", locks);
-        LockWorker t4 = new LockWorker("T4", locks);
+        LockWorkerManager workerManager = new LockWorkerManager(locks);
+        LockWorker t1 = workerManager.createWorker("T1");
+        LockWorker t2 = workerManager.createWorker("T2");
+        LockWorker t3 = workerManager.createWorker("T3");
+        LockWorker t4 = workerManager.createWorker("T4");
         long r1 = 1L;
         try {
             t1.getReadLock(r1, true);
@@ -160,20 +161,17 @@ abstract class RWLockCompatibility extends LockCompatibilityTestSupport {
             Path file = dumper.dumpState(locks, t1, t2, t3, t4);
             throw new RuntimeException("Failed, forensics information dumped to " + file.toAbsolutePath(), e);
         } finally {
-            t1.close();
-            t2.close();
-            t3.close();
-            t4.close();
+            workerManager.closeAll();
         }
     }
 
     @Test
     void shouldIncludeDeadlockCycleForSimpleUpdateDeadlock() throws Exception {
         // given
-        LockWorkerState.resetTransactionIdCounter();
+        LockWorkerManager workerManager = new LockWorkerManager(locks);
         var resource = 10L;
-        try (var t1 = new LockWorker("T1", locks);
-                var t2 = new LockWorker("T1", locks)) {
+        try (var t1 = workerManager.createWorker("T1");
+                var t2 = workerManager.createWorker("T2")) {
             t1.getReadLock(resource, true);
             t2.getReadLock(resource, true);
             var t1ExclusiveAcquire = t1.getWriteLock(resource, false);
@@ -187,6 +185,8 @@ abstract class RWLockCompatibility extends LockCompatibilityTestSupport {
                     .hasMessageContaining(
                             "NODE(10)-[SHARED_OWNER]->(tx:0)-[WAITING_FOR_EXCLUSIVE]->(NODE(10))-[SHARED_OWNER]->(tx:1)-[WAITING_FOR_EXCLUSIVE]->(NODE(10)");
             t1ExclusiveAcquire.get();
+        } finally {
+            workerManager.closeAll();
         }
     }
 


### PR DESCRIPTION
Fixes the test order dependence in https://github.com/neo4j/neo4j/issues/13701 by resetting the `TRANSACTION_ID` static variable.
