### PR TITLE
fix: skip creating Selection for trivially true predicates in planWhere

### DIFF
--- a/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/PlanEventHorizon.scala
+++ b/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/PlanEventHorizon.scala
@@ -31,6 +31,7 @@ import org.neo4j.cypher.internal.compiler.planner.logical.steps.skipAndLimit
 import org.neo4j.cypher.internal.expressions.Expression
 import org.neo4j.cypher.internal.expressions.FunctionInvocation
 import org.neo4j.cypher.internal.expressions.LogicalVariable
+import org.neo4j.cypher.internal.expressions.True
 import org.neo4j.cypher.internal.expressions.functions.Collect
 import org.neo4j.cypher.internal.expressions.functions.UnresolvedFunction
 import org.neo4j.cypher.internal.ir.AbstractProcedureCallProjection
@@ -246,7 +247,7 @@ case object PlanEventHorizon extends EventHorizonPlanner {
     val planSkipAndLimit = step("planSkipAndLimit")(skipAndLimit(_, query, context))
 
     def planWhere(selections: Selections) = step("planWhere")((p: LogicalPlan) =>
-      if (selections.isEmpty) {
+      if (selections.isEmpty || selections.flatPredicatesSet.forall(_.isInstanceOf[True])) {
         p
       } else {
         val remoteBatchingResult =


### PR DESCRIPTION
## Description

Adding a redundant `WHERE true` predicate after a WITH clause causes an internal planner assertion:

```
Expected a sorted plan but got
```

The `WHERE true` predicate is trivially redundant and should be a no-op during planning.
The existing `simplifySelections` rewriter already handles this case by removing
`Selection(Ands(true), source)` → `source`, but it runs after the planning phase.

This fix moves the optimization earlier: during planning, `planWhere` now skips
creating a `Selection` node when all predicates are trivially `True`.
This prevents the planner from encountering an unexpected `Selection` node that
can interfere with ordering propagation.

### Background

The `simplifySelections` rewriter in `simplifySelections.scala` already has:
```scala
case Selection(Ands(preds), source) if isTrue(preds) => source
```

This fix applies the same logic at planning time, consistent with the existing
rewrite approach.

Closes #13909
