### PR TITLE
Fix execution model for unsupported runtime fallback

### DIFF
--- a/community/community-it/cypher-it/src/test/scala/org/neo4j/cypher/CommunityPipelinedFallbackPlanningIT.scala
+++ b/community/community-it/cypher-it/src/test/scala/org/neo4j/cypher/CommunityPipelinedFallbackPlanningIT.scala
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher
+
+import org.neo4j.configuration.GraphDatabaseSettings
+import org.neo4j.graphdb.InputPosition
+import org.neo4j.graphdb.config.Setting
+import org.neo4j.notifications.NotificationCodeWithDescription.runtimeUnsupported
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Duration
+
+/**
+ * Community `runtime=pipelined` has no pipelined executor and falls back to slotted
+ * execution. Planning must therefore use Volcano (row-at-a-time) cost assumptions, not
+ * batched ones: a Cartesian product costed with `ceil(lhsCardinality / batchSize)` RHS
+ * executions but executed with `lhsCardinality` executions can select an orientation that
+ * is catastrophically expensive under the actual slotted execution
+ * (see https://github.com/neo4j/neo4j/issues/13937).
+ *
+ * This test runs the exact #13937 setup and query and asserts that the pipelined-hinted
+ * Community plan is identical to the slotted plan, that both complete with the same
+ * result, and that the unsupported-runtime fallback notification is preserved.
+ */
+class CommunityPipelinedFallbackPlanningIT extends ExecutionEngineFunSuite {
+
+  private lazy val importDir: Path = Files.createTempDirectory("pipelinedFallbackPlanning")
+
+  override def databaseConfig(): Map[Setting[?], Object] = {
+    super.databaseConfig() ++ Map(
+      GraphDatabaseSettings.transaction_timeout -> Duration.ofSeconds(30),
+      GraphDatabaseSettings.load_csv_file_url_root -> importDir
+    )
+  }
+
+  private def writeFuzzCsv(): Unit = {
+    Files.write(
+      importDir.resolve("fuzz.csv"),
+      "a,b\none,two\nthree,four\n".getBytes(StandardCharsets.UTF_8)
+    )
+  }
+
+  private def setUpIssueGraph(): Unit = {
+    execute("DROP INDEX fuzz_node_vector_index IF EXISTS")
+    execute("DROP INDEX fuzz_relationship_vector_index IF EXISTS")
+    execute(
+      """CREATE VECTOR INDEX fuzz_node_vector_index FOR (n:FuzzVector) ON n.embedding
+        |OPTIONS { indexConfig: { `vector.dimensions`: 3, `vector.similarity_function`: 'cosine' } }""".stripMargin
+    )
+    execute(
+      """CREATE VECTOR INDEX fuzz_relationship_vector_index FOR ()-[r:FuzzVectorRel]-() ON r.embedding
+        |OPTIONS { indexConfig: { `vector.dimensions`: 3, `vector.similarity_function`: 'cosine' } }""".stripMargin
+    )
+    execute("CALL db.awaitIndexes()")
+    execute(
+      """CREATE (:FuzzVector {embedding: [1.0, 0.0, 0.0], rank: 1, active: true}),
+        |       (:FuzzVector {embedding: [0.0, 1.0, 0.0], rank: 2, active: false})""".stripMargin
+    )
+    execute(
+      """MATCH (a:FuzzVector), (b:FuzzVector)
+        |WHERE a.rank = 1 AND b.rank = 2
+        |CREATE (a)-[:FuzzVectorRel {embedding: [1.0, 0.0, 0.0], rank: 1}]->(b)""".stripMargin
+    )
+    execute(
+      """UNWIND range(0, 63) AS i
+        |CREATE (:l0:l1:l2:l3:l4:l5:l6:l7:l8:l9:l10:l11 {
+        |  id: i,
+        |  k0: true,
+        |  k8: false,
+        |  k9: i = 63
+        |})""".stripMargin
+    )
+    execute(
+      """UNWIND range(0, 63) AS i
+        |MATCH (a {id: i}),
+        |      (b {id: CASE WHEN i = 63 THEN 0 ELSE i + 1 END})
+        |CREATE (a)-[:rt9 {k8: false}]->(b)""".stripMargin
+    )
+  }
+
+  private def issueQuery(runtime: String): String =
+    s"""CYPHER 25 runtime=$runtime
+       |CREATE ()-[:rt9 {
+       |  k1: COUNT {
+       |    MATCH (), ({k0: true})-[r3 {k8: false}]-()
+       |    WHERE EXISTS {
+       |      CALL () {
+       |        LOAD CSV FROM 'file:///fuzz.csv' AS a
+       |        RETURN 1 AS x
+       |      }
+       |      SKIP 0
+       |    }
+       |    AND COUNT {
+       |      MATCH ()-[r5]-()
+       |      SEARCH r5 IN (VECTOR INDEX fuzz_relationship_vector_index FOR [1.0, 0.0, 0.0] LIMIT 3)
+       |    } >= 0
+       |  }
+       |}]->()
+       |RETURN 1 AS x""".stripMargin
+
+  private def operatorSkeleton(runtime: String): Seq[String] =
+    execute("EXPLAIN " + issueQuery(runtime)).executionPlanDescription().flatten.map(_.name)
+
+  test("pipelined fallback plans like slotted and completes with the same result") {
+    writeFuzzCsv()
+    setUpIssueGraph()
+
+    // Operator names in traversal order capture the plan structure, including Cartesian
+    // product orientation, without coupling to IDs, estimates, or rendering details.
+    // Before the fix the pipelined-hinted plan arranged the Cartesian product differently.
+    operatorSkeleton("pipelined") should equal(operatorSkeleton("slotted"))
+
+    val slottedRows = execute(issueQuery("slotted")).toList
+    slottedRows should equal(List(Map("x" -> 1)))
+
+    val pipelinedResult = execute(issueQuery("pipelined"))
+    pipelinedResult.toList should equal(List(Map("x" -> 1)))
+
+    // The Community fallback contract is unchanged: pipelined still falls back to slotted
+    // with a notification; only the planning assumptions changed.
+    pipelinedResult should containNotifications(
+      runtimeUnsupported(
+        InputPosition.empty,
+        "runtime=pipelined",
+        "runtime=slotted",
+        "This version of Neo4j does not support the requested runtime: `pipelined`"
+      )
+    )
+  }
+}

