### PR TITLE
Return null from temporal truncate with null input

### DIFF
--- a/community/procedure/src/main/java/org/neo4j/procedure/impl/temporal/TemporalFunction.java
+++ b/community/procedure/src/main/java/org/neo4j/procedure/impl/temporal/TemporalFunction.java
@@ -266,15 +266,19 @@ public abstract class TemporalFunction<T extends AnyValue> implements CallableUs
         }
 
         @Override
-        public T apply(Context ctx, AnyValue[] args) throws ProcedureException {
+        public AnyValue apply(Context ctx, AnyValue[] args) throws ProcedureException {
             if (args != null && args.length >= 1 && args.length <= 3) {
                 AnyValue unit = args[0];
 
-                AnyValue input = args.length < 2 || args[1].equals(DEFAULT_TEMPORAL_ARGUMENT_VALUE)
+                AnyValue input = args.length < 2 || DEFAULT_TEMPORAL_ARGUMENT_VALUE.equals(args[1])
                         ? function.apply(ctx, new AnyValue[] {DEFAULT_TEMPORAL_ARGUMENT_VALUE})
                         : args[1];
 
-                AnyValue fields = args.length < 3 || args[2] == NO_VALUE ? EMPTY_MAP : args[2];
+                if (input == NO_VALUE || input == null) {
+                    return NO_VALUE;
+                }
+
+                AnyValue fields = args.length < 3 || args[2] == NO_VALUE || args[2] == null ? EMPTY_MAP : args[2];
                 if (unit instanceof TextValue && input instanceof TemporalValue && fields instanceof MapValue) {
                     return function.truncate(
                             unit(((TextValue) unit).stringValue()),

--- a/community/procedure/src/test/java/org/neo4j/procedure/impl/temporal/TemporalFunctionTest.java
+++ b/community/procedure/src/test/java/org/neo4j/procedure/impl/temporal/TemporalFunctionTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.neo4j.procedure.impl.temporal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.neo4j.kernel.api.procedure.BasicContext.buildContext;
+import static org.neo4j.values.storable.Values.NO_VALUE;
+import static org.neo4j.values.storable.Values.stringValue;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.neo4j.collection.Dependencies;
+import org.neo4j.internal.kernel.api.exceptions.ProcedureException;
+import org.neo4j.internal.kernel.api.procs.QualifiedName;
+import org.neo4j.kernel.api.QueryLanguage;
+import org.neo4j.kernel.api.procedure.Context;
+import org.neo4j.kernel.impl.coreapi.InternalTransaction;
+import org.neo4j.kernel.impl.util.DefaultValueMapper;
+import org.neo4j.procedure.impl.GlobalProceduresRegistry;
+import org.neo4j.procedure.impl.ProcedureConfig;
+import org.neo4j.values.AnyValue;
+
+class TemporalFunctionTest {
+    @ParameterizedTest
+    @MethodSource("truncateFunctions")
+    void truncateShouldReturnNoValueForNoValueInput(QualifiedName functionName, String unit) throws ProcedureException {
+        assertThat(callFunction(functionName, stringValue(unit), NO_VALUE, NO_VALUE))
+                .isEqualTo(NO_VALUE);
+    }
+
+    @ParameterizedTest
+    @MethodSource("truncateFunctions")
+    void truncateShouldReturnNoValueForNullInput(QualifiedName functionName, String unit) throws ProcedureException {
+        assertThat(callFunction(functionName, stringValue(unit), null, NO_VALUE))
+                .isEqualTo(NO_VALUE);
+    }
+
+    private static Stream<Arguments> truncateFunctions() {
+        return Stream.of(
+                Arguments.of(new QualifiedName("date", "truncate"), "day"),
+                Arguments.of(new QualifiedName("datetime", "truncate"), "minute"),
+                Arguments.of(new QualifiedName("localdatetime", "truncate"), "minute"),
+                Arguments.of(new QualifiedName("localtime", "truncate"), "minute"),
+                Arguments.of(new QualifiedName("time", "truncate"), "minute"));
+    }
+
+    private static AnyValue callFunction(QualifiedName name, AnyValue... arguments) throws ProcedureException {
+        var procedures = new GlobalProceduresRegistry();
+        TemporalFunction.registerTemporalFunctions(procedures, ProcedureConfig.DEFAULT);
+
+        var view = procedures.getCurrentView();
+        var functionId = view.function(name, QueryLanguage.CYPHER_5).id();
+        return view.callFunction(context(), functionId, arguments);
+    }
+
+    private static Context context() {
+        return buildContext(new Dependencies(), new DefaultValueMapper(mock(InternalTransaction.class)))
+                .context();
+    }
+}


### PR DESCRIPTION
### Summary
- Return `NO_VALUE` from temporal truncate functions when the temporal input is null/NO_VALUE instead of falling through to invalid signature handling.
- Keep default temporal argument handling null-safe.
- Add focused coverage for all temporal truncate variants.

Fixes #13043

### Tests
- `MAVEN_OPTS="-Xmx2048m" mvn -pl community/procedure spotless:apply`
- `MAVEN_OPTS="-Xmx2048m" mvn -pl community/procedure -Dtest=TemporalFunctionTest test`