### PR TITLE
fix: reject overflow when parsing duration with fractional minutes

### DIFF
--- a/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
@@ -449,7 +449,7 @@ public final class DurationValue extends ScalarValue implements TemporalAmount, 
                 }
                 return approximate(months, days, parseFractional(h, pos) * 3600, 0, sign);
             }
-            long secondsFromHours = optLong(h) * 3600;
+            long secondsFromHours = safeMultiply(optLong(h), 3600, "hours=%d", optLong(h));
             if ((pos = fractionPoint(m)) >= 0) {
                 if (s != null) {
                     return null;

--- a/community/values/src/test/java/org/neo4j/values/storable/DurationValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DurationValueTest.java
@@ -242,6 +242,16 @@ class DurationValueTest {
     }
 
     @Test
+    void shouldRejectFractionalMinutesWhenHoursOverflow() {
+        // 2562047788015216 hours * 3600 overflows long; the fractional-minutes path used to
+        // silently wrap to a negative duration. It must now fail with the same clean
+        // overflow error as the non-fractional path (GH #13950).
+        assertThrows(InvalidArgumentException.class, () -> parse("PT2562047788015216H1.5M"));
+        // Values just below the threshold still parse without wraparound.
+        parse("PT2562047788015215H1.5M");
+    }
+
+    @Test
     void shouldParseNegativeDuration() {
         assertEquals(duration(-12, 0, 0, 0), parse("-P1Y"));
         assertEquals(duration(12, 0, 0, 0), parse("-P-1Y"));


### PR DESCRIPTION
The fractional-minutes branch of `DurationValue.parseDuration` computed `secondsFromHours` with a plain `long` multiplication:

```java
long secondsFromHours = optLong(h) * 3600;
```

For hour values ≥ 2562047788015216 (2^63 / 3600, rounded up), the product wraps around to a negative value. Combined with a fractional minutes component, the result silently becomes an incorrect negative duration instead of failing:

```cypher
RETURN duration('PT2562047788015216H1.5M') AS d
```

returns `PT-2562047788015214H-56M` instead of the clean overflow error the equivalent non-fractional input produces (`22N28` / `22015`).

### Fix

Use the existing `safeMultiply` helper (already used by the years/months/weeks/days parse paths in the same method), which throws `InvalidArgumentException` with the same GQL status `22N28` overflow error the strict non-fractional path already produces via `Math.addExact`/`Math.multiplyExact`.

### Tests

Added `shouldRejectFractionalMinutesWhenHoursOverflow` to `DurationValueTest`:
- `PT2562047788015216H1.5M` must now throw `InvalidArgumentException`
- `PT2562047788015215H1.5M` (just below the threshold) still parses

Verified locally: RED (fix reverted, test fails with "Expected InvalidArgumentException to be thrown, but nothing was thrown") → GREEN (fix applied, full `DurationValueTest` suite 57/57 pass, JDK 21).

Fixes: #13950
