### PR TITLE
fix: preserve LHS provided order in CountIRExpression Apply (GH-13917)

### DIFF
--- a/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/steps/LogicalPlanProducer.scala
@@ -432,10 +432,18 @@ case class LogicalPlanProducer(
     ): LogicalPlan = {
       val solved = solveds.get(lhs.id)
       val plan = Apply(lhs, rhs)
+      // A CountIRExpression is a scalar subquery: for each row of the LHS it produces exactly
+      // one count value and never changes the row order of the LHS. Therefore, unlike other
+      // two-child plans, we can safely propagate the LHS provided order. This is necessary
+      // because the RHS may contain plans that are marked as invalidating provided order in
+      // some execution models (e.g. Union in batched models): such plans do not affect the
+      // LHS row order when they are contained in a scalar subquery, and treating them as
+      // order-invalidating here would produce an empty provided order that breaks
+      // leveraged-order bookkeeping (GH-13917).
       annotate(
         plan,
         solved,
-        providedOrderOfApply(lhs, rhs, plan, context.settings.executionModel, context.providedOrderFactory),
+        ProvidedOrder.Left,
         cachedPropertiesPerPlan.get(rhs.id),
         context
       )
@@ -4955,8 +4963,10 @@ case class LogicalPlanProducer(
   ): Unit = {
     if (AssertionRunner.ASSERTIONS_ENABLED) {
       (plan, providedOrder.orderOrigin) match {
-        case (rollUpApply: RollUpApply, _) if rollUpApply.right.readOnly =>
-          // special case for RollUpApply as it is assumed to not invalidate LHS order regardless of RHS plans
+        case (plan: LogicalBinaryPlan, _) if plan.right.readOnly =>
+          // A read-only RHS (e.g. RollUpApply, Apply for CountIRExpression, SemiApply variants)
+          // is a scalar subquery that never changes the row order of the LHS, regardless of
+          // which plans it contains (e.g. Union in batched execution models).
           ()
         case (plan: LogicalBinaryPlan, Some(ProvidedOrder.Left))
           if invalidatesProvidedOrderRecursive(plan.right, executionModel) =>

--- a/community/cypher/cypher-planner/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/SubqueryExpressionPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/SubqueryExpressionPlanningIntegrationTest.scala
@@ -4283,6 +4283,20 @@ class SubqueryExpressionPlanningIntegrationTest extends CypherPlannerTestSuite
       .build())
   }
 
+  test("should not fail with COUNT expression containing UNION when ORDER BY and pipelined runtime (GH-13917)") {
+    val planner = plannerBuilder()
+      .setExecutionModel(BatchedParallel(1, 2))
+      .build()
+    val query =
+      """WITH 'a' AS x
+        |ORDER BY x
+        |WHERE COUNT { RETURN 1 AS z UNION RETURN 2 AS z } >= 0
+        |RETURN collect(x) AS out""".stripMargin
+
+    val plan = planner.plan(query)
+    plan shouldNot equal(null)
+  }
+
   test("should get simple node COUNT {} from count store") {
     val planner = plannerBuilder().setAllNodesCardinality(100).build()
     val plan = planner.plan("RETURN COUNT { (n) } > 10 AS result").stripProduceResults


### PR DESCRIPTION
## Problem

When a query uses `ORDER BY ... WHERE COUNT { ... UNION ... } >= 0` with the pipelined runtime, planning fails with:

```
While marking leveraged order we encountered a plan with no provided order. This is a bug.
```

## Root cause

`planCountExpressionApply` uses `providedOrderOfApply` to compute the provided order of the Apply node. In the batched execution model, `Union` is marked as order-invalidating, so `invalidatesProvidedOrderRecursive` returns `true` for the RHS (which contains a `UNION`) and the Apply ends up with `ProvidedOrder.empty`. This is incorrect for scalar subqueries — the RHS runs independently per LHS row and never changes the LHS row order.

Later, when `markOrderAsLeveragedBackwardsUntilOrigin` traverses the plan tree from an upstream operator (e.g. `collect` aggregation with ORDER BY), it reaches the Apply node whose `orderOrigin` is `None` and throws the error.

## Fix

1. **`planCountExpressionApply`**: Use `ProvidedOrder.Left` directly instead of `providedOrderOfApply`. A CountIRExpression is a scalar subquery: it produces exactly one count value per LHS row and never changes the row order of the LHS.

2. **`assertRhsDoesNotInvalidateLhsOrder`**: Generalize the RollUpApply exemption to all read-only RHS in binary plans. A read-only scalar subquery never invalidates the LHS order regardless of the plans it contains.

## Testing

Added integration test that plans a pipelined query with `ORDER BY x WHERE COUNT { UNION ... } >= 0 RETURN collect(x)`. The previous code would throw an `IllegalStateException` during planning.

## Related issues

Fixes GH-13917.