### PR TITLE
fix: plan projection before sort in sortFirst to prevent 'Expected a sorted plan' on aliased ORDER BY in correlated subqueries

### DIFF
--- a/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/PlanEventHorizon.scala
+++ b/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/PlanEventHorizon.scala
@@ -411,9 +411,9 @@ case object PlanEventHorizon extends EventHorizonPlanner {
         def sortFirst = combineToStep(
           "sortFirst",
           NonEmptyList(
+            planProjection,
             planSort(),
             planSkipAndLimit,
-            planProjection,
             planWhere(regularProjection.selections)
           )
         )


### PR DESCRIPTION
### Problem

`CYPHER runtime=slotted` queries with `WITH DISTINCT *` followed by `RETURN ... ORDER BY <alias>` in a correlated `CALL` subquery crash with:

```
Internal exception raised AssertionError: Expected a sorted plan but got
.distinct(...)
.cartesianProduct()
...
.build()
```

Reproduction (empty database):
```cypher
CYPHER runtime=slotted
WITH 1 AS seed
CALL (seed) {
  MATCH p = ()-[]-()
  MATCH (n1)
  WITH DISTINCT *
  RETURN p AS p1, seed AS s
  ORDER BY p1 DESC, s DESC
}
RETURN p1, s;
```

### Root cause

`sortFirst` in `PlanEventHorizon` plans sort before the regular projection. When `ORDER BY` references aliases from the `RETURN` projection (e.g., `ORDER BY p1` where `p1 := p`), the alias variables are not yet available in the plan's symbol set, causing `SortPlanner.ensureSortedPlanWithSolved` to fail with an `AssertionError`.

This is a known family of `Expected a sorted plan` bugs (see #13896, #13900, #13909).

### Fix

Swap the order of `planProjection` and `planSort()` in `sortFirst` so that aliases from the `RETURN` projection are available when the planner tries to satisfy the `ORDER BY`. This is semantically correct because `ORDER BY` in Cypher operates on the result of the projection (aliases are resolved).

Fixes: #13915