### PR TITLE
fix: handle missing slot in rewriteCachedProperies to avoid NoSuchElementException on nested COLLECT

### DIFF
--- a/community/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/physicalplanning/SlottedRewriter.scala
+++ b/community/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/physicalplanning/SlottedRewriter.scala
@@ -611,8 +611,8 @@ class SlottedRewriter(tokenContext: ReadTokenContext) {
     val PropertyKeyName(propKey) = pkn
     val entityType = prop.entityType
     val originalEntityName = prop.originalEntityName
-    slotConfiguration(prop.entityName) match {
-      case LongSlot(offset, nullable, cypherType)
+    slotConfiguration.get(prop.entityName) match {
+      case Some(LongSlot(offset, nullable, cypherType))
         if (cypherType == CTNode && entityType == NODE_TYPE) || (cypherType == CTRelationship && entityType == RELATIONSHIP_TYPE) =>
         val propExpression = tokenContext.getOptPropertyKeyId(propKey) match {
           case Some(propId) =>
@@ -646,7 +646,7 @@ class SlottedRewriter(tokenContext: ReadTokenContext) {
         // which is why we do not need an explicit null-check here when the slot is nullable
         propExpression
 
-      case slot @ LongSlot(_, _, _) =>
+      case Some(slot @ LongSlot(_, _, _)) =>
         throw InternalException.internalError(
           this.getClass.getSimpleName,
           s"Unexpected type on slot '$slot' for cached property $prop"
@@ -655,7 +655,7 @@ class SlottedRewriter(tokenContext: ReadTokenContext) {
       // We can skip checking the type of the refslot. We will only get cached properties, if semantic analysis determined that an expression is
       // a node or a relationship. We loose this information for RefSlots for some expressions, otherwise we would have allocated long slots
       // in the first place.
-      case RefSlot(offset, nullable, _) =>
+      case Some(RefSlot(offset, nullable, _)) =>
         val propExpression = tokenContext.getOptPropertyKeyId(propKey) match {
           case Some(propId) =>
             ast.SlottedCachedPropertyWithPropertyToken(

--- a/community/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/physicalplanning/SlottedRewriter.scala
+++ b/community/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/physicalplanning/SlottedRewriter.scala
@@ -686,6 +686,13 @@ class SlottedRewriter(tokenContext: ReadTokenContext) {
           NullCheckReferenceProperty(offset, propExpression)
         else
           propExpression
+
+      case None =>
+        // The entity is not available in the slot configuration for this plan.
+        // This can happen when a cached property references a correlated variable
+        // that is not part of the current scope, e.g. inside a nested COLLECT.
+        // Return the original expression unchanged to avoid a NoSuchElementException.
+        prop
     }
   }
 


### PR DESCRIPTION
## Description

Fix a `NoSuchElementException` (50N00) in `SlottedRewriter.rewriteCachedProperies` when a cached property references a correlated variable that is not available in the nested COLLECT's slot configuration.

## Bug

```cypher
CREATE ({
  id: COUNT {
    CALL () {
      CALL () {
        MATCH (n3)
        RETURN n3 AS n3 LIMIT 0
        UNION
        RETURN null AS n3 LIMIT 0
      }
      WITH n3 AS alias42,
           COLLECT {
             WITH n3 AS alias33, n3 AS alias34
             MATCH p5 = (alias33) <-[]-{1,1} (alias34)
             WHERE (((toStringOrNull(alias33.k1) + toStringOrNull(alias33.k10)) CONTAINS '8sL')
                AND (NOT ((alias33.k8 = true) XOR true)))
             RETURN alias33 AS alias38
           } AS alias39
      RETURN properties(alias42) AS p
    }
  }
}) RETURN 1;
```

Fails with:
```
50N00: Internal exception raised ... key not found: VariableSlotKey(alias33)
NoSuchElementException: key not found: VariableSlotKey(alias33)
```

## Root cause

`rewriteCachedProperies` called `slotConfiguration(prop.entityName)` which throws `NoSuchElementException` when the entity is not in the slot configuration. A nested `COLLECT` subquery may have a cached property referencing a correlated variable whose slot is not available in the inner scope.

## Fix

Use `slotConfiguration.get(prop.entityName)` instead of `slotConfiguration(prop.entityName)`. When the slot is not found (`None`), return the original `ASTCachedProperty` expression unchanged instead of crashing with a 50N00 internal exception.

## Related

Fixes #13923

Closes #13923