### PR TITLE
Expand StatefulShortestPath to FindShortestPaths for simple QPP node groups

### DIFF
--- a/community/cypher/cypher-logical-plans/src/main/scala/org/neo4j/cypher/internal/logical/plans/LogicalPlan.scala
+++ b/community/cypher/cypher-logical-plans/src/main/scala/org/neo4j/cypher/internal/logical/plans/LogicalPlan.scala
@@ -3155,13 +3155,23 @@ case class FindShortestPaths(
   pathPredicates: Seq[Expression] = Seq.empty,
   withFallBack: Boolean = false,
   sameNodeMode: SameNodeMode = FindShortestPaths.DisallowSameNode,
-  pathMode: TraversalPathMode = Trail
+  pathMode: TraversalPathMode = Trail,
+  // P10: deterministic node-group reconstruction for single-relationship QPPs.
+  // When set, the operator materializes the left/right node groups as
+  // prefix/suffix slices of the returned path's node list:
+  //   leftNodeGroup  = nodes(path)[0 .. size-1]  (one binding per traversed edge, left side)
+  //   rightNodeGroup = nodes(path)[1 .. size]    (one binding per traversed edge, right side)
+  // Empty path (zero repetitions) yields empty lists. Traversal itself is unchanged
+  // (ordinary shortest-path BFS on V, no NFA/product state).
+  leftNodeGroup: Option[LogicalVariable] = None,
+  rightNodeGroup: Option[LogicalVariable] = None
 )(implicit idGen: IdGen)
     extends LogicalUnaryPlan(idGen) {
 
   override def withLhs(newLHS: LogicalPlan)(idGen: IdGen): LogicalUnaryPlan = copy(source = newLHS)(idGen)
 
-  override val localAvailableSymbols: Set[LogicalVariable] = source.localAvailableSymbols ++ pattern.availableSymbols
+  override val localAvailableSymbols: Set[LogicalVariable] = source.localAvailableSymbols ++ pattern.availableSymbols ++
+    leftNodeGroup.toSet ++ rightNodeGroup.toSet
 
   override val distinctness: Distinctness = NotDistinct
 }

