### PR TITLE
Fix SHORTEST ACYCLIC returning a path that revisits the target node

### DIFF
--- a/community/cypher/runtime-util/src/main/java/org/neo4j/internal/kernel/api/helpers/traversal/ppbfs/SignpostStack.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/internal/kernel/api/helpers/traversal/ppbfs/SignpostStack.java
@@ -93,6 +93,7 @@ public class SignpostStack {
         this.dgLength = dgLength;
         this.nodeSourceSignpostIndices.add(-1);
         this.dgLengthToTarget = 0;
+        this.signpostTracking.onInitialized(this);
     }
 
     /**

--- a/community/cypher/runtime-util/src/main/java/org/neo4j/internal/kernel/api/helpers/traversal/ppbfs/SignpostTracking.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/internal/kernel/api/helpers/traversal/ppbfs/SignpostTracking.java
@@ -32,6 +32,11 @@ public interface SignpostTracking {
 
     void onPopped(TwoWaySignpost signpost, SignpostStack stack);
 
+    /** Called once the stack's target node has been set, before any signposts are pushed. */
+    default void onInitialized(SignpostStack stack) {
+        // do nothing
+    }
+
     boolean validate(SignpostStack stack);
 
     void clear();
@@ -199,6 +204,11 @@ public interface SignpostTracking {
         }
 
         @Override
+        public void onInitialized(SignpostStack stack) {
+            nodePresence.add(stack.target().id(), 0);
+        }
+
+        @Override
         public boolean canAbandonTraceBranch(SignpostStack stack) {
             var head = stack.headSignpost();
             if (!(head instanceof TwoWaySignpost.RelSignpost)) return false;
@@ -247,6 +257,8 @@ public interface SignpostTracking {
 
         @Override
         public boolean validate(SignpostStack stack) {
+            long targetId = stack.target().id();
+            boolean valid = true;
             int sourceLength = 0;
             for (int i = stack.size() - 1; i >= 0; i--) {
                 TwoWaySignpost signpost = stack.signpost(i);
@@ -258,6 +270,21 @@ public interface SignpostTracking {
                         hooks.invalid(stack);
                         return false;
                     }
+
+                    // Position 1 (i == 0) sits directly against the target and, for quantified
+                    // patterns, may be a state-only signpost (no relationship consumed) whose
+                    // prevNode is the target itself — that's the accepting-state transition into
+                    // the target, not a revisit. Any other position sharing the target's id, or a
+                    // genuine relationship signpost at position 1 (e.g. a self-loop), IS a revisit
+                    // of the target and must be rejected. Keep bookkeeping for the rest of the
+                    // stack going (matching the loop's normal per-signpost side effects below)
+                    // rather than returning immediately, since other in-flight traces rely on the
+                    // validated-length bookkeeping this loop produces for shared signposts/nodes.
+                    boolean isRealStep = signpost instanceof TwoWaySignpost.RelSignpost;
+                    if (signpost.prevNode.id() == targetId && (i > 0 || isRealStep)) {
+                        hooks.invalid(stack);
+                        valid = false;
+                    }
                 }
 
                 if (!signpost.isValidatedAtLength(sourceLength)) {
@@ -267,7 +294,7 @@ public interface SignpostTracking {
                     }
                 }
             }
-            return true;
+            return valid;
         }
 
         @Override

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/internal/kernel/api/helpers/traversal/ppbfs/PGPathPropagatingBFSTest.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/internal/kernel/api/helpers/traversal/ppbfs/PGPathPropagatingBFSTest.scala
@@ -1736,6 +1736,41 @@ class PGPathPropagatingBFSTest extends CypherFunSuite with PGPathPropagatingBFST
       .assertExpected()
   }
 
+  test("acyclic filters paths where an intermediate node revisits the target") {
+    // Exactly mirrors GitHub #13834: MATCH p = SHORTEST 1 ACYCLIC ()-->()-->()-->() RETURN p
+    // Graph: a->b, b->c, c->b — every 3-hop walk from a revisits b, so none should be acyclic.
+    val threeFixedHops: Nfa = nfa("(s) ()-->()-->()-->() (t)") { sb =>
+      val s = sb.newState("s", isStartState = true)
+      val x = sb.newState("x")
+      val y = sb.newState("y")
+      val z = sb.newState("z")
+      val t = sb.newState("t", isFinalState = true)
+
+      s.addNodeJuxtaposition(x)
+      x.addRelationshipExpansion(y)
+      y.addRelationshipExpansion(z)
+      z.addRelationshipExpansion(t)
+    }
+
+    val g = InMemoryGraph.builder
+    val a = g.node()
+    val b = g.node()
+    val c = g.node()
+    g.rel(a, b)
+    g.rel(b, c)
+    g.rel(c, b)
+    val graph = g.build()
+
+    val paths = fixture()
+      .withGraph(graph)
+      .from(a)
+      .withNfa(threeFixedHops)
+      .withPathMode(TraversalPathMode.Acyclic)
+      .paths()
+
+    paths shouldBe empty
+  }
+
   test("acyclic undirected 3-node chain — source n1") {
     val graph = `(n1)-->(n2)-->(n3)`
     fixture()


### PR DESCRIPTION
## What was wrong

Fixes neo4j/neo4j#13834.

`SHORTEST 1 ACYCLIC` could return a path that revisits a node, as long as the revisited node was the **target** (the last node of the path) rather than the source. Internally, the code that checks for revisited nodes never actually tracked the target node itself — it only tracked nodes it saw while walking backwards from the target — so a node showing up twice, once as "the target" and once as "a node along the way," slipped through undetected.

Example from the issue: graph `a->b, b->c, c->b`. Querying `SHORTEST 1 ACYCLIC ()-->()-->()-->()` returned the path `a-b-c-b`, even though `b` appears twice.

## The fix

Two small changes in `SignpostTracking.java` / `SignpostStack.java`:

1. Register the target node itself when a trace starts.
2. Check it during validation — while specifically allowing the one legitimate case where a quantified pattern's internal "we can stop now" bookkeeping step lands back on the target without it being a real second visit.

## Proof it works

**Before the fix** (on `2026.05`, unmodified), a Scala test built from the issue's exact repro graph and pattern fails because it returns 4 invalid, revisiting paths:

```
org.scalatest.exceptions.TestFailedException:
List(
  List(0, 0, 3, 1, 4, 2, 4, 1),
  List(0, 0, 3, 1, 5, 2, 4, 1),
  List(0, 0, 3, 1, 4, 2, 5, 1),
  List(0, 0, 3, 1, 5, 2, 5, 1)
) was not empty
```

**After the fix**, the same test passes — zero paths returned, matching Cypher's ACYCLIC guarantee — and the full existing `PGPathPropagatingBFSTest` suite (69 tests, including this new one) passes:

```
Tests run: 69, Failures: 0, Errors: 0
BUILD SUCCESS
```

The new regression test is included in this PR (`acyclic filters paths where an intermediate node revisits the target` in `PGPathPropagatingBFSTest.scala`), built directly from the issue's own repro graph and pattern, so it will catch any future regression of this exact bug.