### PR TITLE
Add schema notification for vector indexes created without dimensions

### DIFF
--- a/community/common/PublicApi.txt
+++ b/community/common/PublicApi.txt
@@ -144,6 +144,7 @@ org.neo4j.kernel.api.exceptions.Status.Schema::SchemaRuleEntrySizeLimitError org
 org.neo4j.kernel.api.exceptions.Status.Schema::TokenLengthError org.neo4j.kernel.api.exceptions.Status.Schema public static final
 org.neo4j.kernel.api.exceptions.Status.Schema::TokenLimitReached org.neo4j.kernel.api.exceptions.Status.Schema public static final
 org.neo4j.kernel.api.exceptions.Status.Schema::TokenNameError org.neo4j.kernel.api.exceptions.Status.Schema public static final
+org.neo4j.kernel.api.exceptions.Status.Schema::VectorIndexDimensionsNotSpecified org.neo4j.kernel.api.exceptions.Status.Schema public static final
 org.neo4j.kernel.api.exceptions.Status.Schema::code() org.neo4j.kernel.api.exceptions.Status.Code public
 org.neo4j.kernel.api.exceptions.Status.Schema::valueOf(java.lang.String) org.neo4j.kernel.api.exceptions.Status.Schema public static
 org.neo4j.kernel.api.exceptions.Status.Schema::values() org.neo4j.kernel.api.exceptions.Status.Schema[] public static

--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -467,6 +467,11 @@ public interface Status {
                 ClientNotification, "`%s` has no effect.", SeverityLevel.INFORMATION, NotificationCategory.SCHEMA),
         IndexOrConstraintDoesNotExist(
                 ClientNotification, "`%s` has no effect.", SeverityLevel.INFORMATION, NotificationCategory.SCHEMA),
+        VectorIndexDimensionsNotSpecified(
+                ClientNotification,
+                "Vector index created without configured dimensions.",
+                SeverityLevel.INFORMATION,
+                NotificationCategory.SCHEMA),
 
         // database errors
         ConstraintCreationFailed(DatabaseError, "Creating a requested constraint failed."),

--- a/community/community-it/cypher-it/src/test/scala/org/neo4j/cypher/CommunityIndexAndConstraintCommandAcceptanceTest.scala
+++ b/community/community-it/cypher-it/src/test/scala/org/neo4j/cypher/CommunityIndexAndConstraintCommandAcceptanceTest.scala
@@ -38,6 +38,7 @@ import org.neo4j.graphdb.schema.IndexSettingImpl.VECTOR_DIMENSIONS
 import org.neo4j.graphdb.schema.IndexSettingImpl.VECTOR_SIMILARITY_FUNCTION
 import org.neo4j.graphdb.schema.IndexType
 import org.neo4j.internal.schema.AllIndexProviderDescriptors
+import org.neo4j.kernel.api.exceptions.Status
 import org.neo4j.kernel.impl.api.index.IndexingService
 
 import scala.jdk.CollectionConverters.IterableHasAsScala
@@ -158,6 +159,44 @@ class CommunityIndexAndConstraintCommandAcceptanceTest extends ExecutionEngineFu
 
     graph.indexExists(indexName) should be(true)
     graph.getIndexTypeByName(indexName) should be(IndexType.VECTOR)
