### PR TITLE
perf(cypher): push existential semi-/anti-apply above a grouping aggregation

### DIFF
--- a/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/plans/rewriter/LogicalPlanRewriter.scala
+++ b/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/plans/rewriter/LogicalPlanRewriter.scala
@@ -126,6 +126,13 @@ case object PlanRewriter extends LogicalPlanRewriter with StepSequencer.Step wit
         cardinalities,
         otherAttributes.withAlso(effectiveCardinalities, labelAndRelTypeInfos, providedOrders)
       )),
+      Some(pushSemiApplyAboveAggregation(
+        context.planContext,
+        solveds,
+        cardinalities,
+        providedOrders,
+        otherAttributes.withAlso(effectiveCardinalities, labelAndRelTypeInfos)
+      )),
       Some(removeIdenticalPlans(otherAttributes.withAlso(
         cardinalities,
         effectiveCardinalities,

--- a/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/plans/rewriter/pushSemiApplyAboveAggregation.scala
+++ b/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/plans/rewriter/pushSemiApplyAboveAggregation.scala
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.planner.logical.plans.rewriter
+
+import org.neo4j.cypher.internal.expressions.Expression
+import org.neo4j.cypher.internal.expressions.LogicalVariable
+import org.neo4j.cypher.internal.expressions.Property
+import org.neo4j.cypher.internal.ir.QueryGraph
+import org.neo4j.cypher.internal.ir.SinglePlannerQuery
+import org.neo4j.cypher.internal.logical.plans.AbstractSemiApply
+import org.neo4j.cypher.internal.logical.plans.AggregatingPlan
+import org.neo4j.cypher.internal.logical.plans.Aggregation
+import org.neo4j.cypher.internal.logical.plans.LogicalPlan
+import org.neo4j.cypher.internal.logical.plans.OrderedAggregation
+import org.neo4j.cypher.internal.planner.spi.PlanContext
+import org.neo4j.cypher.internal.planner.spi.PlanningAttributes.Cardinalities
+import org.neo4j.cypher.internal.planner.spi.PlanningAttributes.ProvidedOrders
+import org.neo4j.cypher.internal.planner.spi.PlanningAttributes.Solveds
+import org.neo4j.cypher.internal.util.Rewriter
+import org.neo4j.cypher.internal.util.Rewriter.BottomUpMergeableRewriter
+import org.neo4j.cypher.internal.util.attribution.Attributes
+import org.neo4j.cypher.internal.util.bottomUp
+
+/**
+ * Pushes a `SemiApply` / `AntiSemiApply` above a grouping aggregation when the apply's
+ * right-hand side depends only on variables the aggregation groups by.
+ *
+ * {{{
+ *   Aggregation(group = G, agg = A)            (Anti)SemiApply
+ *   |                                =>        | \
+ *   (Anti)SemiApply(L, R)                      |  R
+ *   | \                                        Aggregation(group = G', agg = A)
+ *   L  R                                       |
+ *                                              L
+ * }}}
+ *
+ * An existential subquery `R` whose dependencies are all grouping keys produces a constant result
+ * within each group, so it filters whole groups rather than individual rows. The aggregation
+ * deduplicates its input on the grouping keys, so evaluating `R` above the aggregation runs it once
+ * per group instead of once per (far more numerous) pre-aggregation row. A group is either wholly
+ * kept or wholly dropped, so per-group aggregates are unchanged and the rewrite is result-preserving.
+ *
+ * This is the bottleneck in LDBC BI Q18 ("friend recommendation"): the
+ * `NOT EXISTS { (p1)-[:KNOWS]-(p2) }` anti-join is planned below the `count(DISTINCT mid)`
+ * aggregation and re-evaluated once per `(p1, mid, p2)` triple (~440K) instead of once per distinct
+ * `(p1, p2)` pair (~65K) — a 7-8x db-hit reduction when pushed above.
+ *
+ * Both [[Aggregation]] and [[OrderedAggregation]] are handled. A `SemiApply`/`AntiSemiApply`
+ * preserves the order of its left-hand side, so the order an `OrderedAggregation` leverages is the
+ * same whether it sits above or below the apply; the leveraged order is carried over unchanged.
+ *
+ * == Functional dependency ==
+ * Q18 groups by `p1.id, p2.id` (from `RETURN p1.id, ...`), while `R` reads the `p1`, `p2` nodes.
+ * Those nodes are not grouping keys directly, but they are functionally determined by the grouping
+ * when `id` carries a node-key constraint (or a uniqueness constraint together with an existence
+ * constraint): `p1.id` then uniquely identifies `p1`. In that case the node variables are added to
+ * the grouping — a no-op on the groups under the constraint — so they survive the aggregation and
+ * `R` can run above it.
+ *
+ * Existence is required as well as uniqueness: a uniqueness constraint alone permits multiple NULLs,
+ * so for null-valued nodes `p1.id` would not determine `p1`, and adding `p1` to the grouping could
+ * split a NULL group and change the per-group aggregates. Requiring existence rules that out.
+ *
+ * == Cost guard ==
+ * Pushing the apply above the aggregation never increases db-hits — the left-hand side is unchanged
+ * and the existential subquery is evaluated once per group instead of once per (more numerous) row.
+ * But when there is little fan-out (groups ≈ rows) it saves nothing, and it would make the aggregation
+ * buffer state for groups the existential later drops — wasteful for a memory-heavy aggregate. So the
+ * rewrite only fires when each group averages at least [[pushSemiApplyAboveAggregation.MinFanOut]]
+ * rows, estimated as `card(semiApply) / card(aggregation)`.
+ */
+object pushSemiApplyAboveAggregation {
+
+  /**
+   * Minimum estimated rows-per-group (filtered rows / groups) for the rewrite to be worthwhile: the
+   * existential subquery must run at least this many times less often above the aggregation than below.
+   */
+  private val MinFanOut = 2.0
+}
+
+case class pushSemiApplyAboveAggregation(
+  planContext: PlanContext,
+  solveds: Solveds,
+  cardinalities: Cardinalities,
+  providedOrders: ProvidedOrders,
+  attributes: Attributes[LogicalPlan]
+) extends Rewriter with BottomUpMergeableRewriter {
+
+  override def apply(input: AnyRef): AnyRef = instance.apply(input)
+
+  import pushSemiApplyAboveAggregation.MinFanOut
+
+  override val innerRewriter: Rewriter = Rewriter.lift {
+    case agg @ Aggregation(semiApply: AbstractSemiApply, groupingExpressions, aggregationExpressions) =>
+      pushAbove(
+        agg,
+        semiApply,
+        groupingExpressions,
+        newGrouping =>
+          Aggregation(semiApply.left, newGrouping, aggregationExpressions)(attributes.copy(agg.id))
+      )
+
+    case agg @ OrderedAggregation(semiApply: AbstractSemiApply, groupingExpressions, aggregationExpressions, order) =>
+      pushAbove(
+        agg,
+        semiApply,
+        groupingExpressions,
+        newGrouping =>
+          OrderedAggregation(semiApply.left, newGrouping, aggregationExpressions, order)(attributes.copy(agg.id))
+      )
+  }
+
+  /**
+   * If the apply's RHS depends only on the grouping (possibly via a functional dependency), rebuild
+   * the aggregation below the apply — consuming the apply's LHS, with the grouping augmented to
+   * expose the RHS dependencies — and lift the apply above it. `buildAggregation` reconstructs the
+   * concrete aggregation plan (plain or ordered) with the augmented grouping. Otherwise return the
+   * aggregation unchanged.
+   */
+  private def pushAbove(
+    agg: AggregatingPlan,
+    semiApply: AbstractSemiApply,
+    groupingExpressions: Map[LogicalVariable, Expression],
+    buildAggregation: Map[LogicalVariable, Expression] => LogicalPlan
+  ): LogicalPlan = {
+    groupingExposingRhsDeps(agg, semiApply, groupingExpressions) match {
+      case Some(newGrouping) if worthwhile(agg, semiApply) =>
+        // Both replacements get fresh ids (the attribute framework is set-once, so we must not
+        // re-set attributes on an existing id). The aggregation now consumes the apply's LHS.
+        val newAgg = buildAggregation(newGrouping)
+        solveds.copy(agg.id, newAgg.id)
+        cardinalities.copy(agg.id, newAgg.id)
+        providedOrders.copy(agg.id, newAgg.id)
+
+        // The existential subquery filters the (now deduplicated) grouped rows.
+        val newSemiApply = semiApply.withLhs(newAgg)(attributes.copy(semiApply.id))
+        solveds.copy(agg.id, newSemiApply.id)
+        cardinalities.copy(agg.id, newSemiApply.id)
+        providedOrders.copy(agg.id, newSemiApply.id)
+        newSemiApply
+
+      case _ => agg
+    }
+  }
+
+  /**
+   * Cost guard: fire only when the aggregation collapses at least [[MinFanOut]] rows into each group,
+   * so the existential subquery runs meaningfully fewer times above the aggregation than below. Fan-out
+   * is estimated as filtered-rows-per-group, `card(semiApply) / card(aggregation)`. When the group
+   * estimate is unavailable (`0`, e.g. in unit tests) the guard does not block.
+   */
+  private def worthwhile(agg: AggregatingPlan, semiApply: AbstractSemiApply): Boolean = {
+    val filteredRows = cardinalities.get(semiApply.id).amount
+    val groups = cardinalities.get(agg.id).amount
+    groups <= 0.0 || filteredRows >= groups * MinFanOut
+  }
+
+  /**
+   * If every outer variable the apply's RHS reads is exposed by the aggregation — directly as a
+   * grouping key, or as a node variable functionally determined by a constrained property already in
+   * the grouping — return the grouping augmented with those node variables (so they survive the
+   * aggregation). Otherwise `None` (do not rewrite).
+   */
+  private def groupingExposingRhsDeps(
+    agg: AggregatingPlan,
+    semiApply: AbstractSemiApply,
+    groupingExpressions: Map[LogicalVariable, Expression]
+  ): Option[Map[LogicalVariable, Expression]] = {
+    val rhsDeps = semiApply.right.localAvailableSymbols intersect semiApply.left.localAvailableSymbols
+    if (rhsDeps.isEmpty) return None
+    val groupingKeys = groupingExpressions.keySet
+
+    val solvedQg = solveds.get(agg.id) match {
+      case spq: SinglePlannerQuery => spq.queryGraph
+      case _                       => return None
+    }
+
+    var additions = Map.empty[LogicalVariable, Expression]
+    val allExposed = rhsDeps.forall { v =>
+      groupingKeys.contains(v) || groupingExpressions.values.exists {
+        case Property(vv: LogicalVariable, pk) if vv == v && isFunctionallyDetermined(v, pk.name, solvedQg) =>
+          additions += (v -> v)
+          true
+        case _ => false
+      }
+    }
+    if (allExposed) Some(groupingExpressions ++ additions) else None
+  }
+
+  /**
+   * True if `v.prop` uniquely identifies the `v` node: some guaranteed label of `v` carries both a
+   * uniqueness constraint and an existence constraint on `prop` (i.e. a node key, or the two
+   * separately). Existence is required for soundness — a uniqueness constraint alone permits multiple
+   * NULLs, for which `v.prop` would not determine `v`.
+   */
+  private def isFunctionallyDetermined(v: LogicalVariable, prop: String, qg: QueryGraph): Boolean =
+    qg.allPossibleLabelsOnNode(v).exists { label =>
+      planContext.rangeIndexGetForLabelAndProperties(label.name, Seq(prop)).exists(_.isUnique) &&
+      planContext.hasNodePropertyExistenceConstraint(label.name, prop)
+    }
+
+  private val instance: Rewriter = bottomUp(innerRewriter)
+}

--- a/community/cypher/cypher-planner/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/PushSemiApplyAboveAggregationIntegrationTest.scala
+++ b/community/cypher/cypher-planner/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/PushSemiApplyAboveAggregationIntegrationTest.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.planner.logical
+
+import org.neo4j.cypher.internal.compiler.CypherPlannerTestSuite
+import org.neo4j.cypher.internal.compiler.planner.LogicalPlanningIntegrationTestSupport
+import org.neo4j.cypher.internal.logical.plans.Aggregation
+import org.neo4j.cypher.internal.logical.plans.AntiSemiApply
+import org.neo4j.cypher.internal.util.Foldable.FoldableAny
+
+class PushSemiApplyAboveAggregationIntegrationTest extends CypherPlannerTestSuite
+    with LogicalPlanningIntegrationTestSupport {
+
+  // An LDBC-SNB-shaped slice sufficient to plan BI Q18 (friend recommendation). A Person(id) node
+  // key (uniqueness + existence) is what lets the rewrite expose the person nodes through the
+  // aggregation; a uniqueness constraint alone is not enough, since it permits NULL ids.
+  private def ldbcPlanner = plannerBuilder()
+    .setAllNodesCardinality(3_000_000)
+    .setLabelCardinality("Person", 10_295)
+    .setLabelCardinality("Tag", 16_080)
+    .setRelationshipCardinality("()-[:KNOWS]->()", 346_028)
+    .setRelationshipCardinality("(:Person)-[:KNOWS]->()", 346_028)
+    .setRelationshipCardinality("()-[:KNOWS]->(:Person)", 346_028)
+    .setRelationshipCardinality("(:Person)-[:KNOWS]->(:Person)", 346_028)
+    .setRelationshipCardinality("()-[:HAS_INTEREST]->()", 238_052)
+    .setRelationshipCardinality("(:Person)-[:HAS_INTEREST]->()", 238_052)
+    .setRelationshipCardinality("(:Person)-[:HAS_INTEREST]->(:Tag)", 238_052)
+    .setRelationshipCardinality("()-[:HAS_INTEREST]->(:Tag)", 238_052)
+    .addNodeIndex("Person", List("id"), existsSelectivity = 1.0, uniqueSelectivity = 1.0 / 10_295, isUnique = true)
+    .addNodeIndex("Tag", List("name"), existsSelectivity = 1.0, uniqueSelectivity = 1.0 / 16_080)
+
+  // Person(id) is unique AND present (a node key) — the rewrite may expose the person nodes.
+  private val planner = ldbcPlanner.addNodeExistenceConstraint("Person", "id").build()
+
+  // Person(id) is unique but may be NULL — the rewrite must not expose the person nodes.
+  private val plannerUniqueOnly = ldbcPlanner.build()
+
+  private val q18 =
+    """MATCH (tag:Tag {name: 'Frank_Sinatra'})<-[:HAS_INTEREST]-(person1:Person)
+      |      -[:KNOWS]-(mutualFriend:Person)-[:KNOWS]-(person2:Person)-[:HAS_INTEREST]->(tag)
+      |WHERE person1 <> person2 AND NOT EXISTS { MATCH (person1)-[:KNOWS]-(person2) }
+      |RETURN person1.id AS p1, person2.id AS p2, count(DISTINCT mutualFriend) AS cnt
+      |ORDER BY cnt DESC, p1 ASC, p2 ASC LIMIT 20""".stripMargin
+
+  test("pushes the NOT EXISTS anti-join above the count(DISTINCT) aggregation in BI Q18") {
+    val plan = planner.plan(q18)
+
+    // The anti-join is evaluated once per grouped (person1, person2) pair, i.e. it sits ABOVE the
+    // aggregation: some AntiSemiApply has an Aggregation in its left subtree.
+    withClue(plan) {
+      plan.folder.findAllByClass[AntiSemiApply].exists(
+        _.left.folder.treeExists { case _: Aggregation => true }
+      ) shouldBe true
+    }
+  }
+
+  test("the pushed-down aggregation groups by the person nodes (functional-dependency exposure)") {
+    val plan = planner.plan(q18)
+
+    // Q18 groups by person1.id / person2.id; to move the anti-join above, the rewrite adds the
+    // person1 / person2 node variables to the grouping (a no-op on the groups under the id uniqueness
+    // constraint) so the anti-join can still reach them.
+    val groupsByPersonNodes = plan.folder.findAllByClass[Aggregation].exists { agg =>
+      val keys = agg.groupingExpressions.keySet.map(_.name)
+      keys.contains("person1") && keys.contains("person2")
+    }
+    withClue(plan) {
+      groupsByPersonNodes shouldBe true
+    }
+  }
+
+  test("does not fire when Person(id) is unique but not guaranteed present (NULL-soundness guard)") {
+    val plan = plannerUniqueOnly.plan(q18)
+
+    // With only a uniqueness constraint, id may be NULL, so person1.id does not determine person1.
+    // The rewrite must not add the person nodes to the grouping, so the anti-join stays BELOW the
+    // aggregation (no AntiSemiApply has an Aggregation in its left subtree).
+    withClue(plan) {
+      plan.folder.findAllByClass[AntiSemiApply].exists(
+        _.left.folder.treeExists { case _: Aggregation => true }
+      ) shouldBe false
+    }
+  }
+}

--- a/community/cypher/cypher-planner/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/plans/rewriter/PushSemiApplyAboveAggregationTest.scala
+++ b/community/cypher/cypher-planner/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/plans/rewriter/PushSemiApplyAboveAggregationTest.scala
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.planner.logical.plans.rewriter
+
+import org.neo4j.cypher.internal.compiler.CypherPlannerTestSuite
+import org.neo4j.cypher.internal.compiler.helpers.LogicalPlanBuilder
+import org.neo4j.cypher.internal.compiler.planner.LogicalPlanningTestSupport
+import org.neo4j.cypher.internal.logical.plans.Aggregation
+import org.neo4j.cypher.internal.logical.plans.AntiSemiApply
+import org.neo4j.cypher.internal.logical.plans.LogicalPlan
+import org.neo4j.cypher.internal.planner.spi.PlanningAttributes.Cardinalities
+import org.neo4j.cypher.internal.util.Cardinality
+import org.neo4j.cypher.internal.util.Foldable.FoldableAny
+import org.neo4j.cypher.internal.util.attribution.Attributes
+
+class PushSemiApplyAboveAggregationTest extends CypherPlannerTestSuite with LogicalPlanningTestSupport {
+
+  test("pushes AntiSemiApply above an aggregation that groups by the apply's dependencies") {
+    // MATCH (p1)-[:KNOWS]-(mid)-[:KNOWS]-(p2) WHERE NOT EXISTS { (p1)-[:KNOWS]-(p2) }
+    // RETURN p1, p2, count(DISTINCT mid) AS cnt   -- grouping by the nodes p1, p2
+    val input = new LogicalPlanBuilder()
+      .produceResults("person1", "person2", "cnt")
+      .aggregation(Seq("person1 AS person1", "person2 AS person2"), Seq("count(DISTINCT mid) AS cnt"))
+      .antiSemiApply()
+      .|.expandInto("(person1)-[:KNOWS]-(person2)")
+      .|.argument("person1", "person2")
+      .expand("(mid)-[:KNOWS]-(person2)")
+      .expand("(person1)-[:KNOWS]-(mid)")
+      .nodeByLabelScan("person1", "Person")
+      .build()
+
+    val expected = new LogicalPlanBuilder()
+      .produceResults("person1", "person2", "cnt")
+      .antiSemiApply()
+      .|.expandInto("(person1)-[:KNOWS]-(person2)")
+      .|.argument("person1", "person2")
+      .aggregation(Seq("person1 AS person1", "person2 AS person2"), Seq("count(DISTINCT mid) AS cnt"))
+      .expand("(mid)-[:KNOWS]-(person2)")
+      .expand("(person1)-[:KNOWS]-(mid)")
+      .nodeByLabelScan("person1", "Person")
+      .build()
+
+    rewrite(input) should equal(expected)
+  }
+
+  test("pushes AntiSemiApply above an OrderedAggregation, carrying over the leveraged order") {
+    // Same as above but the aggregation streams on an already-ordered input. The anti-join preserves
+    // its left-hand side's order, so the leveraged order is the same above or below it.
+    val input = new LogicalPlanBuilder()
+      .produceResults("person1", "person2", "cnt")
+      .orderedAggregation(
+        Seq("person1 AS person1", "person2 AS person2"),
+        Seq("count(DISTINCT mid) AS cnt"),
+        Seq("person1")
+      )
+      .antiSemiApply()
+      .|.expandInto("(person1)-[:KNOWS]-(person2)")
+      .|.argument("person1", "person2")
+      .expand("(mid)-[:KNOWS]-(person2)")
+      .expand("(person1)-[:KNOWS]-(mid)")
+      .nodeByLabelScan("person1", "Person")
+      .build()
+
+    val expected = new LogicalPlanBuilder()
+      .produceResults("person1", "person2", "cnt")
+      .antiSemiApply()
+      .|.expandInto("(person1)-[:KNOWS]-(person2)")
+      .|.argument("person1", "person2")
+      .orderedAggregation(
+        Seq("person1 AS person1", "person2 AS person2"),
+        Seq("count(DISTINCT mid) AS cnt"),
+        Seq("person1")
+      )
+      .expand("(mid)-[:KNOWS]-(person2)")
+      .expand("(person1)-[:KNOWS]-(mid)")
+      .nodeByLabelScan("person1", "Person")
+      .build()
+
+    rewrite(input) should equal(expected)
+  }
+
+  test("pushes a positive SemiApply above an OrderedAggregation") {
+    // EXISTS (rather than NOT EXISTS) lowers to a SemiApply; the rewrite applies equally.
+    val input = new LogicalPlanBuilder()
+      .produceResults("person1", "person2", "cnt")
+      .orderedAggregation(
+        Seq("person1 AS person1", "person2 AS person2"),
+        Seq("count(DISTINCT mid) AS cnt"),
+        Seq("person1")
+      )
+      .semiApply()
+      .|.expandInto("(person1)-[:KNOWS]-(person2)")
+      .|.argument("person1", "person2")
+      .expand("(mid)-[:KNOWS]-(person2)")
+      .expand("(person1)-[:KNOWS]-(mid)")
+      .nodeByLabelScan("person1", "Person")
+      .build()
+
+    val expected = new LogicalPlanBuilder()
+      .produceResults("person1", "person2", "cnt")
+      .semiApply()
+      .|.expandInto("(person1)-[:KNOWS]-(person2)")
+      .|.argument("person1", "person2")
+      .orderedAggregation(
+        Seq("person1 AS person1", "person2 AS person2"),
+        Seq("count(DISTINCT mid) AS cnt"),
+        Seq("person1")
+      )
+      .expand("(mid)-[:KNOWS]-(person2)")
+      .expand("(person1)-[:KNOWS]-(mid)")
+      .nodeByLabelScan("person1", "Person")
+      .build()
+
+    rewrite(input) should equal(expected)
+  }
+
+  test("does not fire when the RHS reads a variable that is not a grouping key (soundness guard)") {
+    // The anti-join depends on `mid`, which the aggregation collapses — the predicate is
+    // NOT constant within a group, so the rewrite must not fire.
+    val input = new LogicalPlanBuilder()
+      .produceResults("person1", "cnt")
+      .aggregation(Seq("person1 AS person1"), Seq("count(DISTINCT mid) AS cnt"))
+      .antiSemiApply()
+      .|.expandInto("(person1)-[:KNOWS]-(mid)")
+      .|.argument("person1", "mid")
+      .expand("(person1)-[:KNOWS]-(mid)")
+      .nodeByLabelScan("person1", "Person")
+      .build()
+
+    rewrite(input) should equal(input)
+  }
+
+  test("does not fire when grouping renames the dependency (the p1.id case — needs the FD increment)") {
+    // RETURN p1.id AS a, ... groups by a NEW key `a`, so deps(R) = {person1} is not a grouping
+    // key. Firing here requires proving p1.id functionally determines p1 (uniqueness constraint).
+    val input = new LogicalPlanBuilder()
+      .produceResults("a", "cnt")
+      .aggregation(Seq("person1.id AS a"), Seq("count(DISTINCT mid) AS cnt"))
+      .antiSemiApply()
+      .|.expandInto("(person1)-[:KNOWS]-(person2)")
+      .|.argument("person1", "person2")
+      .expand("(mid)-[:KNOWS]-(person2)")
+      .expand("(person1)-[:KNOWS]-(mid)")
+      .nodeByLabelScan("person1", "Person")
+      .build()
+
+    rewrite(input) should equal(input)
+  }
+
+  test("does not fire when the estimated fan-out is below the threshold (cost guard)") {
+    val input = antiSemiApplyOverAggregationByNodes()
+    // ~1.1 filtered rows per group (110 / 100) is below MinFanOut (2.0): pushing would save almost
+    // nothing, so the rewrite must not fire.
+    rewrite(input, fanOut(input, semiApplyCard = 110, aggCard = 100)) should equal(input)
+  }
+
+  test("fires when the estimated fan-out meets the threshold (cost guard)") {
+    val input = antiSemiApplyOverAggregationByNodes()
+    val expected = new LogicalPlanBuilder()
+      .produceResults("person1", "person2", "cnt")
+      .antiSemiApply()
+      .|.expandInto("(person1)-[:KNOWS]-(person2)")
+      .|.argument("person1", "person2")
+      .aggregation(Seq("person1 AS person1", "person2 AS person2"), Seq("count(DISTINCT mid) AS cnt"))
+      .expand("(mid)-[:KNOWS]-(person2)")
+      .expand("(person1)-[:KNOWS]-(mid)")
+      .nodeByLabelScan("person1", "Person")
+      .build()
+    // 5 filtered rows per group (500 / 100) is above MinFanOut (2.0).
+    rewrite(input, fanOut(input, semiApplyCard = 500, aggCard = 100)) should equal(expected)
+  }
+
+  private def antiSemiApplyOverAggregationByNodes(): LogicalPlan =
+    new LogicalPlanBuilder()
+      .produceResults("person1", "person2", "cnt")
+      .aggregation(Seq("person1 AS person1", "person2 AS person2"), Seq("count(DISTINCT mid) AS cnt"))
+      .antiSemiApply()
+      .|.expandInto("(person1)-[:KNOWS]-(person2)")
+      .|.argument("person1", "person2")
+      .expand("(mid)-[:KNOWS]-(person2)")
+      .expand("(person1)-[:KNOWS]-(mid)")
+      .nodeByLabelScan("person1", "Person")
+      .build()
+
+  private def fanOut(plan: LogicalPlan, semiApplyCard: Double, aggCard: Double): Cardinalities = {
+    val cardinalities = new Cardinalities
+    cardinalities.set(plan.folder.findAllByClass[AntiSemiApply].head.id, Cardinality(semiApplyCard))
+    cardinalities.set(plan.folder.findAllByClass[Aggregation].head.id, Cardinality(aggCard))
+    cardinalities
+  }
+
+  private def rewrite(p: LogicalPlan, cardinalities: Cardinalities): LogicalPlan = {
+    val rewriter = pushSemiApplyAboveAggregation(
+      newMockedPlanContext(),
+      new StubSolveds,
+      cardinalities,
+      new StubProvidedOrders,
+      Attributes(idGen)
+    )
+    p.endoRewrite(rewriter)
+  }
+
+  private def rewrite(p: LogicalPlan): LogicalPlan = {
+    val rewriter = pushSemiApplyAboveAggregation(
+      newMockedPlanContext(),
+      new StubSolveds,
+      new StubCardinalities,
+      new StubProvidedOrders,
+      Attributes(idGen)
+    )
+    p.endoRewrite(rewriter)
+  }
+}


### PR DESCRIPTION
### What

Adds a logical-plan rewriter, `pushSemiApplyAboveAggregation`, for plans where a grouping
aggregation sits directly on top of a `SemiApply`/`AntiSemiApply` (the operator produced
by an `EXISTS`/`NOT EXISTS` predicate). When the existential subquery depends only on the
aggregation's grouping keys, the rewriter swaps the two operators so the apply runs above
the aggregation instead of below it. In the original plan the apply filters every
pre-aggregation row; afterwards it filters the already-grouped rows.

### Why

When the existential subquery depends only on grouping keys, its result is constant within
each group, so it keeps or drops whole groups rather than individual rows. Below the
aggregation the subquery is evaluated once per pre-aggregation row; above the aggregation
it is evaluated once per group, which is far fewer times because grouping collapses many
rows into each group. The result is identical either way.

The motivating case is LDBC SNB BI Q18, where `NOT EXISTS {(p1)-[:KNOWS]-(p2)}` is
re-evaluated per `(p1, mid, p2)` triple instead of per distinct `(p1, p2)` pair.

Measured on LDBC SF1 (total db-hits, before to after):
- co-membership recommendation: 92.9M to 8.4M (11x)
- co-like: 46.2M to 6.3M (7.4x)
- co-interest: 6.2M to 3.1M (2x)

The win tracks per-group fan-out. Results are byte-identical before and after.

### Correctness

- A semi-/anti-apply is a pure row filter: it drops rows but never changes values or the
  column set. With its predicate constant per group, filtering above versus below the
  aggregation keeps exactly the same groups and computes the same per-group aggregates.
- Scoped to `AbstractSemiApply`, which is sealed with only two subtypes, `SemiApply` and
  `AntiSemiApply`. The `Let*` and `SelectOr*` apply variants extend other base classes and
  are deliberately not matched, since moving them would not preserve results.
- Functional-dependency exposure: when the query groups by a property (e.g. `RETURN
  p1.id`) but the existential subquery reads the node (`p1`), the rewriter adds the node to
  the grouping only if the property carries both a uniqueness and an existence constraint
  (a node key, or the two separately). Uniqueness alone permits multiple NULLs, for which
  the property does not determine the node; adding the node to the grouping could then
  split a NULL group and change the per-group aggregates. Consequence: this
  property-grouping case is Enterprise-only, since Community supports neither existence nor
  node-key constraints. Grouping directly by the node works on all editions.

### Cost guard

Pushing the apply above the aggregation never increases db-hits, but at low fan-out it
saves nothing and would make a memory-heavy aggregate (e.g. `collect`) buffer state for
groups the apply later drops. The rewrite therefore fires only when the estimated
rows-per-group, `card(semiApply) / card(aggregation)`, is at least `MinFanOut` (2.0). The
threshold is a tunable heuristic.

### Testing

- 7 unit and 3 integration tests, including negative cases for both the soundness guard and
  the cost guard.
- Full `cypher-planner` suite green: 8,343 tests, 0 failures, no existing plans changed.