### PR TITLE
Fix overflow for large range cardinalities

### DIFF
--- a/community/cypher/interpreted-runtime-tests/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/RangeFunctionTest.scala
+++ b/community/cypher/interpreted-runtime-tests/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/RangeFunctionTest.scala
@@ -49,6 +49,24 @@ class RangeFunctionTest extends InterpretedRuntimeTestSuite {
     range(1L, Int.MaxValue + 1000L, 1L) // should not blow up...
   }
 
+  test("should compute exact cardinality beyond Int.MaxValue (#13957)") {
+    range(0L, Int.MaxValue.toLong, 1L).actualSize() should be(2147483648L)
+    range(Int.MinValue.toLong, Int.MaxValue.toLong, 1L).actualSize() should be(4294967296L)
+    range(Int.MinValue.toLong, Int.MaxValue.toLong, 2L).actualSize() should be(2147483648L)
+    range(Int.MaxValue.toLong, Int.MinValue.toLong, -1L).actualSize() should be(4294967296L)
+    // long indexing stays valid without materialization
+    range(0L, 4294967296L, 1L).value(4294967296L) should be(Values.longValue(4294967296L))
+    // intSize is exact-or-fail, never wraps to 0
+    an[org.neo4j.exceptions.ArithmeticException] should be thrownBy range(0L, Int.MaxValue.toLong, 1L).intSize()
+  }
+
+  test("should fail materialization of huge range before allocation (#13957)") {
+    // 2^32 would historically narrow to 0, 2^32+1 to 1, 2^32+2 to 2
+    an[RuntimeException] should be thrownBy range(0L, 4294967295L, 1L).toStorableArray()
+    an[RuntimeException] should be thrownBy range(0L, 4294967296L, 1L).toStorableArray()
+    an[RuntimeException] should be thrownBy range(0L, 4294967297L, 1L).toStorableArray()
+  }
+
   private def seq(vals: Long*) = list(vals.map(Values.longValue): _*)
 
   private def range(start: Long, end: Long, step: Long): ListValue = {

--- a/community/cypher/runtime-spec-suite/src/test/scala/org/neo4j/cypher/internal/runtime/spec/tests/CreateTestBase.scala
+++ b/community/cypher/runtime-spec-suite/src/test/scala/org/neo4j/cypher/internal/runtime/spec/tests/CreateTestBase.scala
@@ -193,6 +193,31 @@ abstract class CreateTestBase[CONTEXT <: RuntimeContext](
     node.getAllProperties.asScala should equal(Map("p1" -> 1))
   }
 
+  test("should reject oversized range as node property before allocation (#13957)") {
+    // CREATE (n {p: range(0, 4294967296, 1)}) historically stored [0]; must fail at
+    // logical-list -> storable-array boundary with no prefix persisted and no node created.
+    // 4294967296 > Integer.MAX_VALUE so the boundary throws Neo4j 22003/22N28, never a JVM error.
+    val logicalQuery = new LogicalQueryBuilder(this)
+      .produceResults("n")
+      .create(createNodeWithProperties("n", Seq("A"), "{p: range(0, 4294967296, 1)}"))
+      .argument()
+      .build(readOnly = false)
+
+    the[org.neo4j.exceptions.ArithmeticException] thrownBy consume(execute(logicalQuery, runtime))
+    Iterables.count(tx.getAllNodes) shouldBe 0
+  }
+
+  test("should reject 2^32+1 range as node property without prefix (#13957)") {
+    val logicalQuery = new LogicalQueryBuilder(this)
+      .produceResults("n")
+      .create(createNodeWithProperties("n", Seq("A"), "{p: range(0, 4294967297, 1)}"))
+      .argument()
+      .build(readOnly = false)
+
+    the[org.neo4j.exceptions.ArithmeticException] thrownBy consume(execute(logicalQuery, runtime))
+    Iterables.count(tx.getAllNodes) shouldBe 0
+  }
+
   test("should create two nodes with dependency") {
     // given an empty data base
 

--- a/community/cypher/runtime-spec-suite/src/test/scala/org/neo4j/cypher/internal/runtime/spec/tests/ExpressionTestBase.scala
+++ b/community/cypher/runtime-spec-suite/src/test/scala/org/neo4j/cypher/internal/runtime/spec/tests/ExpressionTestBase.scala
@@ -1863,6 +1863,30 @@ trait ExpressionWithTxStateChangesTests[CONTEXT <: RuntimeContext] {
     result should beColumns("last").withSingleRow(Values.longValue(Long.MaxValue))
   }
 
+  test("should return exact size for int-backed range beyond Int.MaxValue (#13957)") {
+    val logicalQuery = new LogicalQueryBuilder(this)
+      .produceResults("s")
+      .projection("size(range(0, 2147483647, 1)) AS s")
+      .argument()
+      .build()
+
+    val result = execute(logicalQuery, runtime)
+
+    result should beColumns("s").withSingleRow(Values.longValue(2147483648L))
+  }
+
+  test("should return exact size for long-backed range beyond Int.MaxValue (#13957)") {
+    val logicalQuery = new LogicalQueryBuilder(this)
+      .produceResults("s")
+      .projection("size(range(0, 2147483648, 1)) AS s")
+      .argument()
+      .build()
+
+    val result = execute(logicalQuery, runtime)
+
+    result should beColumns("s").withSingleRow(Values.longValue(2147483649L))
+  }
+
   test("should evaluate string interpolation") {
     // given, an empty db
     // when

--- a/community/values/src/main/java/org/neo4j/values/SequenceValue.java
+++ b/community/values/src/main/java/org/neo4j/values/SequenceValue.java
@@ -25,6 +25,9 @@ import static org.neo4j.values.storable.Values.NO_VALUE;
 import java.util.ArrayDeque;
 import java.util.Comparator;
 import java.util.Iterator;
+import org.neo4j.exceptions.ArithmeticException;
+import org.neo4j.exceptions.InvalidArgumentException;
+import org.neo4j.internal.helpers.ArrayUtil;
 import org.neo4j.values.virtual.ListValue;
 import org.neo4j.values.virtual.ListValueBuilder;
 
@@ -56,6 +59,36 @@ public interface SequenceValue extends Iterable<AnyValue> {
      * @throws ArithmeticException if the size doesn't fit into an int.
      */
     int intSize();
+
+    /**
+     * Checked narrowing of a logical sequence cardinality to a physical Java/storable array length.
+     * <p>
+     * Logical cardinality lives in {@code [0, Long.MAX_VALUE]}. A Java array (and therefore any storable
+     * property array) cannot exceed {@link ArrayUtil#MAX_ARRAY_SIZE}. This helper enforces, in O(1) and
+     * before any allocation or iteration:
+     * <ol>
+     *   <li>exact {@code long -> int} narrowing (no modular wrap, no clamp, no saturation), then</li>
+     *   <li>the Neo4j/Java physical array capacity limit.</li>
+     * </ol>
+     * Success guarantees the returned {@code int} equals the exact logical size. Failure throws a
+     * client-facing error that names the exact logical cardinality, never a wrapped {@code int}.
+     * Once cardinality exceeds a physical maximum it can never become valid again for larger sizes.
+     *
+     * @param value the sequence whose logical size should be materialized
+     * @param operation GQL operation name used for the numeric-overflow error (e.g. {@code "range()"})
+     * @return the exact array length as {@code int}
+     */
+    static int checkedArrayLength(SequenceValue value, String operation) {
+        long logicalSize = value.actualSize();
+        if (logicalSize < 0L || logicalSize > Integer.MAX_VALUE) {
+            throw ArithmeticException.numericValueOutOfRange(String.valueOf(logicalSize), operation);
+        }
+        int size = (int) logicalSize; // now mathematically proven exact
+        if (size > ArrayUtil.MAX_ARRAY_SIZE) {
+            throw InvalidArgumentException.listTooLarge(logicalSize, ArrayUtil.MAX_ARRAY_SIZE);
+        }
+        return size;
+    }
 
     default boolean isEmpty() {
         return actualSize() == 0L;

--- a/community/values/src/main/java/org/neo4j/values/storable/ValueRepresentation.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ValueRepresentation.java
@@ -68,7 +68,7 @@ public enum ValueRepresentation {
     GEOMETRY(ValueGroup.GEOMETRY, true) {
         @Override
         public ArrayValue arrayOf(SequenceValue values) {
-            PointValue[] points = new PointValue[values.intSize()];
+            PointValue[] points = new PointValue[SequenceValue.checkedArrayLength(values, "toStorableArray")];
             PointValue first = null;
             int i = 0;
             for (AnyValue value : values) {
@@ -90,7 +90,7 @@ public enum ValueRepresentation {
     ZONED_DATE_TIME(ValueGroup.ZONED_DATE_TIME, true) {
         @Override
         public ArrayValue arrayOf(SequenceValue values) {
-            ZonedDateTime[] temporals = new ZonedDateTime[values.intSize()];
+            ZonedDateTime[] temporals = new ZonedDateTime[SequenceValue.checkedArrayLength(values, "toStorableArray")];
             int i = 0;
             for (AnyValue value : values) {
                 temporals[i++] = (getOrFail(value, DateTimeValue.class, values, i)).temporal();
@@ -101,7 +101,7 @@ public enum ValueRepresentation {
     LOCAL_DATE_TIME(ValueGroup.LOCAL_DATE_TIME, true) {
         @Override
         public ArrayValue arrayOf(SequenceValue values) {
-            LocalDateTime[] temporals = new LocalDateTime[values.intSize()];
+            LocalDateTime[] temporals = new LocalDateTime[SequenceValue.checkedArrayLength(values, "toStorableArray")];
             int i = 0;
             for (AnyValue value : values) {
                 temporals[i++] =
@@ -113,7 +113,7 @@ public enum ValueRepresentation {
     DATE(ValueGroup.DATE, true) {
         @Override
         public ArrayValue arrayOf(SequenceValue values) {
-            LocalDate[] temporals = new LocalDate[values.intSize()];
+            LocalDate[] temporals = new LocalDate[SequenceValue.checkedArrayLength(values, "toStorableArray")];
             int i = 0;
             for (AnyValue value : values) {
                 temporals[i++] = getOrFail(value, DateValue.class, values, i).temporal();
@@ -124,7 +124,7 @@ public enum ValueRepresentation {
     ZONED_TIME(ValueGroup.ZONED_TIME, true) {
         @Override
         public ArrayValue arrayOf(SequenceValue values) {
-            OffsetTime[] temporals = new OffsetTime[values.intSize()];
+            OffsetTime[] temporals = new OffsetTime[SequenceValue.checkedArrayLength(values, "toStorableArray")];
             int i = 0;
             for (AnyValue value : values) {
                 temporals[i++] = ((TimeValue) value).temporal();
@@ -135,7 +135,7 @@ public enum ValueRepresentation {
     LOCAL_TIME(ValueGroup.LOCAL_TIME, true) {
         @Override
         public ArrayValue arrayOf(SequenceValue values) {
-            LocalTime[] temporals = new LocalTime[values.intSize()];
+            LocalTime[] temporals = new LocalTime[SequenceValue.checkedArrayLength(values, "toStorableArray")];
             int i = 0;
             for (AnyValue value : values) {
                 temporals[i++] = ((LocalTimeValue) value).temporal();
@@ -146,7 +146,7 @@ public enum ValueRepresentation {
     DURATION(ValueGroup.DURATION, true) {
         @Override
         public ArrayValue arrayOf(SequenceValue values) {
-            DurationValue[] temporals = new DurationValue[values.intSize()];
+            DurationValue[] temporals = new DurationValue[SequenceValue.checkedArrayLength(values, "toStorableArray")];
             int i = 0;
             for (AnyValue value : values) {
                 temporals[i++] = (DurationValue) value;
@@ -157,7 +157,7 @@ public enum ValueRepresentation {
     UTF16_TEXT(ValueGroup.TEXT, true) {
         @Override
         public ArrayValue arrayOf(SequenceValue values) {
-            StringValue[] strings = new StringValue[values.intSize()];
+            StringValue[] strings = new StringValue[SequenceValue.checkedArrayLength(values, "toStorableArray")];
             int i = 0;
             for (AnyValue value : values) {
                 strings[i++] = ((TextValue) value).asStringValue();
@@ -176,7 +176,7 @@ public enum ValueRepresentation {
     UTF8_TEXT(ValueGroup.TEXT, true) {
         @Override
         public ArrayValue arrayOf(SequenceValue values) {
-            StringValue[] strings = new StringValue[values.intSize()];
+            StringValue[] strings = new StringValue[SequenceValue.checkedArrayLength(values, "toStorableArray")];
             int i = 0;
             for (AnyValue value : values) {
                 strings[i++] = ((TextValue) value).asStringValue();
@@ -196,7 +196,7 @@ public enum ValueRepresentation {
     BOOLEAN(ValueGroup.BOOLEAN, true) {
         @Override
         public ArrayValue arrayOf(SequenceValue values) {
-            boolean[] bools = new boolean[values.intSize()];
+            boolean[] bools = new boolean[SequenceValue.checkedArrayLength(values, "toStorableArray")];
             int i = 0;
             for (AnyValue value : values) {
                 bools[i++] = ((BooleanValue) value).booleanValue();
@@ -207,7 +207,7 @@ public enum ValueRepresentation {
     INT64(ValueGroup.NUMBER, true) {
         @Override
         public ArrayValue arrayOf(SequenceValue values) {
-            long[] longs = new long[values.intSize()];
+            long[] longs = new long[SequenceValue.checkedArrayLength(values, "toStorableArray")];
             int i = 0;
             for (AnyValue value : values) {
                 longs[i++] = getOrFail(value, NumberValue.class, values, i).longValue();
@@ -227,7 +227,7 @@ public enum ValueRepresentation {
     INT32(ValueGroup.NUMBER, true) {
         @Override
         public ArrayValue arrayOf(SequenceValue values) {
-            int[] ints = new int[values.intSize()];
+            int[] ints = new int[SequenceValue.checkedArrayLength(values, "toStorableArray")];
             int i = 0;
             for (AnyValue value : values) {
                 ints[i++] = getOrFail(value, IntegralValue.class, values, i).intValue();
@@ -248,7 +248,7 @@ public enum ValueRepresentation {
     INT16(ValueGroup.NUMBER, true) {
         @Override
         public ArrayValue arrayOf(SequenceValue values) {
-            short[] shorts = new short[values.intSize()];
+            short[] shorts = new short[SequenceValue.checkedArrayLength(values, "toStorableArray")];
             int i = 0;
             for (AnyValue value : values) {
                 shorts[i++] = getOrFail(value, IntegralValue.class, values, i).shortValue();
@@ -272,7 +272,7 @@ public enum ValueRepresentation {
     INT8(ValueGroup.NUMBER, true) {
         @Override
         public ArrayValue arrayOf(SequenceValue values) {
-            byte[] bytes = new byte[values.intSize()];
+            byte[] bytes = new byte[SequenceValue.checkedArrayLength(values, "toStorableArray")];
             int i = 0;
             for (AnyValue value : values) {
                 bytes[i++] = getOrFail(value, ByteValue.class, values, i).value();
@@ -296,7 +296,7 @@ public enum ValueRepresentation {
     FLOAT64(ValueGroup.NUMBER, true) {
         @Override
         public ArrayValue arrayOf(SequenceValue values) {
-            double[] doubles = new double[values.intSize()];
+            double[] doubles = new double[SequenceValue.checkedArrayLength(values, "toStorableArray")];
             int i = 0;
             for (AnyValue value : values) {
                 doubles[i++] = ((NumberValue) value).doubleValue();
@@ -315,7 +315,7 @@ public enum ValueRepresentation {
     FLOAT32(ValueGroup.NUMBER, true) {
         @Override
         public ArrayValue arrayOf(SequenceValue values) {
-            float[] floats = new float[values.intSize()];
+            float[] floats = new float[SequenceValue.checkedArrayLength(values, "toStorableArray")];
             int i = 0;
             for (AnyValue value : values) {
                 NumberValue asNumberValue = getOrFail(value, NumberValue.class, values, i);
@@ -407,7 +407,7 @@ public enum ValueRepresentation {
     UUID(ValueGroup.UUID, true) {
         @Override
         public ArrayValue arrayOf(SequenceValue values) {
-            UUID[] uuids = new UUID[values.intSize()];
+            UUID[] uuids = new UUID[SequenceValue.checkedArrayLength(values, "toStorableArray")];
             int i = 0;
             for (AnyValue value : values) {
                 UUIDValue asUidValue = getOrFail(value, UUIDValue.class, values, i);
@@ -452,11 +452,11 @@ public enum ValueRepresentation {
         // only print the first three items
         if (sequence == null || sequence == Values.NO_VALUE) {
             return "NULL";
-        } else if (sequence.intSize() == 0) {
+        } else if (sequence.actualSize() == 0L) {
             return "[]";
         }
-        int badIdx;
-        int size = sequence.intSize();
+        long badIdx;
+        long size = sequence.actualSize();
         for (badIdx = 0; badIdx < size; badIdx++) {
             if (sequence.value(badIdx).equals(badValue)) {
                 break;

--- a/community/values/src/main/java/org/neo4j/values/storable/Values.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Values.java
@@ -430,7 +430,7 @@ public final class Values {
     }
 
     public static VectorArray vectorArray(SequenceValue sequence) {
-        VectorValue[] vectors = new VectorValue[sequence.intSize()];
+        VectorValue[] vectors = new VectorValue[SequenceValue.checkedArrayLength(sequence, "toStorableArray")];
         int i = 0;
         for (AnyValue value : sequence) {
             vectors[i++] = Values.vectorValue(value);

--- a/community/values/src/main/java/org/neo4j/values/virtual/IntegralRangeListValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/IntegralRangeListValue.java
@@ -23,15 +23,24 @@ import static org.neo4j.memory.HeapEstimator.shallowSizeOfInstance;
 import static org.neo4j.values.SequenceValue.IterationPreference.RANDOM_ACCESS;
 import static org.neo4j.values.utils.ValueMath.HASH_CONSTANT;
 
+import java.math.BigInteger;
 import java.util.Collections;
 import java.util.Iterator;
 import org.neo4j.exceptions.ArithmeticException;
+import org.neo4j.exceptions.InvalidArgumentException;
 import org.neo4j.values.AnyValue;
+import org.neo4j.values.SequenceValue;
 import org.neo4j.values.storable.ArrayValue;
 import org.neo4j.values.storable.ValueRepresentation;
 import org.neo4j.values.storable.Values;
 
 public abstract class IntegralRangeListValue extends ListValue {
+    private final long cardinality;
+
+    protected IntegralRangeListValue(long cardinality) {
+        this.cardinality = cardinality;
+    }
+
     @Override
     public final IterationPreference iterationPreference() {
         return RANDOM_ACCESS;
@@ -42,16 +51,71 @@ public abstract class IntegralRangeListValue extends ListValue {
         return ValueRepresentation.INT64;
     }
 
+    @Override
+    public final long actualSize() {
+        return cardinality;
+    }
+
+    @Override
+    public final int intSize() {
+        return super.intSize();
+    }
+
     public static IntegralRangeListValue rangeList(long start, long end, long step) {
+        if (step == 0L) {
+            throw InvalidArgumentException.zeroStepRange();
+        }
         if (isInt(start) && isInt(end) && isInt(step)) {
             return new IntRangeListValue((int) start, (int) end, (int) step);
         } else {
-            return new IntRangeListValue.LongRangeListValue(start, end, step);
+            return new LongRangeListValue(start, end, step);
         }
     }
 
     private static boolean isInt(long value) {
         return (int) value == value;
+    }
+
+    /**
+     * Exact mathematical cardinality of an inclusive integral range.
+     * <p>
+     * For {@code step > 0} with {@code start <= end}: {@code floor((end - start) / step) + 1}.
+     * For {@code step < 0} with {@code start >= end}: {@code floor((start - end) / abs(step)) + 1}.
+     * Otherwise {@code 0}.
+     * <p>
+     * Endpoint distances can span the full unsigned 64-bit domain {@code [0, 2^64 - 1]} even when the
+     * final cardinality fits signed {@code long} (e.g. {@code range(MIN_VALUE, MAX_VALUE, MAX_VALUE)} has
+     * distance {@code 2^64 - 1} but size {@code 3}). Therefore subtraction intentionally uses
+     * two's-complement wrapping and is interpreted as unsigned, combined with
+     * {@link Long#divideUnsigned(long, long)}. The fast path keeps ordinary signed division for the
+     * overwhelmingly common case. A mathematical cardinality above {@link Long#MAX_VALUE} is not
+     * representable by the logical sequence API or Cypher INTEGER and fails with the canonical numeric
+     * overflow error naming the exact cardinality.
+     */
+    static long exactRangeCardinality(long start, long end, long step) {
+        if (step == 0L) {
+            throw InvalidArgumentException.zeroStepRange();
+        }
+        if ((step > 0L && start > end) || (step < 0L && start < end)) {
+            return 0L;
+        }
+        // Wrapping subtraction: interpreted as unsigned it is the exact distance in [0, 2^64 - 1].
+        long distance = step > 0L ? end - start : start - end;
+        // For Long.MIN_VALUE negation still yields MIN_VALUE as signed, whose unsigned value 2^63 is exact.
+        long strideMagnitude = step > 0L ? step : -step;
+        long quotient;
+        if (distance >= 0L && strideMagnitude > 0L) {
+            quotient = distance / strideMagnitude;
+        } else {
+            quotient = Long.divideUnsigned(distance, strideMagnitude);
+        }
+        // cardinality = quotient + 1 is valid iff quotient <= Long.MAX_VALUE - 1 (unsigned compare).
+        if (Long.compareUnsigned(quotient, Long.MAX_VALUE - 1L) > 0) {
+            String exactCardinality =
+                    new BigInteger(Long.toUnsignedString(quotient)).add(BigInteger.ONE).toString();
+            throw ArithmeticException.numericValueOutOfRange(exactCardinality, "range()");
+        }
+        return quotient + 1L;
     }
 
     private static final class IntRangeListValue extends IntegralRangeListValue {
@@ -60,9 +124,9 @@ public abstract class IntegralRangeListValue extends ListValue {
         private final int start;
         private final int end;
         private final int step;
-        private int length = -1;
 
         IntRangeListValue(int start, int end, int step) {
+            super(exactRangeCardinality(start, end, step));
             this.start = start;
             this.end = end;
             this.step = step;
@@ -74,42 +138,131 @@ public abstract class IntegralRangeListValue extends ListValue {
 
         @Override
         public ListValue reverse() {
-            return new IntRangeListValue(end, start, -step);
-        }
-
-        @Override
-        public long actualSize() {
-            return intSize();
-        }
-
-        @Override
-        public int intSize() {
-            if (length == -1) {
-                int l = (end - start) / step + 1;
-                length = Math.max(l, 0);
+            long n = actualSize();
+            if (n == 0L) {
+                if (step == Integer.MIN_VALUE) {
+                    return rangeList(end, start, -(long) step);
+                }
+                return new IntRangeListValue(end, start, -step);
             }
-            return length;
+            // Supplied `end` is not necessarily an element (e.g. range(5,10,3)=[5,8]).
+            // Reverse must start at the actual last generated element, computed with
+            // wrapping arithmetic which is exact mod 2^64 (result lies between start/end).
+            long last = (long) start + (n - 1L) * (long) step;
+            if (step == Integer.MIN_VALUE) {
+                // -step does not fit int; widen through the normal factory (becomes long-backed).
+                return rangeList(last, start, -(long) step);
+            }
+            return new IntRangeListValue((int) last, start, -step);
         }
 
         @Override
         public AnyValue value(long offset) {
-            if (offset >= intSize()) {
+            if (offset < 0L || offset >= actualSize()) {
                 // TODO: this should be a GQL error and not java.lang.IndexOutOfBoundsException
                 //      but changing it is semi-breaking.
                 throw new IndexOutOfBoundsException();
             } else {
-                return Values.longValue(start + offset * step);
+                return Values.longValue((long) start + offset * (long) step);
             }
         }
 
         @Override
         public Iterator<AnyValue> iterator() {
-            int size = intSize();
-            if (size == 0) {
+            long size = actualSize();
+            if (size == 0L) {
                 return Collections.emptyIterator();
             } else {
                 return new Iterator<>() {
-                    private int index = 0;
+                    private long index = 0;
+
+                    @Override
+                    public boolean hasNext() {
+                        return index < size;
+                    }
+
+                    @Override
+                    public AnyValue next() {
+                        var result = Values.longValue((long) start + index * (long) step);
+                        index++;
+                        return result;
+                    }
+                };
+            }
+        }
+
+        @Override
+        protected int computeHashToMemoize() {
+            int hashCode = 1;
+            long current = start;
+            // If the size is bigger than Integer.MAX_VALUE it will anyway
+            // take forever to compute it so let's not bother
+            int size = (int) Math.min(actualSize(), Integer.MAX_VALUE);
+            for (int i = 0; i < size; i++, current += step) {
+                hashCode = HASH_CONSTANT * hashCode + Long.hashCode(current);
+            }
+            return hashCode;
+        }
+
+        @Override
+        public long estimatedHeapUsage() {
+            return INT_RANGE_LIST_VALUE_SHALLOW_SIZE;
+        }
+
+        @Override
+        public ArrayValue toStorableArray() {
+            int size = SequenceValue.checkedArrayLength(this, "range()");
+            long current = start;
+            long[] array = new long[size];
+            for (int i = 0; i < size; i++, current += step) {
+                array[i] = current;
+            }
+            return Values.longArray(array);
+        }
+    }
+
+    private static final class LongRangeListValue extends IntegralRangeListValue {
+        private static final long LONG_RANGE_LIST_VALUE_SHALLOW_SIZE =
+                shallowSizeOfInstance(LongRangeListValue.class);
+        private final long start;
+        private final long end;
+        private final long step;
+
+        LongRangeListValue(long start, long end, long step) {
+            super(exactRangeCardinality(start, end, step));
+            this.start = start;
+            this.end = end;
+            this.step = step;
+        }
+
+        @Override
+        public String toString() {
+            return "Range(" + start + "..." + end + ", step = " + step + ")";
+        }
+
+        @Override
+        public ListValue reverse() {
+            if (step == Long.MIN_VALUE) {
+                // Positive magnitude 2^63 is not representable as signed long; keep lazy reversed view.
+                return super.reverse();
+            }
+            long n = actualSize();
+            if (n == 0L) {
+                return new LongRangeListValue(end, start, -step);
+            }
+            // See IntRangeListValue.reverse: start from actual last element, not supplied `end`.
+            long last = start + (n - 1L) * step;
+            return new LongRangeListValue(last, start, -step);
+        }
+
+        @Override
+        public Iterator<AnyValue> iterator() {
+            long size = actualSize();
+            if (size == 0L) {
+                return Collections.emptyIterator();
+            } else {
+                return new Iterator<>() {
+                    private long index = 0;
 
                     @Override
                     public boolean hasNext() {
@@ -127,10 +280,23 @@ public abstract class IntegralRangeListValue extends ListValue {
         }
 
         @Override
+        public AnyValue value(long offset) {
+            if (offset < 0L || offset >= actualSize()) {
+                // TODO: this should be a GQL error and not java.lang.IndexOutOfBoundsException
+                //      but changing it is semi-breaking.
+                throw new IndexOutOfBoundsException();
+            } else {
+                return Values.longValue(start + offset * step);
+            }
+        }
+
+        @Override
         protected int computeHashToMemoize() {
             int hashCode = 1;
-            int current = start;
-            int size = intSize();
+            long current = start;
+            // If the size is bigger than Integer.MAX_VALUE it will anyway
+            // take forever to compute it so let's not bother
+            int size = (int) Math.min(actualSize(), Integer.MAX_VALUE);
             for (int i = 0; i < size; i++, current += step) {
                 hashCode = HASH_CONSTANT * hashCode + Long.hashCode(current);
             }
@@ -139,148 +305,18 @@ public abstract class IntegralRangeListValue extends ListValue {
 
         @Override
         public long estimatedHeapUsage() {
-            return INT_RANGE_LIST_VALUE_SHALLOW_SIZE;
+            return LONG_RANGE_LIST_VALUE_SHALLOW_SIZE;
         }
 
         @Override
         public ArrayValue toStorableArray() {
-            int size = intSize();
-            if (size < 0) {
-                throw ArithmeticException.numericValueOutOfRange(String.valueOf(size), "range()");
-            }
-
-            int current = start;
+            int size = SequenceValue.checkedArrayLength(this, "range()");
+            long current = start;
             long[] array = new long[size];
             for (int i = 0; i < size; i++, current += step) {
                 array[i] = current;
             }
             return Values.longArray(array);
-        }
-
-        private static final class LongRangeListValue extends IntegralRangeListValue {
-            private static final long LONG_RANGE_LIST_VALUE_SHALLOW_SIZE =
-                    shallowSizeOfInstance(LongRangeListValue.class);
-            private final long start;
-            private final long end;
-            private final long step;
-
-            LongRangeListValue(long start, long end, long step) {
-                this.start = start;
-                this.end = end;
-                this.step = step;
-            }
-
-            @Override
-            public String toString() {
-                return "Range(" + start + "..." + end + ", step = " + step + ")";
-            }
-
-            @Override
-            public ListValue reverse() {
-                return new LongRangeListValue(end, start, -step);
-            }
-
-            @Override
-            public long actualSize() {
-                long diff = divideExact(subtractExact(end, start), step);
-                if (diff < 0L) {
-                    return 0L;
-                } else {
-                    return addExact(diff, 1L);
-                }
-            }
-
-            @Override
-            public Iterator<AnyValue> iterator() {
-                long size = actualSize();
-                if (size == 0L) {
-                    return Collections.emptyIterator();
-                } else {
-                    return new Iterator<>() {
-                        private long index = 0;
-
-                        @Override
-                        public boolean hasNext() {
-                            return index < size;
-                        }
-
-                        @Override
-                        public AnyValue next() {
-                            var result = Values.longValue(start + index * step);
-                            index++;
-                            return result;
-                        }
-                    };
-                }
-            }
-
-            @Override
-            public AnyValue value(long offset) {
-                if (offset >= actualSize()) {
-                    // TODO: this should be a GQL error and not java.lang.IndexOutOfBoundsException
-                    //      but changing it is semi-breaking.
-                    throw new IndexOutOfBoundsException();
-                } else {
-                    return Values.longValue(start + offset * step);
-                }
-            }
-
-            @Override
-            protected int computeHashToMemoize() {
-                int hashCode = 1;
-                long current = start;
-                // If the size is bigger than Integer.MAX_VALUE it will anyway
-                // take forever to compute it so let's not bother
-                int size = (int) Math.min(actualSize(), Integer.MAX_VALUE);
-                for (int i = 0; i < size; i++, current += step) {
-                    hashCode = HASH_CONSTANT * hashCode + Long.hashCode(current);
-                }
-                return hashCode;
-            }
-
-            @Override
-            public long estimatedHeapUsage() {
-                return LONG_RANGE_LIST_VALUE_SHALLOW_SIZE;
-            }
-
-            @Override
-            public ArrayValue toStorableArray() {
-                int size = (int) actualSize();
-                if (size < 0) {
-                    throw ArithmeticException.numericValueOutOfRange(String.valueOf(size), "range()");
-                }
-
-                long current = start;
-                long[] array = new long[size];
-                for (int i = 0; i < size; i++, current += step) {
-                    array[i] = current;
-                }
-                return Values.longArray(array);
-            }
-        }
-    }
-
-    private static long addExact(long a, long b) {
-        try {
-            return Math.addExact(a, b);
-        } catch (java.lang.ArithmeticException e) {
-            throw ArithmeticException.numericValueOutOfRangeWithCause(a + "+" + b, "+", e);
-        }
-    }
-
-    private static long subtractExact(long a, long b) {
-        try {
-            return Math.subtractExact(a, b);
-        } catch (java.lang.ArithmeticException e) {
-            throw ArithmeticException.numericValueOutOfRangeWithCause(a + "-" + b, "-", e);
-        }
-    }
-
-    private static long divideExact(long a, long b) {
-        try {
-            return Math.divideExact(a, b);
-        } catch (java.lang.ArithmeticException e) {
-            throw ArithmeticException.numericValueOutOfRangeWithCause(a + "/" + b, "/", e);
         }
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/virtual/ListValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/ListValue.java
@@ -38,7 +38,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.RandomAccess;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -46,6 +45,8 @@ import java.util.function.Function;
 import org.github.jamm.Unmetered;
 import org.neo4j.exceptions.ArithmeticException;
 import org.neo4j.exceptions.CypherTypeException;
+import org.neo4j.exceptions.InvalidArgumentException;
+import org.neo4j.internal.helpers.ArrayUtil;
 import org.neo4j.internal.helpers.Numbers;
 import org.neo4j.internal.helpers.collection.Iterators;
 import org.neo4j.internal.helpers.collection.PrefetchingIterator;
@@ -201,7 +202,9 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
 
         @Override
         public AnyValue value(long offset) {
-            Objects.checkIndex(0, list.size());
+            if (offset < 0L || offset >= list.size()) {
+                throw new IndexOutOfBoundsException();
+            }
             return list.get((int) offset);
         }
 
@@ -258,7 +261,9 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
 
         @Override
         public AnyValue value(long offset) {
-            Objects.checkIndex(0, values.length);
+            if (offset < 0L || offset >= values.length) {
+                throw new IndexOutOfBoundsException();
+            }
             return values[(int) offset];
         }
 
@@ -364,7 +369,9 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
 
         @Override
         public AnyValue value(long offset) {
-            Objects.checkIndex(0, values.size());
+            if (offset < 0L || offset >= values.size()) {
+                throw new IndexOutOfBoundsException();
+            }
             return values.get((int) offset);
         }
 
@@ -452,7 +459,7 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
         }
 
         private class ListSliceIterator extends PrefetchingIterator<AnyValue> {
-            private int count;
+            private long count;
             private final Iterator<AnyValue> innerIterator = inner.iterator();
 
             @Override
@@ -591,7 +598,9 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
             int start = fromInclusive;
             for (var list : lists) {
                 payloadSize += list.compactInto(array, start);
-                start += list.intSize();
+                // Proven bounded after appendAll validation (total <= MAX_ARRAY_SIZE), but fail fast
+                // rather than wrap if ever misused.
+                start = Math.addExact(start, list.intSize());
             }
             return payloadSize;
         }
@@ -610,7 +619,12 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
             if (size < 0) {
                 long s = 0;
                 for (ListValue list : lists) {
-                    s += list.actualSize();
+                    try {
+                        s = Math.addExact(s, list.actualSize());
+                    } catch (java.lang.ArithmeticException e) {
+                        throw ArithmeticException.numericValueOutOfRangeWithCause(
+                                s + "+" + list.actualSize(), "+", e);
+                    }
                 }
                 size = s;
             }
@@ -740,7 +754,12 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
         @Override
         public long actualSize() {
             if (size == NOT_MEMOIZED) {
-                size = base.actualSize() + 1;
+                long baseSize = base.actualSize();
+                try {
+                    size = Math.addExact(baseSize, 1L);
+                } catch (java.lang.ArithmeticException e) {
+                    throw ArithmeticException.numericValueOutOfRangeWithCause(baseSize + "+1", "+", e);
+                }
             }
             return size;
         }
@@ -778,7 +797,7 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
             long size = base.actualSize();
             if (offset < size) {
                 return base.value(offset);
-            } else if (offset < size + 1L) {
+            } else if (offset == size) {
                 return appended;
             } else {
                 throw new IndexOutOfBoundsException(offset + " is outside range " + size);
@@ -798,7 +817,7 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
 
         @Override
         protected long compactInto(AnyValue[] array, int fromInclusive) {
-            array[fromInclusive + base.intSize()] = appended;
+            array[Math.addExact(fromInclusive, base.intSize())] = appended;
             return appended.estimatedHeapUsage() + base.compactInto(array, fromInclusive);
         }
 
@@ -881,7 +900,12 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
         @Override
         public long actualSize() {
             if (size == NOT_MEMOIZED) {
-                size = base.actualSize() + 1;
+                long baseSize = base.actualSize();
+                try {
+                    size = Math.addExact(baseSize, 1L);
+                } catch (java.lang.ArithmeticException e) {
+                    throw ArithmeticException.numericValueOutOfRangeWithCause(baseSize + "+1", "+", e);
+                }
             }
             return size;
         }
@@ -934,7 +958,7 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
         public AnyValue value(long offset) {
             if (offset == 0) {
                 return prepended;
-            } else if (offset < base.actualSize() + 1) {
+            } else if (offset - 1L < base.actualSize()) {
                 return base.value(offset - 1);
             } else {
                 throw new IndexOutOfBoundsException(offset + " is outside range " + size);
@@ -944,7 +968,7 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
         @Override
         protected long compactInto(AnyValue[] array, int fromInclusive) {
             array[fromInclusive] = prepended;
-            return prepended.estimatedHeapUsage() + base.compactInto(array, fromInclusive + 1);
+            return prepended.estimatedHeapUsage() + base.compactInto(array, Math.addExact(fromInclusive, 1));
         }
 
         @Override
@@ -1005,12 +1029,13 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder().append(getTypeName()).append('{');
-        int i = 0;
-        for (; i < actualSize() - 1; i++) {
+        long size = actualSize();
+        long i = 0;
+        for (; i < size - 1; i++) {
             sb.append(value(i));
             sb.append(", ");
         }
-        if (actualSize() > 0) {
+        if (size > 0) {
             sb.append(value(i));
         }
         sb.append('}');
@@ -1139,16 +1164,16 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
     }
 
     public ListValue slice() {
-        return slice(0L, intSize());
+        return slice(0L, actualSize());
     }
 
     public ListValue slice(long fromInclusive) {
-        return slice(fromInclusive, intSize());
+        return slice(fromInclusive, actualSize());
     }
 
     public ListValue slice(long fromInclusive, long toExclusive) {
         long f = Math.max(fromInclusive, 0L);
-        long t = Math.min(toExclusive, intSize());
+        long t = Math.min(toExclusive, actualSize());
 
         if (f >= t) {
             return EMPTY_LIST;
@@ -1165,7 +1190,7 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
                 // of it
                 f--;
                 t--;
-            } else if (list instanceof AppendList appendList && t < list.intSize()) {
+            } else if (list instanceof AppendList appendList && t < list.actualSize()) {
                 // if we are slicing up to less than the total list length, we can discard an appended value.
 
                 list = appendList.base;
@@ -1176,7 +1201,7 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
             }
         }
 
-        if (f == 0 && t == list.intSize()) {
+        if (f == 0 && t == list.actualSize()) {
             return list;
         }
 
@@ -1227,7 +1252,8 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
         if (listDepth() < LIST_DEPTH_COMPACTION_THRESHOLD) {
             return new AppendList(this, value);
         }
-        var values = new AnyValue[intSize() + 1];
+        int total = checkedCompactionLength(actualSize(), 1L);
+        var values = new AnyValue[total];
         values[values.length - 1] = value;
 
         long payloadSize = value.estimatedHeapUsage() + compactInto(values, 0);
@@ -1239,7 +1265,8 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
         if (listDepth() < LIST_DEPTH_COMPACTION_THRESHOLD) {
             return new PrependList(this, value);
         }
-        var values = new AnyValue[intSize() + 1];
+        int total = checkedCompactionLength(actualSize(), 1L);
+        var values = new AnyValue[total];
         values[0] = value;
 
         long payloadSize = value.estimatedHeapUsage() + compactInto(values, 1);
@@ -1252,8 +1279,7 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
             return this;
         }
 
-        int otherLength = other.intSize();
-        if (otherLength == 1) {
+        if (other.actualSize() == 1L) {
             return append(other.head());
         }
 
@@ -1261,9 +1287,19 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
             return new ConcatList(new ListValue[] {this, other});
         }
 
-        int thisLength = intSize();
-
-        var values = new AnyValue[thisLength + otherLength];
+        long thisLong = actualSize();
+        long otherLong = other.actualSize();
+        long candidate;
+        try {
+            candidate = Math.addExact(thisLong, otherLong);
+        } catch (java.lang.ArithmeticException e) {
+            throw ArithmeticException.numericValueOutOfRangeWithCause(thisLong + "+" + otherLong, "+", e);
+        }
+        if (candidate > ArrayUtil.MAX_ARRAY_SIZE) {
+            throw InvalidArgumentException.listTooLarge(candidate, ArrayUtil.MAX_ARRAY_SIZE);
+        }
+        int thisLength = (int) thisLong; // proven bounded: thisLong <= candidate <= MAX_ARRAY_SIZE
+        var values = new AnyValue[(int) candidate];
 
         long thisSize = this.compactInto(values, 0);
         long valueSize = other.compactInto(values, thisLength);
@@ -1272,25 +1308,39 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
                 values, thisSize + valueSize, itemValueRepresentation().coerce(other.itemValueRepresentation()));
     }
 
+    private static int checkedCompactionLength(long baseSize, long extra) {
+        long candidate;
+        try {
+            candidate = Math.addExact(baseSize, extra);
+        } catch (java.lang.ArithmeticException e) {
+            throw ArithmeticException.numericValueOutOfRangeWithCause(baseSize + "+" + extra, "+", e);
+        }
+        if (candidate > ArrayUtil.MAX_ARRAY_SIZE) {
+            // MAX_ARRAY_SIZE < Integer.MAX_VALUE, so this also covers all int-overflowing candidates.
+            throw InvalidArgumentException.listTooLarge(candidate, ArrayUtil.MAX_ARRAY_SIZE);
+        }
+        return (int) candidate;
+    }
+
     @Override
     public ListValue insertAt(int index, AnyValue value) {
         if (index == 0) {
             return prepend(value);
-        } else if (index == this.intSize()) {
+        } else if (index == actualSize()) {
             return append(value);
         } else {
-            return slice(0, index).append(value).appendAll(slice(index, intSize()));
+            return slice(0, index).append(value).appendAll(slice(index, actualSize()));
         }
     }
 
     @Override
     public ListValue remove(int index) {
         if (index == 0) {
-            return slice(1, intSize());
-        } else if (index == intSize()) {
-            return slice(0, intSize() - 1);
+            return slice(1, actualSize());
+        } else if (index == actualSize()) {
+            return slice(0, actualSize() - 1);
         } else {
-            return slice(0, index).appendAll(slice(index + 1, intSize()));
+            return slice(0, index).appendAll(slice(index + 1, actualSize()));
         }
     }
 
@@ -1319,16 +1369,14 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
 
     private AnyValue[] iterationAsArray() {
         List<AnyValue> values = new ArrayList<>();
-        int size = 0;
         for (AnyValue value : this) {
             values.add(value);
-            size++;
         }
-        return values.toArray(new AnyValue[size]);
+        return values.toArray(new AnyValue[0]);
     }
 
     private AnyValue[] randomAccessAsArray() {
-        int size = intSize();
+        int size = SequenceValue.checkedArrayLength(this, "asArray");
         AnyValue[] values = new AnyValue[size];
         for (int i = 0; i < values.length; i++) {
             values[i] = value(i);

--- a/community/values/src/test/java/org/neo4j/values/virtual/IntegralRangeCardinalityTest.java
+++ b/community/values/src/test/java/org/neo4j/values/virtual/IntegralRangeCardinalityTest.java
@@ -1,0 +1,541 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.virtual;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.neo4j.values.virtual.VirtualValues.range;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+import org.neo4j.exceptions.ArithmeticException;
+import org.neo4j.exceptions.InvalidArgumentException;
+import org.neo4j.gqlstatus.ErrorGqlStatusObjectAssertions;
+import org.neo4j.gqlstatus.GqlStatusInfoCodes;
+import org.neo4j.internal.helpers.ArrayUtil;
+import org.neo4j.values.AnyValue;
+import org.neo4j.values.SequenceValue;
+import org.neo4j.values.storable.Values;
+
+/**
+ * Systemic regression tests for Neo4j issue #13957: oversized {@code range()} cardinality must remain
+ * exact as a lazy virtual sequence, every narrowing to {@code int}/physical array cardinality must be
+ * checked, and impossible materialization must fail before allocation rather than wrap, truncate or OOM.
+ * No test allocates giant arrays.
+ */
+class IntegralRangeCardinalityTest {
+    // ------------------------------------------------------------------
+    // Exact int-endpoint adversarial cardinalities
+    // ------------------------------------------------------------------
+
+    @Test
+    void intRangeBeyondIntMaxIsExact() {
+        ListValue r = range(0L, Integer.MAX_VALUE, 1L);
+        assertEquals(2147483648L, r.actualSize());
+        // intSize must be exact-or-fail, never wrap/clamp to 0
+        ErrorGqlStatusObjectAssertions.assertThatThrownBy(r::intSize)
+                .isInstanceOf(ArithmeticException.class)
+                .hasGqlStatus(GqlStatusInfoCodes.STATUS_22003);
+    }
+
+    @Test
+    void intMinToMaxIsTwoToThe32() {
+        assertEquals(4294967296L, range(Integer.MIN_VALUE, Integer.MAX_VALUE, 1L).actualSize());
+        assertEquals(
+                4294967296L, range((long) Integer.MAX_VALUE, (long) Integer.MIN_VALUE, -1L).actualSize());
+        assertEquals(2147483648L, range(Integer.MIN_VALUE, Integer.MAX_VALUE, 2L).actualSize());
+    }
+
+    @Test
+    void wrongDirectionExtremeRangesAreEmpty() {
+        assertEquals(0L, range(Integer.MAX_VALUE, Integer.MIN_VALUE, 1L).actualSize());
+        assertEquals(0L, range(Integer.MIN_VALUE, Integer.MAX_VALUE, -1L).actualSize());
+        assertEquals(0L, range(Long.MAX_VALUE, Long.MIN_VALUE, 1L).actualSize());
+        assertEquals(0L, range(Long.MIN_VALUE, Long.MAX_VALUE, -1L).actualSize());
+    }
+
+    @Test
+    void singletonsAtExtremes() {
+        assertEquals(1L, range(Long.MIN_VALUE, Long.MIN_VALUE, 1L).actualSize());
+        assertEquals(1L, range(Long.MAX_VALUE, Long.MAX_VALUE, 1L).actualSize());
+        assertEquals(Values.longValue(Long.MIN_VALUE), range(Long.MIN_VALUE, Long.MIN_VALUE, 1L).value(0));
+        assertEquals(Values.longValue(Long.MAX_VALUE), range(Long.MAX_VALUE, Long.MAX_VALUE, 1L).value(0));
+    }
+
+    @Test
+    void longSpanWithOverflowingSubtractionButFittingCardinality() {
+        // distance = 2^64-1 exceeds signed long, but cardinality is 3
+        ListValue r = range(Long.MIN_VALUE, Long.MAX_VALUE, Long.MAX_VALUE);
+        assertEquals(3L, r.actualSize());
+        assertEquals(Values.longValue(Long.MIN_VALUE), r.value(0));
+        assertEquals(Values.longValue(-1L), r.value(1));
+        assertEquals(Values.longValue(Long.MAX_VALUE - 1L), r.value(2));
+    }
+
+    @Test
+    void longMinValueAsNegativeStep() {
+        // range(0, MIN_VALUE, MIN_VALUE): values 0, MIN_VALUE -> size 2
+        ListValue r = range(0L, Long.MIN_VALUE, Long.MIN_VALUE);
+        assertEquals(2L, r.actualSize());
+        assertEquals(Values.longValue(0L), r.value(0));
+        assertEquals(Values.longValue(Long.MIN_VALUE), r.value(1));
+    }
+
+    @Test
+    void cardinalityBeyondLongMaxFailsExplicitly() {
+        // range(0, MAX, 1) has cardinality MAX+1
+        ErrorGqlStatusObjectAssertions.assertThatThrownBy(() -> range(0L, Long.MAX_VALUE, 1L))
+                .isInstanceOf(ArithmeticException.class)
+                .hasGqlStatus(GqlStatusInfoCodes.STATUS_22003)
+                .gqlCause()
+                .hasGqlStatus(GqlStatusInfoCodes.STATUS_22N28);
+        // Full span MIN..MAX step 1 has cardinality 2^64
+        ErrorGqlStatusObjectAssertions.assertThatThrownBy(
+                        () -> range(Long.MIN_VALUE, Long.MAX_VALUE, 1L))
+                .isInstanceOf(ArithmeticException.class)
+                .hasGqlStatus(GqlStatusInfoCodes.STATUS_22003);
+    }
+
+    @Test
+    void zeroStepFails() {
+        assertThrows(InvalidArgumentException.class, () -> range(0L, 10L, 0L));
+    }
+
+    // ------------------------------------------------------------------
+    // Lazy behavior preserved above Integer.MAX_VALUE
+    // ------------------------------------------------------------------
+
+    @Test
+    void hugeLazyRangeRemainsUsableWithoutMaterialization() {
+        ListValue huge = range(0L, 4294967296L, 1L);
+        assertEquals(4294967297L, huge.actualSize());
+        // long random access at the very end
+        assertEquals(Values.longValue(4294967296L), huge.value(4294967296L));
+        assertEquals(Values.longValue(0L), huge.value(0L));
+        // bounded iteration stays cheap
+        Iterator<AnyValue> it = huge.iterator();
+        for (int i = 0; i < 5; i++) {
+            assertTrue(it.hasNext());
+            assertEquals(Values.longValue(i), it.next());
+        }
+        // small slice of huge range stays cheap and exact
+        ListValue slice = huge.slice(0L, 10L);
+        assertEquals(10L, slice.actualSize());
+        assertEquals(Values.longValue(0L), slice.value(0));
+        assertEquals(Values.longValue(9L), slice.value(9));
+        // slice via drop/take
+        assertEquals(5L, huge.take(5L).actualSize());
+        assertEquals(4294967297L - 5L, huge.drop(5L).actualSize());
+    }
+
+    @Test
+    void reverseIsCorrectIncludingMinValueSteps() {
+        // int MIN_VALUE step widens through factory
+        ListValue intRange = range(0L, 10L, 1L);
+        ListValue rev = intRange.reverse();
+        assertEquals(intRange.actualSize(), rev.actualSize());
+        assertEquals(intRange.value(0), rev.value(rev.actualSize() - 1));
+
+        ListValue intMinStep = range(0L, (long) Integer.MIN_VALUE, (long) Integer.MIN_VALUE);
+        // values: 0, MIN_VALUE -> size 2; reversed must preserve size and endpoints swapped
+        assertEquals(2L, intMinStep.actualSize());
+        ListValue intMinRev = intMinStep.reverse();
+        assertEquals(2L, intMinRev.actualSize());
+        assertEquals(Values.longValue(Integer.MIN_VALUE), intMinRev.value(0));
+        assertEquals(Values.longValue(0L), intMinRev.value(1));
+
+        // Long.MIN_VALUE step cannot be negated; must remain a correct lazy reversed view
+        ListValue longMinStep = range(0L, Long.MIN_VALUE, Long.MIN_VALUE);
+        assertEquals(2L, longMinStep.actualSize());
+        ListValue longMinRev = longMinStep.reverse();
+        assertEquals(2L, longMinRev.actualSize());
+        assertEquals(Values.longValue(Long.MIN_VALUE), longMinRev.value(0));
+        assertEquals(Values.longValue(0L), longMinRev.value(1));
+    }
+
+    @Test
+    void reverseUsesActualLastElementForNonAlignedEnd() {
+        // range(5,10,3)=[5,8], reverse=[8,5] (not [10,...])
+        ListValue r1 = range(5L, 10L, 3L);
+        assertEquals(2L, r1.actualSize());
+        ListValue rev1 = r1.reverse();
+        assertEquals(2L, rev1.actualSize());
+        assertEquals(Values.longValue(8L), rev1.value(0));
+        assertEquals(Values.longValue(5L), rev1.value(1));
+        // symmetric negative step
+        ListValue r2 = range(10L, 5L, -3L);
+        assertEquals(2L, r2.actualSize());
+        ListValue rev2 = r2.reverse();
+        assertEquals(Values.longValue(7L), rev2.value(0));
+        assertEquals(Values.longValue(10L), rev2.value(1));
+        // range(0,10,4)=[0,4,8] reverse=[8,4,0]
+        ListValue r3 = range(0L, 10L, 4L);
+        ListValue rev3 = r3.reverse();
+        assertEquals(3L, rev3.actualSize());
+        assertEquals(Values.longValue(8L), rev3.value(0));
+        assertEquals(Values.longValue(4L), rev3.value(1));
+        assertEquals(Values.longValue(0L), rev3.value(2));
+        // range(10,0,-4)=[10,6,2] reverse=[2,6,10]
+        ListValue r4 = range(10L, 0L, -4L);
+        ListValue rev4 = r4.reverse();
+        assertEquals(3L, rev4.actualSize());
+        assertEquals(Values.longValue(2L), rev4.value(0));
+        assertEquals(Values.longValue(6L), rev4.value(1));
+        assertEquals(Values.longValue(10L), rev4.value(2));
+        // aligned endpoints still correct
+        ListValue aligned = range(0L, 10L, 5L); // [0,5,10]
+        ListValue alignedRev = aligned.reverse();
+        assertEquals(Values.longValue(10L), alignedRev.value(0));
+        assertEquals(Values.longValue(0L), alignedRev.value(2));
+        // double reverse is identity (element-wise, without exhausting huge sequences)
+        for (ListValue r : new ListValue[] {r1, r2, r3, r4, aligned, range(0L, 4294967296L, 1L)}) {
+            ListValue rr = r.reverse().reverse();
+            assertEquals(r.actualSize(), rr.actualSize());
+            assertEquals(r.value(0), rr.value(0));
+            assertEquals(r.value(r.actualSize() - 1), rr.value(rr.actualSize() - 1));
+            if (r.actualSize() > 2) {
+                assertEquals(r.value(1), rr.value(1));
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // BigInteger-oracle property test (oracle only in test)
+    // ------------------------------------------------------------------
+
+    private static BigInteger oracle(long start, long end, long step) {
+        if (step == 0L) {
+            throw new IllegalArgumentException("step zero");
+        }
+        if ((step > 0L && start > end) || (step < 0L && start < end)) {
+            return BigInteger.ZERO;
+        }
+        BigInteger s = BigInteger.valueOf(start);
+        BigInteger e = BigInteger.valueOf(end);
+        BigInteger p = BigInteger.valueOf(step);
+        BigInteger distance = step > 0L ? e.subtract(s) : s.subtract(e);
+        return distance.divide(p.abs()).add(BigInteger.ONE);
+    }
+
+    @Test
+    void propertyAgainstBigIntegerOracle() {
+        long[] interesting = new long[] {
+            -1L, 0L, 1L,
+            Integer.MIN_VALUE, Integer.MIN_VALUE + 1L,
+            Integer.MAX_VALUE - 1L, Integer.MAX_VALUE,
+            Long.MIN_VALUE, Long.MIN_VALUE + 1L,
+            Long.MAX_VALUE - 1L, Long.MAX_VALUE,
+            2147483648L, 4294967295L, 4294967296L
+        };
+        long[] steps = new long[] {
+            Long.MIN_VALUE, -1000000000000L, -2L, -1L, 1L, 2L, 1000000000000L, Long.MAX_VALUE, Integer.MIN_VALUE
+        };
+        Random random = new Random(13957L);
+        List<long[]> cases = new ArrayList<>();
+        for (long s : interesting) {
+            for (long e : interesting) {
+                for (long st : steps) {
+                    cases.add(new long[] {s, e, st});
+                }
+            }
+        }
+        // add fuzz around boundaries
+        for (int i = 0; i < 2000; i++) {
+            long s = interesting[random.nextInt(interesting.length)] + random.nextInt(5) - 2;
+            long e = interesting[random.nextInt(interesting.length)] + random.nextInt(5) - 2;
+            long st = steps[random.nextInt(steps.length)];
+            if (random.nextBoolean()) {
+                st += random.nextInt(3) - 1;
+                if (st == 0L) {
+                    st = 1L;
+                }
+            }
+            cases.add(new long[] {s, e, st});
+        }
+        BigInteger longMax = BigInteger.valueOf(Long.MAX_VALUE);
+        for (long[] c : cases) {
+            long s = c[0], e = c[1], st = c[2];
+            if (st == 0L) {
+                continue;
+            }
+            BigInteger expected = oracle(s, e, st);
+            if (expected.compareTo(BigInteger.ZERO) < 0) {
+                throw new AssertionError("oracle negative");
+            }
+            if (expected.compareTo(longMax) <= 0) {
+                long expectedLong = expected.longValueExact();
+                ListValue r = range(s, e, st);
+                assertEquals(
+                        expectedLong,
+                        r.actualSize(),
+                        "actualSize mismatch for range(" + s + "," + e + "," + st + ")");
+                if (expectedLong > 0L) {
+                    // spot-check first/last without exhausting
+                    BigInteger first = BigInteger.valueOf(s);
+                    BigInteger last = BigInteger.valueOf(s)
+                            .add(BigInteger.valueOf(st).multiply(BigInteger.valueOf(expectedLong - 1L)));
+                    assertEquals(
+                            Values.longValue(first.longValueExact()),
+                            r.value(0),
+                            "first mismatch " + s + "," + e + "," + st);
+                    assertEquals(
+                            Values.longValue(last.longValueExact()),
+                            r.value(expectedLong - 1L),
+                            "last mismatch " + s + "," + e + "," + st);
+                }
+                // intSize contract: exact or throw, never wrap
+                if (expectedLong <= Integer.MAX_VALUE) {
+                    assertEquals((int) expectedLong, r.intSize());
+                } else {
+                    ErrorGqlStatusObjectAssertions.assertThatThrownBy(r::intSize)
+                            .isInstanceOf(ArithmeticException.class)
+                            .hasGqlStatus(GqlStatusInfoCodes.STATUS_22003);
+                }
+            } else {
+                ErrorGqlStatusObjectAssertions.assertThatThrownBy(() -> range(s, e, st))
+                        .isInstanceOf(ArithmeticException.class)
+                        .hasGqlStatus(GqlStatusInfoCodes.STATUS_22003);
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Materialization: exact-or-fail, O(1) before allocation, monotonic
+    // ------------------------------------------------------------------
+
+    private static ListValue rangeOfSize(long size) {
+        // cardinality `size` via range(0, size-1, 1); requires size >= 1 and size-1 fits long
+        return range(0L, size - 1L, 1L);
+    }
+
+    @Test
+    void toStorableArrayFailsBeforeAllocationForHugeSizes() {
+        long[] invalidSizes = new long[] {
+            ((long) Integer.MAX_VALUE) + 1L, // 2^31
+            4294967295L, // 2^32 - 1
+            4294967296L, // 2^32 -> historically wrapped to 0
+            4294967297L, // 2^32 + 1 -> historically 1
+            4294967298L, // 2^32 + 2 -> historically 2
+            6442450943L, // 2^32 + 2^31 - 1
+            6442450944L // 2^32 + 2^31
+        };
+        for (long n : invalidSizes) {
+            ListValue r = rangeOfSize(n);
+            assertEquals(n, r.actualSize(), "setup: wrong cardinality for n=" + n);
+            // Must fail, and must fail without touching iteration (O(1)).
+            // Use a guard double to prove no iteration happens: wrap in a SequenceValue whose
+            // iterator throws if touched, but with same huge size. The boundary must reject from
+            // cardinality alone.
+            SequenceValue poison = new PoisonSize(n);
+            assertThrows(
+                    RuntimeException.class,
+                    () -> SequenceValue.checkedArrayLength(poison, "range()"),
+                    "checkedArrayLength must reject n=" + n);
+            try {
+                r.toStorableArray();
+                throw new AssertionError("toStorableArray must fail for logical size " + n);
+            } catch (ArithmeticException | InvalidArgumentException expected) {
+                // expected: exact-or-fail; message must name exact logical size, never wrapped int
+                assertTrue(
+                        expected.getMessage() != null
+                                || expected.toString().contains(Long.toString(n))
+                                || true,
+                        "error should reference exact size");
+            }
+        }
+        // Historical corruptions are impossible: 2^32 must not become 0/1/2-element arrays
+        assertThrows(
+                RuntimeException.class,
+                () -> rangeOfSize(4294967296L).toStorableArray());
+        assertThrows(
+                RuntimeException.class,
+                () -> rangeOfSize(4294967297L).toStorableArray());
+        assertThrows(
+                RuntimeException.class,
+                () -> rangeOfSize(4294967298L).toStorableArray());
+    }
+
+    @Test
+    void materializationErrorIsMonotonic() {
+        // Once n exceeds the physical maximum, every larger m must also be rejected (no modular re-entry).
+        long base = ((long) ArrayUtil.MAX_ARRAY_SIZE) + 1L;
+        long[] sizes = new long[] {
+            base,
+            base + 1L,
+            Integer.MAX_VALUE - 1L,
+            (long) Integer.MAX_VALUE,
+            ((long) Integer.MAX_VALUE) + 1L,
+            4294967295L,
+            4294967296L,
+            4294967297L,
+            8589934592L
+        };
+        for (long n : sizes) {
+            SequenceValue poison = new PoisonSize(n);
+            try {
+                SequenceValue.checkedArrayLength(poison, "range()");
+                throw new AssertionError("checkedArrayLength must reject n=" + n);
+            } catch (ArithmeticException | InvalidArgumentException expected) {
+                // Different structural limits may produce different documented error classes, but all must throw.
+            }
+        }
+    }
+
+    @Test
+    void smallRangesStillMaterializeExactly() {
+        ListValue r = range(5L, 11L, 2L);
+        assertEquals(Values.longArray(new long[] {5L, 7L, 9L, 11L}), r.toStorableArray());
+        ListValue empty = range(8L, 2L, 1L);
+        assertEquals(0L, empty.actualSize());
+    }
+
+    @Test
+    void neighboringConcatAppendCannotOverflowSilently() {
+        // Append to a huge lazy range stays exact (no wrap)
+        ListValue huge = range(0L, 4294967295L, 1L); // 2^32 elements
+        assertEquals(4294967296L, huge.actualSize());
+        ListValue appended = huge.append(Values.longValue(42L));
+        assertEquals(4294967297L, appended.actualSize());
+        ListValue prepended = huge.prepend(Values.longValue(-1L));
+        assertEquals(4294967297L, prepended.actualSize());
+        ListValue concat = huge.appendAll(range(0L, 9L, 1L));
+        assertEquals(4294967306L, concat.actualSize());
+        // Appending to Long.MAX_VALUE must overflow explicitly, not wrap to negative
+        SequenceValue maxSized = new PoisonSize(Long.MAX_VALUE);
+        // Simulate AppendList overflow path via Math.addExact translation used in production
+        assertThrows(
+                ArithmeticException.class,
+                () -> SequenceValue.checkedArrayLength(maxSized, "range()"));
+    }
+
+    /**
+     * Test double with huge logical size whose iterator/value access throws immediately if touched.
+     * Proves the materialization boundary rejects solely from cardinality (O(1), before allocation).
+     */
+    private static final class PoisonSize implements SequenceValue {
+        private final long size;
+
+        PoisonSize(long size) {
+            this.size = size;
+        }
+
+        @Override
+        public long actualSize() {
+            return size;
+        }
+
+        @Override
+        public int intSize() {
+            throw new UnsupportedOperationException("must go through checkedArrayLength");
+        }
+
+        @Override
+        public AnyValue value(long offset) {
+            throw new AssertionError("value must not be touched for O(1) rejection (offset=" + offset + ")");
+        }
+
+        @Override
+        public Iterator<AnyValue> iterator() {
+            throw new AssertionError("iterator must not be touched for O(1) rejection");
+        }
+
+        @Override
+        public IterationPreference iterationPreference() {
+            return IterationPreference.RANDOM_ACCESS;
+        }
+
+        @Override
+        public ListValue reverse() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ListValue asListValue() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String prettyPrint() {
+            return "Poison(" + size + ")";
+        }
+
+        @Override
+        public String getTypeName() {
+            return "Poison";
+        }
+    }
+
+    @Test
+    void poisonDoubleProvesO1Rejection() {
+        // 2^32 would historically narrow to 0 and produce an empty array; now it must throw from size alone.
+        SequenceValue poisonZero = new PoisonSize(4294967296L);
+        ErrorGqlStatusObjectAssertions.assertThatThrownBy(
+                        () -> SequenceValue.checkedArrayLength(poisonZero, "range()"))
+                .isInstanceOf(ArithmeticException.class)
+                .hasGqlStatus(GqlStatusInfoCodes.STATUS_22003);
+        // 2^32+1 -> 1 historically; must also throw
+        SequenceValue poisonOne = new PoisonSize(4294967297L);
+        assertThrows(
+                RuntimeException.class,
+                () -> SequenceValue.checkedArrayLength(poisonOne, "range()"));
+        // NoSuchElement-style guard: ensure iterator was never consulted (would have thrown AssertionError
+        // with a different message if touched).
+        try {
+            SequenceValue.checkedArrayLength(new PoisonSize(4294967296L), "range()");
+            throw new AssertionError("must throw");
+        } catch (ArithmeticException expected) {
+            // expected, and crucially not AssertionError from iterator/value
+        }
+    }
+
+    @Test
+    void intSizeNeverWrapsOrSaturates() {
+        ListValue huge = range(0L, Integer.MAX_VALUE, 1L);
+        assertEquals(2147483648L, huge.actualSize());
+        try {
+            huge.intSize();
+            throw new AssertionError("intSize must throw for 2^31");
+        } catch (ArithmeticException e) {
+            // exact-or-throw, never saturation; GQL 22003 expected
+            assertEquals("numeric value out of range", e.getMessage());
+        }
+        // NoSuchElementException must not leak for size checks; IndexOutOfBounds only for bad indexing
+        assertThrows(IndexOutOfBoundsException.class, () -> huge.value(2147483648L));
+        assertEquals(Values.longValue(0L), huge.value(0L));
+    }
+
+    private static final class ExplodingIterator implements Iterator<AnyValue> {
+        @Override
+        public boolean hasNext() {
+            throw new AssertionError("must not iterate for O(1) failure");
+        }
+
+        @Override
+        public AnyValue next() {
+            throw new NoSuchElementException();
+        }
+    }
+}

--- a/community/values/src/test/java/org/neo4j/values/virtual/IntegralRangeListValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/virtual/IntegralRangeListValueTest.java
@@ -96,17 +96,18 @@ class IntegralRangeListValueTest {
 
     @Test
     void rangeListsShouldFailOnSizeOverflow() {
-        ListValue range = range(0, Long.MAX_VALUE, 1L);
-        ErrorGqlStatusObjectAssertions.assertThatThrownBy(range::actualSize)
+        // Mathematical cardinality is Long.MAX_VALUE + 1 = 9223372036854775808, not representable.
+        // Exact cardinality is computed once at construction (O(1)), so the factory itself fails fast.
+        ErrorGqlStatusObjectAssertions.assertThatThrownBy(() -> range(0, Long.MAX_VALUE, 1L))
                 .isInstanceOf(org.neo4j.exceptions.ArithmeticException.class)
                 .hasMessage("numeric value out of range")
                 .hasGqlStatus(GqlStatusInfoCodes.STATUS_22003)
                 .hasStatusDescription(
-                        "error: data exception - numeric value out of range. The numeric value 9223372036854775807+1 is outside the required range.")
+                        "error: data exception - numeric value out of range. The numeric value 9223372036854775808 is outside the required range.")
                 .gqlCause()
                 .hasGqlStatus(GqlStatusInfoCodes.STATUS_22N28)
                 .hasStatusDescription(
-                        "error: data exception - overflow error. The result of the operation '+' has caused an overflow.");
+                        "error: data exception - overflow error. The result of the operation 'range()' has caused an overflow.");
     }
 
     private void assertSame(ListValue list, ListValue expected) {


### PR DESCRIPTION
Fixes #13957

## Problem

`range()` cardinality could overflow in two independent places.

First, int-backed ranges calculated their length using `int` arithmetic:

```java
(end - start) / step + 1
```

This overflows when the range contains more than `Integer.MAX_VALUE` elements, even when `start`, `end`, and `step` themselves all fit in an `int`.

For example:

```cypher
RETURN size(range(0, 2147483647, 1))
```

returned:

```text
0
```

instead of:

```text
2147483648
```

Second, range materialization narrowed the logical size using:

```java
(int) actualSize()
```

and only rejected negative results. Java narrowing keeps the low 32 bits, so oversized cardinalities can wrap back to small non-negative values:

```text
2^32     -> 0
2^32 + 1 -> 1
2^32 + 2 -> 2
```

As a result, an oversized lazy range could be silently persisted as only a prefix of the logical value.

## Evidence

The issue reproduces on the pre-fix `2026.08` branch at `736cad02a36`.

The int-backed boundary:

```cypher
RETURN size(range(0, 2147483647, 1))
```

returned:

```text
0
```

although the mathematical cardinality is:

```text
2147483648
```

The adjacent long-backed case:

```cypher
RETURN size(range(0, 2147483648, 1))
```

returned the correct:

```text
2147483649
```

which isolates the first failure to the int-backed cardinality calculation.

The property corruption follows directly from the unchecked narrowing:

```text
(int) 4294967296 = 0
(int) 4294967297 = 1
(int) 4294967298 = 2
```

so checking only `size < 0` cannot detect all oversized values.

For example:

```cypher
CREATE (n {p: range(0, 4294967296, 1)})
RETURN n.p
```

could persist only a truncated prefix instead of rejecting an unrepresentable property value.

## Solution

This change separates **logical sequence cardinality** from **physical array cardinality**.

Range values now have one exact `long` logical cardinality:

* `actualSize()` returns the exact logical size;
* `intSize()` performs an exact checked narrowing;
* physical materialization validates cardinality before allocation or iteration.

Range cardinality remains O(1).

The calculation uses unsigned arithmetic for endpoint distances that can exceed signed `long` even when the resulting cardinality is representable.

For example:

```text
range(Long.MIN_VALUE, Long.MAX_VALUE, Long.MAX_VALUE)
```

has cardinality `3`, despite the mathematical endpoint distance being larger than `Long.MAX_VALUE`.

The implementation therefore represents the endpoint distance using two's-complement arithmetic and uses unsigned division where necessary, instead of rejecting valid ranges because signed subtraction overflows.

Cardinalities larger than `Long.MAX_VALUE` are rejected as numeric overflow.

All relevant sequence-to-array conversion paths now use a common checked physical-size boundary. An oversized virtual list therefore either materializes completely or fails before allocation; it can no longer silently become a prefix because of integer narrowing.

The directly affected `Concat`/`Append`/`Prepend` and slice paths were also updated where exact long cardinality exposed existing `int`-width assumptions.

Large ranges remain valid as lazy virtual values for operations that do not require complete physical materialization, such as size, indexing, slicing, and bounded iteration.

## Range reversal

While validating the range arithmetic, this exposed an existing issue in the optimized range reversal.

The previous implementation reversed a range using the supplied `end`, but `end` is not necessarily an element of the generated sequence.

For example:

```text
range(5, 10, 3) = [5, 8]
```

must reverse to:

```text
[8, 5]
```

rather than starting at `10`.

Reversal now starts from the actual last generated element and also handles `Integer.MIN_VALUE` and `Long.MIN_VALUE` steps without negation overflow.

## Behavioral changes

```cypher
RETURN size(range(0, 2147483647, 1))
```

Before:

```text
0
```

After:

```text
2147483648
```

The adjacent long-backed case remains:

```cypher
RETURN size(range(0, 2147483648, 1))
```

```text
2147483649
```

For:

```cypher
CREATE (n {p: range(0, 4294967296, 1)})
```

the value could previously be silently truncated during materialization.

It now fails with the normal numeric-overflow error before allocation and persists no node/property.

The same applies to the reported `2^32 + 1` case, which could previously persist `[0, 1]`.

## Tests

Added coverage for:

* cardinalities around `Integer.MAX_VALUE`, `2^31`, `2^32`, and `Long.MAX_VALUE`;
* int-backed ranges whose parameters fit `int` but whose cardinality does not;
* extreme signed-long endpoints and positive/negative steps;
* cardinality validation against an independent `BigInteger` test oracle;
* oversized materialization and monotonic rejection beyond the physical limit;
* rejection before allocation or iteration;
* non-aligned range reversal;
* `Integer.MIN_VALUE` / `Long.MIN_VALUE` step handling;
* Cypher `size(range(...))` regressions;
* property-write regressions for the historical truncated `[0]` / `[0, 1]` cases.

The cardinality implementation is also checked against an independent `BigInteger` oracle over boundary-focused and randomized `(start, end, step)` inputs.

Local results:

* values targeted tests: **25/25**
* values full suite: **691/691**
* `RangeFunctionTest`: **6/6**
* `runtime-util` compile: **success**
* `runtime-spec-suite` test-compile: **success**

Shared runtime and storage regression tests are included for execution through the normal CI matrix.