--- a/community/cypher/cypher-tests/src/test/scala/org/neo4j/cypher/internal/planning/CommunityRuntimeExecutionModelTest.scala
+++ b/community/cypher/cypher-tests/src/test/scala/org/neo4j/cypher/internal/planning/CommunityRuntimeExecutionModelTest.scala
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.planning
+
+import org.neo4j.common
+import org.neo4j.configuration.Config
+import org.neo4j.cypher.CommunityCypherTestSuite
+import org.neo4j.cypher.internal.CachingPreParser
+import org.neo4j.cypher.internal.CommunityRuntimeFactory
+import org.neo4j.cypher.internal.CommunitySchemaCommandRuntime
+import org.neo4j.cypher.internal.CypherVersion
+import org.neo4j.cypher.internal.TestExecutorCaffeineCacheFactory
+import org.neo4j.cypher.internal.cache.CypherQueryCaches
+import org.neo4j.cypher.internal.cache.CypherQueryCaches.CacheStrategy
+import org.neo4j.cypher.internal.cache.LFUCache
+import org.neo4j.cypher.internal.compiler.CypherParsingConfig
+import org.neo4j.cypher.internal.compiler.CypherPlannerConfiguration
+import org.neo4j.cypher.internal.compiler.ExecutionModel.Volcano
+import org.neo4j.cypher.internal.config.CypherConfiguration
+import org.neo4j.cypher.internal.frontend.phases.CompilationPhaseTracer.NO_TRACING
+import org.neo4j.cypher.internal.frontend.phases.InternalUsageStatsImpl
+import org.neo4j.cypher.internal.frontend.phases.Monitors
+import org.neo4j.cypher.internal.notification.devNullLogger
+import org.neo4j.cypher.internal.options.CypherPlannerOption
+import org.neo4j.cypher.internal.options.CypherRuntimeOption
+import org.neo4j.cypher.internal.preparser.PreParsedQuery
+import org.neo4j.cypher.internal.planner.spi.DatabaseMode
+import org.neo4j.cypher.internal.planner.spi.DatabaseMode.DatabaseMode
+import org.neo4j.cypher.internal.planner.spi.GraphStatistics
+import org.neo4j.cypher.internal.planner.spi.IndexDescriptor
+import org.neo4j.cypher.internal.planner.spi.IndexOrderCapability
+import org.neo4j.cypher.internal.planner.spi.InstrumentedGraphStatistics
+import org.neo4j.cypher.internal.planner.spi.MutableGraphStatisticsSnapshot
+import org.neo4j.cypher.internal.planner.spi.NodesAllCardinality
+import org.neo4j.cypher.internal.planner.spi.NotImplementedPlanContext
+import org.neo4j.cypher.internal.planner.spi.TokenIndexDescriptor
+import org.neo4j.cypher.internal.util.Cardinality
+import org.neo4j.cypher.internal.util.LabelId
+import org.neo4j.cypher.internal.util.RelTypeId
+import org.neo4j.cypher.internal.util.Selectivity
+import org.neo4j.internal.kernel.api.security.CommunitySecurityLog
+import org.neo4j.kernel.impl.query.TransactionalContext
+import org.neo4j.logging.NullLog
+import org.neo4j.logging.NullLogProvider
+import org.neo4j.monitoring
+import org.neo4j.values.virtual.MapValue
+
+import java.time.Clock
+
+import scala.collection.mutable
+
+/**
+ * Regression test for https://github.com/neo4j/neo4j/issues/13937.
+ *
+ * In Community Edition an explicit `runtime=pipelined` (or `runtime=parallel`) has no pipelined
+ * executor: the query falls back to the slotted runtime (see [[CommunityRuntimeFactory]]).
+ * Logical planning must therefore use Volcano (row-at-a-time) cost assumptions, not batched ones:
+ * a Cartesian product costed with `ceil(lhsCardinality / batchSize)` RHS executions but executed
+ * with `lhsCardinality` executions can select an orientation that is catastrophically expensive
+ * under the actual slotted execution.
+ *
+ * These tests plan a real query through the real pre-parser and [[TransformingPlanner]] and assert
+ * the effective [[org.neo4j.cypher.internal.compiler.ExecutionModel]].
+ */
+class CommunityRuntimeExecutionModelTest extends CommunityCypherTestSuite {
+
+  private def planWithCommunityRuntime(queryText: String, runtimeOption: CypherRuntimeOption) = {
+    val stats = new GraphStatistics {
+      override def nodesAllCardinality(): Cardinality = Cardinality.EMPTY
+      override def nodesWithLabelCardinality(labelId: Option[LabelId]): Cardinality = Cardinality.EMPTY
+      override def patternStepCardinality(
+        fromLabel: Option[LabelId],
+        relTypeId: Option[RelTypeId],
+        toLabel: Option[LabelId]
+      ): Cardinality = Cardinality.EMPTY
+      override def uniqueValueSelectivity(index: IndexDescriptor): Option[Selectivity] = Some(Selectivity.ZERO)
+      override def indexPropertyIsNotNullSelectivity(index: IndexDescriptor): Option[Selectivity] =
+        Some(Selectivity.ZERO)
+    }
+
+    val getTx = () => 1L
+    val planContext = new NotImplementedPlanContext {
+      override def statistics: InstrumentedGraphStatistics = InstrumentedGraphStatistics(
+        stats,
+        new MutableGraphStatisticsSnapshot(mutable.Map(NodesAllCardinality -> 1.0))
+      )
+      override def getPropertiesWithExistenceConstraint: Set[String] = Set.empty
+      override def nodeTokenIndex: Option[TokenIndexDescriptor] =
+        Some(TokenIndexDescriptor(common.EntityType.NODE, IndexOrderCapability.BOTH))
+      override def lastCommittedTxIdProvider: () => Long = getTx
+      override def propertyIndexesGetAll(): Iterator[IndexDescriptor] = Iterator.empty
+
+      override def procedureSignatureVersion: Long = -1
+
+      override def databaseMode: DatabaseMode = DatabaseMode.SINGLE
+
+      override def storageHasPropertyColocation: Boolean = true
+      override def storageSupportsFastExpandInto: Boolean = true
+      override def storageIsMvcc: Boolean = false
+      override def txStateHasChanges(): Boolean = false
+    }
+
+    TransformingPlanner.customPlanContextCreator = Some((_, _, _, _, _) => planContext)
+    try {
+      val monitors = new monitoring.Monitors()
+      val cypherConfig = CypherConfiguration.fromConfig(Config.defaults())
+      val caches = new CypherQueryCaches(
+        CypherQueryCaches.Config.fromCypherConfiguration(cypherConfig),
+        getTx,
+        TestExecutorCaffeineCacheFactory,
+        Clock.systemUTC(),
+        monitors,
+        NullLogProvider.getInstance()
+      )
+
+      val planner = DefaultCypherPlanner(
+        CypherParsingConfig(),
+        CypherPlannerConfiguration.defaults(),
+        Clock.systemUTC(),
+        monitors,
+        NullLog.getInstance(),
+        CommunitySecurityLog.NULL_LOG,
+        caches,
+        CypherPlannerOption.default,
+        null,
+        CommunitySchemaCommandRuntime,
+        null,
+        new InternalUsageStatsImpl
+      )
+
+      val preParser = new CachingPreParser(
+        CypherConfiguration.fromConfig(Config.defaults()),
+        new LFUCache[PreParsedQuery.CacheKey, PreParsedQuery](
+          TestExecutorCaffeineCacheFactory,
+          0
+        )
+      )
+      val preParsed = preParser.preParseQuery(queryText, devNullLogger, CypherVersion.Legacy.legacyVersion())
+      val tc = mock[TransactionalContext](org.mockito.Mockito.RETURNS_DEEP_STUBS)
+      val runtime = CommunityRuntimeFactory.getRuntime(runtimeOption, disallowFallback = false)
+
+      planner.parseAndPlan(
+        preParsed,
+        NO_TRACING,
+        tc,
+        MapValue.EMPTY,
+        runtime,
+        devNullLogger,
+        null,
+        cacheStrategy = CacheStrategy.defaultDefault
+      )
+    } finally {
+      TransformingPlanner.customPlanContextCreator = None
+    }
+  }
+
+  test("community explicit pipelined plans with Volcano since it executes as slotted") {
+    val result = planWithCommunityRuntime(
+      "CYPHER runtime=pipelined MATCH (a), (b) RETURN a, b",
+      CypherRuntimeOption.pipelined
+    )
+    result.plannerContext.executionModel should equal(Volcano)
+  }
+
+  test("community explicit parallel plans with Volcano since it executes as slotted") {
+    val result = planWithCommunityRuntime(
+      "CYPHER runtime=parallel MATCH (a), (b) RETURN a, b",
+      CypherRuntimeOption.parallel
+    )
+    result.plannerContext.executionModel should equal(Volcano)
+  }
+
+  test("community slotted plans with Volcano") {
+    val result = planWithCommunityRuntime(
+      "CYPHER runtime=slotted MATCH (a), (b) RETURN a, b",
+      CypherRuntimeOption.slotted
+    )
+    result.plannerContext.executionModel should equal(Volcano)
+  }
+
+  test("community default plans with Volcano") {
+    val result = planWithCommunityRuntime(
+      "MATCH (a), (b) RETURN a, b",
+      CypherRuntimeOption.default
+    )
+    result.plannerContext.executionModel should equal(Volcano)
+  }
+}

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/planning/CypherPlanner.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/planning/CypherPlanner.scala
@@ -658,9 +658,18 @@ final class TransformingPlanner private[planning] (
         graphStatisticsDecorator
       ))
 
