### PR TITLE
docs: correct README build prerequisites to Maven 3.9.11+ and JDK 21

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -22,7 +22,7 @@ We encourage experimentation with Neo4j. You can build extensions to Neo4j, deve
 
 == Dependencies ==
 
-Neo4j is built using https://maven.apache.org/[Apache Maven] version 3.8.2 and a recent version of supported VM. Bash and Make are also required. Note that maven needs more memory than the standard configuration, this can be achieved with `export MAVEN_OPTS="-Xmx2048m"`.
+Neo4j is built using https://maven.apache.org/[Apache Maven] version 3.9.11 or newer and a recent version of supported VM. Bash and Make are also required. Note that maven needs more memory than the standard configuration, this can be achieved with `export MAVEN_OPTS="-Xmx2048m"`.
 
 macOS users need to have https://brew.sh/[Homebrew] installed.
 
@@ -34,9 +34,9 @@ Please note that we do not support building Debian packages on macOS.
 
 === With apt-get on Ubuntu ===
 
-  sudo apt install maven openjdk-17-jdk
+  sudo apt install maven openjdk-21-jdk
 
-Be sure that the `JAVA_HOME` environment variable points to `/usr/lib/jvm/java-17-openjdk-amd64`
+Be sure that the `JAVA_HOME` environment variable points to `/usr/lib/jvm/java-21-openjdk-amd64`
 (you may have various java versions installed).
 
 == Building Neo4j ==


### PR DESCRIPTION
Fixes #13884.

Three lines in the README's Dependencies section. The versions it names can't build the project.

| Line | Before | After | Why |
|---|---|---|---|
| 25 | Maven `3.8.2` | Maven `3.9.11 or newer` | `pom.xml:161` sets `<required.maven.version>3.9.11</required.maven.version>`, and `requireMavenVersion` at `pom.xml:1796-1798` fails the build below it |
| 37 | `openjdk-17-jdk` | `openjdk-21-jdk` | `pom.xml:238` sets `<vm.target.version>21</vm.target.version>`, feeding `maven.compiler.release` at `pom.xml:143` |
| 39 | `java-17-openjdk-amd64` | `java-21-openjdk-amd64` | same |

## How I checked

In the official Maven images, against `eccd584`:

```
maven:3.8.8-eclipse-temurin-17   mvn -B -ntp -N validate
  -> Detected Maven Version: 3.8.8 is not in the allowed range [3.9.11,).

maven:3.9.11-eclipse-temurin-17  mvn -B -ntp -pl annotations -am compile
  -> Fatal error compiling: error: release version 21 not supported

maven:3.9.11-eclipse-temurin-21  mvn -B -ntp -pl annotations -am compile
  -> BUILD SUCCESS
```

The third run is the control — it's the repository that's fine and the two numbers in the README that have drifted. 3.8.8 is already newer than the documented 3.8.2, so 3.8.2 fails the same way.

## Two things I'd like a second opinion on

I built in containers rather than on Ubuntu, so I have **not** verified that `openjdk-21-jdk` is the exact package name in the apt repositories you have in mind, or that `/usr/lib/jvm/java-21-openjdk-amd64` is the right path on every Ubuntu release you support. Those are the two strings I'd most want someone with an Ubuntu box to glance at.

I also kept this deliberately minimal. A more durable version would have the README point at `required.maven.version` and `vm.target.version` instead of restating the numbers, so the two can't drift apart again — happy to do that instead if you'd prefer it.

## On the vehicle

I saw #13815 closed with a note that the contribution process isn't as simple as merging a PR, so I'm not assuming a patch is welcome here. Please close this without hesitation if it's easier to make the change internally — the report in #13884 is the part I actually wanted on record, since this is the first command a new contributor runs.

CLA signed and sent to cla@neo4j.com today.

---

*Prepared with AI assistance; every command quoted above was run and its output copied verbatim, and I've reviewed the change myself.*
