### PR TITLE
Fix datetime epochSeconds overflow

### DIFF
--- a/community/values/src/main/java/org/neo4j/values/storable/DateTimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DateTimeValue.java
@@ -296,8 +296,7 @@ public final class DateTimeValue extends TemporalValue<ZonedDateTime, DateTimeVa
                                     "date time", String.valueOf(epochField), prettyVal);
                         }
                         result = assertValidArgument(
-                                "epochSeconds",
-                                () -> ofInstant(ofEpochMilli(epochSeconds.longValue() * 1000), timezone()));
+                                "epochSeconds", () -> ofInstant(ofEpochSecond(epochSeconds.longValue()), timezone()));
                     } else {
                         AnyValue epochField = fields.get(TemporalFields.epochMillis);
                         if (!(epochField instanceof IntegralValue epochMillis)) {

--- a/community/values/src/test/java/org/neo4j/values/storable/DateTimeValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DateTimeValueTest.java
@@ -443,6 +443,14 @@ class DateTimeValueTest {
                 .assertThrows(InvalidArgumentException.class, "No such field: picosecond");
     }
 
+    @ParameterizedTest
+    @ValueSource(longs = {Long.MIN_VALUE, Long.MAX_VALUE})
+    void shouldRejectOutOfRangeEpochSeconds(long epochSeconds) {
+        assertThrows(InvalidArgumentException.class, () -> fromValues(builder(clock))
+                .add("epochSeconds", epochSeconds)
+                .build());
+    }
+
     @Test
     void shouldFailOnInvalidRawValue() {
         ErrorGqlStatusObjectAssertions.assertThatThrownBy(() -> datetimeRaw(31556889864403200L, 0, UTC))


### PR DESCRIPTION
### Summary

Reject out-of-range `datetime({epochSeconds})` values instead of silently returning wrapped timestamps.

PR #11288 added `epochSeconds` construction by multiplying the input by 1000 and forwarding it to `Instant.ofEpochMilli`. That conversion happens in a Java `long` before the existing temporal validation boundary, so `Long.MAX_VALUE` wraps to `-1000` milliseconds and returns one second before the epoch. `Long.MIN_VALUE` similarly wraps to the epoch.

This change passes seconds directly to `Instant.ofEpochSecond`, matching the existing `datetimeRaw` implementation. The Java time range check now feeds Neo4j's existing `InvalidArgumentException` mapping. Results for valid whole seconds are unchanged, and `epochMillis` is untouched.

Fixes #13850

### Tests

- Added `DateTimeValueTest.shouldRejectOutOfRangeEpochSeconds` for `Long.MIN_VALUE` and `Long.MAX_VALUE`.