### PR TITLE
perf(bolt): coalesce per-statement response flush to once per drained batch

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/protocol/common/connector/connection/AtomicSchedulingConnection.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/protocol/common/connector/connection/AtomicSchedulingConnection.java
@@ -267,6 +267,10 @@ public class AtomicSchedulingConnection extends AbstractConnection {
                     this.executeJob(fsm, it.next());
                 }
 
+                // Flush the batch's buffered responses in a single operation. Responses are now written without
+                // a per-statement flush (see NetworkResponseHandler#onSuccess), so this coalesces the flush over
+                // the whole drained batch instead of paying one flush + blocking sync per statement.
+                this.flush();
             } else {
                 // if there are no jobs, we'll terminate unless there are open transactions or statements remaining
                 // which require us to remain on this thread
@@ -311,6 +315,8 @@ public class AtomicSchedulingConnection extends AbstractConnection {
 
                 if (job != null) {
                     this.executeJob(fsm, job);
+                    // Flush the single job's buffered response before we loop back to wait for more work.
+                    this.flush();
                 } else {
                     // If no job was found in timeout period, check the fsm is still valid,
                     if (!fsm.validate() || !this.connector().configuration().enableTransactionThreadBinding()) {

--- a/community/bolt/src/main/java/org/neo4j/bolt/protocol/common/fsm/response/NetworkResponseHandler.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/protocol/common/fsm/response/NetworkResponseHandler.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.bolt.protocol.common.fsm.response;
 
+import io.netty.channel.ChannelFutureListener;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -149,13 +150,13 @@ public final class NetworkResponseHandler extends AbstractMetadataAwareResponseH
             metadata = MapValue.EMPTY;
         }
 
-        try {
-            this.connection.writeAndFlush(new SuccessMessage(metadata)).sync();
-
-            this.connection.notifyListenersSafely(
-                    "requestResultSuccess", listener -> listener.onResponseSuccess(metadata));
-        } catch (Throwable ex) {
-            throw new BoltStreamingWriteException("Failed to transmit operation result: Response write failure", ex);
-        }
+        // Buffer the SUCCESS response rather than flushing (and blocking on) it per statement: the scheduling
+        // loop flushes once it has drained the pending jobs (see AtomicSchedulingConnection#doExecuteJobs),
+        // coalescing flushes for batched/pipelined clients and avoiding a blocking sync on the bolt worker
+        // thread. Write failures are surfaced asynchronously through the pipeline, matching the record path.
+        this.connection
+                .write(new SuccessMessage(metadata))
+                .addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+        this.connection.notifyListenersSafely("requestResultSuccess", listener -> listener.onResponseSuccess(metadata));
     }
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/protocol/common/fsm/response/NetworkResponseHandlerTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/protocol/common/fsm/response/NetworkResponseHandlerTest.java
@@ -93,6 +93,8 @@ class NetworkResponseHandlerTest {
         handler.onMetadata("baz", Values.stringValue("foo"));
 
         handler.onSuccess();
+        // onSuccess now buffers the response; the scheduling loop flushes once the batch drains
+        this.connection.flush();
 
         var response = this.channel.<SuccessMessage>readOutbound();
 
@@ -110,6 +112,8 @@ class NetworkResponseHandlerTest {
         var handler = new NetworkResponseHandler(this.connection, this.metadataHandler, null, this.logService);
 
         handler.onSuccess();
+        // onSuccess now buffers the response; the scheduling loop flushes once the batch drains
+        this.connection.flush();
 
         var response = this.channel.<SuccessMessage>readOutbound();
 


### PR DESCRIPTION
NetworkResponseHandler.onSuccess wrote each SUCCESS message with a blocking writeAndFlush().sync() per statement. For batched, non-UNWIND write workloads this forces one flush and one blocking sync per statement through the full outbound pipeline (including TrafficAccountantHandler), which dominates the server's on-CPU cost for such clients and regresses throughput relative to 4.x. This was a part of the regression we faced in our workloads after upgrading.

Buffer the SUCCESS write instead via connection.write(...).addListener( FIRE_EXCEPTION_ON_FAILURE)--the same pattern the record path already uses--and flush once after the scheduling loop drains its pending jobs in AtomicSchedulingConnection.doExecuteJobs (both the batched and single-job paths). This restores the 4.x "flush once per drained queue" behaviour and coalesces flushes for batched and pipelined clients. Write failures are surfaced asynchronously through the pipeline rather than by a blocking sync.

Measured ~20-30% higher throughput on batched read and write workloads. The per-statement overhead drops even for single synchronous statements, since the removed cost is the blocking sync rather than the flush count.