+  }
+
+  test("Create node vector index without dimensions should warn") {
+    // WHEN
+    val result = execute(
+      s"CREATE VECTOR INDEX $indexName FOR (n:$label) ON n.$prop OPTIONS {indexConfig: $$map}",
+      Map("map" -> anyMap(
+        VECTOR_SIMILARITY_FUNCTION.getSettingName -> "COSINE"
+      ))
+    )
+
+    // THEN
+    result.queryStatistics() should be(QueryStatistics(indexesAdded = 1))
+
+    graph.indexExists(indexName) should be(true)
+    graph.getIndexTypeByName(indexName) should be(IndexType.VECTOR)
+    result.notifications.map(_.getCode) should contain(
+      Status.Schema.VectorIndexDimensionsNotSpecified.code.serialize()
+    )
+  }
+
+  test("Create node vector index with dimensions should not warn") {
+    // WHEN
+    val result = execute(
+      s"CREATE VECTOR INDEX $indexName FOR (n:$label) ON n.$prop OPTIONS {indexConfig: $$map}",
+      Map("map" -> anyMap(
+        VECTOR_DIMENSIONS.getSettingName -> 50,
+        VECTOR_SIMILARITY_FUNCTION.getSettingName -> "COSINE"
+      ))
+    )
+
+    // THEN
+    result.queryStatistics() should be(QueryStatistics(indexesAdded = 1))
+
+    graph.indexExists(indexName) should be(true)
+    graph.getIndexTypeByName(indexName) should be(IndexType.VECTOR)
+    result.notifications.map(_.getCode) should not contain
+      Status.Schema.VectorIndexDimensionsNotSpecified.code.serialize()
   }
 
   test("Create relationship vector index") {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/index/IndexCommandPlanner.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/index/IndexCommandPlanner.scala
@@ -40,6 +40,7 @@ import org.neo4j.cypher.internal.expressions.functions.Type
 import org.neo4j.cypher.internal.notification.IndexOrConstraintAlreadyExistsNotification
 import org.neo4j.cypher.internal.notification.IndexOrConstraintDoesNotExistNotification
 import org.neo4j.cypher.internal.notification.InternalNotification
+import org.neo4j.cypher.internal.notification.VectorIndexDimensionsNotSpecifiedNotification
 import org.neo4j.cypher.internal.optionsmap.CreateFulltextIndexOptionsConverter
 import org.neo4j.cypher.internal.optionsmap.CreateIndexProviderOnlyOptions
 import org.neo4j.cypher.internal.optionsmap.CreateIndexWithFullOptions
@@ -62,6 +63,7 @@ import org.neo4j.cypher.internal.procs.SuccessResult
 import org.neo4j.cypher.internal.runtime.IndexInformation
 import org.neo4j.cypher.internal.runtime.QueryContext
 import org.neo4j.exceptions.InternalException
+import org.neo4j.graphdb.schema.IndexSettingImpl.VECTOR_DIMENSIONS
 import org.neo4j.graphdb.schema.IndexType
 import org.neo4j.graphdb.schema.IndexType.POINT
 import org.neo4j.graphdb.schema.IndexType.RANGE
@@ -213,6 +215,14 @@ object IndexCommandPlanner {
       val (entityIds, entityType) = getMultipleEntityInfo(entityNames, ctx)
       val propertyKeyIds = props.map(p => propertyToId(ctx)(p).id)
       val additionalPropertyKeyIds = additionalProps.map(p => propertyToId(ctx)(p).id)
+      val finalNotifications =
+        if (indexConfig.get(VECTOR_DIMENSIONS.getSettingName) == null) {
+          notifications + VectorIndexDimensionsNotSpecifiedNotification(
+            createVectorIndexInfo(indexName, entityNames, props, additionalProps, options)
+          )
+        } else {
+          notifications
+        }
       ctx.addVectorIndexRule(
         entityIds,
         entityType,
@@ -222,7 +232,7 @@ object IndexCommandPlanner {
         indexProvider,
         indexConfig
       )
-      SuccessResult(notifications)
+      SuccessResult(finalNotifications)
     }
 
   // Drop methods
@@ -523,6 +533,28 @@ object IndexCommandPlanner {
     val additionalPropertiesString =
       if (additionalProperties.nonEmpty) getPrettyPropertyPattern(additionalProperties, " WITH [", "]") else pretty""
     pretty"VECTOR INDEX$name IF NOT EXISTS FOR $pattern ON $propertyString$additionalPropertiesString${prettyOptions(options)}".prettifiedString
+  }
+
+  private def createVectorIndexInfo(
+    nameOption: Option[String],
+    entityNames: Either[List[LabelName], List[RelTypeName]],
+    properties: Seq[PropertyKeyName],
+    additionalProperties: Seq[PropertyKeyName],
+    options: Options
+  ): String = {
+    val name = getPrettyName(nameOption)
+    val pattern = entityNames match {
+      case Left(labels) =>
+        val innerPattern = labels.map(l => asPrettyString(l.name)).mkPrettyString("e:", "|", "")
+        pretty"($innerPattern)"
+      case Right(relTypes) =>
+        val innerPattern = relTypes.map(r => asPrettyString(r.name)).mkPrettyString("e:", "|", "")
+        pretty"()-[$innerPattern]-()"
+    }
+    val propertyString = getPrettyPropertyPattern(properties, "(", ")")
+    val additionalPropertiesString =
+      if (additionalProperties.nonEmpty) getPrettyPropertyPattern(additionalProperties, " WITH [", "]") else pretty""
+    pretty"CREATE VECTOR INDEX$name FOR $pattern ON $propertyString$additionalPropertiesString${prettyOptions(options)}".prettifiedString
   }
 
   private def lookupIndexInfo(

--- a/community/cypher/front-end/frontend/src/main/scala/org/neo4j/cypher/internal/frontend/notification/NotificationWrapping.scala
+++ b/community/cypher/front-end/frontend/src/main/scala/org/neo4j/cypher/internal/frontend/notification/NotificationWrapping.scala
@@ -93,6 +93,7 @@ import org.neo4j.cypher.internal.notification.ShardedPerformanceNotification
 import org.neo4j.cypher.internal.notification.SubqueryVariableShadowing
 import org.neo4j.cypher.internal.notification.UnboundedShortestPathNotification
 import org.neo4j.cypher.internal.notification.UnsatisfiableRelationshipTypeExpression
+import org.neo4j.cypher.internal.notification.VectorIndexDimensionsNotSpecifiedNotification
 import org.neo4j.cypher.internal.notification.WaitServerCatchingUp
 import org.neo4j.cypher.internal.notification.WaitServerCaughtUp
 import org.neo4j.cypher.internal.notification.WaitServerFailed
@@ -505,6 +506,12 @@ object NotificationWrapping {
         graphdb.InputPosition.empty,
         command,
         name
+      )
+
+    case VectorIndexDimensionsNotSpecifiedNotification(command) =>
+      NotificationCodeWithDescription.vectorIndexDimensionsNotSpecified(
+        graphdb.InputPosition.empty,
+        command
       )
 
     case ImpossibleRevokeCommandWarning(command, cause) =>

--- a/community/cypher/internal-notifications/src/main/scala/org/neo4j/cypher/internal/notification/InternalNotification.scala
+++ b/community/cypher/internal-notifications/src/main/scala/org/neo4j/cypher/internal/notification/InternalNotification.scala
@@ -96,6 +96,7 @@ object InternalNotifications {
     "RequestedTopologyMatchedCurrentTopology",
     "IndexOrConstraintAlreadyExistsNotification",
     "IndexOrConstraintDoesNotExistNotification",
+    "VectorIndexDimensionsNotSpecifiedNotification",
     "DeprecatedFunctionFieldNotification",
     "DeprecatedProcedureFieldNotification",
     "AuthProviderNotDefined",
@@ -232,6 +233,7 @@ case class RequestedTopologyMatchedCurrentTopology() extends InternalNotificatio
 case class IndexOrConstraintAlreadyExistsNotification(command: String, conflicting: String)
     extends InternalNotification
 case class IndexOrConstraintDoesNotExistNotification(command: String, name: String) extends InternalNotification
+case class VectorIndexDimensionsNotSpecifiedNotification(command: String) extends InternalNotification
 case object AggregationSkippedNull extends InternalNotification
 
 case object DeprecatedBooleanCoercion extends InternalNotification {

--- a/community/neo4j-gql-status/src/main/java/org/neo4j/gqlstatus/GqlStatusInfoCodes.java
+++ b/community/neo4j-gql-status/src/main/java/org/neo4j/gqlstatus/GqlStatusInfoCodes.java
@@ -147,6 +147,14 @@ public enum GqlStatusInfoCodes implements GqlStatusInfo {
             Condition.SUCCESSFUL_COMPLETION,
             "index or constraint does not exist",
             NotificationClassification.SCHEMA),
+    STATUS_00NA2(
+            new GqlStatus("00NA2"),
+            "The vector index was created without `vector.dimensions`. This is allowed, but providing dimensions when creating a vector index is recommended, as it ensures that only vectors of that size are indexed and makes dimension mismatches fail clearly at query time. For example, set `OPTIONS { indexConfig: { `vector.dimensions`: 1536 } }` when creating the index.",
+            new GqlParams.GqlParam[] {GqlParams.StringParam.cmd},
+            emptyMap(),
+            Condition.SUCCESSFUL_COMPLETION,
+            "vector index dimensions not specified",
+            NotificationClassification.SCHEMA),
     STATUS_01000(
             new GqlStatus("01000"),
             "",

--- a/community/neo4j-gql-status/src/main/java/org/neo4j/gqlstatus/GqlStatusInfoCodes.java
+++ b/community/neo4j-gql-status/src/main/java/org/neo4j/gqlstatus/GqlStatusInfoCodes.java
@@ -150,7 +150,7 @@ public enum GqlStatusInfoCodes implements GqlStatusInfo {
     STATUS_00NA2(
             new GqlStatus("00NA2"),
             "The vector index was created without `vector.dimensions`. This is allowed, but providing dimensions when creating a vector index is recommended, as it ensures that only vectors of that size are indexed and makes dimension mismatches fail clearly at query time. For example, set `OPTIONS { indexConfig: { `vector.dimensions`: 1536 } }` when creating the index.",
-            new GqlParams.GqlParam[] {GqlParams.StringParam.cmd},
+            new GqlParams.GqlParam[] {},
             emptyMap(),
             Condition.SUCCESSFUL_COMPLETION,
             "vector index dimensions not specified",

--- a/community/neo4j-notifications/src/main/java/org/neo4j/notifications/NotificationCodeWithDescription.java
+++ b/community/neo4j-notifications/src/main/java/org/neo4j/notifications/NotificationCodeWithDescription.java
@@ -379,6 +379,11 @@ public enum NotificationCodeWithDescription {
     INDEX_OR_CONSTRAINT_DOES_NOT_EXIST(
             Status.Schema.IndexOrConstraintDoesNotExist, GqlStatusInfoCodes.STATUS_00NA1, "`%s` does not exist."),
 
+    VECTOR_INDEX_DIMENSIONS_NOT_SPECIFIED(
+            Status.Schema.VectorIndexDimensionsNotSpecified,
+            GqlStatusInfoCodes.STATUS_00NA2,
+            "The vector index was created without `vector.dimensions`. This is allowed, but providing dimensions when creating a vector index is recommended, as it ensures that only vectors of that size are indexed and makes dimension mismatches fail clearly at query time. For example, set `OPTIONS { indexConfig: { `vector.dimensions`: 1536 } }` when creating the index."),
+
     AGGREGATION_SKIPPED_NULL(
             Status.Statement.AggregationSkippedNull,
             GqlStatusInfoCodes.STATUS_01G11,
@@ -943,6 +948,11 @@ public enum NotificationCodeWithDescription {
             InputPosition position, String titleParam, String descriptionParam) {
         return INDEX_OR_CONSTRAINT_DOES_NOT_EXIST.notificationWithTitleAndDescriptionDetails(
                 position, titleParam, new String[] {descriptionParam}, new String[] {titleParam, descriptionParam});
+    }
+
+    public static NotificationImplementation vectorIndexDimensionsNotSpecified(InputPosition position, String command) {
+        return VECTOR_INDEX_DIMENSIONS_NOT_SPECIFIED.notificationWithParameters(
+                position, new String[] {}, new String[] {command});
     }
 
     public static NotificationImplementation deprecatedOptionInOptionMap(String oldOption, String newOption) {

--- a/community/neo4j-notifications/src/main/java/org/neo4j/notifications/NotificationCodeWithDescription.java
+++ b/community/neo4j-notifications/src/main/java/org/neo4j/notifications/NotificationCodeWithDescription.java
@@ -951,8 +951,7 @@ public enum NotificationCodeWithDescription {
     }
 
     public static NotificationImplementation vectorIndexDimensionsNotSpecified(InputPosition position, String command) {
-        return VECTOR_INDEX_DIMENSIONS_NOT_SPECIFIED.notificationWithParameters(
-                position, new String[] {}, new String[] {command});
+        return VECTOR_INDEX_DIMENSIONS_NOT_SPECIFIED.notification(position);
     }
 
     public static NotificationImplementation deprecatedOptionInOptionMap(String oldOption, String newOption) {

--- a/community/neo4j-notifications/src/test/java/org/neo4j/notifications/NotificationCodeWithDescriptionTest.java
+++ b/community/neo4j-notifications/src/test/java/org/neo4j/notifications/NotificationCodeWithDescriptionTest.java
@@ -2355,8 +2355,8 @@ class NotificationCodeWithDescriptionTest {
         byte[] notificationHash = DigestUtils.sha256(notificationBuilder.toString());
 
         byte[] expectedHash = new byte[] {
-            18, -121, 52, -126, -81, -21, -85, 82, 116, 16, 71, -42, -55, 101, 51, 72, 52, -55, 38, -16, 126, -109,
-            -10, 59, -14, -26, -39, 99, 1, -92, 0, -10
+            18, -121, 52, -126, -81, -21, -85, 82, 116, 16, 71, -42, -55, 101, 51, 72, 52, -55, 38, -16, 126, -109, -10,
+            59, -14, -26, -39, 99, 1, -92, 0, -10
         };
 
         if (!Arrays.equals(notificationHash, expectedHash)) {

--- a/community/neo4j-notifications/src/test/java/org/neo4j/notifications/NotificationCodeWithDescriptionTest.java
+++ b/community/neo4j-notifications/src/test/java/org/neo4j/notifications/NotificationCodeWithDescriptionTest.java
@@ -97,6 +97,7 @@ import static org.neo4j.notifications.NotificationCodeWithDescription.shadowingI
 import static org.neo4j.notifications.NotificationCodeWithDescription.subqueryVariableShadowing;
 import static org.neo4j.notifications.NotificationCodeWithDescription.unboundedShortestPath;
 import static org.neo4j.notifications.NotificationCodeWithDescription.unsatisfiableRelationshipTypeExpression;
+import static org.neo4j.notifications.NotificationCodeWithDescription.vectorIndexDimensionsNotSpecified;
 import static org.neo4j.notifications.NotificationCodeWithDescription.waitServerCatchingUp;
 import static org.neo4j.notifications.NotificationCodeWithDescription.waitServerCaughtUp;
 import static org.neo4j.notifications.NotificationCodeWithDescription.waitServerFailed;
@@ -1899,6 +1900,37 @@ class NotificationCodeWithDescriptionTest {
     }
 
     @Test
+    void shouldConstructNotificationsFor_VECTOR_INDEX_DIMENSIONS_NOT_SPECIFIED() {
+        NotificationImplementation notification = vectorIndexDimensionsNotSpecified(InputPosition.empty, """
+                CREATE VECTOR INDEX my_index
+                FOR (n:MyLabel) ON (n.embedding)
+                OPTIONS {
+                  indexConfig: {
+                    `vector.similarity_function`: 'cosine'
+                  }
+                }""");
+
+        verifyNotification(
+                notification,
+                "Vector index created without configured dimensions.",
+                SeverityLevel.INFORMATION,
+                "Neo.ClientNotification.Schema.VectorIndexDimensionsNotSpecified",
+                "The vector index was created without `vector.dimensions`. This is allowed, but providing dimensions when creating a vector index is recommended, as it ensures that only vectors of that size are indexed and makes dimension mismatches fail clearly at query time. For example, set `OPTIONS { indexConfig: { `vector.dimensions`: 1536 } }` when creating the index.",
+                NotificationCategory.SCHEMA,
+                NotificationClassification.SCHEMA,
+                "00NA2",
+                new DiagnosticRecord(info, NotificationClassification.SCHEMA, -1, -1, -1, Map.of("cmd", """
+                                        CREATE VECTOR INDEX my_index
+                                        FOR (n:MyLabel) ON (n.embedding)
+                                        OPTIONS {
+                                          indexConfig: {
+                                            `vector.similarity_function`: 'cosine'
+                                          }
+                                        }""")).asMap(),
+                "note: successful completion - vector index dimensions not specified. The vector index was created without `vector.dimensions`. This is allowed, but providing dimensions when creating a vector index is recommended, as it ensures that only vectors of that size are indexed and makes dimension mismatches fail clearly at query time. For example, set `OPTIONS { indexConfig: { `vector.dimensions`: 1536 } }` when creating the index.");
+    }
+
+    @Test
     void shouldConstructNotificationsFor_INDEX_OR_CONSTRAINT_DOES_NOT_EXIST() {
         NotificationImplementation notification =
                 indexOrConstraintDoesNotExist(InputPosition.empty, "DROP INDEX foo IF EXISTS", "foo");
@@ -2323,8 +2355,8 @@ class NotificationCodeWithDescriptionTest {
         byte[] notificationHash = DigestUtils.sha256(notificationBuilder.toString());
 
         byte[] expectedHash = new byte[] {
-            71, -79, 73, -117, -85, 37, -7, -32, 111, 53, 44, 23, 13, 19, 113, -65, -73, 39, -88, -7, 73, 122, 82, 119,
-            28, 86, 7, -100, 8, 99, -29, 124
+            18, -121, 52, -126, -81, -21, -85, 82, 116, 16, 71, -42, -55, 101, 51, 72, 52, -55, 38, -16, 126, -109,
+            -10, 59, -14, -26, -39, 99, 1, -92, 0, -10
         };
 
         if (!Arrays.equals(notificationHash, expectedHash)) {


### PR DESCRIPTION
This change adds a new informational schema notification for CREATE VECTOR INDEX when the index is created without vector.dimensions.

Behavior:

- index creation still succeeds
- the index is created as requested
- Neo4j returns GQLSTATUS 00NA2
- Neo4j returns Neo.ClientNotification.Schema.VectorIndexDimensionsNotSpecified

The goal is to keep the operation valid while warning that omitting vector.dimensions removes an important validation point. The notification recommends providing dimensions because that constrains indexed vectors to a single size and makes dimension mismatches fail clearly at query time.

Implementation:

- adds the new public notification/status metadata
- emits the notification from the vector index creation path when vector.dimensions is not configured
- adds contract-level notification coverage
- adds execution-path acceptance coverage for:
    - warning present when vector.dimensions is omitted
    - warning absent when vector.dimensions is provided
