### PR TITLE
fix: guard against StackOverflowError from deeply nested expressions

### DIFF
--- a/community/cypher/front-end/ast/src/main/scala/org/neo4j/cypher/internal/ast/prettifier/ExpressionStringifier.scala
+++ b/community/cypher/front-end/ast/src/main/scala/org/neo4j/cypher/internal/ast/prettifier/ExpressionStringifier.scala
@@ -215,10 +215,21 @@ private class DefaultExpressionStringifier(
   }
 
   override def apply(ast: Expression, shouldBacktickEmpty: Boolean): String =
-    withShouldBacktickEmpty(shouldBacktickEmpty)(stringify(ast)._1)
+    withShouldBacktickEmpty(shouldBacktickEmpty)(safeStringify(ast))
 
   override def apply(ast: Expression): String =
-    stringify(ast)._1
+    safeStringify(ast)
+
+  /**
+   * Stringifies the given expression, guarding against StackOverflowError for extremely deeply
+   * nested expressions. Returns a placeholder instead of crashing the error-handling path.
+   */
+  private def safeStringify(ast: Expression): String =
+    try {
+      stringify(ast)._1
+    } catch {
+      case _: StackOverflowError => "<...>"
+    }
 
   override def apply(s: SymbolicName): String = s match {
     case CallableName(namespace, name) =>

--- a/community/cypher/front-end/parser/common/antlr-ast-common/src/main/scala/org/neo4j/cypher/internal/parser/ast/AntlrAstParser.scala
+++ b/community/cypher/front-end/parser/common/antlr-ast-common/src/main/scala/org/neo4j/cypher/internal/parser/ast/AntlrAstParser.scala
@@ -30,6 +30,8 @@ import org.neo4j.cypher.internal.parser.lexer.CypherToken
 import org.neo4j.cypher.internal.parser.lexer.UnicodeEscapeReplacementReader
 import org.neo4j.cypher.internal.util.CypherExceptionFactory
 import org.neo4j.cypher.internal.util.InputPosition
+import org.neo4j.gqlstatus.ErrorGqlStatusObjectImplementation
+import org.neo4j.gqlstatus.GqlStatusInfoCodes
 import org.neo4j.internal.helpers.Exceptions
 
 import scala.jdk.CollectionConverters.CollectionHasAsScala
@@ -44,38 +46,47 @@ trait AntlrAstParser[P <: AstBuildingAntlrParser] extends AstParser {
   protected def errorStrategyConf: CypherErrorStrategy.Conf
 
   final def parse[AST <: AnyRef](f: P => AstRuleCtx): AST = {
-    val listener = new SyntaxErrorListener(exceptionFactory)
-    val parser = newParser(preparsedTokens(listener, fullTokens = false))
+    try {
+      val listener = new SyntaxErrorListener(exceptionFactory)
+      val parser = newParser(preparsedTokens(listener, fullTokens = false))
 
-    // Try parsing with PredictionMode.SLL first (faster but might fail on some syntax)
-    // See https://github.com/antlr/antlr4/blob/dev/doc/faq/general.md#why-is-my-expression-parser-slow
-    parser.getInterpreter.setPredictionMode(PredictionMode.SLL)
+      // Try parsing with PredictionMode.SLL first (faster but might fail on some syntax)
+      // See https://github.com/antlr/antlr4/blob/dev/doc/faq/general.md#why-is-my-expression-parser-slow
+      parser.getInterpreter.setPredictionMode(PredictionMode.SLL)
 
-    // Use bail error strategy to fail fast and avoid recovery attempts
-    parser.setErrorHandler(new BailErrorStrategy)
+      // Use bail error strategy to fail fast and avoid recovery attempts
+      parser.setErrorHandler(new BailErrorStrategy)
 
-    val cst =
-      try {
-        cstIfNoExceptions(doParse(parser, listener, f))
-      } catch {
-        case NonFatal(_) =>
-          // The fast route failed, now try again with full error handling and prediction mode
-
-          // Reset parser and token stream
-          // We do not reuse the TokenStream because we need `fullTokens = true` for better error handling
-          parser.setInputStream(preparsedTokens(listener, fullTokens = true))
-
-          // Slower but correct prediction.
-          parser.getInterpreter.setPredictionMode(PredictionMode.LL)
-
-          // CypherErrorStrategy allows us to get the correct error messages in case we still fail
-          parser.setErrorHandler(new CypherErrorStrategy(errorStrategyConf))
-          parser.addErrorListener(listener)
-
+      val cst =
+        try {
           cstIfNoExceptions(doParse(parser, listener, f))
-      }
+        } catch {
+          case NonFatal(_) =>
+            // The fast route failed, now try again with full error handling and prediction mode
 
-    cst.ast[AST]
+            // Reset parser and token stream
+            // We do not reuse the TokenStream because we need `fullTokens = true` for better error handling
+            parser.setInputStream(preparsedTokens(listener, fullTokens = true))
+
+            // Slower but correct prediction.
+            parser.getInterpreter.setPredictionMode(PredictionMode.LL)
+
+            // CypherErrorStrategy allows us to get the correct error messages in case we still fail
+            parser.setErrorHandler(new CypherErrorStrategy(errorStrategyConf))
+            parser.addErrorListener(listener)
+
+            cstIfNoExceptions(doParse(parser, listener, f))
+        }
+
+      cst.ast[AST]
+    } catch {
+      case _: StackOverflowError =>
+        throw exceptionFactory.syntaxException(
+          ErrorGqlStatusObjectImplementation.from(GqlStatusInfoCodes.STATUS_42001).build(),
+          "The query is too deeply nested. Try simplifying the expression or splitting it into multiple parts.",
+          InputPosition.NONE
+        )
+    }
   }
 
   final def parseCst(f: P => AstRuleCtx): ParsingResult = {


### PR DESCRIPTION
Fixes #13928

## Problem

Deeply nested parenthesized expressions (600+ levels, e.g. `RETURN ((((...1...))))`) raise an uncaught `StackOverflowError` in the generated ANTLR recursive-descent parser (`Cypher25Parser.parenthesizedExpression` ↔ `expression`). The failure chain:

1. **Parser**: uncaught `StackOverflowError` — recursive descent with no depth guard.
2. **Error formatting**: a second `StackOverflowError` while formatting the error message — `DefaultExpressionStringifier.stringify/inner` recurses on the same deep AST.
3. **Protocol**: `NetworkResponseHandler` then fails with an NPE (`payload cannot be null`), the Bolt connection is killed, and each incident appends a ~0.5 MB stack trace to `debug.log`. Repeated submissions act as a slow DoS.

Same shape reproduces with 3000 nested `abs(abs(...))` (function invocation recursion), i.e. any deeply nested expression construct reaches the same stack overflow.

## Fix (2 files)

1. **`AntlrAstParser.parse`** — catches `StackOverflowError` and converts it to a clean, user-facing `SyntaxException` (GQL 42001) with a message about nesting depth. All ANTLR-based parsers (Cypher 5 and Cypher 25) share this entry point, so both dialects are covered at once.

2. **`DefaultExpressionStringifier`** — guards the public `apply()` entry points: a `StackOverflowError` during error-message formatting is caught and a truncated `"<...>"` placeholder returned instead of crashing the error-handling path. This follows the existing pattern in `Clause.scala` (line ~930) which already catches `StackOverflowError` for the same reason.

## Expected behavior after fix

The query still returns `1` for reasonable nesting (parser depth below the JVM stack limit, e.g. 400 levels) and fails with a clean `SyntaxException` instead of killing the connection for extreme nesting (600+ levels).