### PR TITLE
Fix repeated nested COUNT evaluation in optional matches

### DIFF
--- a/community/cypher/cypher-planner-tests/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/LoadCSVCountOptionalPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-tests/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/LoadCSVCountOptionalPlanningIntegrationTest.scala
@@ -1,0 +1,402 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.planner.logical
+
+import org.neo4j.cypher.internal.compiler.CypherPlannerTestSuite
+import org.neo4j.cypher.internal.compiler.ExecutionModel
+import org.neo4j.cypher.internal.compiler.planner.LogicalPlanningIntegrationTestSupport
+import org.neo4j.cypher.internal.logical.plans.Aggregation
+import org.neo4j.cypher.internal.logical.plans.Apply
+import org.neo4j.cypher.internal.logical.plans.CartesianProduct
+import org.neo4j.cypher.internal.logical.plans.Expand
+import org.neo4j.cypher.internal.logical.plans.Limit
+import org.neo4j.cypher.internal.logical.plans.LoadCSV
+import org.neo4j.cypher.internal.logical.plans.LogicalPlan
+import org.neo4j.cypher.internal.logical.plans.Optional
+import org.neo4j.cypher.internal.logical.plans.Selection
+import org.neo4j.cypher.internal.logical.plans.UnwindCollection
+
+import scala.reflect.ClassTag
+
+/**
+ * Regression coverage for Neo4j issue #13924:
+ * nested COUNT + LOAD CSV inside OPTIONAL MATCH WHERE.
+ *
+ * Invariant under test: an outer-only read-only COUNT subquery in an OPTIONAL
+ * WHERE is evaluated once per outer row, above the OPTIONAL RHS fan-out, via an
+ * `Apply` on the outer LHS. The rewritten predicate (`countVar >= 0`) is still
+ * applied by a `Selection` inside the OPTIONAL RHS, preserving null-extension
+ * semantics. Before the fix the COUNT Apply sat on one Cartesian side inside the
+ * OPTIONAL RHS, re-evaluating the nested plan once per RHS candidate row.
+ */
+class LoadCSVCountOptionalPlanningIntegrationTest extends CypherPlannerTestSuite
+    with LogicalPlanningIntegrationTestSupport {
+
+  private def planWith(
+    q: String,
+    model: ExecutionModel,
+    labelA: Int = 100,
+    labelB: Int = 100
+  ) = plannerBuilder()
+    .setAllNodesCardinality(1000)
+    .setLabelCardinality("A", labelA)
+    .setLabelCardinality("B", labelB)
+    .setRelationshipCardinality("(:A)-[]->(:B)", 10)
+    .setRelationshipCardinality("()-[]->()", 10)
+    .setExecutionModel(model)
+    .build()
+    .plan(q)
+
+  test("#13924: minimal COUNT+LOAD CSV in OPTIONAL WHERE uses Apply+Limit, Volcano and Batched agree") {
+    val q =
+      """UNWIND [1, 2] AS k
+        |OPTIONAL MATCH (a:A), (b:B)
+        |WHERE COUNT { LOAD CSV FROM 'file:///fuzz.csv' AS row } >= 0
+        |RETURN k""".stripMargin
+    val volcano = planWith(q, ExecutionModel.Volcano)
+    val batched = planWith(q, ExecutionModel.Batched.default)
+
+    Seq(volcano, batched).foreach { plan =>
+      plan.folder.findAllByClass[LoadCSV] should have size 1
+      plan.folder.findAllByClass[Aggregation] should have size 1
+      // COUNT >= 0 is rewritten to Limit 1 over the inner rows.
+      plan.folder.findAllByClass[Limit] should have size 1
+      plan.folder.findAllByClass[Apply] should not be empty
+      plan.folder.findAllByClass[CartesianProduct] should have size 1
+      plan.folder.findAllByClass[Optional] should have size 1
+    }
+    // Planning shape must not diverge between execution models for this shape;
+    // the slotted/pipelined delta is runtime per-open cost, not a different join order here.
+    volcano.toString shouldEqual batched.toString
+  }
+
+  test("#13924: minimal COUNT+UNWIND in OPTIONAL WHERE uses Apply, Volcano and Batched agree") {
+    val q =
+      """UNWIND [1, 2] AS k
+        |OPTIONAL MATCH (a:A), (b:B)
+        |WHERE COUNT { UNWIND [['a','b'],['c','d']] AS row RETURN row } >= 0
+        |RETURN k""".stripMargin
+    val volcano = planWith(q, ExecutionModel.Volcano)
+    val batched = planWith(q, ExecutionModel.Batched.default)
+
+    Seq(volcano, batched).foreach { plan =>
+      plan.folder.findAllByClass[LoadCSV] shouldBe empty
+      plan.folder.findAllByClass[UnwindCollection].size should be >= 2
+      plan.folder.findAllByClass[Aggregation] should have size 1
+      plan.folder.findAllByClass[Apply] should not be empty
+    }
+    volcano.toString shouldEqual batched.toString
+  }
+
+  test("#13924 scaling: hoisted COUNT stays above the fan-out as populations sweep") {
+    // The nested evaluation must scale with outer rows only, regardless of RHS
+    // candidate population: exactly one LoadCSV/Aggregation above every Optional.
+    val q =
+      """UNWIND [1, 2] AS k
+        |OPTIONAL MATCH (a:A), (b:B)
+        |WHERE COUNT { LOAD CSV FROM 'file:///fuzz.csv' AS row } >= 0
+        |RETURN k""".stripMargin
+    Seq((1, 1), (4, 4), (16, 16), (2, 32), (32, 2)).foreach { case (a, b) =>
+      val plan = planWith(q, ExecutionModel.Volcano, a, b)
+      withClue(s"A=$a B=$b: ") {
+        plan.folder.findAllByClass[LoadCSV] should have size 1
+        plan.folder.findAllByClass[Aggregation] should have size 1
+        plan.folder.findAllByClass[Limit] should have size 1
+        plan.folder.findAllByClass[CartesianProduct] should have size 1
+        optionalSubtrees(plan).foreach { optional =>
+          optional.folder.findAllByClass[LoadCSV] shouldBe empty
+        }
+      }
+    }
+  }
+
+  test("#13924: multiple outer rows keep single nested LOAD CSV (scales with N, not N x M)") {
+    Seq(1, 2, 8).foreach { n =>
+      val list = (1 to n).mkString("[", ", ", "]")
+      val q =
+        s"""UNWIND $list AS k
+           |OPTIONAL MATCH (a:A), (b:B)
+           |WHERE COUNT { LOAD CSV FROM 'file:///fuzz.csv' AS row } >= 0
+           |RETURN k""".stripMargin
+      val plan = planWith(q, ExecutionModel.Volcano)
+      withClue(s"N=$n: ") {
+        plan.folder.findAllByClass[LoadCSV] should have size 1
+        plan.folder.findAllByClass[Aggregation] should have size 1
+      }
+    }
+  }
+
+  test("#13924: correlated nested LOAD CSV references outer row") {
+    val q =
+      """UNWIND [1, 2] AS k
+        |OPTIONAL MATCH (a:A), (b:B)
+        |WHERE COUNT { LOAD CSV FROM 'file:///fuzz.csv' AS row WITH row WHERE row[0] = k RETURN row } >= 0
+        |RETURN k""".stripMargin
+    Seq(ExecutionModel.Volcano, ExecutionModel.Batched.default).foreach { model =>
+      val plan = planWith(q, model)
+      plan.folder.findAllByClass[LoadCSV] should have size 1
+      plan.folder.findAllByClass[Aggregation] should have size 1
+      plan.folder.findAllByClass[Apply] should not be empty
+    }
+  }
+
+  test("#13924: two nested LOAD CSV operators plan independently") {
+    val q =
+      """UNWIND [1, 2] AS k
+        |OPTIONAL MATCH (a:A), (b:B)
+        |WHERE COUNT { LOAD CSV FROM 'file:///fuzz.csv' AS r1 RETURN r1 } >= 0
+        |  AND COUNT { LOAD CSV FROM 'file:///other.csv' AS r2 RETURN r2 } >= 0
+        |RETURN k""".stripMargin
+    val plan = planWith(q, ExecutionModel.Volcano)
+    plan.folder.findAllByClass[LoadCSV] should have size 2
+    plan.folder.findAllByClass[Aggregation].size should be >= 2
+    // Both outer-only COUNTs hoist above the fan-out (chained on the outer LHS
+    // spine under a single root); no CSV or aggregation work remains inside.
+    optionalSubtrees(plan).foreach { optional =>
+      optional.folder.findAllByClass[LoadCSV] shouldBe empty
+      optional.folder.findAllByClass[Aggregation] shouldBe empty
+    }
+    hoistRoots(plan) should have size 1
+  }
+
+  test("#13924: headers vs no-headers nested LOAD CSV") {
+    Seq(
+      "LOAD CSV FROM 'file:///fuzz.csv' AS row",
+      "LOAD CSV WITH HEADERS FROM 'file:///fuzz.csv' AS row"
+    ).foreach { load =>
+      val q =
+        s"""UNWIND [1, 2] AS k
+           |OPTIONAL MATCH (a:A), (b:B)
+           |WHERE COUNT { $load RETURN row } >= 0
+           |RETURN k""".stripMargin
+      val plan = planWith(q, ExecutionModel.Volcano)
+      withClue(s"$load: ") {
+        plan.folder.findAllByClass[LoadCSV] should have size 1
+        plan.folder.findAllByClass[Aggregation] should have size 1
+      }
+    }
+  }
+
+  test("#13924: early termination keeps Limit over nested rows") {
+    // COUNT > 10 (non-trivial bound) still plans a bounded nested evaluation;
+    // COUNT >= 0 always short-circuits to Limit 1.
+    Seq(">= 0", "> 10").foreach { cmp =>
+      val q =
+        s"""UNWIND [1, 2] AS k
+           |OPTIONAL MATCH (a:A), (b:B)
+           |WHERE COUNT { LOAD CSV FROM 'file:///fuzz.csv' AS row RETURN row } $cmp
+           |RETURN k""".stripMargin
+      val plan = planWith(q, ExecutionModel.Volcano)
+      withClue(s"COUNT $cmp: ") {
+        plan.folder.findAllByClass[LoadCSV] should have size 1
+        plan.folder.findAllByClass[Aggregation] should have size 1
+      }
+    }
+  }
+
+  test("#13924: normal top-level LOAD CSV unaffected") {
+    val q =
+      """LOAD CSV FROM 'file:///fuzz.csv' AS row
+        |OPTIONAL MATCH (a:A), (b:B)
+        |RETURN row""".stripMargin
+    val plan = planWith(q, ExecutionModel.Volcano)
+    plan.folder.findAllByClass[LoadCSV] should have size 1
+    plan.folder.findAllByClass[Aggregation] shouldBe empty
+  }
+
+  test("#13924: nested COUNT without CSV (UNWIND-only) stays equivalent across models") {
+    val q =
+      """UNWIND [1, 2] AS k
+        |OPTIONAL MATCH (a:A), (b:B)
+        |WHERE COUNT { UNWIND [1, 2, 3] AS x RETURN x } >= 0
+        |RETURN k""".stripMargin
+    val volcano = planWith(q, ExecutionModel.Volcano)
+    val batched = planWith(q, ExecutionModel.Batched.default)
+    volcano.folder.findAllByClass[LoadCSV] shouldBe empty
+    batched.folder.findAllByClass[LoadCSV] shouldBe empty
+    volcano.toString shouldEqual batched.toString
+  }
+
+  private def optionalSubtrees(plan: LogicalPlan) =
+    plan.folder.findAllByClass[Optional]
+
+  private def insideOptional(plan: LogicalPlan, apply: Apply): Boolean =
+    optionalSubtrees(plan).exists(_.folder.findAllByClass[Apply].exists(_ eq apply))
+
+  /**
+   * Plan nodes of type T under root, following only logical-plan children
+   * (lhs/rhs) and never descending into expressions. In particular, nested
+   * subplans held by per-row NestedPlanExpression pipes are excluded: only
+   * Apply-evaluated (once-per-row) work counts here. (The generic folder
+   * traversal sees through nested subplans, which would conflate legacy
+   * per-row nested evaluation with hoisted Apply evaluation.)
+   */
+  private def barePlans[T <: LogicalPlan: ClassTag](root: LogicalPlan): Seq[T] = {
+    val found = Seq.newBuilder[T]
+    def visit(plan: LogicalPlan): Unit = {
+      if (implicitly[ClassTag[T]].runtimeClass.isInstance(plan)) found += plan.asInstanceOf[T]
+      plan.lhs.foreach(visit)
+      plan.rhs.foreach(visit)
+    }
+    visit(root)
+    found.result()
+  }
+
+  /**
+   * Roots of hoisted COUNT evaluations: an Apply outside every Optional subtree
+   * whose direct right-hand side hosts the Aggregation over the nested rows.
+   * Chained hoists (one Apply per hoisted predicate on the outer LHS spine)
+   * share a single root; deeper Applies inside a COUNT subquery itself only see
+   * Argument/LoadCSV on their right-hand side and are excluded, as is the outer
+   * ApplyOptional Apply whose right-hand side is the LoadCSV-free Optional.
+   */
+  private def hoistRoots(plan: LogicalPlan) = {
+    val candidates = barePlans[Apply](plan).filter { apply =>
+      barePlans[LoadCSV](apply).nonEmpty &&
+      apply.rhs.exists(rhs => barePlans[Aggregation](rhs).nonEmpty) &&
+      !insideOptional(plan, apply)
+    }
+    candidates.filterNot(c => candidates.exists(o => (o ne c) && o.rhs.exists(_.folder.findAllByClass[Apply].exists(_ eq c))))
+  }
+
+  test("#13924 hoist: uncorrelated COUNT is evaluated above the OPTIONAL fan-out") {
+    val q =
+      """UNWIND [1, 2] AS k
+        |OPTIONAL MATCH (a:A), (b:B)
+        |WHERE COUNT { LOAD CSV FROM 'file:///fuzz.csv' AS row } >= 0
+        |RETURN k""".stripMargin
+    Seq(ExecutionModel.Volcano, ExecutionModel.Batched.default).foreach { model =>
+      val plan = planWith(q, model)
+      // The nested CSV work must not sit under the OPTIONAL expansion:
+      // no LoadCSV/Aggregation may remain inside any Optional subtree.
+      optionalSubtrees(plan) should not be empty
+      optionalSubtrees(plan).foreach { optional =>
+        optional.folder.findAllByClass[LoadCSV] shouldBe empty
+        optional.folder.findAllByClass[Aggregation] shouldBe empty
+      }
+      // ...while exactly one nested COUNT evaluation still exists above it.
+      plan.folder.findAllByClass[LoadCSV] should have size 1
+      plan.folder.findAllByClass[Aggregation] should have size 1
+      // And the rewritten predicate is still applied inside the OPTIONAL RHS,
+      // which is what preserves null-extension semantics: a false (or null)
+      // outcome eliminates that outer row's RHS candidates, and the OPTIONAL
+      // still emits exactly one null-extended row instead of dropping the row.
+      optionalSubtrees(plan).flatMap(_.folder.findAllByClass[Selection]) should not be empty
+      // And the hoisted evaluation is a single Apply outside every Optional subtree.
+      hoistRoots(plan) should have size 1
+    }
+  }
+
+  test("#13924 hoist: outer-correlated COUNT is evaluated above the OPTIONAL fan-out") {
+    val q =
+      """UNWIND [1, 2] AS k
+        |OPTIONAL MATCH (a:A), (b:B)
+        |WHERE COUNT { LOAD CSV FROM 'file:///fuzz.csv' AS row WITH row WHERE row[0] = k RETURN row } >= 0
+        |RETURN k""".stripMargin
+    val plan = planWith(q, ExecutionModel.Volcano)
+    optionalSubtrees(plan) should not be empty
+    optionalSubtrees(plan).foreach { optional =>
+      optional.folder.findAllByClass[LoadCSV] shouldBe empty
+    }
+    plan.folder.findAllByClass[LoadCSV] should have size 1
+  }
+
+  test("#13924 hoist: RHS-correlated COUNT stays inside the OPTIONAL RHS") {
+    val q =
+      """UNWIND [1, 2] AS k
+        |OPTIONAL MATCH (a:A), (b:B)
+        |WHERE COUNT { LOAD CSV FROM 'file:///fuzz.csv' AS row WITH row WHERE row[1] = a.name RETURN row } >= 0
+        |RETURN k""".stripMargin
+    val plan = planWith(q, ExecutionModel.Volcano)
+    // The COUNT depends on `a`, introduced by the OPTIONAL pattern, so it must
+    // keep its existing in-RHS evaluation: some Optional subtree still hosts it.
+    optionalSubtrees(plan).map(_.folder.findAllByClass[LoadCSV].size).sum should be >= 1
+    plan.folder.findAllByClass[LoadCSV] should have size 1
+  }
+
+  test("#13924 hoist: mixed predicates split outer COUNT from RHS predicate") {
+    val q =
+      """UNWIND [1, 2] AS k
+        |OPTIONAL MATCH (a:A), (b:B)
+        |WHERE COUNT { LOAD CSV FROM 'file:///fuzz.csv' AS row } >= 0 AND a.prop > 10
+        |RETURN k""".stripMargin
+    val plan = planWith(q, ExecutionModel.Volcano)
+    // Outer-only COUNT moves above the fan-out ...
+    optionalSubtrees(plan).foreach { optional =>
+      optional.folder.findAllByClass[LoadCSV] shouldBe empty
+    }
+    plan.folder.findAllByClass[LoadCSV] should have size 1
+    // ... while the RHS-dependent remainder still constrains the OPTIONAL match.
+    plan.folder.findAllByClass[CartesianProduct] should have size 1
+  }
+
+  test("#13924 hoist: COUNT under CASE keeps legacy per-row nested evaluation") {
+    // A COUNT nested inside CASE cannot be unnested to an Apply by the ordinary
+    // subquery machinery (it becomes a per-row nested pipe), so the hoist must
+    // leave it alone: the CSV work stays inside the OPTIONAL RHS in its legacy
+    // form (here still as an unresolved COUNT expression inside the Filter).
+    val q =
+      """UNWIND [1, 2] AS k
+        |OPTIONAL MATCH (a:A), (b:B)
+        |WHERE CASE WHEN k > 0 THEN COUNT { LOAD CSV FROM 'file:///fuzz.csv' AS row } >= 0 ELSE false END
+        |RETURN k""".stripMargin
+    val plan = planWith(q, ExecutionModel.Volcano)
+    // The legacy in-RHS evaluation site is preserved ...
+    optionalSubtrees(plan).map(_.folder.findAllByClass[LoadCSV].size).sum should be >= 1
+    // ... and no Apply-based hoist is manufactured for the blocked COUNT.
+    hoistRoots(plan) shouldBe empty
+  }
+
+  test("#13924 hoist: EXISTS conjunct stays while outer COUNT hoists") {
+    val q =
+      """UNWIND [1, 2] AS k
+        |OPTIONAL MATCH (a:A), (b:B)
+        |WHERE COUNT { LOAD CSV FROM 'file:///fuzz.csv' AS row } >= 0 AND EXISTS { (a)-->(b) }
+        |RETURN k""".stripMargin
+    val plan = planWith(q, ExecutionModel.Volcano)
+    // The COUNT part still hoists above the fan-out ...
+    optionalSubtrees(plan).foreach { optional =>
+      optional.folder.findAllByClass[LoadCSV] shouldBe empty
+    }
+    plan.folder.findAllByClass[LoadCSV] should have size 1
+    // ... while the OPTIONAL shape (and its EXISTS handling) is preserved:
+    // the EXISTS pattern still expands inside the RHS, not above it.
+    plan.folder.findAllByClass[Expand].size should be >= 1
+    optionalSubtrees(plan) should not be empty
+  }
+
+  test("#13924 hoist: outer writes do not block the hoist and keep their order") {
+    val q =
+      """UNWIND [1, 2] AS k
+        |CREATE (n:N {p: k})
+        |WITH k, n
+        |OPTIONAL MATCH (a:A), (b:B)
+        |WHERE COUNT { LOAD CSV FROM 'file:///fuzz.csv' AS row } >= 0
+        |RETURN k""".stripMargin
+    val plan = planWith(q, ExecutionModel.Volcano)
+    // The hoisted COUNT Apply chains after the outer writes; evaluation stays
+    // once per outer row and never crosses the updating boundary.
+    optionalSubtrees(plan).foreach { optional =>
+      optional.folder.findAllByClass[LoadCSV] shouldBe empty
+    }
+    plan.folder.findAllByClass[LoadCSV] should have size 1
+    plan.folder.findAllByClass[Aggregation] should have size 1
+  }
+}

