### PR TITLE
fix: fallback leftover AllReduceSingletonPredicate in nested expressions (GH #13932)

### DIFF
--- a/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/plans/rewriter/AllReduceFallback.scala
+++ b/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/plans/rewriter/AllReduceFallback.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher.internal.compiler.planner.logical.plans.rewriter
 
 import org.neo4j.cypher.internal.expressions.AllReducePredicate
+import org.neo4j.cypher.internal.expressions.AllReduceSingletonPredicate
 import org.neo4j.cypher.internal.expressions.Ands
 import org.neo4j.cypher.internal.expressions.CaseExpression
 import org.neo4j.cypher.internal.expressions.ContainerIndex
@@ -162,6 +163,17 @@ case class AllReduceFallback(
 
   override val innerRewriter: Rewriter = Rewriter.lift {
     case allReduce: AllReducePredicate => rewriteAllReduce(allReduce)
+    case allReduceSingleton: AllReduceSingletonPredicate =>
+      // Fallback for leftover AllReduceSingletonPredicate that wasn't rewritten by AllReduceSingletonRewriter.
+      // This can happen when the predicate ends up in a nested expression (e.g. inside an EXISTS subquery
+      // used as a CASE property value) where the LogicalPlan-only traversal of AllReduceSingletonRewriter
+      // cannot reach it.
+      // Semantics: single-step reduction - compute the next accumulator value from reductionStep
+      // and check the predicate on it.
+      allReduceSingleton.predicate.replaceAllOccurrencesBy(
+        allReduceSingleton.accumulator,
+        allReduceSingleton.reductionStep
+      )
   }
 
   private val instance: Rewriter = bottomUp(innerRewriter)

--- a/community/cypher/cypher-planner/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/plans/rewriter/AllReduceFallbackTest.scala
+++ b/community/cypher/cypher-planner/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/plans/rewriter/AllReduceFallbackTest.scala
@@ -22,6 +22,7 @@ package org.neo4j.cypher.internal.compiler.planner.logical.plans.rewriter
 import org.neo4j.cypher.internal.ast.AstConstructionTestSupport
 import org.neo4j.cypher.internal.ast.AstConstructionTestSupport.VariableStringInterpolator
 import org.neo4j.cypher.internal.compiler.CypherPlannerTestSuite
+import org.neo4j.cypher.internal.expressions.AllReduceSingletonPredicate
 import org.neo4j.cypher.internal.util.AnonymousVariableNameGenerator
 import org.neo4j.cypher.rendering.QueryRenderer
 
@@ -130,5 +131,52 @@ class AllReduceFallbackTest extends CypherPlannerTestSuite with AstConstructionT
 
     // Test that allReduce gets correctly translated to reduce with CASE and ListLiteral
     AllReduceFallback(new AnonymousVariableNameGenerator()).rewriteAllReduce(allReducePred) shouldBe allReduceFallback
+  }
+
+  test("allReduceSingleton fallback to predicate with reductionStep inlined") {
+    // AllReduceSingletonPredicate(acc, acc + step.x, acc < 11)
+    // This simulates a leftover singleton that wasn't rewritten by AllReduceSingletonRewriter
+    // (e.g. inside an EXISTS subquery in a CASE property value).
+    // Fallback semantics: single-step reduction - predicate evaluated on the next accumulator value.
+    // allReduceSingleton(acc, acc + step.x, acc < 11)  ->  (acc + step.x) < 11
+
+    // Case 1: simple predicate
+    val singleton1 = AllReduceSingletonPredicate(
+      accumulator = v"acc",
+      reductionStep = add(v"acc", prop(v"step", "x")),
+      predicate = lessThan(v"acc", literalInt(11))
+    )(pos)
+
+    val fallback1 = new AllReduceFallback(new AnonymousVariableNameGenerator())
+    fallback1.apply(singleton1) shouldBe lessThan(add(v"acc", prop(v"step", "x")), literalInt(11))
+
+    // Case 2: predicate with multiple accumulator occurrences -> each gets the reductionStep inlined
+    val singleton2 = AllReduceSingletonPredicate(
+      accumulator = v"acc",
+      reductionStep = add(v"acc", literalInt(1)),
+      predicate = ands(lessThan(v"acc", literalInt(10)), greaterThan(v"acc", literalInt(0)))
+    )(pos)
+
+    val fallback2 = new AllReduceFallback(new AnonymousVariableNameGenerator())
+    fallback2.apply(singleton2) shouldBe ands(
+      lessThan(add(v"acc", literalInt(1)), literalInt(10)),
+      greaterThan(add(v"acc", literalInt(1)), literalInt(0))
+    )
+
+    // Case 3: reductionStep that references the accumulator (chained state update)
+    val singleton3 = AllReduceSingletonPredicate(
+      accumulator = v"acc",
+      reductionStep = add(v"acc", multiply(v"acc", literalInt(2))),
+      predicate = notEquals(v"acc", literalInt(0))
+    )(pos)
+
+    val fallback3 = new AllReduceFallback(new AnonymousVariableNameGenerator())
+    fallback3.apply(singleton3) shouldBe notEquals(
+      add(v"acc", multiply(v"acc", literalInt(2))),
+      literalInt(0)
+    )
+
+    // The result must never be an AllReduceSingletonPredicate (would still crash ExpressionConverters)
+    fallback1.apply(singleton1) should not be an[AllReduceSingletonPredicate]
   }
 }


### PR DESCRIPTION
## Problem

A valid `allReduce()` predicate inside an `EXISTS` subquery causes an internal `ExpressionConverters` error when the `EXISTS` expression is used in a `CASE` property value of an updating query (GH #13932).

The error is:
```
Internal exception raised ExpressionConverters: Unknown expression type during transformation (class org.neo4j.cypher.internal.expressions.AllReduceSingletonPredicate)
```

## Root cause

`AllReduceSingletonPredicate` is a planner-level placeholder created during quantified-path-pattern (QPP) inlining. It is expected to be rewritten by `AllReduceSingletonRewriter`, which operates on the LogicalPlan tree with `stopper = !_.isInstanceOf[LogicalPlan]`. When the placeholder ends up in a nested expression (e.g. inside an `EXISTS` subquery used as a `CASE` property value), the LogicalPlan-only traversal cannot reach it. The subsequent `AllReduceFallback` rewriter uses `bottomUp` traversal that covers all expressions, but only handled `AllReducePredicate` — not `AllReduceSingletonPredicate` — so the singleton leaked through to the runtime `ExpressionConverters`.

## Fix

Add a fallback case for `AllReduceSingletonPredicate` in `AllReduceFallback.innerRewriter`. The fallback computes the single-step reduction semantics: `predicate[accumulator := reductionStep]` — i.e., evaluate the reduction step and check the predicate on the result. This is the expression-level equivalent of what `AllReduceSingletonRewriter` does via projection + filter.

## Testing

Added three test cases to `AllReduceFallbackTest`:
- Simple predicate with one accumulator reference
- Predicate with multiple accumulator references (each gets the reductionStep inlined)
- ReductionStep that references the accumulator (chained state update)

All verify that the fallback produces the correct replacement expression.