### PR TITLE
fix: NEXT piped query: CALL subquery importing WITH * and re-aliasing an impo...

### DIFF
--- a/community/cypher/front-end/frontend/src/main/scala/org/neo4j/cypher/internal/frontend/phases/parserTransformers/ExpandClauses.scala
+++ b/community/cypher/front-end/frontend/src/main/scala/org/neo4j/cypher/internal/frontend/phases/parserTransformers/ExpandClauses.scala
@@ -53,11 +53,9 @@ import org.neo4j.cypher.internal.ast.Yield
 import org.neo4j.cypher.internal.ast.semantics.SemanticTable
 import org.neo4j.cypher.internal.ast.semantics.scoping.Result
 import org.neo4j.cypher.internal.ast.semantics.scoping.ScopeState
-import org.neo4j.cypher.internal.ast.semantics.scoping.StatementScope
 import org.neo4j.cypher.internal.ast.semantics.scoping.TableResult
 import org.neo4j.cypher.internal.expressions.CaseExpression
-import org.neo4j.cypher.internal.expressions.ContainerIndex
-import org.neo4j.cypher.internal.expressions.CountStar
+import org.neo4j.cypher.internal.expressions.ContainerIndeximport org.neo4j.cypher.internal.expressions.CountStar
 import org.neo4j.cypher.internal.expressions.Equals
 import org.neo4j.cypher.internal.expressions.Expression
 import org.neo4j.cypher.internal.expressions.FunctionInvocation
@@ -289,15 +287,9 @@ case object ExpandClauses extends StatementRewriter with StepSequencer.Step with
         else withIncomingMappingAndContext(anonymizeResultMapping, SemanticContext(LastInNextCtx, layout.resultMapping))
 
       private def importingWithFor(sq: SingleQuery): Option[PositionedNode[With]] =
-        if (
-          scopeState.recordedScopes.get(Ref(sq)).exists {
-            case StatementScope(_, _, _, _, _, _, _, true) => true
-            case _                                         => false
-          }
-        )
+        if (scopeState.scopeOfOpt(sq).exists(_.inImportingWith))
           sq.partitionedClauses.importingWith.map(PositionedNode(_))
         else None
-
       def inUnionDistinctRefByQuery(ast: ASTNode): Layout =
         copy(
           semanticContext = semanticContext.copy(kind = UnionDistinctCtx),

--- a/community/cypher/front-end/frontend/src/test/scala/org/neo4j/cypher/internal/frontend/phases/ExpandClausesTest.scala
+++ b/community/cypher/front-end/frontend/src/test/scala/org/neo4j/cypher/internal/frontend/phases/ExpandClausesTest.scala
@@ -1337,6 +1337,30 @@ class ExpandClausesTest extends CypherFunSuite with RewritePhaseTest with AstCon
     )
   }
 
+  test("rewrites * in importing with in NEXT query") {
+    assertRewritten(
+      """WITH 1 AS p0
+        |RETURN p0
+        |
+        |NEXT
+        |
+        |CALL {
+        |  WITH *
+        |  MATCH (n)
+        |  RETURN p0 AS p1
+        |}
+        |RETURN p1""".stripMargin,
+      """WITH 1 AS p0
+        |WITH p0 AS p0
+        |CALL {
+        |  WITH p0 AS p0
+        |  MATCH (n)
+        |  RETURN p0 AS p1
+        |}
+        |RETURN p1 AS p1""".stripMargin
+    )
+  }
+
   test("rewrites * in subquery") {
     assertRewritten(
       "match (n) call (*) { return n as res} return res",


### PR DESCRIPTION
Fixes #13901

## Root cause

Importing WITH * dropped in ExpandClauses when the subquery AST was copied by NEXT expansion

## Changes

- Detect a subquery's importing WITH via ScopeState.scopeOfOpt (identity lookup with structural fallback) instead of an identity-only recordedScopes lookup, so the importing `WITH *` is expanded to explicit imported items instead of being simplified away after NEXT expansion copies the AST.