### PR TITLE
fix: report out-of-range duration components as ArgumentError instead of internal error

### DIFF
--- a/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
@@ -510,7 +510,15 @@ public final class DurationValue extends ScalarValue implements TemporalAmount, 
     }
 
     private static long optLong(String value) {
-        return value == null ? 0 : parseLong(value);
+        if (value == null) {
+            return 0;
+        }
+        try {
+            return parseLong(value);
+        } catch (NumberFormatException e) {
+            throw InvalidArgumentException.invalidArgument(
+                    String.format("Invalid value for duration, value is out of range: %s", value), e);
+        }
     }
 
     static DurationValue durationBetween(Temporal from, Temporal to) {

--- a/community/values/src/test/java/org/neo4j/values/storable/DurationValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DurationValueTest.java
@@ -907,6 +907,14 @@ class DurationValueTest {
     }
 
     @Test
+    void shouldThrowWhenDurationComponentExceedsLongRange() {
+        assertThatThrownBy(() -> DurationValue.parse("P9223372036854775808M"))
+                .isInstanceOf(InvalidArgumentException.class)
+                .hasMessageContaining("value is out of range")
+                .hasMessageContaining("9223372036854775808");
+    }
+
+    @Test
     void shouldParseMaxNumberOfSeconds() {
         DurationValue value = DurationValue.parse("PT" + Long.MAX_VALUE + ".999999999S");
         assertEquals(MAX_VALUE, value);


### PR DESCRIPTION
Fixes #13948

## Problem

`RETURN duration('P9223372036854775808M')` fails with an internal server error:

```
Neo.DatabaseError.Statement.ExecutionFailed (50N00)
general processing exception - internal error. Internal exception raised CypherExecution:
For input string: "9223372036854775808"
```

A client input problem (duration component outside the signed-64-bit range) is reported as a server-side failure. The same happens for any oversized component (Y/M/W/D/H) and negative variants.

## Root cause

`DurationValue` statically imports `java.lang.Long.parseLong` and calls it unguarded from `optLong` during ISO-duration parsing (e.g. `long months = optLong(m)`). The raw `NumberFormatException` escapes the parser and is mapped to a 50N00 internal error.

## Fix

Catch `NumberFormatException` in `optLong` and rethrow it as an `InvalidArgumentException` via `invalidArgument`, so oversized components surface as a clean client-side `ArgumentError` (GQL status 22000). `null` input still returns `0`. Added regression test `shouldThrowWhenDurationComponentExceedsLongRange`.
