### PR TITLE
Fix eagerization for keys() property reads

### DIFF
--- a/community/community-it/cypher-it/src/test/scala/org/neo4j/cypher/KeysEagerIT.scala
+++ b/community/community-it/cypher-it/src/test/scala/org/neo4j/cypher/KeysEagerIT.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher
+
+/**
+ * Regression tests for issue #13942.
+ *
+ * `keys(entity)` observes the property-key domain of a node or relationship, so a preceding
+ * clause that SETs a (potentially new) property conflicts with a later `keys()` read.
+ * The planner must insert an Eager barrier between the two clause phases; otherwise the
+ * second clause can observe transaction state from an incomplete preceding clause, and
+ * semantically equivalent query forms (e.g. with and without a Collect/Unwind
+ * materialization) disagree on the result multiset.
+ *
+ * The correct result multiset for both the direct and the materialized form is {0, 0, 2, 2}:
+ * after the MERGE clause has completely executed, `n0` has the property-key domain
+ * {id, k11, k0}, so `coll.remove(keys(n0), 0)` has cardinality 2 for both input rows.
+ */
+class KeysEagerIT extends ExecutionEngineFunSuite {
+
+  private val directQuery =
+    """FOR j IN [0, 2]
+      |MERGE (m:M {id: 129})-[:R]->(n0:N {id: 130, k11: true})
+      |ON MATCH SET n0.k0 = 0
+      |FOR k IN coll.remove(keys(n0), 0)
+      |RETURN j AS row""".stripMargin
+
+  private val materializedQuery =
+    """FOR j IN [0, 2]
+      |MERGE (m:M {id: 129})-[:R]->(n0:N {id: 130, k11: true})
+      |ON MATCH SET n0.k0 = 0
+      |FOR k IN coll.remove(keys(n0), 0)
+      |WITH j AS row
+      |WITH collect(row) AS rows
+      |UNWIND rows AS row
+      |RETURN row""".stripMargin
+
+  private val reducedQuery =
+    """FOR j IN [0, 1]
+      |MERGE (n:N {id: 1})
+      |ON MATCH SET n.k = 1
+      |RETURN j, size(keys(n)) AS keyCount""".stripMargin
+
+  private def clearGraph(): Unit = {
+    execute("MATCH (n) DETACH DELETE n").toList
+  }
+
+  Seq("slotted", "pipelined").foreach { runtime =>
+    test(s"direct keys() query observes completed MERGE state on $runtime") {
+      clearGraph()
+      val result = execute(s"CYPHER 25 runtime=$runtime $directQuery")
+      val rows = result.toList.map(_("row").toString)
+      rows should contain theSameElementsAs Seq("0", "0", "2", "2")
+
+      // write-state oracle: the fix changes planning, not mutation intent.
+      // propertiesSet counts the 3 created properties (m.id, n0.id, n0.k11) plus the single ON MATCH SET (n0.k0).
+      val statistics = result.queryStatistics()
+      statistics.getNodesCreated should equal(2)
+      statistics.getRelationshipsCreated should equal(1)
+      statistics.getPropertiesSet should equal(4)
+
+      val state =
+        execute("MATCH (m:M {id: 129})-[:R]->(n0:N {id: 130}) RETURN n0.id AS id, n0.k11 AS k11, n0.k0 AS k0").toList
+      state should have size 1
+      state.head("id").toString should equal("130")
+      state.head("k11").toString should equal("true")
+      state.head("k0").toString should equal("0")
+    }
+
+    test(s"materialized keys() query agrees with direct form on $runtime") {
+      clearGraph()
+      val rows = execute(s"CYPHER 25 runtime=$runtime $materializedQuery").toList.map(_("row").toString)
+      rows should contain theSameElementsAs Seq("0", "0", "2", "2")
+    }
+
+    test(s"reduced MERGE/keys() regression on $runtime") {
+      clearGraph()
+      val rows = execute(s"CYPHER 25 runtime=$runtime $reducedQuery").toList
+        .map(row => (row("j").toString, row("keyCount").toString))
+      rows should contain theSameElementsAs Seq(("0", "2"), ("1", "2"))
+    }
+  }
+
+  test("repaired plan contains an Eager barrier") {
+    val description = execute(s"CYPHER 25 EXPLAIN $directQuery").executionPlanDescription()
+    description.toString should include("Eager")
+  }
+}