--- a/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/steps/LogicalPlanProducer.scala
@@ -1536,6 +1536,41 @@ case class LogicalPlanProducer(
     newPlan
   }
 
+  /**
+   * Restore original outer-only COUNT predicates in the solved query of an OPTIONAL MATCH
+   * plan built with hoisted outer counts (see ApplyOptionalSolver.hoistOuterOnlyCounts, #13924).
+   *
+   * Physical planning filters on the rewritten predicates (against the computed count
+   * variables), but solved-query bookkeeping must record the original predicates — the
+   * same convention as planSelection, which records original expressions while filtering
+   * on rewritten ones. Only the rewritten predicates are swapped back, and the introduced
+   * count variables are removed from the OPTIONAL argument IDs; all other planning
+   * attributes are carried over to a fresh plan ID (attributes are write-once).
+   */
+  def fixupOptionalHoistedSolved(
+    originalPlan: LogicalPlan,
+    originalPredicates: Seq[Expression],
+    rewrittenPredicates: Seq[Expression],
+    introducedVariables: Set[LogicalVariable]
+  ): LogicalPlan = {
+    def fixQueryGraph(queryGraph: QueryGraph): QueryGraph = {
+      val fixedOptionals = queryGraph.optionalMatches.map { optionalMatch =>
+        if (rewrittenPredicates.forall(optionalMatch.selections.contains))
+          optionalMatch
+            .withSelections((optionalMatch.selections -- rewrittenPredicates) ++ originalPredicates)
+            .withArgumentIds(optionalMatch.argumentIds -- introducedVariables)
+        else optionalMatch
+      }
+      queryGraph.withOptionalMatches(fixedOptionals)
+    }
+    def fixPart(part: SinglePlannerQuery): SinglePlannerQuery =
+      part.updateTail(fixPart).amendQueryGraph(fixQueryGraph)
+    val fixedSolved = fixPart(solveds.get(originalPlan.id).asSinglePlannerQuery)
+    val newPlan = originalPlan.copyPlanWithIdGen(attributesWithoutSolveds.copy(originalPlan.id))
+    solveds.set(newPlan.id, fixedSolved)
+    newPlan
+  }
+
   def planRepeat(
     source: LogicalPlan,
     pattern: QuantifiedPathPattern,

--- a/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/steps/solveOptionalMatches.scala
+++ b/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/steps/solveOptionalMatches.scala
@@ -24,14 +24,21 @@ import org.neo4j.cypher.internal.compiler.planner.logical.LogicalPlanningContext
 import org.neo4j.cypher.internal.compiler.planner.logical.idp.BestResults
 import org.neo4j.cypher.internal.compiler.planner.logical.ordering.InterestingOrderConfig
 import org.neo4j.cypher.internal.compiler.planner.logical.plans.rewriter.unnestOptional
+import org.neo4j.cypher.internal.expressions.Expression
 import org.neo4j.cypher.internal.expressions.LogicalVariable
 import org.neo4j.cypher.internal.ir.QueryGraph
+import org.neo4j.cypher.internal.ir.ast.CountIRExpression
+import org.neo4j.cypher.internal.ir.ast.ExistsIRExpression
+import org.neo4j.cypher.internal.ir.ast.ListIRExpression
 import org.neo4j.cypher.internal.ir.helpers.CachedFunction
 import org.neo4j.cypher.internal.logical.plans.AggregatingPlan
 import org.neo4j.cypher.internal.logical.plans.CachedProperties
 import org.neo4j.cypher.internal.logical.plans.LogicalLeafPlan
 import org.neo4j.cypher.internal.logical.plans.LogicalPlan
+import org.neo4j.cypher.internal.logical.plans.NestedPlanExpression
 import org.neo4j.cypher.internal.macros.AssertMacros3
+import org.neo4j.cypher.internal.util.CancellationChecker
+import org.neo4j.cypher.internal.util.Foldable.FoldableAny
 import org.neo4j.cypher.internal.util.Rewriter
 import org.neo4j.cypher.internal.util.bottomUp
 
@@ -123,14 +130,20 @@ case object ApplyOptionalSolverFactory extends OptionalSolverFactory {
     }
 
     private def generateCandidates(lhs: LogicalPlan): Iterator[LogicalPlan] = {
-      val lhsSymbols = lhs.availableSymbols
-      val lhsCachedProperties = context.staticComponents.planningAttributes.cachedPropertiesPerPlan(lhs.id)
+      // #13924: evaluate outer-only COUNT subqueries once per outer row, before the
+      // OPTIONAL RHS fan-out, instead of once per RHS candidate row (see hoistOuterOnlyCounts).
+      val hoisting = hoistOuterOnlyCounts(lhs, optionalQg)
+      val outerPlan = hoisting.map(_.outerPlan).getOrElse(lhs)
+      val rhsQueryGraph = hoisting.map(_.rhsQueryGraph).getOrElse(optionalQg)
+      val lhsSymbols = outerPlan.availableSymbols
+      val lhsCachedProperties = context.staticComponents.planningAttributes.cachedPropertiesPerPlan(outerPlan.id)
       val inner =
-        if (lhsCachedProperties.isEmpty)
+        if (hoisting.isEmpty && lhsCachedProperties.isEmpty)
           innerPlanWithoutPreviouslyCachedProperties
-        else {
+        else if (hoisting.isEmpty)
           cachedPlanInnerOfOptionalMatch(lhsCachedProperties)
-        }
+        else
+          planInnerWithRewrittenSelections(rhsQueryGraph, lhsCachedProperties)
       inner.allResults.iterator.map { inner =>
         val innerWithFixedArguments = inner.endoRewrite(bottomUp(
           Rewriter.lift {
@@ -142,7 +155,7 @@ case object ApplyOptionalSolverFactory extends OptionalSolverFactory {
                 s"""RHS of optional must maintain LHS available symbols.
                    |
                    |LHS: (available symbols: ${lhsSymbols.map(_.name).mkString("`", "`, `", "`")})
-                   |$lhs
+                   |$outerPlan
                    |
                    |RHS: (available symbols: ${p.availableSymbols.map(_.name).mkString("`", "`, `", "`")})
                    |$inner
@@ -159,25 +172,178 @@ case object ApplyOptionalSolverFactory extends OptionalSolverFactory {
           innerWithFixedArguments,
           lhsSymbols,
           innerContext,
-          optionalQg
+          rhsQueryGraph
         )
         // since inner is solved before the lhs, we are unable to carry the cached properties from lhs to the rhs.
         // therefore, we need to use a union to get the cached properties from both the lhs and rhs.
         val lhsPlanCachedProperties =
-          context.staticComponents.planningAttributes.cachedPropertiesPerPlan.get(lhs.id)
+          context.staticComponents.planningAttributes.cachedPropertiesPerPlan.get(outerPlan.id)
         val rhsPlanCachedProperties =
           context.staticComponents.planningAttributes.cachedPropertiesPerPlan.get(rhs.id)
         val cachedPropertiesForOptional = lhsPlanCachedProperties.union(rhsPlanCachedProperties)
         val applied = context.staticComponents.logicalPlanProducer.planApplyWithCachedProperties(
-          lhs,
+          outerPlan,
           rhs,
           context,
           cachedPropertiesForOptional
         )
+        // If COUNT predicates were hoisted, the solved query still records their
+        // rewritten form (against the introduced count variables). Restore the
+        // original predicates, exactly like planSelection records original
+        // expressions while filtering on rewritten ones, so that VerifyBestPlan
+        // still sees the input query as solved.
+        val appliedWithRestoredSolved = hoisting match {
+          case Some(h) =>
+            context.staticComponents.logicalPlanProducer.fixupOptionalHoistedSolved(
+              applied,
+              h.originalPredicates,
+              h.rewrittenPredicates,
+              h.introducedVariables
+            )
+          case None => applied
+        }
 
         // Often the Apply can be rewritten into an OptionalExpand. We want to do that before cost estimating against the hash joins, otherwise that
         // is not a fair comparison (as they cannot be rewritten to something cheaper).
-        unnestOptional(applied).asInstanceOf[LogicalPlan]
+        unnestOptional(appliedWithRestoredSolved).asInstanceOf[LogicalPlan]
+      }
+    }
+
+    /**
+     * Plan the OPTIONAL RHS for a rewritten optional query graph. Used only when
+     * [[hoistOuterOnlyCounts]] moved predicates, so the shared inner-plan caches
+     * (built for the original selections) must not be reused. Like [[doPlan]],
+     * but for the rewritten query graph. Planning cost only; no runtime impact.
+     */
+    private def planInnerWithRewrittenSelections(
+      rhsQueryGraph: QueryGraph,
+      previouslyCachedProperties: CachedProperties
+    ): BestPlans = {
+      context.staticComponents.queryGraphSolver.plan(
+        rhsQueryGraph,
+        removeColumnsWithoutDependencies(interestingOrderConfig),
+        innerContext.withModifiedPlannerState(_.withPreviouslyCachedProperties(previouslyCachedProperties))
+      )
+    }
+
+    /**
+     * Result of [[hoistOuterOnlyCounts]] when at least one COUNT predicate was hoisted.
+     *
+     * @param outerPlan the outer LHS with one `Apply` per hoisted predicate appended.
+     * @param rhsQueryGraph the OPTIONAL query graph with hoisted predicates rewritten
+     *                      to reference the computed count variables.
+     * @param originalPredicates the original predicate expressions, in the same order
+     *                           as `rewrittenPredicates`.
+     * @param rewrittenPredicates the rewritten predicate expressions now solved inside
+     *                            the OPTIONAL RHS.
+     * @param introducedVariables the count variables introduced on the outer plan,
+     *                            also added to the RHS argument IDs.
+     */
+    private case class OuterCountHoisting(
+      outerPlan: LogicalPlan,
+      rhsQueryGraph: QueryGraph,
+      originalPredicates: Seq[Expression],
+      rewrittenPredicates: Seq[Expression],
+      introducedVariables: Set[LogicalVariable]
+    )
+
+    /**
+     * Solve COUNT subqueries whose dependencies are already satisfied by the
+     * outer LHS before the OPTIONAL RHS fan-out (#13924).
+     *
+     * Without this, an outer-only `COUNT { ... }` in `OPTIONAL MATCH ... WHERE`
+     * is solved inside the OPTIONAL RHS, on one side of its internal Cartesian
+     * product. It is then re-evaluated once per RHS candidate row instead of
+     * once per outer row, even though its value is constant across the fan-out
+     * of one outer row. For an expensive nested plan such as `LOAD CSV` this
+     * dominates execution, while an in-memory `UNWIND` hides the multiplicity.
+     *
+     * This solves each eligible COUNT on `lhs` via an `Apply` (the same
+     * [[SubqueryExpressionSolver]] machinery used for ordinary WHERE subqueries),
+     * so it runs once per outer row, and rewrites the OPTIONAL selections to
+     * reference the computed count variable. The rewritten predicate application
+     * stays inside the OPTIONAL RHS, preserving null-extension semantics: when the
+     * predicate is false (or null) for an outer row, every RHS candidate of that
+     * row is still eliminated and the OPTIONAL still emits exactly one null row.
+     *
+     * Only predicates whose nested subqueries are all outer-only, read-only
+     * `CountIRExpression`s are eligible. Anything else (RHS-correlated COUNTs,
+     * EXISTS/list subqueries, blocked contexts solved as per-row nested pipes,
+     * updating subqueries) keeps the existing in-RHS evaluation. In particular the
+     * evaluation count per outer row can already vary today with plan shape (which
+     * Cartesian side hosts the COUNT Apply), so once-per-outer-row evaluation
+     * introduces no new semantic latitude.
+     */
+    private def hoistOuterOnlyCounts(
+      lhs: LogicalPlan,
+      rhsQueryGraph: QueryGraph
+    ): Option[OuterCountHoisting] = {
+      val cancellationChecker = context.staticComponents.cancellationChecker
+      // Fast path: most OPTIONAL MATCHes have no COUNT subquery at all. A single
+      // traversal avoids any per-predicate work in that common case, so the added
+      // planning cost here is otherwise linear in the total selection size.
+      val mentionsCount = rhsQueryGraph.selections.predicates.folder(cancellationChecker).treeExists {
+        case _: CountIRExpression => true
+      }
+      if (!mentionsCount) {
+        None
+      } else {
+        hoistOuterOnlyCountsSlowPath(lhs, rhsQueryGraph, cancellationChecker)
+      }
+    }
+
+    private def hoistOuterOnlyCountsSlowPath(
+      lhs: LogicalPlan,
+      rhsQueryGraph: QueryGraph,
+      cancellationChecker: CancellationChecker
+    ): Option[OuterCountHoisting] = {
+      val lhsSymbols = lhs.availableSymbols
+      // Selections are stored per conjunct; sorted for a deterministic Apply-chaining order.
+      val orderedPredicates = rhsQueryGraph.selections.predicates.toSeq.sorted
+      val eligible = orderedPredicates.filter { pred =>
+        val counts = pred.expr.folder(cancellationChecker).findAllByClass[CountIRExpression]
+        counts.nonEmpty &&
+        !pred.expr.folder(cancellationChecker).treeExists {
+          case _: ExistsIRExpression => true
+          case _: ListIRExpression   => true
+        } &&
+        counts.forall(_.dependencies.subsetOf(lhsSymbols)) &&
+        counts.forall(_.query.readOnly)
+      }
+      if (eligible.isEmpty) {
+        None
+      } else {
+        var current = lhs
+        // (original, rewritten) only for predicates that actually took the Apply path.
+        val hoistedPairs = eligible.flatMap { pred =>
+          val solver = SubqueryExpressionSolver.solverFor(current, context)
+          val solved = solver.solve(pred.expr)
+          val next = solver.rewrittenPlan()
+          // Accept only the directly-unnested Apply path. A COUNT in a blocked
+          // context (e.g. inside CASE) comes back as a per-row NestedPlanExpression
+          // with no plan change and must keep its existing in-RHS evaluation.
+          val noCountLeft = !solved.folder(cancellationChecker).treeExists { case _: CountIRExpression => true }
+          val noNestedPlan = !solved.folder(cancellationChecker).treeExists { case _: NestedPlanExpression => true }
+          if ((next ne current) && noCountLeft && noNestedPlan) {
+            current = next
+            Some((pred.expr, solved))
+          } else {
+            None
+          }
+        }
+        if (hoistedPairs.isEmpty) {
+          None
+        } else {
+          val (originals, rewritten) = hoistedPairs.unzip
+          // Expose the introduced count variables to the RHS planning as arguments,
+          // exactly like any other outer variable referenced from the OPTIONAL RHS.
+          val introduced = current.availableSymbols -- lhs.availableSymbols
+          val newSelections = rhsQueryGraph.selections -- originals ++ rewritten
+          val newQueryGraph = rhsQueryGraph
+            .withSelections(newSelections)
+            .withArgumentIds(rhsQueryGraph.argumentIds ++ introduced)
+          Some(OuterCountHoisting(current, newQueryGraph, originals, rewritten, introduced))
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

Optional-match planning could solve an outer-only nested `COUNT` expression inside the OPTIONAL RHS after unrelated pattern expansion, causing repeated nested execution.

This change solves eligible read-only `CountIRExpression`s on the outer input before RHS expansion while keeping predicate application inside `Optional`.

Fixes #13924.

## Root cause

The nested `COUNT`'s dependencies were already satisfied by the outer LHS, but `ApplyOptionalSolver` solved it inside one Cartesian side of the OPTIONAL RHS.

Unrelated RHS expansion therefore multiplied nested execution: for the issue shape, 18 legitimate outer contexts became 18 × 221 = 3,978 nested `COUNT` evaluations before the remaining RHS side expanded candidates further.

After the fix, the `COUNT` `Apply` sits above the OPTIONAL fan-out, so the nested plan runs once per outer row: 3,978 → 18 evaluations by plan structure, not a measured wall-clock speedup.

## Fix

- Identify OPTIONAL predicates containing eligible outer-only read-only `CountIRExpression`s.
- Solve those nested expressions through the existing `SubqueryExpressionSolver` on the outer LHS.
- Carry the resulting expression/count variables into the OPTIONAL RHS through `argumentIds`.
- Keep predicate application inside `Optional` / RHS `Selection`.
- Restore the original predicates into solved-query metadata using the `LogicalPlanProducer` fixup on a fresh plan ID.

The key semantic distinction is that evaluation of the nested expression moves outward, while application of the OPTIONAL predicate does not. This preserves OPTIONAL null-extension semantics.

## Semantics

- No CSV caching; `LOAD CSV` lifecycle and resource semantics are unchanged.
- Evaluation remains once per logical outer row, not once per distinct value.
- RHS-correlated `COUNT`s, updating subqueries, CASE-blocked contexts, and other ineligible nested-expression shapes retain their existing placement.
- Predicate application remains inside `Optional`, preserving null-extension semantics.

## Evidence

- [The original reproducer and timing isolation in #13924](https://github.com/neo4j/neo4j/issues/13924) establish the pathological `COUNT` + `LOAD CSV` shape and the equivalent-inner-`UNWIND` control.
- The patch is a single commit, [`e9b756d`](https://github.com/iancuuandrei/neo4j-contributions/commit/e9b756db6e93a84417d132851bcec847446db648), on top of baseline [`bbf3b91`](https://github.com/neo4j/neo4j/commit/bbf3b91f46a761809c19dfca0c3a09a6a8ea09e8).
- [`ApplyOptionalSolver` hoisting implementation](https://github.com/iancuuandrei/neo4j-contributions/blob/e9b756db6e93a84417d132851bcec847446db648/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/steps/solveOptionalMatches.scala) contains the dependency/read-only eligibility check, evaluation through `SubqueryExpressionSolver` on the outer LHS, generated-variable propagation through RHS `argumentIds`, and the conservative fallback when an expression cannot be safely unnested.
- [`LogicalPlanProducer.fixupOptionalHoistedSolved`](https://github.com/iancuuandrei/neo4j-contributions/blob/e9b756db6e93a84417d132851bcec847446db648/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/steps/LogicalPlanProducer.scala) restores the original predicates and argument IDs in solved metadata on a fresh plan ID.
- [`LoadCSVCountOptionalPlanningIntegrationTest`](https://github.com/iancuuandrei/neo4j-contributions/blob/e9b756db6e93a84417d132851bcec847446db648/community/cypher/cypher-planner-tests/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/LoadCSVCountOptionalPlanningIntegrationTest.scala) encodes the structural proof: eligible outer-only counts leave no `LoadCSV`/`Aggregation` under `Optional`, the rewritten `Selection` remains inside `Optional`, RHS-correlated counts remain in the RHS, mixed predicates split correctly, and blocked contexts retain their legacy placement.
- The `3,978 → 18` count follows directly from the reproducer and verified plan placement. Before the OPTIONAL there are `3 alias0 × 2 alias1 × 3 outer CSV = 18` outer contexts. The preceding writes leave `128 + 21 + 18 + 54 = 221` total nodes, so the disconnected `()` side produces 221 candidates per outer context. With the nested `COUNT` solved after that side, it is evaluated `18 × 221 = 3,978` times. Hoisting its `Apply` above the OPTIONAL fan-out reduces this to one evaluation per outer context: 18. This is a structural evaluation-count result, not a measured runtime factor.

## Testing

- Added 17 focused regression and negative-control cases in `LoadCSVCountOptionalPlanningIntegrationTest`.
- Three hoisting tests fail on the pristine baseline and pass with the fix; the RHS-correlated negative control passes on both.
- Structural assertions verify that the nested `COUNT` `Apply` moves outside `Optional` while the `Selection` using the generated result stays inside it.
- Relevant planner, slotted-runtime, and physical-planning suites pass with the change.
- Existing unrelated failures in `SubqueryExpression` and `EagerPlanning` were reproduced unchanged on the pristine baseline.