### PR TITLE
Fix cached IN results for null-containing lists

### DIFF
--- a/community/values/src/main/java/org/neo4j/values/utils/InCache.java
+++ b/community/values/src/main/java/org/neo4j/values/utils/InCache.java
@@ -91,7 +91,7 @@ public class InCache implements AutoCloseable {
                 iterator = list.iterator();
                 this.seen = HeapTrackingCollections.newSet(memoryTracker);
             }
-            if (seen.contains(value)) {
+            if (!(value instanceof SequenceValue || value instanceof MapValue) && seen.contains(value)) {
                 return TRUE;
             }
 

--- a/community/values/src/test/java/org/neo4j/values/utils/InCacheTest.java
+++ b/community/values/src/test/java/org/neo4j/values/utils/InCacheTest.java
@@ -137,6 +137,21 @@ class InCacheTest {
     }
 
     @Test
+    void shouldPreserveUndefinedEqualityForCachedLists() {
+        InCache cache = new InCache();
+        ListValue list = list(list(intValue(1), NO_VALUE));
+        for (int i = 0; i < 127; i++) {
+            list = list.append(intValue(i));
+        }
+
+        ListValue value = list(intValue(1), NO_VALUE);
+
+        assertEquals(NO_VALUE, cache.check(value, list, EmptyMemoryTracker.INSTANCE));
+        assertEquals(NO_VALUE, cache.check(value, list, EmptyMemoryTracker.INSTANCE));
+        assertEquals(NO_VALUE, cache.check(value, list, EmptyMemoryTracker.INSTANCE));
+    }
+
+    @Test
     void shouldHandleMapsWithNulls() {
         // given
         InCache cache = new InCache();


### PR DESCRIPTION
Fix incorrect cached `IN` results for null-containing lists

## Issue

Closes #13958.

## Background

For lists with 128 or more elements, `InCache` caches values in a hash set. Hash-based equality treats list values containing `NO_VALUE` as equal even when Cypher's ternary equality is undefined, so repeated `IN` evaluations can change from `NULL` to `TRUE`.

## Changes

- Avoid the hash-set fast path for sequence and map values.
- Add a regression test that exercises the cache after its delayed initialization with a 128+ element list.

## Compatibility

Scalar membership checks retain the existing fast path. Sequence and map membership checks preserve the existing ternary-equality semantics, with a linear scan for cached lookups.

## Tests

- `git diff --check` (passed)
- `mvn -pl community/values -DskipITs -Dtest=InCacheTest -Dsurefire.failIfNoSpecifiedTests=false -Dhttps.protocols=TLSv1.2 test` (blocked: Maven Central terminated the TLS handshake while resolving `io.netty:netty-bom:4.2.16.Final`)

## Limitations

The focused Maven test could not run locally because the dependency download failed before compilation. The source and regression test are intentionally limited to the reported cache path.