--- a/community/cypher/cypher-planner-tests/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/EagerPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-tests/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/EagerPlanningIntegrationTest.scala
@@ -53,6 +53,7 @@ import org.neo4j.cypher.internal.logical.builder.AbstractLogicalPlanBuilder.remo
 import org.neo4j.cypher.internal.logical.builder.AbstractLogicalPlanBuilder.setLabel
 import org.neo4j.cypher.internal.logical.builder.TestNFABuilder
 import org.neo4j.cypher.internal.logical.plans.DynamicElement
+import org.neo4j.cypher.internal.logical.plans.Eager
 import org.neo4j.cypher.internal.logical.plans.Expand.ExpandAll
 import org.neo4j.cypher.internal.logical.plans.IndexOrderNone
 import org.neo4j.cypher.internal.logical.plans.LogicalPlanAstConstructionTestSupport
@@ -3535,6 +3536,46 @@ class EagerPlanningIntegrationTest extends CypherPlannerTestSuite
         .allNodeScan("n")
         .build()
     )
+  }
+
+  test("Eager should be inserted between MERGE ON MATCH SET and keys() read") {
+    val planner = plannerBuilder()
+      .setAllNodesCardinality(100)
+      .setLabelCardinality("N", 10)
+      .build()
+
+    val query =
+      """FOR j IN [0, 2]
+        |MERGE (n0:N {id: 130, k11: true})
+        |ON MATCH SET n0.k0 = 0
+        |FOR k IN coll.remove(keys(n0), 0)
+        |RETURN j AS row""".stripMargin
+
+    val plan = planner.plan(CypherVersion.Cypher25, query)
+
+    withClue(s"Plan was:\n$plan\n") {
+      val eagers = plan.folder.findAllByClass[Eager]
+      eagers should not be empty
+      val conflictedProperties = eagers.flatMap(_.reasons).collect {
+        case EagernessReason.ReasonWithConflict(PropertyReadSetConflict(prop), _) => prop.name
+      }
+      conflictedProperties should contain("k0")
+    }
+  }
+
+  test("no Eager should be inserted for keys() of a map") {
+    val planner = plannerBuilder()
+      .setAllNodesCardinality(100)
+      .build()
+
+    val query =
+      """MATCH (n)
+        |SET n.prop = 42
+        |RETURN keys({a: 1}) AS keys""".stripMargin
+
+    val plan = planner.plan(query)
+
+    plan.folder.findAllByClass[Eager] shouldBe empty
   }
 
 }

--- a/community/cypher/cypher-planner-tests/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/plans/rewriter/eager/EagerWhereNeededRewriterTest.scala
+++ b/community/cypher/cypher-planner-tests/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/plans/rewriter/eager/EagerWhereNeededRewriterTest.scala
@@ -30,6 +30,7 @@ import org.neo4j.cypher.internal.expressions.HasDegreeGreaterThan
 import org.neo4j.cypher.internal.expressions.HasDegreeGreaterThanOrEqual
 import org.neo4j.cypher.internal.expressions.HasDegreeLessThan
 import org.neo4j.cypher.internal.expressions.HasDegreeLessThanOrEqual
+import org.neo4j.cypher.internal.expressions.MapExpression
 import org.neo4j.cypher.internal.expressions.MultiRelationshipPathStep
 import org.neo4j.cypher.internal.expressions.NilPathStep
 import org.neo4j.cypher.internal.expressions.NodePathStep
@@ -89,6 +90,7 @@ import org.neo4j.cypher.internal.util.symbols.CTAny
 import org.neo4j.cypher.internal.util.symbols.CTDateTime
 import org.neo4j.cypher.internal.util.symbols.CTInteger
 import org.neo4j.cypher.internal.util.symbols.CTList
+import org.neo4j.cypher.internal.util.symbols.CTMap
 import org.neo4j.cypher.internal.util.symbols.CTNode
 import org.neo4j.cypher.internal.util.symbols.StorableType
 import org.neo4j.cypher.internal.util.symbols.invariantTypeSpec
@@ -481,6 +483,162 @@ class EagerWhereNeededRewriterTest extends CypherPlannerTestSuite with LogicalPl
         .allNodeScan("n")
         .build()
     )
