### PR TITLE
Fix SlottedCachedNodeProperty raw cast: use makeGetPrimitiveNodeFunctionFor for ref-slot values

### DIFF
--- a/community/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/SlottedCachedNodeProperty.scala
+++ b/community/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/expressions/SlottedCachedNodeProperty.scala
@@ -38,11 +38,11 @@ case class SlottedCachedNodeProperty(
   cachedPropertyOffset: Int
 ) extends AbstractCachedNodeProperty with SlottedExpression {
 
-  override def getId(ctx: ReadableRow): Long =
-    if (offsetIsForLongSlot)
-      ctx.getLongAt(nodeOffset)
-    else
-      ctx.getRefAt(nodeOffset).asInstanceOf[VirtualNodeValue].id()
+  private val getLongId: ToLongFunction[ReadableRow] =
+    if (offsetIsForLongSlot) (ctx: ReadableRow) => ctx.getLongAt(nodeOffset)
+    else SlotConfigurationUtils.makeGetPrimitiveNodeFunctionFor(nodeOffset)
+
+  override def getId(ctx: ReadableRow): Long = getLongId.applyAsLong(ctx)
 
   override def getCachedProperty(ctx: ReadableRow): Value = ctx.getCachedPropertyAt(cachedPropertyOffset)
 


### PR DESCRIPTION
## Fix \`SlottedCachedNodeProperty.getId()\` raw cast for non-long-slot values

The `SlottedCachedNodeProperty.getId()` method performs a raw cast `asInstanceOf[VirtualNodeValue]` when the node is stored in a reference slot (not a long slot), causing a `ClassCastException` when a non-node value (e.g., a map from `UNWIND`) is bound to the node variable.

### Bug

```cypher
UNWIND [{name:'Tom'}] AS p MATCH (p:Person) WHERE p.name = 'Tom' RETURN p.name
```

Fails with:
```
Neo.DatabaseError.Statement.ExecutionFailed (50N00)
class org.neo4j.values.virtual.SingletonMapValue cannot be cast to class org.neo4j.values.virtual.VirtualNodeValue
```

Instead of the expected clean client-side type error:
```
Neo.ClientError.Statement.TypeError (22N01)
Expected the value Map{name -> String("Tom")} to be of type NODE...
```

### Root cause

`SlottedCachedNodeProperty.getId()` directly casts a reference-slot value to `VirtualNodeValue` without catching the `ClassCastException`:

```scala
ctx.getRefAt(nodeOffset).asInstanceOf[VirtualNodeValue].id()
```

Other classes (`SlottedCachedNodePropertyLate`, `SlottedCachedRelationshipProperty`, `SlottedCachedRelationshipPropertyLate`) already use `SlotConfigurationUtils.makeGetPrimitiveNodeFunctionFor()` / `makeGetPrimitiveRelationshipFunctionFor()` which catches the CCE and throws a clean `ParameterWrongTypeException`.

### Fix

Align `SlottedCachedNodeProperty` with `SlottedCachedNodePropertyLate` by using `makeGetPrimitiveNodeFunctionFor`, which produces the correct `Neo.ClientError.Statement.TypeError (22N01)` on type mismatch.

Fixes: #13919
