### PR TITLE
fix: evaluate projection expressions in simple COUNT subquery

### DIFF
--- a/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/ast/convert/plannerQuery/CreateIrExpressions.scala
+++ b/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/ast/convert/plannerQuery/CreateIrExpressions.scala
@@ -108,7 +108,12 @@ case class CreateIrExpressions(
           case query: RegularSinglePlannerQuery =>
             query.tailOrSelf.horizon match {
               // Simply some Return items but no SKIP, LIMIT, WHERE, DISTINCT, aggregation, etc.
-              case RegularQueryProjection(_, QueryPagination(None, None), Selections(SetExtractor()), _, _) =>
+              // Only if all returned projections are pure variable references (e.g. RETURN n) can we
+              // simply override the final horizon with our aggregation. If a projection contains an
+              // actual expression (e.g. RETURN 1 / z), it may raise a runtime error that must
+              // propagate (GH-13943), so we keep the projection and add the aggregation in a tail.
+              case RegularQueryProjection(projections, QueryPagination(None, None), Selections(SetExtractor()), _, _)
+                  if projections.values.forall(_.isInstanceOf[LogicalVariable]) =>
                 // We can simply override the final horizon with our aggregation.
                 plannerQuery.asSinglePlannerQuery
                   .updateTailOrSelf(_.withHorizon(

--- a/community/cypher/cypher-planner/src/test/scala/org/neo4j/cypher/internal/compiler/ast/convert/plannerQuery/CreateIrExpressionsTest.scala
+++ b/community/cypher/cypher-planner/src/test/scala/org/neo4j/cypher/internal/compiler/ast/convert/plannerQuery/CreateIrExpressionsTest.scala
@@ -34,6 +34,7 @@ import org.neo4j.cypher.internal.ast.semantics.SemanticTable
 import org.neo4j.cypher.internal.compiler.CypherPlannerTestSuite
 import org.neo4j.cypher.internal.expressions
 import org.neo4j.cypher.internal.expressions.AssertIsNode
+import org.neo4j.cypher.internal.expressions.Divide
 import org.neo4j.cypher.internal.expressions.MatchMode
 import org.neo4j.cypher.internal.expressions.RelationshipChain
 import org.neo4j.cypher.internal.expressions.RelationshipsPattern
@@ -776,6 +777,48 @@ class CreateIrExpressionsTest extends CypherPlannerTestSuite with AstConstructio
         |  RETURN n AS n
         |}""".stripMargin
     )
+  }
+
+  test("should keep projection expressions in simple COUNT subquery so runtime errors propagate") {
+    // GH-13943: `RETURN COUNT { WITH 0 AS z RETURN 1 / z AS boom }` must evaluate `1 / z`.
+    // The simple-case rewrite overrides the final horizon with count(*) which would silently
+    // discard the `1 / z` projection and swallow the division-by-zero runtime error.
+    val z = v"z"
+    val boom = v"boom"
+    val simpleMatchQuery = singleQuery(
+      with_(aliasedReturnItem(literalInt(0), "z")),
+      return_(aliasedReturnItem(divide(literalInt(1), varFor("z")), "boom"))
+    )
+
+    val esc = CountExpression(simpleMatchQuery)(pos, Some(Set(z, boom)), Some(Set.empty))
+
+    val nameGenerator = makeAnonymousVariableNameGenerator()
+    val countVariable = varFor(nameGenerator.nextName)
+
+    val rewritten = rewrite(esc)
+    val countIRExpression = rewritten.asInstanceOf[CountIRExpression]
+
+    def allHorizons(pq: SinglePlannerQuery): List[QueryHorizon] = pq match {
+      case rq: RegularSinglePlannerQuery => rq.horizon :: rq.tail.toList.flatMap(allHorizons)
+      case uq: UnionQuery                => allHorizons(uq.lhs.asSinglePlannerQuery) ++ allHorizons(uq.rhs)
+    }
+
+    val horizons = allHorizons(countIRExpression.query.asSinglePlannerQuery)
+
+    // The final projection expression (1 / z) must be kept in the rewritten query so that the
+    // division-by-zero runtime error is propagated instead of silently counting the row.
+    val divideProjectionKept = horizons.exists {
+      case rp: RegularQueryProjection => rp.projections.values.exists(_.isInstanceOf[Divide])
+      case _                          => false
+    }
+    divideProjectionKept shouldBe true
+
+    // The count aggregation must still be present (as a tail) so the subquery returns a count.
+    val aggregationPresent = horizons.exists {
+      case ap: AggregatingQueryProjection => ap.aggregationExpressions.contains(countVariable)
+      case _                              => false
+    }
+    aggregationPresent shouldBe true
   }
 
   test("Rewrites CountExpression with ORDER BY") {


### PR DESCRIPTION
## Problem

`RETURN COUNT { WITH 0 AS z RETURN 1 / z AS boom }` silently returns `c = 1` instead of raising the division-by-zero error. The `1 / z` expression in the final `RETURN` projection of the COUNT subquery is never evaluated.

Equivalent materializations raise correctly:
- `CALL { WITH 0 AS z RETURN 1 / z AS boom } RETURN count(boom)` → `Neo.ClientError.Statement.ArithmeticError / by zero` (GQLSTATUS 22012)
- `COUNT { ... WHERE 1 / z IS NOT NULL ... }` → same error
- `COLLECT { ... RETURN 1 / z ... }` → same error

## Root cause

In `CreateIrExpressions.scala`, the `CountExpression` rewrite has two branches:
- **Simple case** (no SKIP/LIMIT/WHERE/DISTINCT/aggregation — pure `RegularQueryProjection`): it *overrides* the final horizon with `AggregatingQueryProjection(count(*))` via `withHorizon(...)`. That discards the original RETURN projection expressions entirely, so `1 / z` is never evaluated and its runtime error never propagates. Only the row count is observed.
- **Complex case** (`case _`): it *keeps* the original horizon and appends the aggregation as a new tail via `withTail(...)`, so the projection IS evaluated and errors propagate.

## Fix

The simple-case override is a deliberate optimization that keeps the tail-less `CountIRExpression` shape `QuerySolvableByGetDegree` recognizes (→ GetDegree / count-store planning). It is only safe when the returned projections are pure variable references (e.g. `RETURN n`), which cannot raise runtime errors. When any projection contains an actual expression (e.g. `RETURN 1 / z`), the simple-case guard no longer matches and the rewrite falls through to the tail-appending branch — keeping the projection (so the expression is evaluated and errors propagate) and appending the `count(*)` aggregation as a tail.

This preserves the GetDegree/count-store optimization for side-effect-free projections while forcing evaluation for expressions that can raise.

## Test

Added a regression test to `CreateIrExpressionsTest` covering `RETURN COUNT { WITH 0 AS z RETURN 1 / z AS boom }`:
- the rewritten query keeps the `1 / z` projection (a `RegularQueryProjection` containing the `Divide` expression),
- the `count(*)` aggregation is still present as a tail.

Verified locally:
- `CreateIrExpressionsTest`: 36 tests pass
- `SubqueryCallPlanningIntegrationTest`: 121 tests pass
- `GetDegreeRewriterCountExpressionTest`: 29 tests pass (GetDegree optimization intact)
- `GetDegreeRewriterExistsExpressionTest`: 10 tests pass
