### PR TITLE
fix: throw division by zero for modulo by zero instead of overflow

### DIFF
--- a/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherMath.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherMath.java
@@ -315,6 +315,9 @@ public final class CypherMath {
         if (lhs == NO_VALUE || rhs == NO_VALUE) {
             return NO_VALUE;
         } else if (lhs instanceof NumberValue lhsNumber && rhs instanceof NumberValue rhsNumber) {
+            if (rhsNumber instanceof IntegralValue && rhsNumber.equals(ZERO_INT)) {
+                throw ArithmeticException.divisionByZero();
+            }
             try {
                 if (lhsNumber instanceof FloatingPointValue || rhsNumber instanceof FloatingPointValue) {
                     return doubleValue(lhsNumber.doubleValue() % rhsNumber.doubleValue());


### PR DESCRIPTION
### Problem

`RETURN 5 % 0` throws an overflow error (`22003: Data exception - numeric value out of range`) instead of a clean division-by-zero error.

### Root cause

`CypherMath.modulo()` performs the integer modulo operation before checking for a zero divisor. Java's `long % 0` throws `java.lang.ArithmeticException: / by zero`, which is caught by the existing catch block and re-wrapped as `ArithmeticException.wrappedArithmeticException(...)` with GQL status `STATUS_22003` (numeric value out of range / overflow).

In contrast, `CypherMath.divide()` correctly checks for zero divisor *before* the operation via `divideCheckForNull()`, which throws `ArithmeticException.divisionByZero()` with the correct GQL status `STATUS_22012` (division by zero).

### Fix

Add a zero-divisor check to `CypherMath.modulo()` before the integer modulo operation, matching the same pattern used by `divideCheckForNull()`:

```java
if (rhsNumber instanceof IntegralValue && rhsNumber.equals(ZERO_INT)) {
    throw ArithmeticException.divisionByZero();
}
```

The check is placed before the `try` block so the Neo4j `ArithmeticException` (a `RuntimeException`, not a `java.lang.ArithmeticException`) is not caught and re-wrapped by the existing catch clause.

Floating-point modulo by zero (`5.0 % 0.0`) is unaffected — Java returns `NaN` for that case, not an exception.

### Verification

```cypher
RETURN 5 % 0
```

Before: `22003: Data exception - numeric value out of range / The numeric value 5 % 0 is outside the range...`
After: `/ by zero` (division by zero)

Fixes #13913