+    // The execution model must be compatible with the runtime that will actually execute the query.
+    // In Community Edition an explicit `runtime=pipelined` (or `runtime=parallel`) has no pipelined
+    // executor: the query falls back to the slotted runtime (see CommunityRuntimeFactory), which executes
+    // row-at-a-time. Planning such a query with batched cost assumptions (e.g. Cartesian-product RHS work
+    // discounted by ceil(lhsCardinality / batchSize)) can select a plan that is catastrophically expensive
+    // under the actual Volcano execution (see #13937). The `default` branch already trusted
+    // `correspondingRuntimeOption` for this; explicit options must do the same. Runtimes that genuinely
+    // provide batched execution (e.g. Enterprise pipelined) report a batched corresponding option, so
+    // their planning is unaffected.
     val inferredRuntime: CypherRuntimeOption = options.queryOptions.runtime match {
       case CypherRuntimeOption.default => runtime.correspondingRuntimeOption.getOrElse(CypherRuntimeOption.default)
-      case x                           => x
+      case explicit                    => runtime.correspondingRuntimeOption.getOrElse(explicit)
     }
     val containsUpdates: Boolean = syntacticQuery.statement().containsUpdates
     val inferredRuntimeConfig = () => options.queryOptions.parallelRuntimeConfigOption


