### PR TITLE
Bump Jetty to 12.1.10, Netty to 4.2.16.Final and Jackson to 2.22.1 for the July 2026 advisories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <guava.version>33.6.0-jre</guava.version>
     <!-- no more patch releases for jackson-annotations so different versioning from jackson -->
     <jackson.annotations.version>2.22</jackson.annotations.version>
-    <jackson.version>2.22.0</jackson.version>
+    <jackson.version>2.22.1</jackson.version>
     <jakarta.activation-api.version>1.2.2</jakarta.activation-api.version>
     <jakarta.inject.version>2.0.1</jakarta.inject.version>
     <jakarta.ws.rs-api.version>2.1.6</jakarta.ws.rs-api.version>
@@ -125,7 +125,7 @@
     <jdk25.custom.options />
     <jersey.version>2.46</jersey.version>
     <jetty.toolchain.version>4.0.9</jetty.toolchain.version>
-    <jetty.version>12.1.8</jetty.version>
+    <jetty.version>12.1.10</jetty.version>
     <json-unit.version>5.1.2</json-unit.version>
     <json4s.version>4.1.0</json4s.version>
     <jsr305.version>3.0.2</jsr305.version>
@@ -149,7 +149,7 @@
      - Please note that when updating this dependency (i.e. due to a security vulnerability or bug) that the corresponding driver dependency also
      - needs updating.
      -->
-    <netty.version>4.2.15.Final</netty.version>
+    <netty.version>4.2.16.Final</netty.version>
     <opencypher.version>1.0.0-M23</opencypher.version>
     <oshi-common.version>7.3.0</oshi-common.version>
     <parallel.tests>false</parallel.tests>


### PR DESCRIPTION
Three property lines in `pom.xml`, covering the issues I opened earlier today: #13881 (Jetty), #13882 (Netty), #13883 (Jackson).

All three pinned versions sit inside the affected ranges of advisories published on 2026-07-21/22 — after this branch's last commit and after 2026.06.0 went to Central — and every fix is a patch release inside the line already in use.

```diff
-    <jackson.version>2.22.0</jackson.version>
+    <jackson.version>2.22.1</jackson.version>
-    <jetty.version>12.1.8</jetty.version>
+    <jetty.version>12.1.10</jetty.version>
-    <netty.version>4.2.15.Final</netty.version>
+    <netty.version>4.2.16.Final</netty.version>
```

| Component | Advisories cleared | Why this version |
|---|---|---|
| Jetty 12.1.8 → **12.1.10** | CVE-2026-6790 (`jetty-server`, fixed 12.1.9), CVE-2026-8384 (`jetty-util`, fixed 12.1.9), CVE-2026-10051 (`jetty-server`, fixed 12.1.10) | 12.1.10 is the lowest version clearing all three. 12.1.11 is the newest on Central if you'd rather go there. |
| Netty 4.2.15.Final → **4.2.16.Final** | the 2026-07-22 batch | Every advisory in that batch gives the 4.2 range as `4.2.0.Final → 4.2.16.Final`. |
| Jackson 2.22.0 → **2.22.1** | GHSA-r7wm-3cxj-wff9, CVE-2026-59889, CVE-2026-54515 | Lowest version clearing all three. |

## How much each one actually matters

I'd rather be straight about this than let the CVE count speak for itself.

- **Jetty is the one I'd prioritise.** All three land on the HTTP server, and `server.http_enabled_transports` defaults to `EnumSet.allOf(...)`, so HTTP/1.1 and HTTP/2 are both served out of the box on 7474. Details in #13881.
- **Netty: one of the ten reaches a default configuration** — GHSA-4mp9-239f-g9hg, via the `WebSocketServerProtocolHandler` in `TransportSelectionHandler` for Bolt-over-WebSocket. Two more need `internal.dbms.bolt.proxy_protocol.enabled`, which defaults to `false`. I went through the other seven and could not find the handlers they describe anywhere in main source; I am **not** claiming those affect Neo4j. Working in #13882.
- **Jackson is hygiene, not a hole.** I looked for each advisory's precondition — the non-blocking parser, `@JsonView`, case-insensitive *property* matching — and found none of them in main source. It's a library that reads untrusted request JSON sitting one patch behind its fix. Reasoning in #13883.

## What I deliberately left alone

- **`jackson.annotations.version` (line 109)** stays at `2.22`. The comment above it says there are no more patch releases for that artifact and it's versioned separately on purpose.
- **`lz4.version` (line 141)** stays at `1.11.0` even though CVE-2026-59949 applies to it, because nothing in this repository depends on `at.yawk.lz4:lz4-java` — no module pom, no import in any `.java` or `.scala`. Since `org.neo4j:parent` is published, the managed version is still inherited by whatever does use it, so you may want it anyway; I didn't want to change a pin I couldn't justify from this tree.

## How I verified it

On `maven:3.9.11-eclipse-temurin-21`, against this branch:

```
mvn -B -ntp -N validate
  -> BUILD SUCCESS; Rules 0-6 all pass, including DependencyConvergence
     and BanDuplicatePomDependencyVersions

mvn -B -ntp -pl community/server,community/bolt -am compile -DskipTests
  -> BUILD SUCCESS; 109 modules built
```

The convergence rule was the one I most wanted to see pass, since a BOM bump is where transitive conflicts usually show up. I did **not** run the test suite — a full `mvn clean install` on this repository is beyond what I could run locally, so the compile is the limit of what I've actually demonstrated.

## Happy to split or close

If it's easier to take these separately, say the word and I'll split it into three. And if it's simpler to make the change internally — which I gather from other threads is usually the case here — please just close this; the three issues are the part I wanted on record.

CLA signed and sent to cla@neo4j.com today.

---

*Prepared with AI assistance; every command quoted above was run and its output copied verbatim, and I've reviewed the change myself.*