+  }
+
+  test("inserts eager between property set and keys read") {
+    val planBuilder = new LogicalPlanBuilder()
+      .produceResults("keys")
+      .projection("keys(n) AS keys")
+      .setNodeProperty("m", "prop", "42")
+      .expand("(n)-[r]->(m)")
+      .allNodeScan("n")
+    val plan = planBuilder.build()
+    val rewrittenPlan = eagerizePlan(planBuilder, plan)
+
+    rewrittenPlan should equal(
+      new LogicalPlanBuilder()
+        .produceResults("keys")
+        .projection("keys(n) AS keys")
+        .eager(ListSet(PropertyReadSetConflict(propName("prop")).withConflict(Conflict(Id(2), Id(1)))))
+        .setNodeProperty("m", "prop", "42")
+        .expand("(n)-[r]->(m)")
+        .allNodeScan("n")
+        .build()
+    )
+  }
+
+  test("inserts eager between relationship property set and keys read") {
+    val planBuilder = new LogicalPlanBuilder()
+      .produceResults("keys")
+      .projection("keys(r) AS keys")
+      .setRelationshipProperty("r", "prop", "5")
+      .apply()
+      .|.allRelationshipsScan("(n)-[r]->(m)")
+      .unwind("[1,2,3] AS i")
+      .argument()
+    val plan = planBuilder.build()
+    val rewrittenPlan = eagerizePlan(planBuilder, plan)
+
+    rewrittenPlan should equal(
+      new LogicalPlanBuilder()
+        .produceResults("keys")
+        .projection("keys(r) AS keys")
+        .eager(ListSet(PropertyReadSetConflict(propName("prop")).withConflict(Conflict(Id(2), Id(1)))))
+        .setRelationshipProperty("r", "prop", "5")
+        .apply()
+        .|.allRelationshipsScan("(n)-[r]->(m)")
+        .unwind("[1, 2, 3] AS i")
+        .argument()
+        .build()
+    )
+  }
+
+  test("inserts eager between Merge with ON MATCH and keys read") {
+    val planBuilder = new LogicalPlanBuilder()
+      .produceResults("row")
+      .projection("j AS row")
+      .unwind("coll.remove(keys(n0), 0) AS k")
+      .merge(nodes = Seq(createNode("n0", "N")), onMatch = Seq(setNodeProperty("n0", "k0", "0")))
+      .unwind("[0, 2] AS j")
+      .argument()
+    val plan = planBuilder.build()
+    val rewrittenPlan = eagerizePlan(planBuilder, plan)
+
+    rewrittenPlan should equal(
+      new LogicalPlanBuilder()
+        .produceResults("row")
+        .projection("j AS row")
+        .unwind("coll.remove(keys(n0), 0) AS k")
+        .eager(ListSet(PropertyReadSetConflict(propName("k0")).withConflict(Conflict(Id(3), Id(2)))))
+        .merge(nodes = Seq(createNode("n0", "N")), onMatch = Seq(setNodeProperty("n0", "k0", "0")))
+        .unwind("[0, 2] AS j")
+        .argument()
+        .build()
+    )
+  }
+
+  test("inserts eager between Merge with ON CREATE and keys read") {
+    val planBuilder = new LogicalPlanBuilder()
+      .produceResults("row")
+      .projection("j AS row")
+      .unwind("coll.remove(keys(n0), 0) AS k")
+      .merge(nodes = Seq(createNode("n0", "N")), onCreate = Seq(setNodeProperty("n0", "k0", "0")))
+      .unwind("[0, 2] AS j")
+      .argument()
+    val plan = planBuilder.build()
+    val rewrittenPlan = eagerizePlan(planBuilder, plan)
+
+    rewrittenPlan should equal(
+      new LogicalPlanBuilder()
+        .produceResults("row")
+        .projection("j AS row")
+        .unwind("coll.remove(keys(n0), 0) AS k")
+        .eager(ListSet(PropertyReadSetConflict(propName("k0")).withConflict(Conflict(Id(3), Id(2)))))
+        .merge(nodes = Seq(createNode("n0", "N")), onCreate = Seq(setNodeProperty("n0", "k0", "0")))
+        .unwind("[0, 2] AS j")
+        .argument()
+        .build()
+    )
+  }
+
+  test("inserts eager between Apply with Merge ON MATCH RHS and keys read above Apply") {
+    val planBuilder = new LogicalPlanBuilder()
+      .produceResults("row")
+      .projection("j AS row")
+      .unwind("coll.remove(keys(n0), 0) AS k")
+      .apply()
+      .|.merge(nodes = Seq(createNode("n0", "N")), onMatch = Seq(setNodeProperty("n0", "k0", "0")))
+      .|.nodeByLabelScan("n0", "N")
+      .unwind("[0, 2] AS j")
+      .argument()
+    val plan = planBuilder.build()
+    val rewrittenPlan = eagerizePlan(planBuilder, plan)
+
+    withClue(s"Plan was:\n$rewrittenPlan\n") {
+      rewrittenPlan should equal(
+        new LogicalPlanBuilder()
+          .produceResults("row")
+          .projection("j AS row")
+          .unwind("coll.remove(keys(n0), 0) AS k")
+          .eager(ListSet(PropertyReadSetConflict(propName("k0")).withConflict(Conflict(Id(4), Id(2)))))
+          .apply()
+          .|.merge(nodes = Seq(createNode("n0", "N")), onMatch = Seq(setNodeProperty("n0", "k0", "0")))
+          .|.nodeByLabelScan("n0", "N")
+          .unwind("[0, 2] AS j")
+          .argument()
+          .build()
+      )
+    }
+  }
+
+  test("inserts no eager between property set and keys read of a map") {
+    val planBuilder = new LogicalPlanBuilder()
+      .produceResults("keys")
+      .projection("keys({a: 1}) AS keys")
+      .setNodeProperty("m", "prop", "42")
+      .expand("(n)-[r]->(m)")
+      .allNodeScan("n")
+    val plan = planBuilder.build()
+    // The plan builder only records types for variables, so give the map literal the precise
+    // static type that full semantic analysis would infer. keys(map) must then stay a plain
+    // value operation without any graph property dependency.
+    val mapExpression = plan.folder.findAllByClass[MapExpression].head
+    val rewrittenPlan =
+      eagerizePlan(planBuilder, plan, extraSemanticInfo = _.addTypeInfo(mapExpression, CTMap.invariant))
+
+    rewrittenPlan should equal(plan)
+  }
+
+  test("inserts no eager for read-only keys") {
+    val planBuilder = new LogicalPlanBuilder()
+      .produceResults("keys")
+      .projection("keys(n) AS keys")
+      .expand("(n)-[r]->(m)")
+      .allNodeScan("n")
+    val plan = planBuilder.build()
+    val rewrittenPlan = eagerizePlan(planBuilder, plan)
+
+    rewrittenPlan should equal(plan)
   }
 
   test("inserts eager when setting concrete properties from map") {

--- a/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/plans/rewriter/eager/ReadFinder.scala
+++ b/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/plans/rewriter/eager/ReadFinder.scala
@@ -60,6 +60,7 @@ import org.neo4j.cypher.internal.expressions.RelTypeName
 import org.neo4j.cypher.internal.expressions.RelationshipTypeToken
 import org.neo4j.cypher.internal.expressions.ScopeExpression
 import org.neo4j.cypher.internal.expressions.Variable
+import org.neo4j.cypher.internal.expressions.functions.Keys
 import org.neo4j.cypher.internal.expressions.functions.Labels
 import org.neo4j.cypher.internal.expressions.functions.Properties
 import org.neo4j.cypher.internal.ir.CreatePattern
@@ -1238,7 +1239,7 @@ object ReadFinder {
         acc =>
           TraverseChildren(acc.withUnknownLabelsRead(asMaybeVar(f.args.head)))
 
-      case f: FunctionInvocation if f.function == Properties =>
+      case f: FunctionInvocation if f.function == Properties || f.function == Keys =>
         acc =>
           var result = acc
           val typeGetter = semanticTable.typeFor(f.args(0))


### PR DESCRIPTION
Fixes #13942.

## Problem

A query combining `MERGE ... ON MATCH SET` with a downstream `keys(entity)` read could produce different results depending on whether a semantics-preserving materialization was present.

For example:

```cypher
FOR j IN [0, 2]
MERGE (m:M {id: 129})-[:R]->(n0:N {id: 130, k11: true})
ON MATCH SET n0.k0 = 0
FOR k IN coll.remove(keys(n0), 0)
RETURN j AS row
```

The direct form returned four rows, while an equivalent form with a `collect`/`UNWIND` materialization returned three.

The four-row result is the correct one. Once the `MERGE` clause has completed, `n0` has the property-key domain:

```text
{id, k11, k0}
```

so both rows entering the following `FOR` must observe three keys, and each produces two rows after `coll.remove(..., 0)`:

```text
{0, 0, 2, 2}
```

A materialization boundary must not change that result.

## Root cause

The eagerization read analysis in `ReadFinder` already treated `properties(entity)` as an unknown/all-property read, but did not do the same for `keys(entity)`.

As a result, a write such as:

```cypher
SET n0.k0 = 0
```

was not considered to conflict with a downstream `keys(n0)` read, even though that write may change the entity's property-key domain.

Without that dependency, the planner could omit the Eager barrier required to preserve clause-level read/write semantics.

## Fix

`keys(node)` and `keys(relationship)` now reuse the same existing unknown-property-read classification as `properties()`.

This allows the existing eagerization machinery to do the rest:

```text
keys(entity)
  → unknown property read
  → conflict with property write
  → PropertyReadSetConflict
  → required Eager barrier
```

No changes were needed to `MERGE` write extraction, `ConflictFinder`, Eager placement, `FOR`/`Unwind`, runtime implementations, kernel transaction visibility, or the existing property-conflict representation.

`keys(map)` remains a plain value operation and does not introduce a graph-property read or an Eager.

## Correctness

After the fix, both the direct and materialized forms return:

```text
{0, 0, 2, 2}
```

under both slotted and pipelined runtimes.

The write behavior is unchanged:

```text
2 nodes created
1 relationship created
4 properties set
```

with final graph state equivalent to:

```text
(:M {id: 129})-[:R]->(:N {id: 130, k11: true, k0: 0})
```

## Evidence

The regression coverage in this PR directly checks the semantic and planner invariants described above:

* [`[KeysEagerIT.scala](https://github.com/iancuuandrei/neo4j-contributions/blob/8591b4bd8cf95e2c761df6427d31f67566bc7cb7/community/community-it/cypher-it/src/test/scala/org/neo4j/cypher/KeysEagerIT.scala)`](https://github.com/iancuuandrei/neo4j-contributions/blob/8591b4bd8cf95e2c761df6427d31f67566bc7cb7/community/community-it/cypher-it/src/test/scala/org/neo4j/cypher/KeysEagerIT.scala) — reproduces #13942, checks direct/materialized equivalence under slotted and pipelined runtimes, validates the final graph/write state, and verifies the Eager appears in the plan.
* [`[EagerPlanningIntegrationTest.scala](https://github.com/iancuuandrei/neo4j-contributions/blob/8591b4bd8cf95e2c761df6427d31f67566bc7cb7/community/cypher/cypher-planner-tests/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/EagerPlanningIntegrationTest.scala)`](https://github.com/iancuuandrei/neo4j-contributions/blob/8591b4bd8cf95e2c761df6427d31f67566bc7cb7/community/cypher/cypher-planner-tests/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/EagerPlanningIntegrationTest.scala) — verifies the planner derives the `PropertyReadSetConflict` for the issue shape.
* [`[EagerWhereNeededRewriterTest.scala](https://github.com/iancuuandrei/neo4j-contributions/blob/8591b4bd8cf95e2c761df6427d31f67566bc7cb7/community/cypher/cypher-planner-tests/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/plans/rewriter/eager/EagerWhereNeededRewriterTest.scala)`](https://github.com/iancuuandrei/neo4j-contributions/blob/8591b4bd8cf95e2c761df6427d31f67566bc7cb7/community/cypher/cypher-planner-tests/src/test/scala/org/neo4j/cypher/internal/compiler/planner/logical/plans/rewriter/eager/EagerWhereNeededRewriterTest.scala) — covers node/relationship `keys()`, `MERGE` ON MATCH/ON CREATE, and no-Eager controls.
* [`[ReadFinder.scala](https://github.com/iancuuandrei/neo4j-contributions/blob/8591b4bd8cf95e2c761df6427d31f67566bc7cb7/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/plans/rewriter/eager/ReadFinder.scala)`](https://github.com/iancuuandrei/neo4j-contributions/blob/8591b4bd8cf95e2c761df6427d31f67566bc7cb7/community/cypher/cypher-planner/src/main/scala/org/neo4j/cypher/internal/compiler/planner/logical/plans/rewriter/eager/ReadFinder.scala) — the production change itself.

## Tests

All targeted suites pass:

```text
EagerWhereNeededRewriterTest      361 run, 0 failures
EagerPlanningIntegrationTest      103 run, 0 failures
ConflictFinderTest,
CandidateListFinderTest,
BestPositionFinderTest             42 run, 0 failures
KeysEagerIT                          7 run, 0 failures
```