### PR DESCRIPTION
## Summary

Community Edition falls back from unsupported explicit runtimes such as `runtime=pipelined` to the slotted runtime. However, logical planning still used the execution model associated with the requested runtime.

As a result, Community could cost Cartesian products using batched execution assumptions while ultimately executing the selected plan with Volcano/slotted semantics.

This change resolves explicit runtime hints through the selected runtime's `correspondingRuntimeOption` before choosing the planner execution model.

## Why

For Cartesian products, batched planning estimates RHS executions per batch, while the slotted runtime executes the RHS once per LHS row.

In #13937, this mismatch causes the `runtime=pipelined` query in Community Edition to select the opposite Cartesian orientation and perform substantially more work, even though the query ultimately executes using the slotted runtime.

## Evidence

The mismatch can be followed directly through the `2026.08` Community code.

### Community `runtime=pipelined` actually falls back to slotted

[`[CommunityRuntimeFactory](https://github.com/neo4j/neo4j/blob/736cad02a36bb4a0d32c1064f44768339c814269/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CommunityRuntimeFactory.scala)`](https://github.com/neo4j/neo4j/blob/736cad02a36bb4a0d32c1064f44768339c814269/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CommunityRuntimeFactory.scala) constructs unsupported explicit runtimes as a fallback chain containing:

```text
UnknownRuntime(requested)
→ CommunitySchemaCommandRuntime
→ CommunitySlottedRuntime
```

[`[FallbackRuntime.correspondingRuntimeOption](https://github.com/neo4j/neo4j/blob/736cad02a36bb4a0d32c1064f44768339c814269/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherRuntime.scala)`](https://github.com/neo4j/neo4j/blob/736cad02a36bb4a0d32c1064f44768339c814269/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherRuntime.scala) therefore resolves this Community runtime to the first executable runtime with a corresponding option, which is `slotted`.

This is also the existing documented Community behavior: [`[RuntimeUnsupportedNotificationTest](https://github.com/neo4j/neo4j/blob/736cad02a36bb4a0d32c1064f44768339c814269/community/community-it/cypher-it/src/test/scala/org/neo4j/cypher/RuntimeUnsupportedNotificationTest.scala)`](https://github.com/neo4j/neo4j/blob/736cad02a36bb4a0d32c1064f44768339c814269/community/community-it/cypher-it/src/test/scala/org/neo4j/cypher/RuntimeUnsupportedNotificationTest.scala) expects:

```text
runtime=pipelined
→ runtime=slotted
```

with a fallback notification when `cypher_hints_error=false`.

### The planner nevertheless used batched assumptions

On the baseline, [`[TransformingPlanner.doPlan](https://github.com/neo4j/neo4j/blob/736cad02a36bb4a0d32c1064f44768339c814269/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/planning/CypherPlanner.scala)`](https://github.com/neo4j/neo4j/blob/736cad02a36bb4a0d32c1064f44768339c814269/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/planning/CypherPlanner.scala) resolves only `runtime=default` through `runtime.correspondingRuntimeOption`; an explicit runtime is passed through unchanged.

The same file maps:

```text
pipelined → BatchedSingleThreaded
parallel  → BatchedParallel
otherwise → Volcano
```

so Community `runtime=pipelined` was logically planned as batched even though the whole query would execute using the slotted runtime.

### The cost difference is explicit

[`[CardinalityCostModel](https://github.com/neo4j/neo4j/blob/736cad02a36bb4a0d32c1064f44768339c814269/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/CardinalityCostModel.scala)`](https://github.com/neo4j/neo4j/blob/736cad02a36bb4a0d32c1064f44768339c814269/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/CardinalityCostModel.scala) explicitly models a Cartesian product as:

```text
Batched: RHS executes once per LHS batch
Volcano: RHS executes once per LHS row
```

and computes the RHS multiplier using:

```scala
batchSize.numBatchesFor(lhsCardinality)
```

For a true batched runtime this is correct. For a plan subsequently executed by slotted/Volcano it can underestimate repeated RHS work by up to approximately the batch size and can change which Cartesian orientation is considered cheaper.

### The exact #13937 reproducer demonstrates the consequence

Using the exact setup and query from #13937 on Community `2026.08`:

```text
baseline runtime=slotted:    ~0.86 s
baseline runtime=pipelined:  ~8.4 s
```

Both return `x = 1`, but the two hints select opposite Cartesian orientations.

A separate batch-size probe also isolates the planner model as the cause:

```text
baseline pipelined, batch size = 1
→ good/Volcano-compatible orientation

baseline pipelined, normal batched size
→ bad orientation
```

After resolving the execution model through the actual fallback runtime:

```text
patched runtime=pipelined: ~0.32–0.46 s
```

and its relevant plan structure matches `runtime=slotted`.

The regression is encoded in the added tests:

* [`[CommunityRuntimeExecutionModelTest](https://github.com/iancuuandrei/neo4j-contributions/blob/bd6753a7f2fe6d7fe70dea4e5f1095a3b3446ca0/community/cypher/cypher-tests/src/test/scala/org/neo4j/cypher/internal/planning/CommunityRuntimeExecutionModelTest.scala)`](https://github.com/iancuuandrei/neo4j-contributions/blob/bd6753a7f2fe6d7fe70dea4e5f1095a3b3446ca0/community/cypher/cypher-tests/src/test/scala/org/neo4j/cypher/internal/planning/CommunityRuntimeExecutionModelTest.scala) goes through the real Community planning path and verifies that unsupported `pipelined`/`parallel` runtimes use `Volcano`. It fails behaviorally on the baseline, which selects `BatchedSingleThreaded`/`BatchedParallel`.
* [`[CommunityPipelinedFallbackPlanningIT](https://github.com/iancuuandrei/neo4j-contributions/blob/bd6753a7f2fe6d7fe70dea4e5f1095a3b3446ca0/community/community-it/cypher-it/src/test/scala/org/neo4j/cypher/CommunityPipelinedFallbackPlanningIT.scala)`](https://github.com/iancuuandrei/neo4j-contributions/blob/bd6753a7f2fe6d7fe70dea4e5f1095a3b3446ca0/community/community-it/cypher-it/src/test/scala/org/neo4j/cypher/CommunityPipelinedFallbackPlanningIT.scala) runs the exact issue setup/query, verifies the relevant pipelined-fallback and slotted plan structures agree, checks the result, and preserves the existing fallback notification contract.

## Fix

Use the runtime already selected by the compiler to determine the effective runtime for planning:

```scala
case explicit =>
  runtime.correspondingRuntimeOption.getOrElse(explicit)
```

This makes Community `pipelined`/`parallel` fallback queries plan using Volcano semantics, matching the runtime that will actually execute them.

Genuine pipelined and parallel runtimes continue to use their batched execution models. Existing Community fallback behavior and runtime-unsupported notifications are unchanged.

This is a planner/runtime compatibility fix; it does not change the pipelined executor.

## Validation

The exact #13937 reproduction was tested on Community Edition with a 30-second transaction timeout. Timings below are measurements from the reproduction machine:

* baseline `runtime=slotted`: ~0.86 s, returns `x = 1`
* baseline `runtime=pipelined`: ~8.4 s, returns `x = 1`
* patched `runtime=pipelined`: ~0.32–0.46 s, with the same relevant plan structure as `runtime=slotted`

Targeted tests passing with the patch:

* `CommunityRuntimeExecutionModelTest`: 4/4
* `CypherPlannerTest`: 4/4
* `CacheKeyTest`: 5/5
* `PreParserTest`: 54/54
* `CardinalityCostModelTest`: 52/52
* `CartesianProductPlanningIntegrationTest`: 15/15
* `RuntimeUnsupportedNotificationTest`: 2/2
* `CommunityPipelinedFallbackPlanningIT`: 1/1

Fixes #13937