### PR TITLE
fix: detect overflow when parsing duration with fractional minutes

### DIFF
--- a/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
@@ -449,7 +449,13 @@ public final class DurationValue extends ScalarValue implements TemporalAmount, 
                 }
                 return approximate(months, days, parseFractional(h, pos) * 3600, 0, sign);
             }
-            long secondsFromHours = optLong(h) * 3600;
+            long hoursLong = optLong(h);
+            long secondsFromHours;
+            try {
+                secondsFromHours = Math.multiplyExact(hoursLong, 3600L);
+            } catch (java.lang.ArithmeticException e) {
+                throw invalidDuration(months, days, hoursLong, 0, 0, 0, e);
+            }
             if ((pos = fractionPoint(m)) >= 0) {
                 if (s != null) {
                     return null;

--- a/community/values/src/test/java/org/neo4j/values/storable/DurationValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DurationValueTest.java
@@ -907,6 +907,15 @@ class DurationValueTest {
     }
 
     @Test
+    void shouldThrowOnHoursOverflowWithFractionalMinutes() {
+        long hours = 2562047788015216L; // ceil(2^63 / 3600): hours * 3600 overflows long
+        assertThatThrownBy(() -> DurationValue.parse("PT" + hours + "H1.5M"))
+                .isInstanceOf(InvalidArgumentException.class)
+                .hasMessageContaining("Invalid value for duration")
+                .hasMessageContaining("hours=" + hours);
+    }
+
+    @Test
     void shouldParseMaxNumberOfSeconds() {
         DurationValue value = DurationValue.parse("PT" + Long.MAX_VALUE + ".999999999S");
         assertEquals(MAX_VALUE, value);


### PR DESCRIPTION
Fixes #13950

## Problem

`RETURN duration('PT2562047788015216H1.5M')` silently returns a **negative** duration:

```
PT-2562047788015214H-56M
```

instead of failing with the clean overflow error that the equivalent non-fractional input produces:

```
22N28: data exception - overflow error. The result of the operation 'duration()' has caused an overflow.
  22015: data exception - interval field overflow
```

## Root cause

In `DurationValue.parseDuration` the fractional-minutes branch computes

```java
long secondsFromHours = optLong(h) * 3600;
```

without `Math.multiplyExact`. For an hours value >= `ceil(2^63 / 3600)` = 2562047788015216 the multiplication wraps to a negative `long`, which then flows into the constructed duration. The non-fractional path ~40 lines below uses `Math.addExact`/`Math.multiplyExact` and correctly rejects the same magnitude. Values just below the threshold (e.g. `PT2562047788015215H1.5M`) parse without wraparound.

## Fix

Guard the multiplication with `Math.multiplyExact` inside the same `try/catch` pattern already used by the non-fractional path, and surface the overflow through `invalidDuration` (the existing `22N28`/`22015` GQL status). Added a regression test `shouldThrowOnHoursOverflowWithFractionalMinutes`.
