### PR TITLE
fix: FILTER type predicate does not narrow conditional-query output after NEX...

### DIFF
--- a/community/cypher/front-end/ast/src/main/scala/org/neo4j/cypher/internal/ast/Query.scala
+++ b/community/cypher/front-end/ast/src/main/scala/org/neo4j/cypher/internal/ast/Query.scala
@@ -1607,16 +1607,31 @@ case class ConditionalQueryWhen(
   }
 
   private def defineReturnScope: SemanticCheck = (state: SemanticState) => {
+    val branchScopes = allBranches.map { branch =>
+      branch.query.finalScope(state.scope(branch.query).getOrElse(Scope.empty))
+    }
+    val scope = branchScopes.tail.foldLeft(branchScopes.head) { (acc, branchScope) =>
+      widenTypesOfCommonSymbols(acc, branchScope)
+    }
     val result = SemanticCheckResult.success(state.newChildScope)
-    val headQuery = branches.head.query
-    val headScope = state.scope(headQuery)
-    val scope = headQuery.finalScope(headScope.getOrElse(Scope.empty))
     SemanticCheckResult(result.state.importValuesFromScope(scope).popScope, Seq.empty)
   }
 
+  private def widenTypesOfCommonSymbols(scope: Scope, otherScope: Scope): Scope =
+    scope.symbolTable.foldLeft(scope) { case (acc, (name, symbol)) =>
+      otherScope.symbol(name).fold(acc) { otherSymbol =>
+        acc.updateVariable(
+          name,
+          symbol.types.union(otherSymbol.types),
+          symbol.definition,
+          symbol.uses,
+          symbol.unionSymbol
+        )
+      }
+    }
+
   override def checkImportingWith(optional: Boolean): SemanticCheck =
     allBranches.foldSemanticCheck(_.query.checkImportingWith(optional))
-
   override def invalidImportingWith: Seq[SemanticError] = allBranches.flatMap(_.query.invalidImportingWith)
 
   override def isCorrelated: Boolean =

--- a/community/cypher/front-end/frontend/src/test/scala/org/neo4j/cypher/internal/frontend/ConditionalQueryWhenSemanticAnalysisTest.scala
+++ b/community/cypher/front-end/frontend/src/test/scala/org/neo4j/cypher/internal/frontend/ConditionalQueryWhenSemanticAnalysisTest.scala
@@ -308,6 +308,38 @@ class ConditionalQueryWhenSemanticAnalysisTest
     run(query).hasNoErrors
   }
 
+  test("Output type of a column is the union of the types returned by all branches") {
+    val query =
+      """UNWIND [30, 20] AS age
+        |RETURN age
+        |NEXT
+        |WHEN age >= 25 THEN
+        |  RETURN {v: age} AS a
+        |ELSE
+        |  RETURN [age] AS a
+        |NEXT
+        |FILTER a IS :: LIST<INTEGER>
+        |RETURN size(a) AS s
+        |""".stripMargin
+    run(query).hasNoErrors
+  }
+
+  test("Output type of a column is the union of the types returned by all branches, reversed branch order") {
+    val query =
+      """UNWIND [30, 20] AS age
+        |RETURN age
+        |NEXT
+        |WHEN age >= 25 THEN
+        |  RETURN [age] AS a
+        |ELSE
+        |  RETURN {v: age} AS a
+        |NEXT
+        |FILTER a IS :: LIST<INTEGER>
+        |RETURN size(a) AS s
+        |""".stripMargin
+    run(query).hasNoErrors
+  }
+
   test("Should import all variables from outer scope in subquery expression") {
     val query =
       """


### PR DESCRIPTION
Fixes #13818

## Root cause

Conditional query output column types taken only from the first WHEN branch

## Changes

- ConditionalQueryWhen.defineReturnScope now widens each output column's TypeSpec to the union of the types produced by all branches (mirroring Union.defineUnionVariables) instead of importing only the head branch's scope, so `a` is MAP | LIST<INTEGER> and size(a) type-checks. Added regression tests in ConditionalQueryWhenSemanticAnalysisTest.