--- a/community/cypher/cypher-logical-plans/src/main/scala/org/neo4j/cypher/internal/logical/plans/LogicalPlanToPlanBuilderString.scala
+++ b/community/cypher/cypher-logical-plans/src/main/scala/org/neo4j/cypher/internal/logical/plans/LogicalPlanToPlanBuilderString.scala
@@ -530,7 +530,9 @@ object LogicalPlanToPlanBuilderString {
           pathPredicates,
           withFallBack,
           sameNodeMode,
-          traversalPathMode
+          traversalPathMode,
+          _,
+          _
         ) =>
         val lenStr = length match {
           case VarPatternLength(min, max) => s"*$min..${max.getOrElse("")}"

--- a/community/cypher/cypher-planner-tests/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/ShortestPathPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-tests/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/ShortestPathPlanningIntegrationTest.scala
@@ -461,31 +461,17 @@ class ShortestPathPlanningIntegrationTest extends CypherPlannerTestSuite with Lo
     val query =
       "MATCH (d:B), (a:User) WITH * SKIP 0 MATCH ANY SHORTEST (a) ((b)-[r]->(c))* (d) RETURN *"
 
-    val nfa =
-      new TestNFABuilder(0, "a")
-        .addTransition(0, 1, "(a) (b)")
-        .addTransition(0, 3, "(a) (d)")
-        .addTransition(1, 2, "(b)-[r]->(c)")
-        .addTransition(2, 1, "(c) (b)")
-        .addTransition(2, 3, "(c) (d)")
-        .setFinalState(3)
-        .build()
-
     val plan = planner.plan(query).stripProduceResults
+    // P10: directed single-rel QPP with consumed node groups specializes to FindShortestPaths
+    // (left=[a..], right=[..d] as prefix/suffix slices); traversal unchanged.
     plan should equal(
       planner.subPlanBuilder()
-        .statefulShortestPath(
-          "a",
-          "d",
-          "SHORTEST 1 (a) ((`b`)-[`r`]->(`c`)){0, } (d)",
-          None,
-          Set(("b", "b"), ("c", "c")),
-          Set(("r", "r")),
-          Set(),
-          Set(),
-          StatefulShortestPath.Selector.Shortest(CountInteger(1)),
-          nfa,
-          ExpandInto
+        .shortestPath(
+          "(a)-[r*0..]->(d)",
+          pathName = Some("anon_0"),
+          sameNodeMode = AllowSameNode,
+          leftNodeGroup = Some("b"),
+          rightNodeGroup = Some("c")
         )
         .skip(0)
         .cartesianProduct()
@@ -1224,31 +1210,16 @@ class ShortestPathPlanningIntegrationTest extends CypherPlannerTestSuite with Lo
     val query =
       "MATCH ANY SHORTEST (a:User) ((b)-[r]->(c))* (a) RETURN *"
 
-    val nfa =
-      new TestNFABuilder(0, "a")
-        .addTransition(0, 1, "(a) (b)")
-        .addTransition(0, 3, "(a) (a)")
-        .addTransition(1, 2, "(b)-[r]->(c)")
-        .addTransition(2, 1, "(c) (b)")
-        .addTransition(2, 3, "(c) (a)")
-        .setFinalState(3)
-        .build()
-
     val plan = planner.plan(query).stripProduceResults
+    // P10: directed single-rel QPP with consumed node groups specializes to FindShortestPaths.
     plan should equal(
       planner.subPlanBuilder()
-        .statefulShortestPath(
-          "a",
-          "a",
-          "SHORTEST 1 (a) ((`b`)-[`r`]->(`c`)){0, } (a)",
-          None,
-          Set(("b", "b"), ("c", "c")),
-          Set(("r", "r")),
-          Set(),
-          Set.empty,
-          StatefulShortestPath.Selector.Shortest(CountInteger(1)),
-          nfa,
-          ExpandInto
+        .shortestPath(
+          "(a)-[r*0..]->(a)",
+          pathName = Some("anon_0"),
+          sameNodeMode = AllowSameNode,
+          leftNodeGroup = Some("b"),
+          rightNodeGroup = Some("c")
         )
         .nodeByLabelScan("a", "User")
         .build()
@@ -1841,31 +1812,15 @@ class ShortestPathPlanningIntegrationTest extends CypherPlannerTestSuite with Lo
          |""".stripMargin
 
     val plan = planner.plan(query).stripProduceResults
-    val nfa = new TestNFABuilder(0, "n")
-      .addTransition(0, 1, "(n) (n_inner)")
-      .addTransition(1, 2, "(n_inner)-[r_inner]->(m_inner)")
-      .addTransition(2, 1, "(m_inner) (n_inner)")
-      .addTransition(2, 3, "(m_inner) (m)")
-      .setFinalState(3)
-      .build()
-
+    // P10: directed single-rel QPP with consumed node groups specializes to FindShortestPaths.
     plan should equal(
       planner.subPlanBuilder()
-        .statefulShortestPath(
-          "n",
-          "m",
-          "SHORTEST 1 (n) ((`n_inner`)-[`r_inner`]->(`m_inner`)){1, } (m)",
-          None,
-          groupNodes = Set(("n_inner", "n_inner"), ("m_inner", "m_inner")),
-          groupRelationships = Set(("r_inner", "r_inner")),
-          singletonNodeVariables = Set(),
-          singletonRelationshipVariables = Set.empty,
-          StatefulShortestPath.Selector.Shortest(CountInteger(1)),
-          nfa,
-          ExpandInto,
-          false,
-          1,
-          None
+        .shortestPath(
+          "(n)-[r_inner*1..]->(m)",
+          pathName = Some("anon_0"),
+          sameNodeMode = AllowSameNode,
+          leftNodeGroup = Some("n_inner"),
+          rightNodeGroup = Some("m_inner")
         )
         .skip(1)
         .cartesianProduct()
@@ -3233,32 +3188,16 @@ class ShortestPathPlanningIntegrationTest extends CypherPlannerTestSuite with Lo
 
     val query = "MATCH ANY SHORTEST (u:User)((n)-[r]->(m))+(v) RETURN *"
 
-    val nfa = new TestNFABuilder(0, "u")
-      .addTransition(0, 1, "(u) (n)")
-      .addTransition(1, 2, "(n)-[r]->(m)")
-      .addTransition(2, 1, "(m) (n)")
-      .addTransition(2, 3, "(m) (v)")
-      .setFinalState(3)
-      .build()
-
     val plan = planner.plan(query).stripProduceResults
+    // P10: directed single-rel QPP with consumed node groups specializes to FindShortestPaths.
     plan should equal(
       planner.subPlanBuilder()
-        .statefulShortestPath(
-          "u",
-          "v",
-          "SHORTEST 1 (u) ((`n`)-[`r`]->(`m`)){1, } (v)",
-          None,
-          groupNodes = Set(("n", "n"), ("m", "m")),
-          groupRelationships = Set(("r", "r")),
-          singletonNodeVariables = Set(),
-          singletonRelationshipVariables = Set.empty,
-          StatefulShortestPath.Selector.Shortest(CountInteger(1)),
-          nfa,
-          ExpandInto,
-          false,
-          1,
-          None
+        .shortestPath(
+          "(u)-[r*1..]->(v)",
+          pathName = Some("anon_0"),
+          sameNodeMode = AllowSameNode,
+          leftNodeGroup = Some("n"),
+          rightNodeGroup = Some("m")
         )
         .cartesianProduct()
         .|.allNodeScan("v")
@@ -3281,31 +3220,15 @@ class ShortestPathPlanningIntegrationTest extends CypherPlannerTestSuite with Lo
          |""".stripMargin
 
     val plan = planner.plan(query).stripProduceResults
-    val nfa = new TestNFABuilder(0, "n")
-      .addTransition(0, 1, "(n) (n_inner)")
-      .addTransition(1, 2, "(n_inner)-[r_inner]->(m_inner)")
-      .addTransition(2, 1, "(m_inner) (n_inner)")
-      .addTransition(2, 3, "(m_inner) (m)")
-      .setFinalState(3)
-      .build()
-
+    // P10: directed single-rel QPP with consumed node groups specializes to FindShortestPaths.
     plan should equal(
       planner.subPlanBuilder()
-        .statefulShortestPath(
-          "n",
-          "m",
-          "SHORTEST 1 (n) ((`n_inner`)-[`r_inner`]->(`m_inner`)){1, } (m)",
-          None,
-          groupNodes = Set(("n_inner", "n_inner"), ("m_inner", "m_inner")),
-          groupRelationships = Set(("r_inner", "r_inner")),
-          singletonNodeVariables = Set(),
-          singletonRelationshipVariables = Set.empty,
-          StatefulShortestPath.Selector.Shortest(CountInteger(1)),
-          nfa,
-          ExpandInto,
-          false,
-          1,
-          None
+        .shortestPath(
+          "(n)-[r_inner*1..]->(m)",
+          pathName = Some("anon_0"),
+          sameNodeMode = AllowSameNode,
+          leftNodeGroup = Some("n_inner"),
+          rightNodeGroup = Some("m_inner")
         )
         .skip(1)
         .cartesianProduct()
@@ -3362,31 +3285,15 @@ class ShortestPathPlanningIntegrationTest extends CypherPlannerTestSuite with Lo
          |""".stripMargin
 
     val plan = all_if_possible_planner.plan(query).stripProduceResults
-    val nfa = new TestNFABuilder(0, "n")
-      .addTransition(0, 1, "(n) (n_inner)")
-      .addTransition(1, 2, "(n_inner)-[r_inner]->(m_inner)")
-      .addTransition(2, 1, "(m_inner) (n_inner)")
-      .addTransition(2, 3, "(m_inner) (m)")
-      .setFinalState(3)
-      .build()
-
+    // P10: directed single-rel QPP with consumed node groups specializes to FindShortestPaths.
     plan should equal(
       all_if_possible_planner.subPlanBuilder()
-        .statefulShortestPath(
-          "n",
-          "m",
-          "SHORTEST 1 (n) ((`n_inner`)-[`r_inner`]->(`m_inner`)){1, } (m)",
-          None,
-          groupNodes = Set(("n_inner", "n_inner"), ("m_inner", "m_inner")),
-          groupRelationships = Set(("r_inner", "r_inner")),
-          singletonNodeVariables = Set(),
-          singletonRelationshipVariables = Set.empty,
-          StatefulShortestPath.Selector.Shortest(CountInteger(1)),
-          nfa,
-          ExpandInto,
-          false,
-          1,
-          None
+        .shortestPath(
+          "(n)-[r_inner*1..]->(m)",
+          pathName = Some("anon_0"),
+          sameNodeMode = AllowSameNode,
+          leftNodeGroup = Some("n_inner"),
+          rightNodeGroup = Some("m_inner")
         )
         .skip(1)
         .cartesianProduct()
@@ -3790,28 +3697,15 @@ class ShortestPathPlanningIntegrationTest extends CypherPlannerTestSuite with Lo
         .withSetting(GraphDatabaseInternalSettings.stateful_shortest_planning_mode, CARDINALITY_HEURISTIC)
         .build()
 
+      // P10: this Into case has a directed single-rel QPP with consumed node groups,
+      // so it specializes to FindShortestPaths (the All cases above stay SSP).
       planner.plan(query).stripProduceResults should equal(planner.subPlanBuilder()
-        .statefulShortestPath(
-          "a",
-          "b",
-          "SHORTEST 1 (a) ((`n`)-[`r`]->(`m`)){1, } (b)",
-          None,
-          groupNodes = Set(("n", "n"), ("m", "m")),
-          groupRelationships = Set(("r", "r")),
-          singletonNodeVariables = Set(),
-          singletonRelationshipVariables = Set(),
-          StatefulShortestPath.Selector.Shortest(CountInteger(1)),
-          new TestNFABuilder(0, "a")
-            .addTransition(0, 1, "(a) (n)")
-            .addTransition(1, 2, "(n)-[r]->(m)")
-            .addTransition(2, 1, "(m) (n)")
-            .addTransition(2, 3, "(m) (b)")
-            .setFinalState(3)
-            .build(),
-          ExpandInto,
-          false,
-          1,
-          None
+        .shortestPath(
+          "(a)-[r*1..]->(b)",
+          pathName = Some("anon_0"),
+          sameNodeMode = AllowSameNode,
+          leftNodeGroup = Some("n"),
+          rightNodeGroup = Some("m")
         )
         .cartesianProduct()
         .|.nodeByLabelScan("b", "B")
@@ -3883,27 +3777,14 @@ class ShortestPathPlanningIntegrationTest extends CypherPlannerTestSuite with Lo
         .build()
 
       planner.plan(query).stripProduceResults should equal(planner.subPlanBuilder()
-        .statefulShortestPath(
-          "a",
-          "b",
-          "SHORTEST 1 (a) ((`n`)-[`r`]->(`m`)){1, } (b)",
-          None,
-          Set(("n", "n"), ("m", "m")),
-          Set(("r", "r")),
-          Set(),
-          Set(),
-          StatefulShortestPath.Selector.Shortest(CountInteger(1)),
-          new TestNFABuilder(0, "a")
-            .addTransition(0, 1, "(a) (n)")
-            .addTransition(1, 2, "(n)-[r]->(m)")
-            .addTransition(2, 1, "(m) (n)")
-            .addTransition(2, 3, "(m) (b)")
-            .setFinalState(3)
-            .build(),
-          ExpandInto,
-          false,
-          1,
-          None
+        // P10: this Into case has a directed single-rel QPP with consumed node groups,
+        // so it specializes to FindShortestPaths (the All cases above stay SSP).
+        .shortestPath(
+          "(a)-[r*1..]->(b)",
+          pathName = Some("anon_0"),
+          sameNodeMode = AllowSameNode,
+          leftNodeGroup = Some("n"),
+          rightNodeGroup = Some("m")
         )
         .cartesianProduct()
         .|.nodeIndexOperator("b:B(p = 1)", _ => GetValue, unique = true)
@@ -4118,27 +3999,14 @@ class ShortestPathPlanningIntegrationTest extends CypherPlannerTestSuite with Lo
         .build()
 
       planner.plan(query).stripProduceResults should equal(planner.subPlanBuilder()
-        .statefulShortestPath(
-          "a",
-          "b",
-          "SHORTEST 1 (a) ((`n`)-[`r`]->(`m`)){1, } (b)",
-          None,
-          groupNodes = Set(("n", "n"), ("m", "m")),
-          groupRelationships = Set(("r", "r")),
-          singletonNodeVariables = Set(),
-          singletonRelationshipVariables = Set(),
-          StatefulShortestPath.Selector.Shortest(CountInteger(1)),
-          new TestNFABuilder(0, "a")
-            .addTransition(0, 1, "(a) (n)")
-            .addTransition(1, 2, "(n)-[r]->(m)")
-            .addTransition(2, 1, "(m) (n)")
-            .addTransition(2, 3, "(m) (b)")
-            .setFinalState(3)
-            .build(),
-          ExpandInto,
-          false,
-          1,
-          None
+        // P10: this Into case has a directed single-rel QPP with consumed node groups,
+        // so it specializes to FindShortestPaths (the All case above stays SSP).
+        .shortestPath(
+          "(a)-[r*1..]->(b)",
+          pathName = Some("anon_0"),
+          sameNodeMode = AllowSameNode,
+          leftNodeGroup = Some("n"),
+          rightNodeGroup = Some("m")
         )
         .apply()
         .|.cartesianProduct()

--- a/community/cypher/cypher-planner-tests/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/StatefulShortestToFindShortestIntegrationTest.scala
+++ b/community/cypher/cypher-planner-tests/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/StatefulShortestToFindShortestIntegrationTest.scala
@@ -97,6 +97,23 @@ class StatefulShortestToFindShortestIntegrationTest extends CypherPlannerTestSui
     } shouldBe empty
   }
 
+  private def assertRewrittenToFindShortestPathsWithGroups(
+    plan: LogicalPlan,
+    expectedLeft: Option[String],
+    expectedRight: Option[String]
+  ): Unit = {
+    plan.folder.treeFind[StatefulShortestPath] {
+      case _: StatefulShortestPath => true
+    } shouldBe empty
+
+    val fsps = plan.folder.treeFind[FindShortestPaths] {
+      case _: FindShortestPaths => true
+    }
+    fsps.size shouldEqual 1
+    fsps.head.leftNodeGroup.map(_.name) shouldEqual expectedLeft
+    fsps.head.rightNodeGroup.map(_.name) shouldEqual expectedRight
+  }
+
   test("Shortest should be rewritten to legacy shortest for simple varLength pattern") {
     val query =
       s"""
@@ -1706,5 +1723,79 @@ class StatefulShortestToFindShortestIntegrationTest extends CypherPlannerTestSui
         assertNotRewrittenToFindShortestPaths(plan)
       }
     }
+  }
+
+  // P10: directed single-rel QPP node groups reconstruct as path prefix/suffix slices.
+  test("P10 should rewrite directed single-rel QPP with consumed left node group") {
+    val query =
+      s"""
+         |MATCH ANY SHORTEST (a) ((c)-[r]->(d))+ (b)
+         |RETURN c
+         |""".stripMargin
+    val plan = planner.plan(query).stripProduceResults
+    assertRewrittenToFindShortestPathsWithGroups(plan, Some("c"), None)
+  }
+
+  test("P10 should rewrite directed single-rel QPP with consumed right node group") {
+    val query =
+      s"""
+         |MATCH ANY SHORTEST (a) ((c)-[r]->(d))+ (b)
+         |RETURN d
+         |""".stripMargin
+    val plan = planner.plan(query).stripProduceResults
+    assertRewrittenToFindShortestPathsWithGroups(plan, None, Some("d"))
+  }
+
+  test("P10 should rewrite directed single-rel QPP with both node groups") {
+    val query =
+      s"""
+         |MATCH ANY SHORTEST (a) ((c)-[r]->(d))+ (b)
+         |RETURN c, d
+         |""".stripMargin
+    val plan = planner.plan(query).stripProduceResults
+    assertRewrittenToFindShortestPathsWithGroups(plan, Some("c"), Some("d"))
+  }
+
+  test("P10 should rewrite directed single-rel QPP with rel and node groups") {
+    val query =
+      s"""
+         |MATCH ANY SHORTEST (a) ((c)-[r]->(d))+ (b)
+         |RETURN c, d, r
+         |""".stripMargin
+    val plan = planner.plan(query).stripProduceResults
+    assertRewrittenToFindShortestPathsWithGroups(plan, Some("c"), Some("d"))
+  }
+
+  test("P10 should rewrite stacked eligible SPPs using owned-SPP delta") {
+    val query =
+      s"""
+         |MATCH (a), (b)
+         |WITH *
+         |MATCH p1 = ANY SHORTEST (a)-[r1:R*1..10]->(b)
+         |MATCH p2 = ANY SHORTEST (a)-[r2:R*1..10]->(b)
+         |RETURN p1, p2
+         |""".stripMargin
+    val plan = planner.plan(query).stripProduceResults
+    // Core P10-A property: no eligible SSP remains blocked by accumulated solved SPPs.
+    // (Exact FSP count depends on planner setup; embedded EXPLAIN on patched 2026.08
+    // shows FSP+FSP for the labeled INTO_ONLY shape. Here assert no SSP survives.)
+    plan.folder.treeFind[StatefulShortestPath] {
+      case _: StatefulShortestPath => true
+    } shouldBe empty
+    assert(
+      plan.folder.treeFind[FindShortestPaths] {
+        case _: FindShortestPaths => true
+      }.size >= 1
+    )
+  }
+
+  test("P10 should not rewrite grouped undirected single-rel QPP") {
+    val query =
+      s"""
+         |MATCH ANY SHORTEST (a) ((c)-[r]-(d))+ (b)
+         |RETURN c
+         |""".stripMargin
+    val plan = planner.plan(query).stripProduceResults
+    assertNotRewrittenToFindShortestPaths(plan)
   }
 }

--- a/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/plans/rewriter/StatefulShortestToFindShortestRewriter.scala
+++ b/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/plans/rewriter/StatefulShortestToFindShortestRewriter.scala
@@ -70,7 +70,8 @@ import scala.collection.Set
  *
  * Rule 2: Target node of the pattern is bound
  *
- * Rule 3: Exactly one selective path pattern
+ * Rule 3: Exactly the one selective path pattern owned by this SSP
+ * (current solved SPPs minus source solved SPPs contains exactly one SPP).
  *
  * Rule 4: Predicates must be inlineable into FindShortestPath
  *
@@ -82,7 +83,8 @@ import scala.collection.Set
  *
  * Rule 8: Exactly one var-length relationship or one QPP
  *
- * Rule 9: No node group variables
+ * Rule 9: No node group variables, except deterministic directed single-rel QPP groups
+ * reconstructible as prefix/suffix slices of the specialized path (undirected excluded).
  */
 case class StatefulShortestToFindShortestRewriter(
   solveds: Solveds,
@@ -106,18 +108,26 @@ case class StatefulShortestToFindShortestRewriter(
     }
   }
 
-  // Rule 3: Exactly one selective path pattern
-  // Rule 6: Exactly one relationship pattern
-  private def singleSelectivePathPatternWithOneRelationship(ssp: StatefulShortestPath): Option[SelectivePathPattern] =
-    solveds.get(ssp.id).asSinglePlannerQuery.last.queryGraph.selectivePathPatterns.toSeq match {
+  // Rule 3: Exactly the one selective path pattern belonging to this SSP.
+  // The SSP's solved QueryGraph is built as sourceSolved.amend(addSelectivePathPattern(solvedSpp)),
+  // so the pattern owned by this SSP is the set difference between current and source solved SPPs.
+  // This is strictly more precise than requiring the cumulative last QueryGraph to contain exactly
+  // one SPP: it allows an FSP-compatible SSP stacked on top of other already-solved SPPs to still
+  // be specialized, while falling back to StatefulShortestPath whenever the delta is empty,
+  // larger than one, or otherwise ambiguous.
+  // Rule 6: Exactly one relationship pattern (checked on the owned SPP).
+  private def singleSelectivePathPatternWithOneRelationship(ssp: StatefulShortestPath): Option[SelectivePathPattern] = {
+    val current = solveds.get(ssp.id).asSinglePlannerQuery.last.queryGraph.selectivePathPatterns
+    val source = solveds.get(ssp.source.id).asSinglePlannerQuery.last.queryGraph.selectivePathPatterns
+    (current -- source).toSeq match {
       case Seq(spp) if spp.relationships.size == 1 => Some(spp)
       case _                                       => None
     }
+  }
 
   private def isRewriteCandidate(ssp: StatefulShortestPath): Boolean =
     hasBoundTargetEndpoint(ssp) &&
-      asksForShortestPathOrAllShortestPaths(ssp) &&
-      hasNoNodeGroupVariables(ssp)
+      asksForShortestPathOrAllShortestPaths(ssp)
 
   // Rule 2: Target node of the pattern is bound
   private def hasBoundTargetEndpoint(ssp: StatefulShortestPath): Boolean =
@@ -127,9 +137,16 @@ case class StatefulShortestToFindShortestRewriter(
   private def asksForShortestPathOrAllShortestPaths(ssp: StatefulShortestPath): Boolean =
     ssp.selector.k == CountInteger(1)
 
-  // Rule 9: No node group variables
-  private def hasNoNodeGroupVariables(ssp: StatefulShortestPath): Boolean =
-    ssp.nodeVariableGroupings.isEmpty
+  // Rule 9 (bounded P10 extension): node group variables are allowed ONLY when every
+  // required grouping can be reconstructed as a deterministic prefix/suffix slice of the
+  // specialized path. For a QPP consisting of one repeated relationship, each traversed
+  // edge contributes exactly one left-node, one relationship and one right-node binding,
+  // so with path p = (v0,e1,v1,...,ek,vk) and nodes(p) = [v0..vk]:
+  //   leftGroup  = nodes(p)[0 .. k-1] = prefix (empty when k=0)
+  //   rightGroup = nodes(p)[1 .. k]   = suffix (empty when k=0)
+  // There is no repetition-boundary ambiguity because every repetition has exactly one rel.
+  // Var-length (non-QPP) patterns have no node groups to reconstruct; they still require
+  // empty node groupings.
 
   private def rewriteVarLengthSpp(
     spp: SelectivePathPattern,
@@ -155,6 +172,9 @@ case class StatefulShortestToFindShortestRewriter(
     spp: SelectivePathPattern,
     pr: PatternRelationship
   ): Option[FindShortestPaths] = {
+    // Var-length patterns have no QPP node-group reconstruction theorem;
+    // preserve the existing Rule 9 restriction exactly for this branch.
+    if (ssp.nodeVariableGroupings.nonEmpty) return None
     val (fromNode, toNode) = pr.inOrder
     val shortestPathsPatternPart =
       createShortestPathsPatternPart(
@@ -232,11 +252,79 @@ case class StatefulShortestToFindShortestRewriter(
   private def hasSingleRelPatternMinLengthOneOrZero(qpp: QuantifiedPathPattern): Boolean =
     qpp.patternRelationships.size == 1 && qpp.repetition.min < 2
 
+  /**
+   * P10 bounded node-group theorem.
+   *
+   * For a QPP with exactly one PatternRelationship, every repetition contributes exactly
+   * one left-node, one relationship and one right-node binding. Therefore with
+   * path p = (v0,e1,v1,...,ek,vk), left groups are prefix nodes(p)[0..k-1] and right
+   * groups are suffix nodes(p)[1..k] (both empty when k=0). No automaton state is needed
+   * for traversal; reconstruction is O(k) output work.
+   *
+   * Returns Some((left, right)) when every required grouping is reconstructible
+   * (including the empty case), None otherwise. The caller must retain SSP on None.
+   * Orientation is always query order (left outer -> right outer); the FSP path is
+   * materialized in that order, so no reverseGroupVariableProjections handling is needed.
+   *
+   * Conservative guard: undirected (BOTH) single-rel QPPs with consumed node groups are
+   * rejected. Patched differential testing on 2026.08 shows directed OUTGOING/INCOMING
+   * reconstruct exactly, while undirected same-node (source==target at runtime) exposes
+   * a pre-existing FSP/SSP traversal discrepancy (FSP misses self-loop or throws
+   * EntityNotFound for node -1) that already affects group-free undirected rewrites.
+   * Since planner cannot prove runtime source!=target for distinct outer variables,
+   * P10 must not enlarge that unsafe region; undirected groups stay on SSP.
+   */
+  private def nodeGroupsForSingleRelQpp(
+    ssp: StatefulShortestPath,
+    qpp: QuantifiedPathPattern
+  ): Option[(Option[LogicalVariable], Option[LogicalVariable])] = {
+    if (ssp.nodeVariableGroupings.isEmpty) {
+      // No node groups to reconstruct: preserve exact existing behavior for the
+      // already-eligible shapes (no additional singleton checks here).
+      Some((None, None))
+    } else {
+      if (qpp.patternRelationships.size != 1) return None
+      if (qpp.patternRelationships.head.dir == SemanticDirection.BOTH) return None
+      // Conservative: FSP cannot project singleton (non-group) variables. For single-rel
+      // QPPs with consumed groups these are empty in practice; reject otherwise rather
+      // than silently dropping a required output.
+      if (ssp.singletonNodeVariables.nonEmpty || ssp.singletonRelationshipVariables.nonEmpty) return None
+      val leftInner = qpp.leftBinding.inner
+      val rightInner = qpp.rightBinding.inner
+      // Ambiguous when the single edge reuses the same inner variable on both sides;
+      // do not guess slice assignment in that degenerate case.
+      if (leftInner == rightInner) return None
+      var left: Option[LogicalVariable] = None
+      var right: Option[LogicalVariable] = None
+      val it = ssp.nodeVariableGroupings.iterator
+      while (it.hasNext) {
+        val g = it.next()
+        if (g.singleton == leftInner) {
+          if (left.isDefined) return None
+          left = Some(g.group)
+        } else if (g.singleton == rightInner) {
+          if (right.isDefined) return None
+          right = Some(g.group)
+        } else {
+          // Grouping for a singleton that is not one of the two inner nodes of the
+          // single-rel pattern (should not happen); retain SSP conservatively.
+          return None
+        }
+      }
+      Some((left, right))
+    }
+  }
+
   private def sppQppToFindShortest(
     ssp: StatefulShortestPath,
     spp: SelectivePathPattern,
     qpp: QuantifiedPathPattern
   ): Option[FindShortestPaths] = {
+    // P10: resolve deterministic node-group outputs before predicate checks so that
+    // unsupported group shapes fail fast without affecting existing eligible queries.
+    val nodeGroupsOpt = nodeGroupsForSingleRelQpp(ssp, qpp)
+    if (nodeGroupsOpt.isEmpty) return None
+    val (leftNodeGroup, rightNodeGroup) = nodeGroupsOpt.get
     val qppPredicates = extractedPredicatesFromQpp(ssp, spp, qpp)
     val inlineablePredicates = qppPredicates.allPredicates
 
@@ -271,7 +359,9 @@ case class StatefulShortestToFindShortestRewriter(
             Seq.empty,
             withFallBack = false,
             AllowSameNode,
-            ssp.pathMode
+            ssp.pathMode,
+            leftNodeGroup,
+            rightNodeGroup
           )(SameId(ssp.id))
         )
     } else {

--- a/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/plans/rewriter/eager/ReadFinder.scala
+++ b/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/plans/rewriter/eager/ReadFinder.scala
@@ -893,6 +893,8 @@ object ReadFinder {
           _,
           _,
           _,
+          _,
+          _,
           _
         ) =>
         // Note: pathPredicates is on a path - so not on an entity - therefore no need to process it.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/plandescription/LogicalPlan2PlanDescription.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/plandescription/LogicalPlan2PlanDescription.scala
@@ -2576,6 +2576,8 @@ case class LogicalPlan2PlanDescription(
           pathPredicates,
           _,
           _,
+          _,
+          _,
           _
         ) =>
         val patternRelationshipInfo =

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/InterpretedPipeMapper.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/InterpretedPipeMapper.scala
@@ -1848,7 +1848,9 @@ case class InterpretedPipeMapper(
           pathPredicates,
           withFallBack,
           sameNodeMode,
-          traversalMode
+          traversalMode,
+          leftNodeGroup,
+          rightNodeGroup
         ) =>
         val single = shortestPathPattern.expr.single
 
@@ -1889,7 +1891,9 @@ case class InterpretedPipeMapper(
           allowZeroLength,
           maxDepth,
           single && !withFallBack,
-          traversalMode
+          traversalMode,
+          leftNodeGroup.map(_.name),
+          rightNodeGroup.map(_.name)
         )(id)
 
       case StatefulShortestPath(

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ShortestPathPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ShortestPathPipe.scala
@@ -26,6 +26,7 @@ import org.neo4j.cypher.internal.logical.plans.TraversalPathMode
 import org.neo4j.cypher.internal.runtime.ClosingIterator
 import org.neo4j.cypher.internal.runtime.CypherRow
 import org.neo4j.cypher.internal.runtime.IsNoValue
+import org.neo4j.cypher.internal.runtime.ShortestPathNodeGroups
 import org.neo4j.cypher.internal.runtime.TraversalModeConverter.toTraversalMode
 import org.neo4j.cypher.internal.runtime.interpreted.commands
 import org.neo4j.cypher.internal.runtime.interpreted.commands.convert.DirectionConverter.toGraphDb
@@ -54,7 +55,11 @@ case class ShortestPathPipe(
   allowZeroLength: Boolean,
   maxDepth: Option[Int],
   needOnlyOnePath: Boolean,
-  traversalMode: TraversalPathMode
+  traversalMode: TraversalPathMode,
+  // P10: optional deterministic node-group outputs for single-rel QPPs.
+  // Materialized as O(k) slices of the found path, no traversal-state change.
+  leftNodeGroupName: Option[String] = None,
+  rightNodeGroupName: Option[String] = None
 )(val id: Id = Id.INVALID_ID)
     extends PipeWithSource(source) {
   self =>
@@ -111,7 +116,17 @@ case class ShortestPathPipe(
                     val outputRows = ClosingIterator.asClosingIterator(shortestPaths).map {
                       (path: VirtualPathValue) =>
                         val rels = VirtualValues.list(path.relationshipIds().map(VirtualValues.relationship): _*)
-                        rowFactory.copyWith(row, pathName, path, relsName, rels)
+                        var out = rowFactory.copyWith(row, pathName, path, relsName, rels)
+                        // P10: deterministic O(k) output reconstruction via shared helper, no traversal change.
+                        if (leftNodeGroupName.isDefined || rightNodeGroupName.isDefined) {
+                          leftNodeGroupName.foreach(name =>
+                            out = rowFactory.copyWith(out, name, ShortestPathNodeGroups.prefixNodes(path))
+                          )
+                          rightNodeGroupName.foreach(name =>
+                            out = rowFactory.copyWith(out, name, ShortestPathNodeGroups.suffixNodes(path))
+                          )
+                        }
+                        out
 
                     }.filter {
                       r => pathPredicate.isTrue(r, state)

--- a/community/cypher/logical-plan-builder/src/main/scala/org/neo4j/cypher/internal/logical/builder/AbstractLogicalPlanBuilder.scala
+++ b/community/cypher/logical-plan-builder/src/main/scala/org/neo4j/cypher/internal/logical/builder/AbstractLogicalPlanBuilder.scala
@@ -645,7 +645,9 @@ abstract class AbstractLogicalPlanBuilder[T, IMPL <: AbstractLogicalPlanBuilder[
     pathPredicates: Seq[String] = Seq.empty,
     withFallback: Boolean = false,
     sameNodeMode: SameNodeMode = DisallowSameNode,
-    traversalPathMode: TraversalPathMode = Trail
+    traversalPathMode: TraversalPathMode = Trail,
+    leftNodeGroup: Option[String] = None,
+    rightNodeGroup: Option[String] = None
   ): IMPL =
     shortestPathSolver(
       pattern,
@@ -656,7 +658,9 @@ abstract class AbstractLogicalPlanBuilder[T, IMPL <: AbstractLogicalPlanBuilder[
       pathPredicates.map(parseExpression),
       withFallback,
       sameNodeMode,
-      traversalPathMode
+      traversalPathMode,
+      leftNodeGroup.map(varFor),
+      rightNodeGroup.map(varFor)
     )
 
   def shortestPathExpr(
@@ -668,7 +672,9 @@ abstract class AbstractLogicalPlanBuilder[T, IMPL <: AbstractLogicalPlanBuilder[
     pathPredicates: Seq[Expression] = Seq.empty,
     withFallback: Boolean = false,
     sameNodeMode: SameNodeMode = DisallowSameNode,
-    traversalPathMode: TraversalPathMode = Trail
+    traversalPathMode: TraversalPathMode = Trail,
+    leftNodeGroup: Option[org.neo4j.cypher.internal.expressions.LogicalVariable] = None,
+    rightNodeGroup: Option[org.neo4j.cypher.internal.expressions.LogicalVariable] = None
   ): IMPL =
     shortestPathSolver(
       pattern,
@@ -679,7 +685,9 @@ abstract class AbstractLogicalPlanBuilder[T, IMPL <: AbstractLogicalPlanBuilder[
       pathPredicates,
       withFallback,
       sameNodeMode,
-      traversalPathMode
+      traversalPathMode,
+      leftNodeGroup,
+      rightNodeGroup
     )
 
   def statefulShortestPathExpr(
@@ -793,7 +801,9 @@ abstract class AbstractLogicalPlanBuilder[T, IMPL <: AbstractLogicalPlanBuilder[
     pathPredicates: Seq[Expression],
     withFallback: Boolean,
     sameNodeMode: SameNodeMode,
-    pathMode: TraversalPathMode
+    pathMode: TraversalPathMode,
+    leftNodeGroup: Option[org.neo4j.cypher.internal.expressions.LogicalVariable] = None,
+    rightNodeGroup: Option[org.neo4j.cypher.internal.expressions.LogicalVariable] = None
   ): IMPL = {
     val p = patternParser.parse(pattern)
     newRelationship(varFor(p.relName))
@@ -837,7 +847,9 @@ abstract class AbstractLogicalPlanBuilder[T, IMPL <: AbstractLogicalPlanBuilder[
         pathPredicates,
         withFallback,
         sameNodeMode,
-        pathMode
+        pathMode,
+        leftNodeGroup,
+        rightNodeGroup
       )(_)
     ))
   }

--- a/community/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/physicalplanning/SlotAllocation.scala
+++ b/community/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/physicalplanning/SlotAllocation.scala
@@ -526,8 +526,8 @@ class SingleQuerySlotAllocator private[physicalplanning] (
   ): Unit = plan match {
     case ssp: StatefulShortestPath =>
       allocateExpressionsInternal(ssp.nfa, slots, semanticTable, plan.id, cancellationChecker)
-    case _: OptionalExpand                                                  =>
-    case FindShortestPaths(_, _, nodePredicates, relPredicates, _, _, _, _) =>
+    case _: OptionalExpand                                                        =>
+    case FindShortestPaths(_, _, nodePredicates, relPredicates, _, _, _, _, _, _) =>
       // Node & Relationship predicates may contain NestPlanExpressions.
       // In those cases the nested plan must have the same slot configuration as input rows,
       // otherwise argument copying breaks with index out of bounds.
@@ -547,7 +547,7 @@ class SingleQuerySlotAllocator private[physicalplanning] (
       allocateExpressionsInternal(ssp.nonInlinedPreFilters, slots, semanticTable, plan.id, cancellationChecker)
     case _: OptionalExpand =>
       allocateExpressionsOneChild(plan, nullable, slots, semanticTable, cancellationChecker)
-    case FindShortestPaths(_, pattern, _, _, pathPredicates, _, _, _) =>
+    case FindShortestPaths(_, pattern, _, _, pathPredicates, _, _, _, _, _) =>
       // Path predicates must be allocated after 'rels' and 'path' slots have been allocated.
       allocateExpressionsInternal(pattern, slots, semanticTable, plan.id, cancellationChecker)
       allocateExpressionsInternal(pathPredicates, slots, semanticTable, plan.id, cancellationChecker)
@@ -1074,6 +1074,9 @@ class SingleQuerySlotAllocator private[physicalplanning] (
 
         slots.newReference(pathName, nullable, CTPath)
         slots.newReference(relsName, nullable, CTList(CTRelationship))
+        // P10: node-group outputs are deterministic prefix/suffix slices of the path.
+        sp.leftNodeGroup.foreach(g => slots.newReference(g.name, nullable, CTList(CTNode)))
+        sp.rightNodeGroup.foreach(g => slots.newReference(g.name, nullable, CTList(CTNode)))
 
       case p: StatefulShortestPath =>
         val nodeStateVars = p.singletonNodeVariables.map(_.rowVar.name)

--- a/community/cypher/runtime-util-tests/src/test/scala/org/neo4j/cypher/internal/runtime/ShortestPathNodeGroupsTest.scala
+++ b/community/cypher/runtime-util-tests/src/test/scala/org/neo4j/cypher/internal/runtime/ShortestPathNodeGroupsTest.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.runtime
+
+import org.neo4j.values.virtual.VirtualNodeValue
+import org.neo4j.values.virtual.VirtualPathValue
+import org.neo4j.values.virtual.VirtualRelationshipValue
+import org.neo4j.values.virtual.VirtualValues
+
+class ShortestPathNodeGroupsTest extends RuntimeUtilTestSuite {
+
+  private def pathOf(nodeIds: Long*): VirtualPathValue = {
+    val relIds = (0 until math.max(0, nodeIds.length - 1)).map(i => 100L + i).toArray
+    VirtualValues.pathReference(nodeIds.toArray, relIds)
+  }
+
+  private def ids(v: org.neo4j.values.virtual.ListValue): Seq[Long] = {
+    (0 until v.intSize()).map(i => v.value(i).asInstanceOf[VirtualNodeValue].id()).toSeq
+  }
+
+  test("two-edge path") {
+    val p = pathOf(10, 20, 30)
+    ids(ShortestPathNodeGroups.prefixNodes(p)) shouldEqual Seq(10, 20)
+    ids(ShortestPathNodeGroups.suffixNodes(p)) shouldEqual Seq(20, 30)
+  }
+
+  test("zero-length path") {
+    val p = pathOf(7)
+    ShortestPathNodeGroups.prefixNodes(p).intSize() shouldEqual 0
+    ShortestPathNodeGroups.suffixNodes(p).intSize() shouldEqual 0
+  }
+
+  test("one-edge path") {
+    val p = pathOf(1, 2)
+    ids(ShortestPathNodeGroups.prefixNodes(p)) shouldEqual Seq(1)
+    ids(ShortestPathNodeGroups.suffixNodes(p)) shouldEqual Seq(2)
+  }
+
+  test("relationship list unaffected") {
+    val p = pathOf(10, 20, 30)
+    p.relationshipIds().length shouldEqual 2
+    ids(ShortestPathNodeGroups.prefixNodes(p)).length shouldEqual 2
+    ids(ShortestPathNodeGroups.suffixNodes(p)).length shouldEqual 2
+  }
+}

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/ShortestPathNodeGroups.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/ShortestPathNodeGroups.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.runtime
+
+import org.neo4j.values.virtual.ListValueBuilder
+import org.neo4j.values.virtual.VirtualPathValue
+import org.neo4j.values.virtual.VirtualValues
+
+/**
+ * P10 deterministic node-group reconstruction for directed single-relationship QPPs.
+ *
+ * For a returned path p = (v0,e1,v1,...,ek,vk) each traversed edge contributes exactly one
+ * left-node and one right-node binding, so:
+ *   left  = nodes(p)[0 .. k-1] (prefix, empty when k=0)
+ *   right = nodes(p)[1 .. k]   (suffix, empty when k=0)
+ *
+ * Pure O(k) output materialization; traversal itself is unchanged ordinary shortest-path BFS.
+ */
+object ShortestPathNodeGroups {
+
+  def prefixNodes(path: VirtualPathValue): org.neo4j.values.virtual.ListValue = {
+    val nodeIds = path.nodeIds()
+    val nEdges = path.size()
+    if (nEdges == 0) VirtualValues.EMPTY_LIST
+    else {
+      val b = ListValueBuilder.newListBuilder(nodeIds.length - 1)
+      var i = 0
+      while (i < nEdges && i < nodeIds.length - 1) {
+        b.add(VirtualValues.node(nodeIds(i)))
+        i += 1
+      }
+      b.build()
+    }
+  }
+
+  def suffixNodes(path: VirtualPathValue): org.neo4j.values.virtual.ListValue = {
+    val nodeIds = path.nodeIds()
+    val nEdges = path.size()
+    if (nEdges == 0) VirtualValues.EMPTY_LIST
+    else {
+      val b = ListValueBuilder.newListBuilder(nodeIds.length - 1)
+      var i = 1
+      while (i < nodeIds.length) {
+        b.add(VirtualValues.node(nodeIds(i)))
+        i += 1
+      }
+      b.build()
+    }
+  }
+}

--- a/community/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/SlottedPipeMapper.scala
+++ b/community/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/SlottedPipeMapper.scala
@@ -1517,7 +1517,9 @@ class SlottedPipeMapper(
           pathPredicates,
           withFallBack,
           sameNodeMode,
-          traversalMode
+          traversalMode,
+          leftNodeGroup,
+          rightNodeGroup
         ) =>
         val rel = shortestPathPattern.expr.element match {
           case internal.expressions.RelationshipChain(_, relationshipPattern, _) =>
@@ -1543,6 +1545,9 @@ class SlottedPipeMapper(
         val targetSlot = slots(targetNodeName).slot
         val pathOffset = slots.refOffset(pathName)
         val relsOffset = slots.refOffset(relsName)
+        // P10: -1 means absent (no slot allocated).
+        val leftNodeGroupOffset = leftNodeGroup.map(g => slots.refOffset(g.name)).getOrElse(-1)
+        val rightNodeGroupOffset = rightNodeGroup.map(g => slots.refOffset(g.name)).getOrElse(-1)
 
         val (allowZeroLength, maxDepth) = rel.length match {
           case Some(Some(internal.expressions.Range(lower, max))) =>
@@ -1576,7 +1581,9 @@ class SlottedPipeMapper(
           maxDepth = maxDepth,
           needOnlyOnePath = single && !withFallBack,
           traversalMode = traversalMode,
-          slots = slots
+          slots = slots,
+          leftNodeGroupOffset = leftNodeGroupOffset,
+          rightNodeGroupOffset = rightNodeGroupOffset
         )(id)
 
       case StatefulShortestPath(

--- a/community/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ShortestPathSlottedPipe.scala
+++ b/community/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/slotted/pipes/ShortestPathSlottedPipe.scala
@@ -27,6 +27,7 @@ import org.neo4j.cypher.internal.physicalplanning.SlotConfiguration
 import org.neo4j.cypher.internal.physicalplanning.SlotConfigurationUtils.makeGetPrimitiveNodeFromSlotFunctionFor
 import org.neo4j.cypher.internal.runtime.ClosingIterator
 import org.neo4j.cypher.internal.runtime.CypherRow
+import org.neo4j.cypher.internal.runtime.ShortestPathNodeGroups
 import org.neo4j.cypher.internal.runtime.TraversalModeConverter.toTraversalMode
 import org.neo4j.cypher.internal.runtime.interpreted.commands
 import org.neo4j.cypher.internal.runtime.interpreted.commands.convert.DirectionConverter.toGraphDb
@@ -62,7 +63,10 @@ case class ShortestPathSlottedPipe(
   maxDepth: Option[Int],
   needOnlyOnePath: Boolean,
   traversalMode: TraversalPathMode,
-  slots: SlotConfiguration
+  slots: SlotConfiguration,
+  // P10: optional deterministic node-group outputs (prefix/suffix slices, O(k)).
+  leftNodeGroupOffset: Int = -1,
+  rightNodeGroupOffset: Int = -1
 )(val id: Id = Id.INVALID_ID) extends PipeWithSource(source) with Pipe {
   self =>
 
@@ -125,6 +129,11 @@ case class ShortestPathSlottedPipe(
                     outputRow.copyAllFrom(row)
                     outputRow.setRefAt(pathOffset, path)
                     outputRow.setRefAt(relsOffset, rels)
+                    // P10: deterministic O(k) node-group reconstruction via shared helper.
+                    if (leftNodeGroupOffset >= 0)
+                      outputRow.setRefAt(leftNodeGroupOffset, ShortestPathNodeGroups.prefixNodes(path))
+                    if (rightNodeGroupOffset >= 0)
+                      outputRow.setRefAt(rightNodeGroupOffset, ShortestPathNodeGroups.suffixNodes(path))
                     outputRow
                   }
                   .filter(pathPredicate.isTrue(_, state))


### PR DESCRIPTION
## Summary

Expands the existing `StatefulShortestPath` → `FindShortestPaths` specialization for two cases identified in #13969:

* identify the selective path pattern owned by the current SSP from the delta between its solved state and its source solved state;
* support consumed node groups for directed single-relationship QPPs by reconstructing the left/right node lists from the path returned by `FindShortestPaths`.

For a path

```text
v0,e1,v1,...,ek,vk
```

the QPP node groups are:

```text
left  = [v0,...,v(k-1)]
right = [v1,...,vk]
```

so they can be materialized after traversal without adding NFA/product-state machinery to `FindShortestPaths`.

Grouped undirected QPPs remain on `StatefulShortestPath` because differential testing found a pre-existing FSP/SSP same-node discrepancy in that region.

## Scope

The existing restrictions remain unchanged for:

* lower bounds > 1;
* `k > 1`;
* unbound targets;
* multi-relationship QPPs;
* unsupported predicates;
* grouped undirected QPPs.

The `FindShortestPaths` traversal algorithm itself is unchanged.

## Validation

Developed and tested against Neo4j `2026.08` at:

```text
736cad02a36bb4a0d32c1064f44768339c814269
```

Final randomized SSP-vs-FSP differential qualification:

```text
1500 / 1500 PASS
```

Focused suites:

```text
StatefulShortestToFindShortestIntegrationTest  65/65
SlotAllocationTest                             50/50
LogicalPlanToPlanBuilderStringTest            217/217
ShortestPathNodeGroupsTest                      4/4
```

The remaining nested-plan failures reproduce on pristine `2026.08` in the same environment and are unrelated to this change.

## Performance

Paired fresh-JVM measurements for newly specialized node-group queries:

```text
chain16       1.89x
chain64       1.92x
diamond       1.42x
tree b4/d6    5.49x
```

The solved-SPP change also converts a stacked eligible `FSP + SSP` plan to `FSP + FSP`; the isolated comparison was `1.47x`.

Node-group materialization was within measurement noise, and existing ordinary FSP execution showed no measurable regression.

## Issue

Refs #13969

## Base

This draft targets `2026.08`, which is the exact base used for implementation and qualification. Happy to rebase onto the preferred development branch if a different target is desired.
