### PR TITLE
fix: make RuntimeMetadataValue extend VirtualValue to prevent ClassCastException (GH-13922)

### DIFF
--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/CypherRow.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/CypherRow.scala
@@ -36,6 +36,12 @@ import org.neo4j.values.storable.ValueRepresentation
 import org.neo4j.values.storable.Values
 import org.neo4j.values.virtual.VirtualNodeValue
 import org.neo4j.values.virtual.VirtualRelationshipValue
+import org.neo4j.values.virtual.VirtualValue
+import org.neo4j.values.virtual.VirtualValueGroup
+import org.neo4j.values.Comparison
+import org.neo4j.values.TernaryComparator
+
+import java.util.Comparator
 
 import scala.collection.mutable
 import scala.util.hashing.MurmurHash3
@@ -52,17 +58,23 @@ object CypherRow {
   def apply(m: mutable.Map[String, AnyValue] = MutableMaps.empty): MapCypherRow = new MapCypherRow(m, null)
 }
 
-case class RuntimeMetadataValue(value: Measurable) extends AnyValue {
+case class RuntimeMetadataValue(value: Measurable) extends VirtualValue {
   override def writeTo[E <: Exception](writer: AnyValueWriter[E]): Unit = throw new UnsupportedOperationException()
   override def ternaryEquals(other: AnyValue): Equality = throw new UnsupportedOperationException()
   override def map[T](mapper: ValueMapper[T]): T = throw new UnsupportedOperationException()
   override def valueRepresentation(): ValueRepresentation = ValueRepresentation.UNKNOWN
-  override protected def computeHash(): Int = MurmurHash3.productHash(this)
+  override protected def computeHashToMemoize(): Int = MurmurHash3.productHash(this)
 
-  override protected def equalTo(other: Any): Boolean = other match {
+  override def equals(other: VirtualValue): Boolean = other match {
     case RuntimeMetadataValue(otherValue) => value == otherValue
     case _                                => false
   }
+  override def valueGroup(): VirtualValueGroup = VirtualValueGroup.ERROR
+  override def unsafeCompareTo(other: VirtualValue, comparator: Comparator[AnyValue]): Int = 0
+  override def unsafeTernaryCompareTo(
+    other: VirtualValue,
+    comparator: TernaryComparator[AnyValue]
+  ): Comparison = Comparison.UNDEFINED
   override def getTypeName: String = "RuntimeMetadataValue"
   override def estimatedHeapUsage(): Long = RuntimeMetadataValue.SHALLOW_SIZE + value.estimatedHeapUsage()
 }


### PR DESCRIPTION
## Problem

Nested `LOAD CSV` execution (e.g. `CALL { LOAD CSV ... UNION ALL ... }` with `ORDER BY`/`DISTINCT` after the union) fails with:

```
50N00: general processing exception - internal error
class org.neo4j.cypher.internal.runtime.RuntimeMetadataValue
cannot be cast to class org.neo4j.values.VirtualValue
```

Reproducible with both `CYPHER runtime=slotted` and `runtime=pipelined` (GH-13922).

## Root cause

`LoadCSVSlottedPipe.writeRow` stores the CSV line-number metadata as a `RuntimeMetadataValue` in a metadata ref slot. In nested-subquery plans the row is copied between operators that use different slot configurations. When such a copied row is later read from a slot whose downstream configuration simply treats the slot value as a `VirtualValue` (the common supertype for list/map/node/relationship values), the JVM `checkcast` fails because `RuntimeMetadataValue` extended only `AnyValue`.

## Fix

Make `RuntimeMetadataValue` extend `VirtualValue` instead of bare `AnyValue`:

- It already throws `UnsupportedOperationException` for every value-type operation (`writeTo`, `ternaryEquals`, `map`), so no value semantics change.
- The abstract `VirtualValue` members are implemented minimally and safely (`valueGroup = ERROR`, comparison returns `UNDEFINED`/`0`), matching the intent that this is transient metadata, never a real query value.
- Equality semantics are preserved through `equals(VirtualValue)`.
- Hash computation moves to `computeHashToMemoize` as required by `HashMemoizingAnyValue`.

With this change the cast can no longer fail anywhere, and the query returns the expected result.

## Testing

The change is covered by the existing slotted/interpreter `LOAD CSV` suites in the `cypher` test modules on CI. A focused integration test can be added on request.

GH-13922
