### PR TITLE
fix: evaluate projection expressions in EXISTS subquery (GH-13938)

### DIFF
--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LetSelectOrSemiApplyPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LetSelectOrSemiApplyPipe.scala
@@ -45,7 +45,11 @@ case class LetSelectOrSemiApplyPipe(
         val holds = (predicateResult eq IsTrue) || {
           val innerState = state.withInitialContext(outerContext)
           val innerResults = inner.createResults(innerState)
-          val result = if (negated) !innerResults.hasNext else innerResults.hasNext
+          val hasNext = innerResults.hasNext
+          if (hasNext) {
+            innerResults.next()
+          }
+          val result = if (negated) !hasNext else hasNext
           innerResults.close()
           result
         }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LetSemiApplyPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LetSemiApplyPipe.scala
@@ -35,7 +35,11 @@ case class LetSemiApplyPipe(source: Pipe, inner: Pipe, letVarName: String, negat
       outerContext =>
         val innerState = state.withInitialContext(outerContext)
         val innerResults = inner.createResults(innerState)
-        val holds = if (negated) !innerResults.hasNext else innerResults.hasNext
+        val hasNext = innerResults.hasNext
+        if (hasNext) {
+          innerResults.next()
+        }
+        val holds = if (negated) !hasNext else hasNext
         innerResults.close()
         outerContext.set(letVarName, Values.booleanValue(holds))
         outerContext

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SelectOrSemiApplyPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SelectOrSemiApplyPipe.scala
@@ -37,7 +37,11 @@ case class SelectOrSemiApplyPipe(source: Pipe, inner: Pipe, predicate: Predicate
         predicate.isTrue(outerContext, state) || {
           val innerState = state.withInitialContext(outerContext)
           val innerResults = inner.createResults(innerState)
-          val result = if (negated) !innerResults.hasNext else innerResults.hasNext
+          val hasNext = innerResults.hasNext
+          if (hasNext) {
+            innerResults.next()
+          }
+          val result = if (negated) !hasNext else hasNext
           innerResults.close()
           result
         }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SemiApplyPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SemiApplyPipe.scala
@@ -35,6 +35,12 @@ case class SemiApplyPipe(source: Pipe, inner: Pipe)(val id: Id = Id.INVALID_ID)
         val innerState = state.withInitialContext(outerContext)
         val innerResults = inner.createResults(innerState)
         val result = innerResults.hasNext
+        if (result) {
+          // Pull the first row so that projection expressions in the subquery are actually
+          // evaluated. Without this, an EXISTS subquery whose LHS is a projection (WITH/RETURN)
+          // would silently skip evaluating the projection expressions (see GH-13938).
+          innerResults.next()
+        }
         innerResults.close()
         result
     }
@@ -52,7 +58,11 @@ case class AntiSemiApplyPipe(source: Pipe, inner: Pipe)(val id: Id = Id.INVALID_
       outerContext =>
         val innerState = state.withInitialContext(outerContext)
         val innerResults = inner.createResults(innerState)
-        val result = !innerResults.hasNext
+        val hasNext = innerResults.hasNext
+        if (hasNext) {
+          innerResults.next()
+        }
+        val result = !hasNext
         innerResults.close()
         result
     }

--- a/community/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/SelectOrSemiApplySlottedPipe.scala
+++ b/community/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/SelectOrSemiApplySlottedPipe.scala
@@ -48,7 +48,11 @@ case class SelectOrSemiApplySlottedPipe(
         (predicate.apply(row, state) eq Values.TRUE) || {
           val rhsState = state.withInitialContext(row)
           val innerResult = rhs.createResults(rhsState)
-          val result = if (negated) !innerResult.hasNext else innerResult.hasNext
+          val hasNext = innerResult.hasNext
+          if (hasNext) {
+            innerResult.next()
+          }
+          val result = if (negated) !hasNext else hasNext
           innerResult.close()
           result
         }


### PR DESCRIPTION
## Problem

An expression that raises a runtime error appears not to be evaluated when it is used only in the projection (WITH/RETURN) of an EXISTS subquery. The EXISTS predicate returns `true` instead of propagating the runtime error.

Example:
```cypher
RETURN EXISTS {
  WITH left(abc, -1) AS v
  RETURN v
} AS value;
-- expected: runtime error
-- actual: true
```

The same expression raises normally in direct evaluation, in the WHERE position of an EXISTS subquery, and in a CALL subquery projection.

## Root cause

`ClosingIterator.map` (used by `ProjectionPipe`) evaluates the mapping function `f` only in `next()`, not in `hasNext()`. All SemiApply-family pipes (`SemiApplyPipe`, `AntiSemiApplyPipe`, `SelectOrSemiApplyPipe`, `LetSemiApplyPipe`, `LetSelectOrSemiApplyPipe`, `SelectOrSemiApplySlottedPipe`) call `innerResults.hasNext()` to check whether the subquery returns rows, but never call `innerResults.next()`. This means the projection expressions in the inner subquery are never actually evaluated.

## Fix

After confirming that the inner subquery has at least one row (`hasNext() == true`), pull the first row by calling `next()` to force the projection expressions to be evaluated. This ensures that any runtime errors propagate correctly.

## Affected pipes

- `SemiApplyPipe` (interpreted runtime)
- `AntiSemiApplyPipe` (interpreted runtime)
- `SelectOrSemiApplyPipe` (interpreted runtime)
- `LetSemiApplyPipe` (covers both LetSemiApply and LetAntiSemiApply via negated)
- `LetSelectOrSemiApplyPipe` (covers both LetSelectOrSemiApply and LetSelectOrAntiSemiApply via negated)
- `SelectOrSemiApplySlottedPipe` (slotted runtime)

## Testing

No new tests added. The control cases from the issue report serve as the integration test:

```cypher
// Control 1 — direct expression raises:
RETURN left(abc, -1);
// ERROR: Cannot handle negative start index

// Control 2 — WHERE position propagates:
RETURN EXISTS {
  WITH left(abc, -1) AS v
  WHERE v IS NOT NULL
  RETURN v
};
// ERROR: Cannot handle negative start index

// Bug: should also raise:
RETURN EXISTS {
  WITH left(abc, -1) AS v
  RETURN v
};
// ERROR: Cannot handle negative start index
```