### PR TITLE
fix: guard against compilation hang on large AND chains of constant predicates

### DIFF
--- a/community/cypher/front-end/expressions/src/main/scala/org/neo4j/cypher/internal/expressions/PredicateExpressions.scala
+++ b/community/cypher/front-end/expressions/src/main/scala/org/neo4j/cypher/internal/expressions/PredicateExpressions.scala
@@ -54,10 +54,19 @@ object Ands {
       True()(InputPosition.NONE)
     } else {
       val distinct = ListSet.from(exprs)
-      if (distinct.size == 1)
-        distinct.head
-      else
-        Ands(distinct)(distinct.head.position)
+      // Short-circuit: False in any conjunction makes the whole thing False
+      if (distinct.exists(_.isInstanceOf[False])) {
+        False()(distinct.head.position.zeroLength)
+      } else {
+        // Remove any True literals; if none remain, return True
+        val nonTrue = distinct.filterNot(_.isInstanceOf[True])
+        if (nonTrue.isEmpty)
+          True()(distinct.head.position.zeroLength)
+        else if (nonTrue.size == 1)
+          nonTrue.head
+        else
+          Ands(nonTrue)(nonTrue.head.position)
+      }
     }
 
   def apply(exprs: IterableOnce[Expression])(position: InputPosition): Ands = {

--- a/community/cypher/front-end/frontend/src/main/scala/org/neo4j/cypher/internal/frontend/phases/rewriting/cnf/simplifyPredicates.scala
+++ b/community/cypher/front-end/frontend/src/main/scala/org/neo4j/cypher/internal/frontend/phases/rewriting/cnf/simplifyPredicates.scala
@@ -49,9 +49,6 @@ import org.neo4j.cypher.internal.util.symbols.CTBoolean
 import org.neo4j.cypher.internal.util.topDown
 
 case class simplifyPredicates(semanticState: SemanticState, cancellationChecker: CancellationChecker) extends Rewriter {
-  private val T = True()(null)
-  private val F = False()(null)
-
   private val step: Rewriter = Rewriter.lift { case e: Expression => computeReplacement(e) }
 
   private val instance = fixedPoint(cancellationChecker)(topDown(step))
@@ -76,20 +73,20 @@ case class simplifyPredicates(semanticState: SemanticState, cancellationChecker:
     case Ands(exps) if exps.isEmpty =>
       throw new IllegalStateException("Found an instance of Ands with empty expressions")
     case Ors(exps) if exps.isEmpty => throw new IllegalStateException("Found an instance of Ors with empty expressions")
-    case p @ Ands(exps) if exps.contains(F) => False()(p.position.zeroLength)
-    case p @ Ors(exps) if exps.contains(T)  => True()(p.position.zeroLength)
+    case p @ Ands(exps) if exps.exists(_.isInstanceOf[False]) => False()(p.position.zeroLength)
+    case p @ Ors(exps) if exps.exists(_.isInstanceOf[True])  => True()(p.position.zeroLength)
     case p @ Ands(exps) if exps.size == 1   => simplifyToInnerExpression(p, exps.head)
     case p @ Ors(exps) if exps.size == 1    => simplifyToInnerExpression(p, exps.head)
-    case p @ Ands(exps) if exps.contains(T) =>
-      val nonTrue = exps.filterNot(T == _)
+    case p @ Ands(exps) if exps.exists(_.isInstanceOf[True]) =>
+      val nonTrue = exps.filterNot(_.isInstanceOf[True])
       if (nonTrue.isEmpty)
         True()(p.position.zeroLength)
       else if (nonTrue.size == 1)
         simplifyToInnerExpression(p, nonTrue.head)
       else
         Ands(nonTrue)(p.position)
-    case p @ Ors(exps) if exps.contains(F) =>
-      val nonFalse = exps.filterNot(F == _)
+    case p @ Ors(exps) if exps.exists(_.isInstanceOf[False]) =>
+      val nonFalse = exps.filterNot(_.isInstanceOf[False])
       if (nonFalse.isEmpty)
         False()(p.position.zeroLength)
       else if (nonFalse.size == 1)


### PR DESCRIPTION
Fixes #13929

## Problem

`RETURN 1=1 AND 1=1 AND ... AND 1=1` with 200+ terms hangs query compilation on 2026.06.0+ (CPU pinned, transaction never registered). The same query compiles and returns in ~1.9s on 2026.05.0.

## Root cause

Two issues combined:

1. `simplifyPredicates` relied on `exps.contains(T)` / `exps.contains(F)` where `T = True()(null)` / `F = False()(null)`. Since `True`/`False` are case classes whose second parameter list (the `position`) participates in `equals`/`hashCode`, the sentinel instances never match the actual `True()(position)` instances present in the conjunction, so constant-predicate simplification silently never ran.
2. `Ands.create` did not fold `True`/`False` constants at construction time, so large conjunctions of constant predicates were kept as large `Ands` nodes through planning.

## Fix

- In `Ands.create`: short-circuit on `False`, drop `True` literals, and return a single expression when the conjunction collapses. This is O(n) and prevents large constant conjunctions from ever being constructed.
- In `simplifyPredicates`: use `isInstanceOf[True]` / `isInstanceOf[False]` instead of sentinel `equals` comparisons, so simplification no longer depends on `equals` semantics.
